### PR TITLE
Simple spelling fixes in the documentation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -62,13 +62,13 @@
 - fix(flex) fix layout update and invalidation issues 
 - fix(flex) fix NULL pointer dereference 
 - fix(obj, switch) do not send LV_EVENT_VALUE_CHANGED twice  
-- fix(color) overflow with 16 bit color depth  
+- fix(color) overflow with 16-bit color depth  
 - fix(coords) fix using large coordinates  
 - fix(chart) fix crash if no series are added 
 - fix(chart) invalidation with LV_CHART_UPDATE_MODE_SHIFT 
 - fix(align) fix lv_obj_align_to  G
 - fix(table) invalidate the table on cell value change  
-- fix(label) remove dupliacted lv_obj_refresh_self_size 
+- fix(label) remove duplicated lv_obj_refresh_self_size 
 - fix(draw) underflow in subpixel font drawing 
 - fix (scroll) do not send unnecessary scroll end events  
 
@@ -76,7 +76,7 @@
 ## v8.0.1 (14.06.2021)
 - docs(filesystem) update to v8 <a href="https://github.com/lvgl/lvgl/commit/7971ade4">7971ade4</a> 
 - fix(msgbox) create modals on top layer instead of act screen <a href="https://github.com/lvgl/lvgl/commit/5cf6303e">5cf6303e</a> 
-- fix(colowheel) disable LV_OBJ_FLAG_SCROLL_CHAIN by default <a href="https://github.com/lvgl/lvgl/commit/48d1c292">48d1c292</a> 
+- fix(colorwheel) disable LV_OBJ_FLAG_SCROLL_CHAIN by default <a href="https://github.com/lvgl/lvgl/commit/48d1c292">48d1c292</a> 
 - docs(grid) typo fix (#2310) <a href="https://github.com/lvgl/lvgl/commit/69d109d2">69d109d2</a> 
 - fix(arduino) fix the prototype of my_touchpad_read in the LVGL_Arduino.ino <a href="https://github.com/lvgl/lvgl/commit/1a62f7a6">1a62f7a6</a> 
 - fix(meter) fix needle image invalidation <a href="https://github.com/lvgl/lvgl/commit/54d8e817">54d8e817</a> 
@@ -84,12 +84,12 @@
 - fix(calendar) fix the position calculation today <a href="https://github.com/lvgl/lvgl/commit/ad05e196">ad05e196</a> 
 - fix(typo) rename LV_OBJ_FLAG_SNAPABLE to LV_OBJ_FLAG_SNAPPABLE <a href="https://github.com/lvgl/lvgl/commit/e697807c">e697807c</a> 
 - docs(color) language fixes (#2302) <a href="https://github.com/lvgl/lvgl/commit/07ecc9f1">07ecc9f1</a> 
-- fix(tick) minor optmization on lv_tick_inc call test <a href="https://github.com/lvgl/lvgl/commit/b4305df5">b4305df5</a> 
+- fix(tick) minor optimization on lv_tick_inc call test <a href="https://github.com/lvgl/lvgl/commit/b4305df5">b4305df5</a> 
 - Spelling and other language fixes to documentation (#2293) <a href="https://github.com/lvgl/lvgl/commit/d0aaacaf">d0aaacaf</a> 
-- fix(theme) show disabled state on buttons of btnmatrix, msgbox and kayboard <a href="https://github.com/lvgl/lvgl/commit/0be582b3">0be582b3</a> 
+- fix(theme) show disabled state on buttons of btnmatrix, msgbox and keyboard <a href="https://github.com/lvgl/lvgl/commit/0be582b3">0be582b3</a> 
 - fix(scroll) keep the scroll position on object deleted <a href="https://github.com/lvgl/lvgl/commit/52edbb46">52edbb46</a> 
-- fix(msgbox) handle NULL btn map paramter <a href="https://github.com/lvgl/lvgl/commit/769c4a30">769c4a30</a> 
-- fix(group) allow refocusing obejcts <a href="https://github.com/lvgl/lvgl/commit/1520208b">1520208b</a> 
+- fix(msgbox) handle NULL btn map parameter <a href="https://github.com/lvgl/lvgl/commit/769c4a30">769c4a30</a> 
+- fix(group) allow refocusing objects <a href="https://github.com/lvgl/lvgl/commit/1520208b">1520208b</a> 
 - docs(overview) spelling fixes <a href="https://github.com/lvgl/lvgl/commit/d2efb8c6">d2efb8c6</a> 
 - Merge branch 'master' of https://github.com/lvgl/lvgl <a href="https://github.com/lvgl/lvgl/commit/45960838">45960838</a> 
 - feat(timer) check if lv_tick_inc is called <a href="https://github.com/lvgl/lvgl/commit/aa6641a6">aa6641a6</a> 
@@ -97,11 +97,11 @@
 - fix(theme) fix the switch style in the default theme <a href="https://github.com/lvgl/lvgl/commit/0c0dc8ea">0c0dc8ea</a> 
 - docs fix typo <a href="https://github.com/lvgl/lvgl/commit/8ab80645">8ab80645</a> 
 - Merge branch 'master' of https://github.com/lvgl/lvgl <a href="https://github.com/lvgl/lvgl/commit/e796448f">e796448f</a> 
-- feat(event) pass the scroll aniamtion to LV_EVENT_SCROLL_BEGIN <a href="https://github.com/lvgl/lvgl/commit/ca54ecfe">ca54ecfe</a> 
+- feat(event) pass the scroll animation to LV_EVENT_SCROLL_BEGIN <a href="https://github.com/lvgl/lvgl/commit/ca54ecfe">ca54ecfe</a> 
 - fix(tabview) fix with left and right tabs <a href="https://github.com/lvgl/lvgl/commit/17c57449">17c57449</a> 
 - chore(docs) force docs rebuild <a href="https://github.com/lvgl/lvgl/commit/4a0f4139">4a0f4139</a> 
 - chore(docs) always deploy master to docs/master as well <a href="https://github.com/lvgl/lvgl/commit/6d05692d">6d05692d</a> 
-- fix(template) udpate lv_objx_template to v8 <a href="https://github.com/lvgl/lvgl/commit/38bb8afc">38bb8afc</a> 
+- fix(template) update lv_objx_template to v8 <a href="https://github.com/lvgl/lvgl/commit/38bb8afc">38bb8afc</a> 
 - docs(extra) add extra/README.md <a href="https://github.com/lvgl/lvgl/commit/8cd504d5">8cd504d5</a> 
 - Update CHANGELOG.md <a href="https://github.com/lvgl/lvgl/commit/48fd73d2">48fd73d2</a> 
 - Update quick-overview.md (#2295) <a href="https://github.com/lvgl/lvgl/commit/5616471c">5616471c</a> 
@@ -109,15 +109,15 @@
 - adding micropython examples (#2286) <a href="https://github.com/lvgl/lvgl/commit/c60ed68e">c60ed68e</a> 
 - docs(color) minor fix <a href="https://github.com/lvgl/lvgl/commit/ac8f4534">ac8f4534</a> 
 - fix(example) revert test code <a href="https://github.com/lvgl/lvgl/commit/77e2c1ff">77e2c1ff</a> 
-- fix(draw) with additive blending with 32 bit color depth <a href="https://github.com/lvgl/lvgl/commit/786db2af">786db2af</a> 
+- fix(draw) with additive blending with 32-bit color depth <a href="https://github.com/lvgl/lvgl/commit/786db2af">786db2af</a> 
 - docs(color) update colors' docs <a href="https://github.com/lvgl/lvgl/commit/9056b5ee">9056b5ee</a> 
 - Merge branch 'master' of https://github.com/lvgl/lvgl <a href="https://github.com/lvgl/lvgl/commit/a711a1dd">a711a1dd</a> 
 - perf(refresh) optimize where to wait for lv_disp_flush_ready with 2 buffers <a href="https://github.com/lvgl/lvgl/commit/d0172f14">d0172f14</a> 
 - docs(lv_obj_style) update add_style and remove_style function headers (#2287) <a href="https://github.com/lvgl/lvgl/commit/60f7bcbf">60f7bcbf</a> 
 - fix memory leak of spangroup (#2285) <a href="https://github.com/lvgl/lvgl/commit/33e0926a">33e0926a</a> 
-- fix make lv_img_cache.h public becasue cache invalidation is public <a href="https://github.com/lvgl/lvgl/commit/38ebcd81">38ebcd81</a> 
+- fix make lv_img_cache.h public because cache invalidation is public <a href="https://github.com/lvgl/lvgl/commit/38ebcd81">38ebcd81</a> 
 - Merge branch 'master' of https://github.com/lvgl/lvgl <a href="https://github.com/lvgl/lvgl/commit/2b292495">2b292495</a> 
-- fix(btnmamatrix) fix focus event handling <a href="https://github.com/lvgl/lvgl/commit/3b58ef14">3b58ef14</a> 
+- fix(btnmatrix) fix focus event handling <a href="https://github.com/lvgl/lvgl/commit/3b58ef14">3b58ef14</a> 
 - Merge pull request #2280 from lvgl/dependabot/pip/docs/urllib3-1.26.5 <a href="https://github.com/lvgl/lvgl/commit/a2f45b26">a2f45b26</a> 
 - fix(label) calculating the clip area <a href="https://github.com/lvgl/lvgl/commit/57e211cc">57e211cc</a> 
 - chore(deps): bump urllib3 from 1.26.4 to 1.26.5 in /docs <a href="https://github.com/lvgl/lvgl/commit/b2f77dfc">b2f77dfc</a> 
@@ -142,8 +142,8 @@ v8 is a major change and therefore it's not backward compatible with v7.
 - `lv_cont` removed, layout features are moved to `lv_obj`
 - `lv_page` removed, scroll features are moved to `lv_obj`
 - `lv_objmask` the same can be achieved by events
-- `lv_meter` added as the unioin of `lv_linemeter` and `lv_gauge`
-- `lv_span` new widget mimicing HTML `<span>`
+- `lv_meter` added as the union of `lv_linemeter` and `lv_gauge`
+- `lv_span` new widget mimicking HTML `<span>`
 - `lv_animing` new widget for simple slideshow animations
 - \+ many minor changes and improvements
 
@@ -247,7 +247,7 @@ v8 is a major change and therefore it's not backward compatible with v7.
 
 ### New features
 - feat(chart) add lv_chart_remove_series and lv_chart_hide_series
-- feat(img_cahce) allow disabling image caching
+- feat(img_cache) allow disabling image caching
 - calendar: make get_day_of_week() public
 - Added support for Zephyr integration
  
@@ -267,7 +267,7 @@ v8 is a major change and therefore it's not backward compatible with v7.
 
 ### Bugfixes
 - fix(lv_scr_load_anim) fix when multiple screen are loaded at tsame time with delay
-- fix(page) fix LV_SCOLLBAR_MODE_DRAG
+- fix(page) fix LV_SCROLLBAR_MODE_DRAG
 
 ## v7.8.0 (01.12.2020)
 
@@ -307,7 +307,7 @@ v8 is a major change and therefore it's not backward compatible with v7.
 ### Bugfixes
 - Respect btnmatrix's `one_check` in `lv_btnmatrix_set_btn_ctrl`
 - Gauge: make the needle images to use the styles from `LV_GAUGE_PART_PART`
-- Group: fix in `lv_group_remove_obj` to handle deleting hidden obejcts correctly
+- Group: fix in `lv_group_remove_obj` to handle deleting hidden objects correctly
 
 ## v7.7.0 (20.10.2020)
 
@@ -362,7 +362,7 @@ v8 is a major change and therefore it's not backward compatible with v7.
 - Adjust button matrix button width to include padding when spanning multiple units.
 - Add rounding to btnmatrix line height calculation
 - Add `decmopr_buf` to GC roots
-- Fix divisioin by zero in draw_pattern (lv_draw_rect.c) if the image or letter is not found
+- Fix division by zero in draw_pattern (lv_draw_rect.c) if the image or letter is not found
 - Fix drawing images with 1 px height or width
 
 ## v7.4.0 (01.09.2020)
@@ -380,8 +380,8 @@ The main new features of v7.4 are run-time font loading, style caching and arc k
 ### Bugfixes
 - Fix color bleeding on border drawing
 - Fix using 'LV_SCROLLBAR_UNHIDE' after 'LV_SCROLLBAR_ON'
-- Fix croping of last column/row if an image is zoomed
-- Fix zooming and rotateing mosaic images
+- Fix cropping of last column/row if an image is zoomed
+- Fix zooming and rotating mosaic images
 - Fix deleting tabview with LEFT/RIGHT tab position
 - Fix btnmatrix to not send event when CLICK_TRIG = true and the cursor slid from a pressed button
 - Fix roller width if selected text is larger than the normal
@@ -392,13 +392,13 @@ The main new features of v7.4 are run-time font loading, style caching and arc k
 - Fix drawing value string twice
 - Rename  `lv_chart_clear_serie` to `lv_chart_clear_series` and `lv_obj_align_origo` to `lv_obj_align_mid`
 - Add linemeter's mirror feature again
-- Fix text decor (udnerline strikethrough) with older versions of font converter
+- Fix text decor (underline strikethrough) with older versions of font converter
 - Fix setting local style property multiple times 
 - Add missing background drawing and radius handling to image button
 - Allow adding extra label to list buttons
 - Fix crash if `lv_table_set_col_cnt` is called before `lv_table_set_row_cnt` for the first time
 - Fix overflow in large image transformations
-- Limit extra button click area of button matrix's buttons. With large paddings it was counter intuitive. (Gaps are mapped to button when clicked).
+- Limit extra button click area of button matrix's buttons. With large paddings it was counter-intuitive. (Gaps are mapped to button when clicked).
 - Fix `lv_btnmatrix_set_one_check` not forcing exactly one button to be checked
 - Fix color picker invalidation in rectangle mode
 - Init disabled days to gray color in calendar
@@ -418,8 +418,8 @@ The main new features of v7.4 are run-time font loading, style caching and arc k
 - Prevent duplicated sending of `LV_EVENT_INSERT` from text area
 - Tidy outer edges of cpicker widget.
 - Remove duplicated lines from `lv_tabview_add_tab`
-- btnmatrix: hadle combined states of buttons (e.g. chacked + disabled)
-- textarea: fix typo in lv_textarea_set_sscrollbar_mode
+- btnmatrix: handle combined states of buttons (e.g. checked + disabled)
+- textarea: fix typo in lv_textarea_set_scrollbar_mode
 - gauge: fix image needle drawing
 - fix using freed memory in _lv_style_list_remove_style
 
@@ -436,7 +436,7 @@ The main new features of v7.4 are run-time font loading, style caching and arc k
 - Add `lv_chart_get_point_id()` function - Get an individual point value in the chart series directly based on index
 - Add `ext_buf_assigned` bit field to `lv_chart_series_t` structure - it's true if external buffer is assigned to series
 - Add `lv_chart_set_series_axis()` to assign series to primary or secondary axis
-- Add `lv_chart_set_y_range()` to allow setting range of secondary y axis (based on `lv_chart_set_range` but extended with an axis parameter)
+- Add `lv_chart_set_y_range()` to allow setting range of secondary y-axis (based on `lv_chart_set_range` but extended with an axis parameter)
 - Allow setting different font for the selected text in `lv_roller`
 - Add `theme->apply_cb` to replace `theme->apply_xcb` to make it compatible with the MicroPython binding
 - Add `lv_theme_set_base()` to allow easy extension of built-in (or any) themes
@@ -448,7 +448,7 @@ The main new features of v7.4 are run-time font loading, style caching and arc k
 - Use 14px font by default to for better compatibility with smaller displays 
 - `linemeter` fix conversation of current value to "level"
 - Fix drawing on right border
-- Set the cursor image non clickable by default
+- Set the cursor image non-clickable by default
 - Improve mono theme when used with keyboard or encoder
 
 ## v7.1.0 (07.07.2020)
@@ -481,7 +481,7 @@ The main new features of v7.4 are run-time font loading, style caching and arc k
 - Fix gestures
 - Do not call `set_px_cb` for transparent pixel
 - Fix list button focus in material theme
-- Fix crash when the a text area is cleared with the backspace of a keyboard
+- Fix crash when a text area is cleared with the backspace of a keyboard
 - Add version number to `lv_conf_template.h`
 - Add log in true double buffering mode with `set_px_cb`
 - `lv_dropdown`: fix missing `LV_EVENT_VALUE_CHANGED` event when used with encoder
@@ -501,7 +501,7 @@ The main new features of v7.4 are run-time font loading, style caching and arc k
 ## v7.0.1 (01.06.2020)
 
 ### Bugfixes
-- Make the Microptyhon working by adding the required variables as GC_ROOT
+- Make Micropython working by adding the required variables as GC_ROOT
 - Prefix some internal API functions with `_` to reduce the API of LVGL 
 - Fix built-in SimSun CJK font
 - Fix UTF-8 encoding when `LV_USE_ARABIC_PERSIAN_CHARS` is enabled
@@ -539,7 +539,7 @@ The API in this regard remained the same but some new functions were added:
 - `lv_img_set_angle`: set image object's angle without using canvas
 - `lv_img_set_pivot`: set the pivot point of rotation
 
-The new drawing engine brought new drawing features too. They are highlighted in the "style" section.
+The new drawing engine brought new drawing features too. They are highlighted in the "style" section.
 
 ### New style system
 The old style system is replaced with a new more flexible and lightweighted one. 
@@ -554,8 +554,8 @@ As part of these updates, a lot of objects were reworked and the APIs have been 
 - dashed vertical and horizontal lines (*dash gap*, *dash_width*)
 - *outline*: a border-like part drawn out of the background. Can have spacing to the background.
 - *pattern*: display and image in the middle of the background or repeat it
-- *value* display a text which is stored in the style. It can be used e.g. as a lighweighted text on buttons too.
-- *margin*: similar to *padding* but used to keep space outside of the object
+- *value* display a text which is stored in the style. It can be used e.g. as a light-weighted text on buttons too.
+- *margin*: similar to *padding* but used to keep space outside the object
 
 Read the [Style](https://docs.littlevgl.com/v7/en/html/overview/style.html) section of the documentation to learn how the new styles system works.
 
@@ -584,7 +584,7 @@ The following object types are renamed:
 ### Reworked and improved object
 - `dropdown`: Completely reworked. Now creates a separate list when opened and can be dropped to down/up/left/right.
 - `label`: `body_draw` is removed, instead, if its style has a visible background/border/shadow etc it will be drawn. Padding really makes the object larger (not just virtually as before)
-- `arc`: can draw bacground too.
+- `arc`: can draw background too.
 - `btn`: doesn't store styles for each state because it's done naturally in the new style system.
 - `calendar`: highlight the pressed datum. The used styles are changed: use `LV_CALENDAR_PART_DATE` normal for normal dates, checked for highlighted, focused for today, pressed for the being pressed. (checked+pressed, focused+pressed also work)
 - `chart`: only has `LINE` and `COLUMN` types because with new styles all the others can be described. LV_CHART_PART_SERIES sets the style of the series. bg_opa > 0 draws an area in LINE mode. `LV_CHART_PART_SERIES_BG` also added to set a different style for the series area. Padding in `LV_CHART_PART_BG` makes the series area smaller, and it ensures space for axis labels/numbers.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,7 +9,7 @@
 
 Join LVGL's community and leave your footprint in the library!
 
-There are a lot of ways to contribute to LVGL even if you are are new to the library or even new to programming. 
+There are a lot of ways to contribute to LVGL even if you are new to the library or even new to programming. 
 
 It might be scary to make the first step but you have nothing to be afraid of. 
 A friendly and helpful community is waiting for you. Get to know like-minded people and make something great together.
@@ -217,9 +217,9 @@ Participating in the discussions is one of the best ways to become part of the p
 ### Add features
 If you have created a cool widget, or added useful feature to LVGL feel free to open a new PR for it. 
 We collect the optional features (a.k.a. plugins) in [lvgl/src/extra](https://github.com/lvgl/lvgl/tree/master/src/extra) folder so if you are interested in adding a new features please use this folder. 
-The [README](https://github.com/lvgl/lvgl/blob/master/src/extra/README.md) file describes the basics rules of contribution and and also lists some ideas.
+The [README](https://github.com/lvgl/lvgl/blob/master/src/extra/README.md) file describes the basics rules of contribution and also lists some ideas.
 
-For further ideas take a look at the our [Roadmap](/ROADMAP) page. If you are interested in any of them feel free to share your opinion and/or participate in the the implementation.
+For further ideas take a look at the [Roadmap](/ROADMAP) page. If you are interested in any of them feel free to share your opinion and/or participate in the implementation.
 
 Other features which are (still) not on the road map are listed in the [Feature request](https://forum.lvgl.io/c/feature-request/9) category of the Forum. 
 

--- a/docs/get-started/arduino.md
+++ b/docs/get-started/arduino.md
@@ -39,9 +39,9 @@ LVGL has its own configuration file called `lv_conf.h`. When LVGL is installed t
 Take a look at [LVGL_Arduino.ino](https://github.com/lvgl/lvgl/blob/master/examples/arduino/LVGL_Arduino/LVGL_Arduino.ino) to see how to initialize LVGL.
 TFT_eSPI is used as the display driver.
 
-In the INO file you can see how to register a display and a touch pad for LVGL and call an example.
+In the INO file you can see how to register a display and a touchpad for LVGL and call an example.
 
-Note that, there is no dedicated INO file for every example but you can call functions like `lv_example_btn_1()` or `lv_example_slider_1()` to run an example.
+Note that, there is no dedicated INO file for every example, but you can call functions like `lv_example_btn_1()` or `lv_example_slider_1()` to run an example.
 Most of the examples are available in the [`lvgl/examples`](https://github.com/lvgl/lvgl/tree/master/examples) folder. Some are also available in [`lv_demos`](https://github.com/lvgl/lv_demos), which needs to be installed and configured separately.
 
 ## Debugging and logging

--- a/docs/get-started/micropython.md
+++ b/docs/get-started/micropython.md
@@ -26,7 +26,7 @@ Currently, Micropython [does not have a good high-level GUI library](https://for
 
 ### Here are some advantages of using LVGL in Micropython:
 
-- Develop GUI in Python, a very popular high level language. Use paradigms such as Object Oriented Programming.
+- Develop GUI in Python, a very popular high level language. Use paradigms such as Object-Oriented Programming.
 - Usually, GUI development requires multiple iterations to get things right. With C, each iteration consists of **`Change code` > `Build` > `Flash` > `Run`**.  
 In Micropython it's just **`Change code` > `Run`** ! You can even run commands interactively using the [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop) (the interactive prompt)
 
@@ -44,7 +44,7 @@ This goes well with [CircuitPython vision](https://learn.adafruit.com/welcome-to
 ## So what does it look like?
 
 > TL;DR:
-> It's very much like the C API, but Object Oriented for LVGL components.
+> It's very much like the C API, but Object-Oriented for LVGL components.
 
 Let's dive right into an example!  
 

--- a/docs/get-started/nuttx.md
+++ b/docs/get-started/nuttx.md
@@ -12,9 +12,9 @@ The best way to think about NuttX is to think of it as a small Unix/Linux for mi
 
 ### Highlights of NuttX
 
-- **Small** - Fits and runs in microcontrollers as small as 32KB Flash and 8KB of RAM.
+- **Small** - Fits and runs in microcontrollers as small as 32 kB Flash and 8 kB of RAM.
 - **Compliant** - Strives to be as compatible as possible with POSIX and Linux.
-- **Versatile** - Supports many architectures (ARM, ARM Thumb, AVR, MIPS, OpenRISC, RISC-V 32-bit and 64-bit, RX65N, x86-64, Xtensa, Z80/Z180, etc).
+- **Versatile** - Supports many architectures (ARM, ARM Thumb, AVR, MIPS, OpenRISC, RISC-V 32-bit and 64-bit, RX65N, x86-64, Xtensa, Z80/Z180, etc.).
 - **Modular** - Its modular design allows developers to select only what really matters and use modules to include new features.
 - **Popular** - NuttX is used by many companies around the world. Probably you already used a product with NuttX without knowing it was running NuttX.
 - **Predictable** - NuttX is a preemptible Realtime kernel, so you can use it to create predictable applications for realtime control.
@@ -56,7 +56,7 @@ Let's use the [Windows Subsystem for Linux](https://acassis.wordpress.com/2018/0
 $ sudo apt-get install automake bison build-essential flex gcc-arm-none-eabi gperf git libncurses5-dev libtool libusb-dev libusb-1.0.0-dev pkg-config kconfig-frontends openocd
 ```
 
-### Now let's to create a workspace to save our files
+### Now let's create a workspace to save our files
 
 ```shell
 $ mkdir ~/nuttxspace

--- a/docs/get-started/pc-simulator.md
+++ b/docs/get-started/pc-simulator.md
@@ -9,7 +9,7 @@ You can try out LVGL **using only your PC** (i.e. without any development boards
 
 Using the simulator on the PC has the following advantages:
 - Hardware independent - Write code, run it on the PC and see the result on the PC monitor.
-- Cross-platform - Any Windows, Linux or MacOS system can run the PC simulator.  
+- Cross-platform - Any Windows, Linux or macOS system can run the PC simulator.  
 - Portability - the written code is portable, which means you can simply copy it when using an embedded hardware.
 - Easy Validation - The simulator is also very useful to report bugs because it means common platform for every user. So it's a good idea to reproduce a bug in the simulator and use the code snippet in the [Forum](https://forum.lvgl.io).
 
@@ -45,7 +45,7 @@ You can download Eclipse's CDT from: [https://www.eclipse.org/cdt/downloads.php]
 
 ### Install SDL 2
 
-The PC simulator uses the [SDL 2](https://www.libsdl.org/download-2.0.php) cross platform library to simulate a TFT display and a touch pad. 
+The PC simulator uses the [SDL 2](https://www.libsdl.org/download-2.0.php) cross-platform library to simulate a TFT display and a touchpad. 
 
 #### Linux
 On **Linux** you can easily install SDL2 using a terminal:
@@ -82,16 +82,16 @@ You can find the latest one on [GitHub](https://github.com/lvgl/lv_sim_eclipse_s
 
 Run Eclipse CDT. It will show a dialogue about the **workspace path**. Before accepting the path, check that path and copy (and unzip) the downloaded pre-configured project there. After that, you can accept the workspace path. Of course you can modify this path but, in that case copy the project to the corresponding location.
 
-Close the start up window and go to **File-&gt;Import** and choose **General-&gt;Existing project into Workspace**. **Browse the root directory** of the project and click **Finish**
+Close the start-up window and go to **File-&gt;Import** and choose **General-&gt;Existing project into Workspace**. **Browse the root directory** of the project and click **Finish**
 
 On **Windows** you have to do two additional things:
 
 - Copy the **SDL2.dll** into the project's Debug folder 
-- Right click on the project -&gt; Project properties -&gt; C/C++ Build -&gt; Settings -&gt; Libraries -&gt; Add ... and add _mingw32_ above SDLmain and SDL. (The order is important: mingw32, SDLmain, SDL)
+- Right-click on the project -&gt; Project properties -&gt; C/C++ Build -&gt; Settings -&gt; Libraries -&gt; Add ... and add _mingw32_ above SDLmain and SDL. (The order is important: mingw32, SDLmain, SDL)
 
 ### Compile and Run
 
-Now you are ready to run LVGL on your PC. Click on the Hammer Icon on the top menu bar to Build the project. If you have done everything right, then you will not get any errors. Note that on some systems additional steps might be required to "see" SDL 2 from Eclipse but, in most of cases the configurations in the downloaded project is enough.
+Now you are ready to run LVGL on your PC. Click on the Hammer Icon on the top menu bar to Build the project. If you have done everything right, then you will not get any errors. Note that on some systems additional steps might be required to "see" SDL 2 from Eclipse but, in most cases the configuration in the downloaded project is enough.
 
 After a success build, click on the Play button on the top menu bar to run the project. Now a window should appear in the middle of your screen.
 

--- a/docs/get-started/quick-overview.md
+++ b/docs/get-started/quick-overview.md
@@ -59,7 +59,7 @@ void my_disp_flush(lv_disp_drv_t * disp, const lv_area_t * area, lv_color_t * co
 }
 
 ```
-- Implement and register a function which can read an input device. E.g. for a touch pad:
+- Implement and register a function which can read an input device. E.g. for a touchpad:
 ```c
 static lv_indev_drv_t indev_drv;           /*Descriptor of a input device driver*/
 lv_indev_drv_init(&indev_drv);             /*Basic initialization*/
@@ -94,7 +94,7 @@ Every object has a parent object where it is created. For example if a label is 
 
 The child object moves with the parent and if the parent is deleted the children will be deleted too. 
 
-Children can be visible only on their parent. It other words, the parts of the children outside of the parent are clipped.
+Children can be visible only on their parent. In other words, the parts of the children outside the parent are clipped.
 
 A Screen is the "root" parent. You can have any number of screens. 
 
@@ -142,7 +142,7 @@ void btn_event_cb(lv_event_t * e)
 
 Instead of `LV_EVENT_CLICKED` `LV_EVENT_ALL` can be used too to call the callback for any event. 
 
-From `lv_event_t * e` the current event code can be get with
+From `lv_event_t * e` the current event code can be retrieved with
 ```c
 lv_event_code_t code = lv_event_get_code(e);
 ```
@@ -185,9 +185,9 @@ lv_obj_clear_state(obj, LV_STATE_...);
 ```
 
 ### Styles
-Styles contains properties such as background color, border width, font, etc to describe the appearance of the objects.
+Styles contains properties such as background color, border width, font, etc. to describe the appearance of the objects.
 
-The styles are `lv_style_t` variables. Only their pointer is saved in the objects so they need to be static or global.
+The styles are `lv_style_t` variables. Only their pointer is saved in the objects, so they need to be static or global.
 Before using a style it needs to be initialized with `lv_style_init(&style1)`. After that properties can be added. For example:
 ```
 static lv_style_t style1;

--- a/docs/intro/index.md
+++ b/docs/intro/index.md
@@ -126,7 +126,7 @@ Every MCU which is capable of driving a display via Parallel port, SPI, RGB inte
 
 This includes:
 - "Common" MCUs like STM32F, STM32H, NXP Kinetis, LPC, iMX, dsPIC33, PIC32 etc. 
-- Bluetooth, GSM, WiFi modules like Nordic NRF and Espressif ESP32
+- Bluetooth, GSM, Wi-Fi modules like Nordic NRF and Espressif ESP32
 - Linux with frame buffer device such as /dev/fb0. This includes Single-board computers like the Raspberry Pi
 - And anything else with a strong enough MCU and a periphery to drive a display
 
@@ -181,7 +181,7 @@ my_flush_cb(NULL, &a, buf);
 ### Why I see nonsense colors on the screen? 
 Probably LVGL's color format is not compatible with your displays color format. Check `LV_COLOR_DEPTH` in *lv_conf.h*.
 
-If you are using 16 bit colors with SPI (or other byte-oriented interface) probably you need to set `LV_COLOR_16_SWAP  1` in *lv_conf.h*. 
+If you are using 16-bit colors with SPI (or other byte-oriented interface) probably you need to set `LV_COLOR_16_SWAP  1` in *lv_conf.h*. 
 It swaps the upper and lower bytes of the pixels.
 
 ### How to speed up my UI?

--- a/docs/layouts/flex.md
+++ b/docs/layouts/flex.md
@@ -19,9 +19,9 @@ Note that the flex layout feature of LVGL needs to be globally enabled with `LV_
 - tracks: the rows or columns
 - main direction: row or column, the direction in which the items are placed
 - cross direction: perpendicular to the main direction
-- wrap: if there there is no more space in the track a new track is started
+- wrap: if there is no more space in the track a new track is started
 - grow: if set on an item it will grow to fill the remaining space on the track. 
-The available space will be distributed among items respective to the their grow value (larger value means more space)
+The available space will be distributed among items respective to their grow value (larger value means more space)
 - gap: the space between the rows and columns or the items on a track
 
 ## Simple interface
@@ -62,8 +62,8 @@ The first item will have one unit of space against the container edge, but two u
 
 ### Flex grow
 
-Flex grow can be used to make one or more children fill the available space on the track. If more children has grow the available space will be distributed proportionally to the grow values.
-For example let's there is 400 px remaining space and 4 object with grow:
+Flex grow can be used to make one or more children fill the available space on the track. When more children have grow parameters, the available space will be distributed proportionally to the grow values.
+For example, there is 400 px remaining space and 4 objects with grow:
 - `A` with grow = 1
 - `B` with grow = 1
 - `C` with grow = 2

--- a/docs/layouts/grid.md
+++ b/docs/layouts/grid.md
@@ -42,7 +42,7 @@ Besides simple settings the size in pixel you can use two special values:
 - `LV_GRID_FR(X)` tell what portion of the remaining space should be used by this track. Larger value means larger space.
 
 ### Grid items
-By default the children are not added to the grid. They need to be added manually to a cell. 
+By default, the children are not added to the grid. They need to be added manually to a cell. 
 
 To do this call `lv_obj_set_grid_cell(child, column_align, column_pos, column_span, row_align, row_pos, row_span)`.
 

--- a/docs/overview/color.md
+++ b/docs/overview/color.md
@@ -6,7 +6,7 @@
 
 The color module handles all color-related functions like changing color depth, creating colors from hex code, converting between color depths, mixing colors, etc.
 
-`lv_color_t` is used to store a color, its fileds are set according to `LV_COLOR_DEPTH` in `lv_conf.h`. (See below)
+`lv_color_t` is used to store a color, its fields are set according to `LV_COLOR_DEPTH` in `lv_conf.h`. (See below)
 
 You may set `LV_COLOR_16_SWAP` in `lv_conf.h` to swap the bytes of *RGB565* colors. You may need this to send the 16-bit colors via a byte-oriented interface like SPI. As 16-bit numbers are stored in Little Endian format (lower byte on the lower address), the interface will send the lower byte first. However, displays usually need the higher byte first. A mismatch in the byte order will result in highly distorted colors.
 

--- a/docs/overview/coords.md
+++ b/docs/overview/coords.md
@@ -7,17 +7,17 @@
 ## Overview
 Similarly to many other parts of LVGL, the concept of setting the coordinates was inspired by CSS. By no means a complete implementation of the standard but subsets of CSS were implemented (sometimes with minor adjustments).
 In shorts this means:
-- the set coordinates (size, position, layouts, etc) are stored in styles
+- the set coordinates (size, position, layouts, etc.) are stored in styles
 - support min-width, max-width, min-height, max-height
 - have pixel, percentage, and "content" units 
-- x=0; y=0 coordinate means the to top-left corner of the parent plus the left/top padding plus border width
+- x=0; y=0 coordinate means the top-left corner of the parent plus the left/top padding plus border width
 - width/height means the full size, the "content area" is smaller with padding and border width 
 - a subset of flexbox and grid layouts are supported
  
 ###  Units
 - pixel: Simply a position in pixels. A simple integer always means pixel. E.g. `lv_obj_set_x(btn, 10)`
 - percentage: The percentage of the size of the object or its parent (depending on the property). The `lv_pct(value)` converts a value to percentage. E.g. `lv_obj_set_width(btn, lv_pct(50))`
-- `LV_SIZE_CONTENT`: Special value to set the width/height of an object to involve all the children. Its similar to `auto` in CSS. E.g. `lv_obj_set_width(btn, LV_SIZE_CONTENT)`.
+- `LV_SIZE_CONTENT`: Special value to set the width/height of an object to involve all the children. It's similar to `auto` in CSS. E.g. `lv_obj_set_width(btn, LV_SIZE_CONTENT)`.
 
 ### Boxing model
 LVGL follows CSS's [border-box](https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing) model.
@@ -27,11 +27,11 @@ An object's "box" is built from the following parts:
 - padding: space between the sides of the object and its children. 
 - content: the content area which size if the bounding box reduced by the border width and the size of the paddings.
 
-![The box models of LVGL: The content area is smaller then the bounding box with the padding and border width](/misc/boxmodel.png)
+![The box models of LVGL: The content area is smaller than the bounding box with the padding and border width](/misc/boxmodel.png)
 
 The border is drawn inside the bounding box. Inside the border LVGL keeps "padding size" to place the children. 
 
-The outline is drawn outside of the bounding box.
+The outline is drawn outside the bounding box.
 
 ### Important notes
 This section describes special cases in which LVGL's behavior might be unexpected.
@@ -40,7 +40,7 @@ This section describes special cases in which LVGL's behavior might be unexpecte
 LVGL doesn't recalculate all the coordinate changes immediately. This is done to improve performance. 
 Instead, the objects are marked as "dirty" and before redrawing the screen LVGL checks if there are any "dirty" objects. If so it refreshes their position, size and layout.
 
-In other words, if you need to get the any coordinate of an object and it the coordinates were just changed LVGL's needs to be forced to recalculate the coordinates. 
+In other words, if you need to get the coordinate of an object and the coordinates were just changed LVGL needs to be forced to recalculate the coordinates. 
 To do this call `lv_obj_update_layout(obj)`.
  
 The size and position might depend on the parent or layout. Therefore `lv_obj_update_layout` recalculates the coordinates of all objects on the screen of `obj`.
@@ -49,7 +49,7 @@ The size and position might depend on the parent or layout. Therefore `lv_obj_up
 As it's described in the [Using styles](#using-styles) section the coordinates can be set via style properties too. 
 To be more precise under the hood every style coordinate related property is stored as style a property. If you use `lv_obj_set_x(obj, 20)` LVGL saves `x=20` in the local style of the object.
 
-It's an internal mechanism and doesn't matter much as you use LVGL. However, there is one case in which you need to aware of that. If the style(s) of an object are removed by 
+It's an internal mechanism and doesn't matter much as you use LVGL. However, there is one case in which you need to be aware of that. If the style(s) of an object are removed by 
 ```c
 lv_obj_remove_style_all(obj)
 ```
@@ -82,7 +82,7 @@ lv_obj_set_y(obj, 20);
 lv_obj_set_pos(obj, 10, 20); 	//Or in one function
 ```
 
-By default the the x and y coordinates are measured from the top left corner of the parent's content area. 
+By default, the x and y coordinates are measured from the top left corner of the parent's content area. 
 For example if the parent has 5 pixels padding on every side, the above code will place `obj` at (15, 25) because the content area starts after the padding.
 
 If percentage values are calculated from the parents content area size. 
@@ -91,7 +91,7 @@ lv_obj_set_x(btn, lv_pct(10)); //x = 10 % of parant content area width
 ```
 
 ### Align
-In some cases it's convenient to change the origin of the positioning from the the default top left. If the origin is changed e.g. to bottom-right, the (0,0) position means: align to the bottom-right corner. 
+In some cases it's convenient to change the origin of the positioning from the default top left. If the origin is changed e.g. to bottom-right, the (0,0) position means: align to the bottom-right corner. 
 To change the origin use:
 ```c
 lv_obj_set_align(obj, align);
@@ -113,7 +113,7 @@ The following alignment options can be used:
 - `LV_ALIGN_RIGHT_MID`
 - `LV_ALIGN_CENTER`
 
-It quite common to align a children to the center of its parent, there fore is a dedicated function for it:
+It's quite common to align a child to the center of its parent, therefore a dedicated function exists:
 ```c
 lv_obj_center(obj);
 
@@ -123,12 +123,12 @@ lv_obj_align(obj, LV_ALIGN_CENTER, 0, 0);
 
 If the parent's size changes the set alignment and position of the children is applied again automatically.
 
-The functions introduced above aligns the object to its parent. However it's also possible to align an object to an arbitrary object.
+The functions introduced above align the object to its parent. However, it's also possible to align an object to an arbitrary object.
 ```c
 lv_obj_align_to(obj_to_align, reference_obj, align, x, y);
 ```
 
-Besides the alignments options above the following can be used to align the object outside of the reference object:
+Besides the alignments options above, the following can be used to align the object outside the reference object:
 
 - `LV_ALIGN_OUT_TOP_LEFT`
 - `LV_ALIGN_OUT_TOP_MID`
@@ -176,7 +176,7 @@ lv_obj_set_content_width(obj, 50); //The actual width: padding left + 50 + paddi
 lv_obj_set_content_height(obj, 30); //The actual width: padding top + 30 + padding bottom
 ```
 
-The size of the bounding box and the content area can be get with the following functions:
+The size of the bounding box and the content area can be retrieved with the following functions:
 ```c
 lv_coord_t w = lv_obj_get_width(obj);
 lv_coord_t h = lv_obj_get_height(obj);
@@ -186,10 +186,10 @@ lv_coord_t content_h = lv_obj_get_content_height(obj);
 
 ## Using styles
 Under the hood the position, size and alignment properties are style properties. 
-The above described "simple functions" hide the style related code for the sake of simplicity and set the position, size, and alignment properties in the local styles of the obejct.
+The above described "simple functions" hide the style related code for the sake of simplicity and set the position, size, and alignment properties in the local styles of the object.
 
 However, using styles as to set the coordinates has some great advantages:
-- It makes it easy to set the width/height/etc for several objects together. E.g. make all the sliders 100x10 pixels sized. 
+- It makes it easy to set the width/height/etc. for several objects together. E.g. make all the sliders 100x10 pixels sized. 
 - It also makes possible to modify the values in one place.
 - The values can be overwritten by other styles. For example `style_btn` makes the object `100x50` by default but adding `style_full_width` overwrites only the width of the object.
 - The object can have different position or size in different state. E.g. 100 px wide in `LV_STATE_DEFAULT` but 120 px in `LV_STATE_PRESSED`.
@@ -234,7 +234,7 @@ lv_obj_add_style(btn3, &style_normal, LV_STATE_DEFAULT);
 lv_obj_add_style(btn3, &style_pressed, LV_STATE_PRESSED);
 ```
 
-It works but it's not really flexible because the pressed coordinate is hard-coded. If the buttons are not at y=100 `style_pressed` won't work as expected. To solve this translations can be used:
+It works, but it's not really flexible because the pressed coordinate is hard-coded. If the buttons are not at y=100 `style_pressed` won't work as expected. To solve this, translations can be used:
 ```c
 static lv_style_t style_normal;
 lv_style_init(&style_normal);
@@ -268,9 +268,9 @@ Similarly to the position the size can be changed relative to the current size a
 The transformed width and height are added on both sides of the object. This means 10 px transformed width makes the object 2x10 pixel wider.
 
 Unlike position translation, the size transformation doesn't make the object "really" larger. In other words scrollbars, layouts, `LV_SIZE_CONTENT` will not consider the transformed size. 
-Hence size transformation if "only" a visual effect. 
+Hence, size transformation if "only" a visual effect. 
 
-This code makes the a button larger when it's pressed:
+This code enlarges a button when it's pressed:
 ```c
 static lv_style_t style_pressed;
 lv_style_init(&style_pressed);
@@ -281,7 +281,7 @@ lv_obj_add_style(btn, &style_pressed, LV_STATE_PRESSED);
 ```
 
 ### Min and Max size
-Similarly to CSS, LVGL also support `min-width`, `max-width`, `min-height` and `max-height`. These are limits preventing an object's size to be smaller/larger then these values. 
+Similarly to CSS, LVGL also support `min-width`, `max-width`, `min-height` and `max-height`. These are limits preventing an object's size to be smaller/larger than these values. 
 They are especially useful if the size is set by percentage or `LV_SIZE_CONTENT`.
 ```c
 static lv_style_t style_max_height;
@@ -329,7 +329,7 @@ These flags can be added/removed with `lv_obj_add/clear_flag(obj, FLAG);`
 
 ### Adding new layouts
 
-LVGL can be freely extended by a custom layouts like this:
+LVGL can be freely extended by a custom layout like this:
 ```c
 uint32_t MY_LAYOUT;
 
@@ -345,7 +345,7 @@ void my_layout_update(lv_obj_t * obj, void * user_data)
 }
 ```
 
-Custom style properties can be added too that can be get and used in the update callback. For example:
+Custom style properties can be added which can be retrieved and used in the update callback. For example:
 ```c
 uint32_t MY_PROP;
 ...
@@ -364,5 +364,3 @@ static inline void lv_style_set_my_prop(lv_style_t * style, uint32_t value)
 ```
 
 ## Examples
-
-

--- a/docs/overview/display.md
+++ b/docs/overview/display.md
@@ -9,7 +9,7 @@
 
 ## Multiple display support
 
-In LVGL, you can have multiple displays, each with their own driver and objects. The only limitation is that every display needs to be have same color depth (as defined in `LV_COLOR_DEPTH`). 
+In LVGL, you can have multiple displays, each with their own driver and objects. The only limitation is that every display needs to have the same color depth (as defined in `LV_COLOR_DEPTH`). 
 If the displays are different in this regard the rendered image can be converted to the correct format in the drivers `flush_cb`.
 
 Creating more displays is easy: just initialize more display buffers and register another driver for every display.
@@ -53,9 +53,9 @@ The screen's size is always equal to its display and size their position is (0;0
 
 A screen can be created from any object type but the two most typical types are the [Base object](/widgets/obj) and the [Image](/widgets/core/img) (to create a wallpaper).
 
-To create a screen, use `lv_obj_t * scr = lv_<type>_create(NULL, copy)`. `copy` can be an other screen to copy it.
+To create a screen, use `lv_obj_t * scr = lv_<type>_create(NULL, copy)`. `copy` can be another screen to copy it.
 
-To load a screen, use `lv_scr_load(scr)`. To get the active screen, use `lv_scr_act()`. These functions works on the default display. If you want to to specify which display to work on, use `lv_disp_get_scr_act(disp)` and `lv_disp_load_scr(disp, scr)`. Screen can be loaded with animations too. Read more [here](object.html#load-screens).
+To load a screen, use `lv_scr_load(scr)`. To get the active screen, use `lv_scr_act()`. These functions work on the default display. If you want to specify which display to work on, use `lv_disp_get_scr_act(disp)` and `lv_disp_load_scr(disp, scr)`. Screen can be loaded with animations too. Read more [here](object.html#load-screens).
 
 Screens can be deleted with `lv_obj_del(scr)`, but ensure that you do not delete the currently loaded screen.
 
@@ -72,7 +72,7 @@ As this mode operates on the Alpha channel of the pixels `LV_COLOR_DEPTH = 32` i
 In summary, to enable transparent screen and displays to create OSD menu-like UIs:
 - Enable `LV_COLOR_SCREEN_TRANSP` in `lv_conf.h`
 - Be sure to use `LV_COLOR_DEPTH 32`
-- Set the screens opacity to `LV_OPA_TRANSP` e.g. with `lv_obj_set_style_local_bg_opa(lv_scr_act(), LV_OBJMASK_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP)`
+- Set the screen's opacity to `LV_OPA_TRANSP` e.g. with `lv_obj_set_style_local_bg_opa(lv_scr_act(), LV_OBJMASK_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP)`
 - Set the display opacity to `LV_OPA_TRANSP` with `lv_disp_set_bg_opa(NULL, LV_OPA_TRANSP);`
 
 ## Features of displays

--- a/docs/overview/drawing.md
+++ b/docs/overview/drawing.md
@@ -4,7 +4,7 @@
 ```
 # Drawing
 
-With LVGL, you don't need to draw anything manually. Just create objects (like buttons, labels, arc, etc), move and change them, and LVGL will refresh and redraw what is required.
+With LVGL, you don't need to draw anything manually. Just create objects (like buttons, labels, arc, etc.), move and change them, and LVGL will refresh and redraw what is required.
 
 However, it might be useful to have a basic understanding of how drawing happens in LVGL to add customization, make it easier to find bugs or just out of curiosity.
 
@@ -62,7 +62,7 @@ LVGL performs the following steps to render any shape, image or text. It can be 
 3. **Create masks** If the shape is very simple and doesn't require masks go to #5.  Else create the required masks in the draw function. (e.g. a rounded rectangle mask)
 4. **Calculate all the added mask** It creates 0..255 values into a *mask buffer* with the "shape" of the created masks. 
 E.g. in case of a "line mask" according to the parameters of the mask, keep one side of the buffer as it is (255 by default) and set the rest to 0 to indicate that this side should be removed.
-5. **Blend a color or image** During blending masks (make some pixels transparent or opaque), blending modes (additive, subtractive, etc) and opacity are handled.
+5. **Blend a color or image** During blending masks (make some pixels transparent or opaque), blending modes (additive, subtractive, etc.) and opacity are handled.
 
 LVGL has the following built-in mask types which can be calculated and applied real-time:
 - `LV_DRAW_MASK_TYPE_LINE` Removes a side from a line (top, bottom, left or right). `lv_draw_line` uses 4 of it. 
@@ -72,7 +72,7 @@ Essentially, every (skew) line is bounded with 4 line masks by forming a rectang
 - `LV_DRAW_MASK_TYPE_FADE` Create a vertical fade (change opacity) 
 - `LV_DRAW_MASK_TYPE_MAP` The mask is stored in an array and the necessary parts are applied 
 
-Masks are used the create almost every basic primitives:
+Masks are used to create almost every basic primitive:
 - **letters** Create a mask from the letter and draw a rectangle with the letter's color considering the mask.
 - **line** Created from 4 "line masks", to mask out the left, right, top and bottom part of the line to get perfectly perpendicular line ending.
 - **rounded rectangle** A mask is created real-time to add radius to the corners.
@@ -83,7 +83,7 @@ Masks are used the create almost every basic primitives:
 
 ### Using masks
 
-Every mask type has a related paramter to describe the mask's data. The following paramater types exist:
+Every mask type has a related parameter to describe the mask's data. The following parameter types exist:
 - `lv_draw_mask_line_param_t`
 - `lv_draw_mask_radius_param_t`
 - `lv_draw_mask_angle_param_t`
@@ -96,23 +96,23 @@ Every mask type has a related paramter to describe the mask's data. The followin
 4. Remove the mask from the draw engine with `lv_draw_mask_remove_id(mask_id)` of `lv_draw_mask_remove_custom(ptr)`.
 5. Free the parameter with `lv_draw_mask_free_param(&param)`.
 
-A parameter can be added and removed any number of times but it needs to be freed when not required anymore. 
+A parameter can be added and removed any number of times, but it needs to be freed when not required anymore. 
 
 `lv_draw_mask_add` saves only the pointer of the mask so the parameter needs to be valid while in use. 
 
 ## Hook drawing
 Although widgets can be very well customized by styles there might be cases when something really custom is required. 
-To ensure a great level of flexibility LVGL sends a lot events during drawing with parameters that tell what LVGL is about to draw. 
+To ensure a great level of flexibility LVGL sends a lot of events during drawing with parameters that tell what LVGL is about to draw. 
 Some fields of these parameters can be modified to draw something else or any custom drawing can be added manually.
 
-A good use case for it is the [Button matrix](/widgets/core/btnmatrix) widget. By default its buttons can be styled in different states but you can't style the buttons one by one. 
-However, an event is sent for every button and you can for example tell LVGL to use different colors on a specific button or to manually draw an image on some buttons.
+A good use case for it is the [Button matrix](/widgets/core/btnmatrix) widget. By default, its buttons can be styled in different states, but you can't style the buttons one by one. 
+However, an event is sent for every button, and you can for example tell LVGL to use different colors on a specific button or to manually draw an image on some buttons.
 
 Below each of these events are described in detail.
 
 ### Main drawing
 
-These events are related to the actual drawing of the object. E.g. drawing of buttons, texts, etc happens here.
+These events are related to the actual drawing of the object. E.g. drawing of buttons, texts, etc. happens here.
 
 `lv_event_get_clip_area(event)` can be used to get the current clip area. The clip area is required in draw functions to make them draw only on a limited area. 
 
@@ -196,10 +196,10 @@ Finish the drawing of a part. This is a good place to draw extra content on the 
 
 This event is used to check whether an object fully covers an area or not. 
 
-`lv_event_get_cover_area(event)` returns an pointer to an area to check and `lv_event_set_cover_res(event, res)` can be used to set one of these results:
+`lv_event_get_cover_area(event)` returns a pointer to an area to check and `lv_event_set_cover_res(event, res)` can be used to set one of these results:
 - `LV_COVER_RES_COVER` the areas is fully covered by the object
 - `LV_COVER_RES_NOT_COVER` the areas is not covered by the object
-- `LV_COVER_RES_MASKED` there is a mask on the object so it can not cover the area
+- `LV_COVER_RES_MASKED` there is a mask on the object, so it can not cover the area
 
 Here are some reasons why an object would be unable to fully cover an area:
 - It's simply not fully in area
@@ -214,12 +214,12 @@ In short if for any reason the area below the object is visible than it doesn't 
 Before sending this event LVGL checks if at least the widget's coordinates fully cover the area or not. If not the event is not called.
 
 You need to check only the drawing you have added. The existing properties known by widget are handled in the widget's internal events. 
-E.g. if a widget has &gt; 0 radius it might not cover an area but you need to handle `radius` only if you will modify it and the widget can't know about it. 
+E.g. if a widget has &gt; 0 radius it might not cover an area, but you need to handle `radius` only if you will modify it and the widget can't know about it. 
 
 #### LV_EVENT_REFR_EXT_DRAW_SIZE
 
-If you need to draw outside of a widget LVGL needs to know about it to provide the extra space for drawing. 
-Let's say you create an event the writes the current value of a slider above its knob. In this case LVGL needs to know that the slider's draw area should be larger with the size required for the text.
+If you need to draw outside a widget, LVGL needs to know about it to provide the extra space for drawing. 
+Let's say you create an event which writes the current value of a slider above its knob. In this case LVGL needs to know that the slider's draw area should be larger with the size required for the text.
 
-You can simple set the required draw area with `lv_event_set_ext_draw_size(e, size)`. 
+You can simply set the required draw area with `lv_event_set_ext_draw_size(e, size)`. 
 

--- a/docs/overview/event.md
+++ b/docs/overview/event.md
@@ -63,7 +63,7 @@ The event codes can be grouped into these categories:
 
 All objects (such as Buttons/Labels/Sliders etc.) regardless their type receive the *Input device*, *Drawing* and *Other* events. 
 
-However the *Special events* are specific to a particular widget type. See the [widgets' documentation](/widgets/index) to learn when they are sent, 
+However, the *Special events* are specific to a particular widget type. See the [widgets' documentation](/widgets/index) to learn when they are sent, 
 
 *Custom events* are added by the user and therefore these are never sent by LVGL.
 
@@ -78,14 +78,14 @@ The following event codes exist:
 - `LV_EVENT_LONG_PRESSED_REPEAT`  Called after `long_press_time` in every `long_press_repeat_time` ms.  Not called if scrolled.
 - `LV_EVENT_CLICKED`      Called on release if the object did not scroll (regardless of long press)
 - `LV_EVENT_RELEASED`     Called in every case when the object has been released
-- `LV_EVENT_SCROLL_BEGIN` Scrolling begins. The event paramter is `NULL` or an `lv_anim_t *` with the scroll animation descriptor to modify if required. 
+- `LV_EVENT_SCROLL_BEGIN` Scrolling begins. The event parameter is `NULL` or an `lv_anim_t *` with the scroll animation descriptor to modify if required. 
 - `LV_EVENT_SCROLL_END`   Scrolling ends.
 - `LV_EVENT_SCROLL`       The object was scrolled
 - `LV_EVENT_GESTURE`      A gesture is detected. Get the gesture with `lv_indev_get_gesture_dir(lv_indev_get_act());`
 - `LV_EVENT_KEY`          A key is sent to the object. Get the key with `lv_indev_get_key(lv_indev_get_act());`
 - `LV_EVENT_FOCUSED`      The object is focused 
-- `LV_EVENT_DEFOCUSED`    The object is defocused
-- `LV_EVENT_LEAVE`        The object is defocused but still selected
+- `LV_EVENT_DEFOCUSED`    The object is unfocused
+- `LV_EVENT_LEAVE`        The object is unfocused but still selected
 - `LV_EVENT_HIT_TEST`     Perform advanced hit-testing. Use `lv_hit_test_info_t * a = lv_event_get_hit_test_info(e)` and check if `a->point` can click the object or not. If not set `a->res = false` 
 
 

--- a/docs/overview/file-system.md
+++ b/docs/overview/file-system.md
@@ -15,7 +15,7 @@ See it's [README](https://github.com/lvgl/lv_fs_if#readme) for the details.
 ## Add a driver
 
 ### Registering a driver
-To add a driver, `lv_fs_drv_t` needs to be initialized like below. `lv_fs_drv_t` needs to be static, global or dynamically allocated and not a local varaible.
+To add a driver, `lv_fs_drv_t` needs to be initialized like below. `lv_fs_drv_t` needs to be static, global or dynamically allocated and not a local variable.
 ```c
 static lv_fs_drv_t drv;                   /*Needs to be static or global*/
 lv_fs_drv_init(&drv);                     /*Basic initialization*/
@@ -53,7 +53,7 @@ void * (*open_cb)(lv_fs_drv_t * drv, const char * path, lv_fs_mode_t mode);
 `path` is path after the driver letter (e.g. "S:path/to/file.txt" -> "path/to/file.txt"). `mode` can be `LV_FS_MODE_WR` or `LV_FS_MODE_RD` to open for write or read.
 
 The return value is a pointer the *file object* the describes the opened file or `NULL` if there were any issues (e.g. the file wasn't found). 
-The returned file object will be passed to to other file system related callbacks. (see below)
+The returned file object will be passed to other file system related callbacks. (see below)
 
 ### Other callbacks
 The other callbacks are quite similar. For example `write_cb` looks like this:

--- a/docs/overview/font.md
+++ b/docs/overview/font.md
@@ -18,7 +18,7 @@ The *bpp* also affects the required memory size to store the font. For example, 
 ## Unicode support
 
 LVGL supports **UTF-8** encoded Unicode characters.
-Your editor needs to be configureed to save your code/text as UTF-8 (usually this the default) and be sure that, `LV_TXT_ENC` is set to `LV_TXT_ENC_UTF8` in *lv_conf.h*. (This is the default value)
+Your editor needs to be configured to save your code/text as UTF-8 (usually this the default) and be sure that, `LV_TXT_ENC` is set to `LV_TXT_ENC_UTF8` in *lv_conf.h*. (This is the default value)
 
 To test it try
 ```c
@@ -62,7 +62,7 @@ Containing all the ASCII characters, the degree symbol (U+00B0), the bullet symb
 - `LV_FONT_UNSCII_16` 16 px pixel perfect font with only ASCII characters
 
 
-The built-in fonts are **global variables** with names like `lv_font_montserrat_16` for a 16 px hight font. To use them in a style, just add a pointer to a font variable like shown above.
+The built-in fonts are **global variables** with names like `lv_font_montserrat_16` for a 16 px height font. To use them in a style, just add a pointer to a font variable like shown above.
 
 The built-in fonts with *bpp = 4* contain the ASCII characters and use the [Montserrat](https://fonts.google.com/specimen/Montserrat) font.
 
@@ -138,7 +138,7 @@ For subpixel rendering the fonts need to be generated with special settings:
 - In the command line tool use `--lcd` flag. Note that the generated font needs about 3 times more memory.
 
 Subpixel rendering works only if the color channels of the pixels have a horizontal layout. That is the R, G, B channels are next each other and not above each other. 
-The order of color channels also needs to match with the library settings. By default LVGL assumes `RGB` order, however this can be swapped by setting `LV_SUBPX_BGR  1` in *lv_conf.h*.
+The order of color channels also needs to match with the library settings. By default, LVGL assumes `RGB` order, however this can be swapped by setting `LV_SUBPX_BGR  1` in *lv_conf.h*.
 
 ### Compress fonts
 The bitmaps of the fonts can be compressed by 
@@ -149,7 +149,7 @@ The compression is more effective with larger fonts and higher bpp. However, it'
 Therefore it's recommended to compress only the largest fonts of user interface, because
 - they need the most memory 
 - they can be compressed better
-- and probably they are used less frequently then the medium sized fonts, so the performance cost is smaller.
+- and probably they are used less frequently then the medium-sized fonts, so the performance cost is smaller.
 
 ## Add new font
 
@@ -167,7 +167,7 @@ To make the fonts globally available (like the builtin fonts), add them to `LV_F
 The built-in symbols are created from the [FontAwesome](https://fontawesome.com/) font. 
 
 1. Search symbol on [https://fontawesome.com](https://fontawesome.com). For example the [USB symbol](https://fontawesome.com/icons/usb?style=brands). Copy it's Unicode ID which is `0xf287` in this case.
-2. Open the [Online font converter](https://lvgl.io/tools/fontconverter). Add Add [FontAwesome.woff](https://lvgl.io/assets/others/FontAwesome5-Solid+Brands+Regular.woff). . 
+2. Open the [Online font converter](https://lvgl.io/tools/fontconverter). Add [FontAwesome.woff](https://lvgl.io/assets/others/FontAwesome5-Solid+Brands+Regular.woff). . 
 3. Set the parameters such as Name, Size, BPP. You'll use this name to declare and use the font in your code.
 4. Add the Unicode ID of the symbol to the range field. E.g.` 0xf287` for the USB symbol. More symbols can be enumerated with `,`.
 5. Convert the font and copy it to your project. Make sure to compile the .c file of your font.

--- a/docs/overview/image.md
+++ b/docs/overview/image.md
@@ -161,7 +161,7 @@ With *User encoded* formats, the color format in the open function (`dsc->header
 
 Here's an example of getting LVGL to work with PNG images.
 
-First, you need to create a new image decoder and set some functions to open/close the PNG files. It should looks like this:
+First, you need to create a new image decoder and set some functions to open/close the PNG files. It should look like this:
 
 ```c
 /*Create a new decoder and register functions */
@@ -256,10 +256,10 @@ So in summary:
 - In `decoder_open`, you should try to open the image source pointed by `dsc->src`. Its type is already in `dsc->src_type == LV_IMG_SRC_FILE/VARIABLE`.
 If this format/type is not supported by the decoder, return `LV_RES_INV`.
 However, if you can open the image, a pointer to the decoded *True color* image should be set in `dsc->img_data`.
-If the format is known but you don't want to decode the entire image (e.g. no memory for it) set `dsc->img_data = NULL` to call `read_line` to get the pixels.
+If the format is known, but you don't want to decode the entire image (e.g. no memory for it), set `dsc->img_data = NULL` to call `read_line` to get the pixels.
 - In `decoder_close` you should free all the allocated resources.
 - `decoder_read` is optional. Decoding the whole image requires extra memory and some computational overhead.
-However, if can decode one line of the image without decoding the whole image, you can save memory and time.
+However, it can decode one line of the image without decoding the whole image, you can save memory and time.
 To indicate that the *line read* function should be used, set `dsc->img_data = NULL` in the open function.
 
 
@@ -295,7 +295,7 @@ The number of cache entries can be defined in `LV_IMG_CACHE_DEF_SIZE` in *lv_con
 The size of the cache can be changed at run-time with `lv_img_cache_set_size(entry_num)`.
 
 ### Value of images
-When you use more images than cache entries, LVGL can't cache all of the images. Instead, the library will close one of the cached images (to free space).
+When you use more images than cache entries, LVGL can't cache all the images. Instead, the library will close one of the cached images (to free space).
 
 To decide which image to close, LVGL uses a measurement it previously made of how long it took to open the image. Cache entries that hold slower-to-open images are considered more valuable and are kept in the cache as long as possible.
 

--- a/docs/overview/indev.md
+++ b/docs/overview/indev.md
@@ -38,10 +38,10 @@ You can fully control the user interface without touchpad or mouse using a keypa
 
 ### Groups
 
-The objects, you want to control with keypad or encoder, needs to be added to a *Group*.
+The objects, you want to control with keypad or encoder, need to be added to a *Group*.
 In every group, there is exactly one focused object which receives the pressed keys or the encoder actions.
-For example, if a [Text area](/widgets/core/textarea) is focused and you press some letter on a keyboard, the keys will be sent and inserted into the text area.
-Similarly, if a [Slider](/widgets/core/slider) is focused and you press the left or right arrows, the slider's value will be changed.
+For example, if a [Text area](/widgets/core/textarea) is focused, and you press some letter on a keyboard, the keys will be sent and inserted into the text area.
+Similarly, if a [Slider](/widgets/core/slider) is focused, and you press the left or right arrows, the slider's value will be changed.
 
 You need to associate an input device with a group. An input device can send the keys to only one group but, a group can receive data from more than one input device too.
 
@@ -56,13 +56,13 @@ There are some predefined keys which have special meaning:
 - **LV_KEY_ENTER** Triggers `LV_EVENT_PRESSED/CLICKED/LONG_PRESSED` etc. events
 - **LV_KEY_UP** Increase value or move upwards
 - **LV_KEY_DOWN** Decrease value or move downwards
-- **LV_KEY_RIGHT** Increase value or move the the right
-- **LV_KEY_LEFT** Decrease value or move the the left
+- **LV_KEY_RIGHT** Increase value or move to the right
+- **LV_KEY_LEFT** Decrease value or move to the left
 - **LV_KEY_ESC**  Close or exit (E.g. close a [Drop down list](/widgets/core/dropdown))
 - **LV_KEY_DEL**  Delete (E.g. a character on the right in a [Text area](/widgets/core/textarea))
 - **LV_KEY_BACKSPACE** Delete a character on the left (E.g. in a [Text area](/widgets/core/textarea))
 - **LV_KEY_HOME** Go to the beginning/top (E.g. in a [Text area](/widgets/core/textarea))
-- **LV_KEY_END** Go to the end (E.g. in a [Text area](/widgets/core/textarea)))
+- **LV_KEY_END** Go to the end (E.g. in a [Text area](/widgets/core/textarea))
 
 The most important special keys are `LV_KEY_NEXT/PREV`, `LV_KEY_ENTER` and `LV_KEY_UP/DOWN/LEFT/RIGHT`.
 In your `read_cb` function, you should translate some of your keys to these special keys to navigate in the group and interact with the selected object.
@@ -75,7 +75,7 @@ With an encoder, you should use only `LV_KEY_LEFT`, `LV_KEY_RIGHT`, and `LV_KEY_
 
 Since a keypad has plenty of keys, it's easy to navigate between the objects and edit them using the keypad. But the encoders have a limited number of "keys" and hence it is difficult to navigate using the default options. *Navigate* and *Edit* are created to avoid this problem with the encoders.
 
-In *Navigate* mode, the encoders `LV_KEY_LEFT/RIGHT` is translated to `LV_KEY_NEXT/PREV`. Therefore the next or previous object will be selected by turning the encoder.
+In *Navigate* mode, the encoders `LV_KEY_LEFT/RIGHT` is translated to `LV_KEY_NEXT/PREV`. Therefore, the next or previous object will be selected by turning the encoder.
 Pressing `LV_KEY_ENTER` will change to *Edit* mode.
 
 In *Edit* mode, `LV_KEY_NEXT/PREV` is usually used to edit the object.
@@ -83,18 +83,18 @@ Depending on the object's type, a short or long press of `LV_KEY_ENTER` changes 
 Usually, an object which can not be pressed (like a [Slider](/widgets/core/slider)) leaves *Edit* mode on short click. But with objects where short click has meaning (e.g. [Button](/widgets/core/btn)), a long press is required.
 
 #### Default group
-Interactive widgets - such as buttons, checkboxes, sliders, etc - can be automatically added to a default group.
+Interactive widgets - such as buttons, checkboxes, sliders, etc. - can be automatically added to a default group.
 Just create a group with `lv_group_t * g = lv_group_create();` and set the default group with `lv_group_set_default(g);`
 
 Don't forget to assign the input device(s) to the default group with ` lv_indev_set_group(my_indev, g);`.
 
 ### Styling
 
-If an object is focused either by clicking it via touchpad, or focused via an encoder or keypad it goes to `LV_STATE_FOCUSED`. Hence focused styles will be applied on it. 
+If an object is focused either by clicking it via touchpad, or focused via an encoder or keypad it goes to `LV_STATE_FOCUSED`. Hence, focused styles will be applied on it. 
 
 If the object goes to edit mode it goes to `LV_STATE_FOCUSED | LV_STATE_EDITED` state so these style properties will be shown. 
 
-For a more detaild description read the [Style](https://docs.lvgl.io/v7/en/html/overview/style.html) section.
+For a more detailed description read the [Style](https://docs.lvgl.io/v7/en/html/overview/style.html) section.
 
 ## API
 

--- a/docs/overview/layer.md
+++ b/docs/overview/layer.md
@@ -42,7 +42,7 @@ lv_obj_del(label2);
 
 There are 4 explicit way to bring an object to the foreground:
 - Use `lv_obj_move_foreground(obj)` to explicitly tell the library to bring an object to the foreground. Similarly, use `lv_obj_move_background(obj)` to move to the background.
-- Use `lv_obj_move_up(obj)` moves the object one position up in the hierarchy, Similary, use `lv_obj_move_down(obj)` moves the object one position down in the hierarchy. 
+- Use `lv_obj_move_up(obj)` moves the object one position up in the hierarchy, Similarly, use `lv_obj_move_down(obj)` moves the object one position down in the hierarchy. 
 - Use `lv_obj_swap(obj1, obj2)` to swap the relative position of two objects.
 - When `lv_obj_set_parent(obj, new_parent)` is used, `obj` will be on the foreground on the `new_parent`.
 

--- a/docs/overview/object.md
+++ b/docs/overview/object.md
@@ -59,7 +59,7 @@ There is no limitation for the type of the parent but, there are typical parent 
 ### Moving together
 
 If the position of the parent changes the children will move with the parent.
-Therefore all positions are relative to the parent.
+Therefore, all positions are relative to the parent.
 
 ![](/misc/par_child1.png "Objects are moving together 1")
 
@@ -104,7 +104,7 @@ Every widget has its own **create** function with a prototype like this:
 lv_obj_t * lv_<widget>_create(lv_obj_t * parent, <other paramaters if any>);
 ```
 
-In most of the cases the create functions have only a *parent* parameter that tells on which object create the new widget.
+Typically, the create functions only have a *parent* parameter telling them on which object to create the new widget.
 
 The return value is a pointer to the created object with `lv_obj_t *` type.
 
@@ -121,7 +121,7 @@ This is useful e.g. if you want to delete the parent of an object in the child's
 
 You can remove all the children of an object (but not the object itself) using `lv_obj_clean(obj)`.
 
-You can use `lv_obj_del_delayed(obj, 1000)` to delete an object after some time. The delay is expressed in millliseconds. 
+You can use `lv_obj_del_delayed(obj, 1000)` to delete an object after some time. The delay is expressed in milliseconds. 
 
 
 ## Screens
@@ -166,7 +166,7 @@ A new screen can be loaded with animation too using `lv_scr_load_anim(scr, trans
 
 Setting `auto_del` to `true` will automatically delete the old screen when the animation is finished.
 
-The new screen will become active (returned by `lv_scr_act()`) when the animations starts after `delay` time.
+The new screen will become active (returned by `lv_scr_act()`) when the animation starts after `delay` time.
 
 ### Handling multiple displays
 Screens are created on the currently selected *default display*.
@@ -179,7 +179,7 @@ Visit [Multi-display support](/overview/display) to learn more.
 ## Parts
 
 The widgets are built from multiple parts. For example a [Base object](/widgets/obj) uses the main and scrollbar parts but a [Slider](/widgets/core/slider) uses the main, the indicator and the knob parts. 
-Parts are similar to *pseudo elements* in CSS.
+Parts are similar to *pseudo-elements* in CSS.
 
 The following predefined parts exist in LVGL:
 - `LV_PART_MAIN` A background like rectangle*/``
@@ -193,7 +193,7 @@ The following predefined parts exist in LVGL:
 - `LV_PART_CUSTOM_FIRST` Custom parts can be added from here.
 
 The main purpose of parts to allow styling the "components" of the widgets. 
-Therefore the parts are described in more detail in the [Style overview](/overview/style) section.
+Therefore, the parts are described in more detail in the [Style overview](/overview/style) section.
 
 ## States
 The object can be in a combination of the following states:
@@ -211,12 +211,12 @@ The object can be in a combination of the following states:
 - `LV_STATE_USER_3` Custom state
 - `LV_STATE_USER_4` Custom state
 
-The states are usually automatically changed by the library as the user presses, releases, focuses etc an object. 
+The states are usually automatically changed by the library as the user presses, releases, focuses, etc. an object. 
 However, the states can be changed manually too. 
 To set or clear given state (but leave the other states untouched) use `lv_obj_add/clear_state(obj, LV_STATE_...)`
-In both cases ORed state values can be used as well. E.g. `lv_obj_add_state(obj, part, LV_STATE_PRESSED | LV_PRESSED_CHECKED)`.
+In both cases OR-ed state values can be used as well. E.g. `lv_obj_add_state(obj, part, LV_STATE_PRESSED | LV_PRESSED_CHECKED)`.
 
 To learn more about the states read the related section of the [Style overview](/overview/style).
 
 ## Snapshot
-A snapshot image could be generated for object together with its children. Check details in [Snapshot](/others/snapshot).
+A snapshot image could be generated for an object together with its children. Check details in [Snapshot](/others/snapshot).

--- a/docs/overview/scroll.md
+++ b/docs/overview/scroll.md
@@ -24,7 +24,7 @@ The scrollbars are displayed according to the set `mode`. The following `mode`s 
 
 
 #### Styling
-The scrollbars have their own dedicated part, called `LV_PART_SCROLLBAR`. For example a scrollbar can turned to red like this:
+The scrollbars have their own dedicated part, called `LV_PART_SCROLLBAR`. For example a scrollbar can turn to red like this:
 ```c
 static lv_style_t style_red;
 lv_style_init(&style_red);
@@ -48,7 +48,7 @@ lv_obj_add_style(obj, &style_blue, LV_STATE_SCROLLED | LV_PART_SCROLLBAR);
 ```
 
 If the base direction of the `LV_PART_SCROLLBAR` is RTL (`LV_BASE_DIR_RTL`) the vertical scrollbar will be placed on the left. 
-Note that, the `base_dir` style property is inhertied. Therefore it can be set directly on the `LV_PART_SCROLLBAR` part of an object
+Note that, the `base_dir` style property is inherited. Therefore, it can be set directly on the `LV_PART_SCROLLBAR` part of an object
 or on the obejct's or any parent's main part to make scrollbar inherit the base direction. 
 
 ### Events
@@ -63,7 +63,7 @@ TODO
 
 ## Features of scrolling
 
-Besides managing "normal" scrolling there are many interesting and useful additional features too.
+Besides, managing "normal" scrolling there are many interesting and useful additional features too.
 
 
 ### Scrollable
@@ -86,8 +86,8 @@ OR-ed values are also possible. E.g. `LV_DIR_TOP | LV_DIR_LEFT`.
 
 
 ### Scroll chain
-If an object can't be scrolled further (e.g. it's content has reached the bottom most position) the scrolling is propagated to it's parent. If the parent an be scrolled in that direction than it will be scrolled instead.
-It propagets to the grandparent and grand-grandparents too.
+If an object can't be scrolled further (e.g. it's content has reached the bottom most position) the scrolling is propagated to its parent. If the parent can be scrolled in that direction than it will be scrolled instead.
+It propagates to the grandparent and grand-grandparents too.
 
 The propagation on scrolling is called "scroll chaining" and it can be enabled/disabled with the `LV_OBJ_FLAG_SCROLL_CHAIN` flag. 
 If chaining is disabled the propagation stops on the object and the parent(s) won't be scrolled.
@@ -127,7 +127,7 @@ So this requires to make the children snappable and set a scroll snap alignment 
 This feature can be enabled by the `LV_OBJ_FLAG_SCROLL_ONE` flag.
 
 ### Scroll on focus
-Imagine that there a lot of objects in a group that are on scrollable object. Pressing the "Tab" button focuses the next object but it might be out of the visible area of the scrollable object. 
+Imagine that there a lot of objects in a group that are on scrollable object. Pressing the "Tab" button focuses the next object, but it might be out of the visible area of the scrollable object. 
 If the "scroll on focus" features is enabled LVGL will automatically scroll to the objects to bring the children into the view. 
 The scrolling happens recursively therefore even nested scrollable object are handled properly. 
 The object will be scrolled to the view even if it's on a different page of a tabview. 

--- a/docs/overview/style-props.md
+++ b/docs/overview/style-props.md
@@ -18,7 +18,7 @@ Sets the width of object. Pixel, percentage and `LV_SIZE_CONTENT` values can be 
 ### min_width
 Sets a minimal width. Pixel and percentage values can be used. Percentage values are relative to the width of the parent's content area.
 <ul>
-<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> idget dependent</li>
+<li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> widget dependent</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Layout</strong> Yes</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Ext. draw</strong> No</li>
@@ -169,7 +169,7 @@ Zoom image-like objects. Multiplied with the zoom set on the object. The value 2
 
 
 ## Padding
-Properties to describe spacing betwwen the parent's sides and the children and among the children. Very similar to the padding properties in HTML.
+Properties to describe spacing between the parent's sides and the children and among the children. Very similar to the padding properties in HTML.
 
 
 ### pad_top
@@ -238,7 +238,7 @@ Sets the padding between the columns. Used by the layouts.
 
 
 ## Miscellaneous
-Mixed proprites for various purposes.
+Mixed properties for various purposes.
 
 
 ### radius
@@ -264,7 +264,7 @@ Enable to clip the overflowed content on the rounded corner. Can be `true` or `f
 
 
 ### opa
-Scale down all opacity values of the object by this factor. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 256, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc means semi transparency.
+Scale down all opacity values of the object by this factor. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 256, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc. means semi-transparency.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_COVER`</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> Yes</li>
@@ -297,7 +297,7 @@ The intensity of mixing of color filter.
 
 
 ### anim_time
-The animation time in milliseconds. It's meaning is widget specific. E.g. blink time of the cursor on the text area or scroll time of a roller. See the widgets' documentation to learn more.
+The animation time in milliseconds. Its meaning is widget specific. E.g. blink time of the cursor on the text area or scroll time of a roller. See the widgets' documentation to learn more.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -308,7 +308,7 @@ The animation time in milliseconds. It's meaning is widget specific. E.g. blink 
 
 
 ### anim_speed
-The animation speed in pixel/sec. It's meaning is widget specific. E.g. scroll speed of label. See the widgets' documentation to learn more.
+The animation speed in pixel/sec. Its meaning is widget specific. E.g. scroll speed of label. See the widgets' documentation to learn more.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -330,7 +330,7 @@ An initialized `lv_style_transition_dsc_t` to describe a transition.
 
 
 ### blend_mode
-Describes how to blend the colors to the background. The possibel values are `LV_BLEND_MODE_NORMAL/ADDITIVE/SUBTRACTIVE`
+Describes how to blend the colors to the background. The possible values are `LV_BLEND_MODE_NORMAL/ADDITIVE/SUBTRACTIVE`
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_BLEND_MODE_NORMAL`</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -352,7 +352,7 @@ Set the layout if the object. The children will be repositioned and resized acco
 
 
 ### base_dir
-Set the base direction of the obejct. The possible values are `LV_BIDI_DIR_LTR/RTL/AUTO`.
+Set the base direction of the object. The possible values are `LV_BIDI_DIR_LTR/RTL/AUTO`.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_BASE_DIR_AUTO`</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> Yes</li>
@@ -377,7 +377,7 @@ Set the background color of the object.
 
 
 ### bg_opa
-Set the opacity of the background. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 256, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc means semi transparency.
+Set the opacity of the background. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 256, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc. means semi-transparency.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_TRANSP`</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -443,7 +443,7 @@ Set a background image. Can be a pointer to `lv_img_dsc_t`, a path to a file or 
 
 
 ### bg_img_opa
-Set the opacity of the background image. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 256, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc means semi transparency.
+Set the opacity of the background image. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 256, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc. means semi-transparency.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_COVER`</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -465,7 +465,7 @@ Set a color to mix to the background image.
 
 
 ### bg_img_recolor_opa
-Set the intensity of background image recoloring. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means no mixing, 256, `LV_OPA_100` or `LV_OPA_COVER` means full recoloring, other values or LV_OPA_10, LV_OPA_20, etc are interpreted proportionally.
+Set the intensity of background image recoloring. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means no mixing, 256, `LV_OPA_100` or `LV_OPA_COVER` means full recoloring, other values or LV_OPA_10, LV_OPA_20, etc. are interpreted proportionally.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_TRANSP`</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -476,7 +476,7 @@ Set the intensity of background image recoloring. Value 0, `LV_OPA_0` or `LV_OPA
 
 
 ### bg_img_tiled
-If enbaled the background image will be tiled. The possible values are `true` or `false`.
+If enabled the background image will be tiled. The possible values are `true` or `false`.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -501,7 +501,7 @@ Set the color of the border
 
 
 ### border_opa
-Set the opcitiy of the border. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 256, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc means semi transparency.
+Set the opacity of the border. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 256, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc. means semi-transparency.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_COVER`</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -512,7 +512,7 @@ Set the opcitiy of the border. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means full
 
 
 ### border_width
-Set hte width of the border. Only pixel values can be used.
+Set the width of the border. Only pixel values can be used.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -523,7 +523,7 @@ Set hte width of the border. Only pixel values can be used.
 
 
 ### border_side
-Set ony which side(s) the border should be drawn. The possible values are `LV_BORDER_SIDE_NONE/TOP/BOTTOM/LEFT/RIGHT/INTERNAL`. OR-ed calues an be used as well, e.g. `LV_BORDER_SIDE_TOP | LV_BORDER_SIDE_LEFT`.
+Set ony which side(s) the border should be drawn. The possible values are `LV_BORDER_SIDE_NONE/TOP/BOTTOM/LEFT/RIGHT/INTERNAL`. OR-ed values can be used as well, e.g. `LV_BORDER_SIDE_TOP | LV_BORDER_SIDE_LEFT`.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_BORDER_SIDE_NONE`</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -534,7 +534,7 @@ Set ony which side(s) the border should be drawn. The possible values are `LV_BO
 
 
 ### border_post
-Sets whether the the border should be drawn before or after the children ar drawn. `true`: after children, `false`: before children
+Sets whether the border should be drawn before or after the children are drawn. `true`: after children, `false`: before children
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -544,7 +544,7 @@ Sets whether the the border should be drawn before or after the children ar draw
 
 
 ## Text
-Properties to describe the propeties of text. All these properties are inherited.
+Properties to describe the properties of text. All these properties are inherited.
 
 
 ### text_color
@@ -559,7 +559,7 @@ Sets the color of the text.
 
 
 ### text_opa
-Set the opacity of the text. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 256, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc means semi transparency.
+Set the opacity of the text. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 256, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc. means semi-transparency.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_COVER`</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> Yes</li>
@@ -628,7 +628,7 @@ Properties to describe the images
 
 
 ### img_opa
-Set the opacity of an image. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 256, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc means semi transparency.
+Set the opacity of an image. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 256, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc. means semi-transparency.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_COVER`</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -639,7 +639,7 @@ Set the opacity of an image. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully 
 
 
 ### img_recolor
-Set color to mixt to the image.
+Set color to mix to the image.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `0x000000`</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -650,7 +650,7 @@ Set color to mixt to the image.
 
 
 ### img_recolor_opa
-Set the intensity of the color mixing. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 256, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc means semi transparency.
+Set the intensity of the color mixing. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 256, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc. means semi-transparency.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -660,7 +660,7 @@ Set the intensity of the color mixing. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` me
 
 
 ## Outline
-Properties to describe the outline. It's like a border but drawn outside of the rectangles.
+Properties to describe the outline. It's like a border but drawn outside the rectangles.
 
 
 ### outline_width
@@ -686,7 +686,7 @@ Set the color of the outline.
 
 
 ### outline_opa
-Set the opacity of the outline. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 256, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc means semi transparency.
+Set the opacity of the outline. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 256, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc. means semi-transparency.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_COVER`</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -744,7 +744,7 @@ Set an offset on the shadow in pixels in Y direction.
 
 
 ### shadow_spread
-Make the shadow calcuation to use a larger or smaller rectangle as base. The value can be in pixel t make the area larger/smaller
+Make the shadow calculation to use a larger or smaller rectangle as base. The value can be in pixel to make the area larger/smaller
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -766,7 +766,7 @@ Set the color of the shadow
 
 
 ### shadow_opa
-Set the opacity of the shadow. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 256, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc means semi transparency.
+Set the opacity of the shadow. Value 0, `LV_OPA_0` or `LV_OPA_TRANSP` means fully transparent, 256, `LV_OPA_100` or `LV_OPA_COVER` means fully covering, other values or LV_OPA_10, LV_OPA_20, etc. means semi-transparency.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> `LV_OPA_COVER`</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>
@@ -849,7 +849,7 @@ TODO
 
 
 ### arc_width
-Set the width (ticjkness) of the arcs in pixel.
+Set the width (thickness) of the arcs in pixel.
 <ul>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Default</strong> 0</li>
 <li style='display:inline; margin-right: 20px; margin-left: 0px'><strong>Inherited</strong> No</li>

--- a/docs/overview/style.md
+++ b/docs/overview/style.md
@@ -6,13 +6,13 @@
 
 *Styles* are used to set the appearance of the objects. Styles in lvgl are heavily inspired by CSS. The concept in nutshell is as follows:
 - A style is an `lv_style_t` variable which can hold properties like border width, text color and so on. It's similar to a `class` in CSS. 
-- Styles can be assigned to objects to change their appearance. During the assignment the target part (*pseudo element* in CSS) and target state (*pseudo class*) can be specified.
+- Styles can be assigned to objects to change their appearance. During the assignment the target part (*pseudo-element* in CSS) and target state (*pseudo class*) can be specified.
 For example one can add `style_blue` to the knob of a slider when it's in pressed state.
 - The same style can be used by any number of objects.
 - Styles can be cascaded which means multiple styles can be assigned to an object and each style can have different properties. 
-Therefore not all properties have to be specified in style. LVLG will look for a property until a style defines it or use a default if it's not spefied by any of the styles.
+Therefore, not all properties have to be specified in style. LVLG will look for a property until a style defines it or use a default if it's not specified by any of the styles.
 For example `style_btn` can result in a default gray button and `style_btn_red` can add only a `background-color=red` to overwrite the background color.
-- Later added styles have higher precedence. It means if a property is specified in two styles the later added will be used.
+- Later added styles have higher precedence. It means if a property is specified in two styles the latter added will be used.
 - Some properties (e.g. text color) can be inherited from the parent(s) if it's not specified in the object. 
 - Objects can have local styles that have higher precedence than "normal" styles.
 - Unlike CSS (where pseudo-classes describe different states, e.g. `:focus`), in LVGL a property is assigned to a given state. 
@@ -54,21 +54,21 @@ To determine which state's property to use let's take an example. Imagine the ba
 The pressed state has 0x0020 precedence which is higher than the default state's 0x0000 precedence, so gray color will be used.
 3. When the object is focused the same thing happens as in pressed state and red color will be used. (Focused state has higher precedence than default state).
 4. When the object is focused and pressed both gray and red would work, but the pressed state has higher precedence than focused so gray color will be used.
-5. It's possible to set e.g rose color for `LV_STATE_PRESSED | LV_STATE_FOCUSED`. 
+5. It's possible to set e.g. rose color for `LV_STATE_PRESSED | LV_STATE_FOCUSED`. 
 In this case, this combined state has 0x0020 + 0x0002 = 0x0022 precedence, which is higher than the pressed state's precedence so rose color would be used.
 6. When the object is in checked state there is no property to set the background color for this state. So for lack of a better option, the object remains white from the default state's property.
 
 Some practical notes:
-- The precedence (value) of states is quite intuitive and it's something the user would expect naturally. E.g. if an object is focused the user will still want to see if it's pressed, therefore pressed state has a higher precedence. 
+- The precedence (value) of states is quite intuitive, and it's something the user would expect naturally. E.g. if an object is focused the user will still want to see if it's pressed, therefore pressed state has a higher precedence. 
 If the focused state had a higher precedence it would overwrite the pressed color.
 - If you want to set a property for all states (e.g. red background color) just set it for the default state. If the object can't find a property for its current state it will fall back to the default state's property.
 - Use ORed states to describe the properties for complex cases. (E.g. pressed + checked + focused)
 - It might be a good idea to use different style elements for different states. 
-For example, finding background colors for released, pressed, checked + pressed, focused, focused + pressed, focused + pressed + checked, etc states is quite difficult. 
+For example, finding background colors for released, pressed, checked + pressed, focused, focused + pressed, focused + pressed + checked, etc. states is quite difficult. 
 Instead, for example, use the background color for pressed and checked states and indicate the focused state with a different border color. 
 
 ## Cascading styles
-It's not required to set all the properties in one style. It's possible to add more styles to an object and let the later added style to modify or extend appearance.
+It's not required to set all the properties in one style. It's possible to add more styles to an object and have the later added style modify or extend appearance.
 For example, create a general gray button style and create a new for red buttons where only the new background color is set. 
 
 This is much like in CSS when used classes are listed like `<div class=".btn .btn-red">`.
@@ -80,12 +80,12 @@ So let's examine the following case:
 - the red button style defines the background color as red only in the default state
 
 In this case, when the button is released (it's in default state) it will be red because a perfect match is found in the most recently added style (red). 
-When the button is pressed the light-gray color is a better match because it describes the current state perfectly, so the button will be light-gray. 
+When the button is pressed the light-gray color is a better match because it describes the current state perfectly, so the button will be light-gray. 
 
 ## Inheritance 
-Some properties (typically that are related to texts) can be inherited from the parent object's styles. 
+Some properties (typically those related to text) can be inherited from the parent object's styles. 
 Inheritance is applied only if the given property is not set in the object's styles (even in default state). 
-In this case, if the property is inheritable, the property's value will be searched in the parents too until an object specifies a value for the property. The parents will use their own state to detemine the value. 
+In this case, if the property is inheritable, the property's value will be searched in the parents too until an object specifies a value for the property. The parents will use their own state to determine the value. 
 So if a button is pressed, and the text color comes from here, the pressed text color will be used.
 
 
@@ -106,10 +106,10 @@ The following predefined parts exist in LVGL:
 
 For example a [Slider](/widgets/core/slider) has three parts:
 - Background
-- Indiactor
+- Indicator
 - Knob
 
-It means the all three parts of the slider can have their own styles. See later how to add style styles to objects and parts.
+It means all three parts of the slider can have their own styles. See later how to add styles to objects and parts.
 
 ## Initialize styles and set/get properties
 
@@ -193,16 +193,16 @@ To refresh all parts and properties use `lv_obj_refresh_style(obj, LV_PART_ANY, 
 ### Get a property's value on an object
 To get a final value of property - considering cascading, inheritance, local styles and transitions (see below) - get functions like this can be used: 
 `lv_obj_get_style_<property_name>(obj, <part>)`. 
-These functions uses the object's current state and if no better candidate returns a default value.  
+These functions use the object's current state and if no better candidate returns a default value.  
 For example:
 ```c
 lv_color_t color = lv_obj_get_style_bg_color(btn, LV_PART_MAIN);
 ```
 
 ## Local styles
-Besides "normal" styles, the objects can store local styles too. This concept is similar to inline styles in CSS (e.g. `<div style="color:red">`) with some modification. 
+Besides, "normal" styles, the objects can store local styles too. This concept is similar to inline styles in CSS (e.g. `<div style="color:red">`) with some modification. 
 
-So local styles are like normal styles but they can't be shared among other objects. If used, local styles are allocated automatically, and freed when the object is deleted.
+So local styles are like normal styles, but they can't be shared among other objects. If used, local styles are allocated automatically, and freed when the object is deleted.
 They are useful to add local customization to the object.
 
 Unlike in CSS, in LVGL local styles can be assigned to states (*pseudo-classes*) and parts (*pseudo-elements*).
@@ -216,7 +216,7 @@ lv_obj_set_style_local_bg_color(slider, lv_color_red(), LV_PART_INDICATOR | LV_S
 For the full list of style properties click [here](/overview/style-props).
 
 ### Typical background properties
-In the documentation of the widgets you will see sentences like "The widget use the typical background properties". The "typical background properties" are the ones related to:
+In the documentation of the widgets you will see sentences like "The widget uses the typical background properties". The "typical background properties" are the ones related to:
 - Background
 - Border
 - Outline
@@ -240,7 +240,7 @@ The transition properties can be defined for each state. For example, setting 50
 Setting 100 ms transition time in the pressed state will mean a 100 ms transition time when going to pressed state.
 So this example configuration will result in going to pressed state quickly and then going back to default slowly. 
 
-To describe a transition an `lv_transition_dsc_t` variable needs to initialized and added to a style:
+To describe a transition an `lv_transition_dsc_t` variable needs to be initialized and added to a style:
 ```c
 /*Only its pointer is saved so must static, global or dynamically allocated */
 static const lv_style_prop_t trans_props[] = {
@@ -262,7 +262,7 @@ TODO
 Themes are a collection of styles. If there is an active theme LVGL applies it on every created widget.
 This will give a default appearance to the UI which can then be modified by adding further styles.
 
-Every display can have a different theme. For example you could have a colorful theme on a TFT and monochrome theme on a secondary monochrome display.
+Every display can have a different theme. For example, you could have a colorful theme on a TFT and monochrome theme on a secondary monochrome display.
 
 To set a theme for a display, 2 steps are required:
 1. Initialize a theme

--- a/docs/overview/timer.md
+++ b/docs/overview/timer.md
@@ -62,9 +62,9 @@ It can be misleading if you use an operating system and call `lv_timer_handler` 
 
 ## Asynchronous calls
 
-In some cases, you can't do an action immediately. For example, you can't delete an object because something else is still using it or you don't want to block the execution now.
+In some cases, you can't do an action immediately. For example, you can't delete an object because something else is still using it, or you don't want to block the execution now.
 For these cases, `lv_async_call(my_function, data_p)` can be used to make `my_function` be called on the next call of `lv_timer_handler`. `data_p` will be passed to function when it's called.
-Note that, only the pointer of the data is saved so you need to ensure that the variable will be "alive" while the function is called. It can be *static*, global or dynamically allocated data.
+Note that only the data pointer is saved, so you need to ensure that the variable will be "alive" while the function is called. It can be *static*, global or dynamically allocated data.
 
 For example:
 ```c

--- a/docs/porting/display.md
+++ b/docs/porting/display.md
@@ -10,10 +10,10 @@ To register a display for LVGL a `lv_disp_draw_buf_t` and a `lv_disp_drv_t` vari
 
 ## Draw buffer
 
-Draw buffer(s) are simple array(s) that LVGL uses to render the content of the screen. 
-Once rendering is ready the content of the draw buffer is sent to the display using the `flush_cb` function set in the display driver (see below).
+Draw buffer(s) are simple array(s) that LVGL uses to render the screen content. 
+Once rendering is ready the content of the draw buffer is sent to the display using the `flush_cb` function, set in the display driver (see below).
 
-A draw draw buffer can be initialized via a `lv_disp_draw_buf_t` variable like this:
+A draw buffer can be initialized via a `lv_disp_draw_buf_t` variable like this:
 ```c
 /*A static or global variable to store the buffers*/
 static lv_disp_draw_buf_t disp_buf;
@@ -26,7 +26,7 @@ static lv_color_t buf_2[MY_DISP_HOR_RES * 10];
 lv_disp_draw_buf_init(&disp_buf, buf_1, buf_2, MY_DISP_HOR_RES*10);
 ```
 
-Note that `lv_disp_draw_buf_t` needs to be static, global or dynamically allocated and not a local variable destroyed if goes out of the scope. 
+Note that `lv_disp_draw_buf_t` needs to be static, global or dynamically allocated and not a local variable destroyed when it goes out of the scope. 
 
 As you can see the draw buffer can be smaller than the screen. In this case, the larger areas will be redrawn in smaller parts that fit into the draw buffer(s).
 If only a small area changes (e.g. a button is pressed) then only that area will be refreshed.
@@ -44,7 +44,7 @@ This way, the rendering and refreshing of the display become parallel.
 In the display driver (`lv_disp_drv_t`) the `full_refresh` bit can be enabled to force LVGL to always redraw the whole screen. This works in both *one buffer* and *two buffers* modes.
 
 If `full_refresh` is enabled and 2 screen sized draw buffers are provided, LVGL's display handling works like "traditional" double buffering. 
-This means in `flush_cb` only the address of the frame buffer needs to be changed to the provided pointer (`color_p` parameter).
+This means in `flush_cb` only the address of the framebuffer needs to be changed to the provided pointer (`color_p` parameter).
 This configuration should be used if the MCU has LCD controller periphery and not with an external display controller (e.g. ILI9341 or SSD1963). 
 
 You can measure the performance of different draw buffer configurations using the [benchmark example](https://github.com/lvgl/lv_demos/tree/master/src/lv_demo_benchmark).
@@ -56,7 +56,7 @@ Once the buffer initialization is ready a `lv_disp_drv_t` display driver needs t
 2. its fields need to be set
 3. it needs to be registered in LVGL with `lv_disp_drv_register(&disp_drv)`
 
-Note that `lv_disp_drv_t` also needs to be static, global or dynamically allocated and not a local variable destroyed if goes out of the scope. 
+Note that `lv_disp_drv_t` also needs to be static, global or dynamically allocated and not a local variable destroyed when it goes out of the scope. 
 
 ### Mandatory fields
 In the most simple case only the following fields of `lv_disp_drv_t` need to be set:

--- a/docs/porting/indev.md
+++ b/docs/porting/indev.md
@@ -169,7 +169,7 @@ void button_read(lv_indev_drv_t * drv, lv_indev_data_t*data){
 
 ### Parameters
 
-The default value of the following parameters can changed in `lv_indev_drv_t`:
+The default value of the following parameters can be changed in `lv_indev_drv_t`:
 - `scroll_limit` Number of pixels to slide before actually scrolling the object.
 - `scroll_throw`  Scroll throw (momentum) slow-down in [%]. Greater value means faster slow-down.
 - `long_press_time` Press time to send `LV_EVENT_LONG_PRESSED` (in milliseconds)
@@ -179,7 +179,7 @@ The default value of the following parameters can changed in `lv_indev_drv_t`:
 ### Feedback
 
 Besides `read_cb` a `feedback_cb` callback can be also specified in `lv_indev_drv_t`.
-`feedback_cb` is called when any type of event is sent by the input devices (independently from its type). This allows generating feedback for the user, e.g. to play a sound on `LV_EVENT_CLICKED`.
+`feedback_cb` is called when any type of event is sent by the input devices (independently of its type). This allows generating feedback for the user, e.g. to play a sound on `LV_EVENT_CLICKED`.
 
 
 ### Associating with a display
@@ -187,7 +187,7 @@ Every input device is associated with a display. By default, a new input device 
 The associated display is stored and can be changed in `disp` field of the driver.
 
 ### Buffered reading
-By default LVGL calls `read_cb` periodically. This way there is a chance that some user gestures are missed. 
+By default, LVGL calls `read_cb` periodically. This way there is a chance that some user gestures are missed. 
 
 To solve this you can write an event driven driver for your input device that buffers measured data. In `read_cb` you can set the buffered data instead of reading the input device. 
 You can set the `data->continue_reading` flag to tell that LVGL there is more data to read and it should call the `read_cb` again.

--- a/docs/porting/project.md
+++ b/docs/porting/project.md
@@ -3,7 +3,7 @@
 :github_url: |github_link_base|/porting/project.md
 ```
 
-# Set-up a project
+# Set up a project
 
 ## Get the library
 
@@ -19,7 +19,7 @@ There is a configuration header file for LVGL called **lv_conf.h**. In this you 
 
 Copy **lvgl/lv_conf_template.h** next to the *lvgl* directory and rename it to *lv_conf.h*. Open the file and change the `#if 0` at the beginning to `#if 1` to enable its content.
 
-*lv_conf.h* can be copied to another place as well but then you should add `LV_CONF_INCLUDE_SIMPLE` define to your compiler options (e.g. `-DLV_CONF_INCLUDE_SIMPLE` for gcc compiler) and set the include path manually. 
+*lv_conf.h* can be copied to another place as well, but then you should add the `LV_CONF_INCLUDE_SIMPLE` define to your compiler options (e.g. `-DLV_CONF_INCLUDE_SIMPLE` for gcc compiler) and set the include path manually. 
 In this case LVGL will attempt to include `lv_conf.h` simply with `#include "lv_conf.h"`.
 
 In the config file comments explain the meaning of the options. Be sure to set at least `LV_COLOR_DEPTH` according to your display's color depth.

--- a/docs/widgets/core/arc.md
+++ b/docs/widgets/core/arc.md
@@ -6,11 +6,11 @@
 
 ## Overview
 
-The Arc consists of a background and a foreground arc. The foregrond (indicator) can be touch-adjusted.
+The Arc consists of a background and a foreground arc. The foreground (indicator) can be touch-adjusted.
 
 ## Parts and Styles
 - `LV_PART_MAIN`  Draws a background using the typical background style properties and an arc using the arc style properties. The arc's size and position will respect the *padding* style properties.
-- `LV_PART_INDICATOR` Draws an other arc using the *arc* style properties. Its padding values are interpreted relative to the background arc. 
+- `LV_PART_INDICATOR` Draws another arc using the *arc* style properties. Its padding values are interpreted relative to the background arc. 
 - `LV_PART_KNOB` Draws a handle on the end of the indicator using all background properties and padding values. With zero padding the knob size is the same as the indicator's width. 
 Larger padding makes it larger, smaller padding makes it smaller. 
 
@@ -47,12 +47,12 @@ The change rate is defined in degree/second unit and can be set with `lv_arc_set
 
 
 ### Setting the indicator manually
-It also possible to set the angles of the indicator arc directly with `lv_arc_set_angles(arc, start_angle, end_angle)` function or `lv_arc_set_start/end_angle(arc, start_angle)`.
-In this case the set "value" and "mode" is ignored.
+It's also possible to set the angles of the indicator arc directly with `lv_arc_set_angles(arc, start_angle, end_angle)` function or `lv_arc_set_start/end_angle(arc, start_angle)`.
+In this case the set "value" and "mode" are ignored.
 
-In other words, settings angles and values are independent. You should use either value and angle settings. Mixing the two might result in unintended behavior. 
+In other words, settings angles and values are independent. You should use either value or angle settings. Mixing the two might result in unintended behavior. 
 
-To make the arc non-adjustabe remove the style of the knob and make the object non-clickable:
+To make the arc non-adjustable, remove the style of the knob and make the object non-clickable:
 ```c
 lv_obj_remove_style(arc, NULL, LV_PART_KNOB);
 lv_obj_clear_flag(arc, LV_OBJ_FLAG_CLICKABLE);

--- a/docs/widgets/core/bar.md
+++ b/docs/widgets/core/bar.md
@@ -15,7 +15,7 @@ Not only the end, but also the start value of the bar can be set, which changes 
 
 ## Parts and Styles
 - `LV_PART_MAIN` The background of the bar and it uses the typical background style properties. Adding padding makes the indicator smaller or larger. The `anim_time` style property sets the animation time if the values set with `LV_ANIM_ON`.
-- `LV_PART_INDICATOR` The indicator itself; also also uses all the typical background properties.
+- `LV_PART_INDICATOR` The indicator itself; also uses all the typical background properties.
  
 ## Usage
 
@@ -27,7 +27,7 @@ The default range is 1..100.
 The new value in `lv_bar_set_value` can be set with or without an animation depending on the last parameter (`LV_ANIM_ON/OFF`).
 
 ### Modes
-The bar can be one the following modes:
+The bar can be one of the following modes:
 - `LV_BAR_MODE_NORMAL` A normal bar as described above
 - `LV_BAR_SYMMETRICAL` Draw the indicator from the zero value to current value. Requires a negative minimum range and positive maximum range.
 - `LV_BAR_RANGE` Allows setting the start value too by `lv_bar_set_start_value(bar, new_value, LV_ANIM_ON/OFF)`. The start value always has to be smaller than the end value.

--- a/docs/widgets/core/btnmatrix.md
+++ b/docs/widgets/core/btnmatrix.md
@@ -42,7 +42,7 @@ In addition to the width, each button can be customized with the following param
 - `LV_BTNMATRIX_CTRL_CUSTOM_1` Custom free to use flag
 - `LV_BTNMATRIX_CTRL_CUSTOM_2` Custom free to use flag
 
-By default all flags are disabled.
+By default, all flags are disabled.
 
 To set or clear a button's control attribute, use `lv_btnmatrix_set_btn_ctrl(btnm, btn_id, LV_BTNM_CTRL_...)` and 
 `lv_btnmatrix_clear_btn_ctrl(btnm, btn_id, LV_BTNMATRIX_CTRL_...)` respectively. More `LV_BTNM_CTRL_...` values can be OR-ed

--- a/docs/widgets/core/canvas.md
+++ b/docs/widgets/core/canvas.md
@@ -59,7 +59,7 @@ The draw function can draw to any color format. For example, it's possible to dr
 `lv_canvas_transform()` can be used to rotate and/or scale the image of an image and store the result on the canvas. 
 The function needs the following parameters:
 - `canvas` pointer to a canvas object to store the result of the transformation.
-- `img pointer` to an image descriptor to transform. Can be the image descriptor of an other canvas too (`lv_canvas_get_img()`).
+- `img pointer` to an image descriptor to transform. Can be the image descriptor of another canvas too (`lv_canvas_get_img()`).
 - `angle` the angle of rotation (0..3600), 0.1 deg resolution
 - `zoom` zoom factor (256: no zoom, 512: double size, 128: half size);
 - `offset_x` offset X to tell where to put the result data on destination canvas

--- a/docs/widgets/core/checkbox.md
+++ b/docs/widgets/core/checkbox.md
@@ -7,13 +7,13 @@
 
 ## Overview
 
-The Checkbox object is created from a "tick box" and a label. When the Chackbox is clicked the tick box is toggled.
+The Checkbox object is created from a "tick box" and a label. When the Checkbox is clicked the tick box is toggled.
 
 ## Parts and Styles
-- `LV_PART_MAIN` The is the background of the Checkbox and it uses the text and all the typical backround style properties. 
+- `LV_PART_MAIN` The is the background of the Checkbox and it uses the text and all the typical background style properties. 
 `pad_column` adjusts the spacing between the tickbox and the label
-- `LV_PART_INDICATOR` The "tick box" is a square that uses all the typical backround style properties. 
-By default its size is equal to the height of the main part's font. Padding properties make the tick box larger in the respective directions.
+- `LV_PART_INDICATOR` The "tick box" is a square that uses all the typical background style properties. 
+By default, its size is equal to the height of the main part's font. Padding properties make the tick box larger in the respective directions.
 
 The Checkbox is added to the default group (if it is set). 
 

--- a/docs/widgets/core/dropdown.md
+++ b/docs/widgets/core/dropdown.md
@@ -22,7 +22,7 @@ The Dropdown widget is built from the elements: "button" and "list" (both not re
 - `LV_PART_MAIN` The background of the button. Uses the typical background properties and text properties for the text on it.
 - `LV_PART_INDICATOR` Typically an arrow symbol that can be an image or a text (`LV_SYMBOL`).
 
-The button goes to `LV_STATE_CHECKED` when its opened.
+The button goes to `LV_STATE_CHECKED` when it's opened.
 
 ### List
 - `LV_PART_MAIN` The list itself. Uses the typical background properties. `max_height` can be used to limit the height of the list. 
@@ -63,7 +63,7 @@ The list can be created on any side. The default `LV_DIR_BOTTOM` can be modified
 If the list would be vertically out of the screen, it will be aligned to the edge.
 
 ### Symbol
-A symbol (typically an arrow) can be added to the drop down list with `lv_dropdown_set_symbol(dropdown, LV_SYMBOL_...)`
+A symbol (typically an arrow) can be added to the dropdown list with `lv_dropdown_set_symbol(dropdown, LV_SYMBOL_...)`
 
 If the direction of the drop-down list is  `LV_DIR_LEFT` the symbol will be shown on the left, otherwise on the right.
 

--- a/docs/widgets/core/img.md
+++ b/docs/widgets/core/img.md
@@ -94,7 +94,7 @@ Note that the real coordinates of image objects won't change during transformati
 
 ### Size mode
 
-By default if the image is zoom or rotated the real coordinates of the image object are not changed. 
+By default, when the image is zoomed or rotated the real coordinates of the image object are not changed. 
 The larger content simply overflows the object's boundaries. 
 It also means the layouts are not affected the by the transformations. 
 

--- a/docs/widgets/core/label.md
+++ b/docs/widgets/core/label.md
@@ -38,7 +38,7 @@ Similary, the policies can be applied if the height of the text is greater than 
 - `LV_LABEL_LONG_DOT` Replaces the last 3 characters from bottom right corner of the label with dots (`.`) 
 - `LV_LABEL_LONG_SCROLL` If the text is wider than the label scroll it horizontally back and forth. If it's higher, scroll vertically. Only one direction is scrolled and horizontal scrolling has higher precedence.
 - `LV_LABEL_LONG_SCROLL_CIRCULAR` If the text is wider than the label scroll it horizontally continously. If it's higher, scroll vertically. Only one direction is scrolled and horizontal scrolling has higher precedence.
-- `LV_LABEL_LONG_CLIP` Simply clip the parts of the text outside of the label.
+- `LV_LABEL_LONG_CLIP` Simply clip the parts of the text outside the label.
 
 You can specify the long mode with `lv_label_set_long_mode(label, LV_LABEL_LONG_...)`
 
@@ -51,7 +51,7 @@ In the text, you can use commands to recolor parts of the text. For example: `"W
 This feature can be enabled individually for each label by `lv_label_set_recolor()` function. 
 
 ### Text selection
-If enabled by `LV_LABEL_TEXT_SELECTION` part of the text can be selected. It's similar when on PC a you use your mouse to select a text. 
+If enabled by `LV_LABEL_TEXT_SELECTION` part of the text can be selected. It's similar to when you use your mouse on a PC to select a text. 
 The whole mechanism (click and select the text as you drag your finger/mouse) is implemented in [Text area](/widgets/core/textarea) and the Label widget only allows manual text selection with
 `lv_label_get_text_selection_start(label, start_char_index)` and `lv_label_get_text_selection_start(label, end_char_index)`.
  

--- a/docs/widgets/core/line.md
+++ b/docs/widgets/core/line.md
@@ -16,10 +16,10 @@ The Line object is capable of drawing straight lines between a set of points.
 The points have to be stored in an `lv_point_t` array and passed to the object by the `lv_line_set_points(lines, point_array, point_cnt)` function. 
 
 ### Auto-size
-By default the Line's width and height are set to `LV_SIZE_CONTENT`. This means it will automatically set its size to fit all the points. If the size is set explicitly, parts on the line may not be visible.
+By default, the Line's width and height are set to `LV_SIZE_CONTENT`. This means it will automatically set its size to fit all the points. If the size is set explicitly, parts on the line may not be visible.
 
 ### Invert y
-By default, the *y == 0* point is in the top of the object. It might be conter-intuitive in some cases so the y coordinates can be inverted with `lv_line_set_y_invert(line, true)`. In this case,  *y == 0* will be the bottom of the object. 
+By default, the *y == 0* point is in the top of the object. It might be counter-intuitive in some cases so the y coordinates can be inverted with `lv_line_set_y_invert(line, true)`. In this case,  *y == 0* will be the bottom of the object. 
 *y invert* is disabled by default.
 
 ## Events

--- a/docs/widgets/core/roller.md
+++ b/docs/widgets/core/roller.md
@@ -30,7 +30,7 @@ The get the *index* of the currently selected option use `lv_roller_get_selected
 ### Visible rows
 The number of visible rows can be adjusted with `lv_roller_set_visible_row_count(roller, num)`.
 
-This function calculates the height with the current style. If the font, line space, border width, etc of the roller changes this function needs to be called again. 
+This function calculates the height with the current style. If the font, line space, border width, etc. of the roller changes this function needs to be called again. 
 
 ## Events
 - `LV_EVENT_VALUE_CHANGED` Sent when a new option is selected.

--- a/docs/widgets/core/slider.md
+++ b/docs/widgets/core/slider.md
@@ -12,7 +12,7 @@ The Slider object looks like a [Bar](/widgets/core/bar) supplemented with a knob
 ## Parts and Styles 
 - `LV_PART_MAIN` The background of the slider. Uses all the typical background style properties. `padding` makes the indicator smaller in the respective direction.
 - `LV_PART_INDICATOR` The indicator that shows the current state of the slider. Also uses all the typical background style properties.
-- `LV_PART_KNOB` A rectangle (or circle) drawn at the current value. Also uses all the typical background properties to describe the knob(s). By default the knob is square (with a optional corner radius) with side length equal to the smaller side of the slider. The knob can be made larger with the `padding` values. Padding values can be asymmetric too. 
+- `LV_PART_KNOB` A rectangle (or circle) drawn at the current value. Also uses all the typical background properties to describe the knob(s). By default, the knob is square (with an optional corner radius) with side length equal to the smaller side of the slider. The knob can be made larger with the `padding` values. Padding values can be asymmetric too. 
 
 ## Usage
 
@@ -22,9 +22,9 @@ To set an initial value use `lv_slider_set_value(slider, new_value, LV_ANIM_ON/O
 To specify the range (min, max values), `lv_slider_set_range(slider, min , max)` can be used.
 
 ### Modes
-The slider can be one the following modes:
+The slider can be one of the following modes:
 - `LV_SLIDER_MODE_NORMAL` A normal slider as described above
-- `LV_SLIDER_SYMMETRICAL` Draw the indicator form the zero value to current value. Requires negaitve minimum range and positive maximum range.
+- `LV_SLIDER_SYMMETRICAL` Draw the indicator form the zero value to current value. Requires negative minimum range and positive maximum range.
 - `LV_SLIDER_RANGE` Allows setting the start value too by `lv_bar_set_start_value(bar, new_value, LV_ANIM_ON/OFF)`. The start value has to be always smaller than the end value.
 
 The mode can be changed with `lv_slider_set_mode(slider, LV_SLIDER_MODE_...)`
@@ -35,7 +35,7 @@ In the latter case the knob moves to the point clicked and slider value changes 
 
 ## Events
 - `LV_EVENT_VALUE_CHANGED` Sent while the slider is being dragged or changed with keys. 
-The event is sent continuously while the slider is dragged and once when released. Use `lv_slider_is_dragged` to detemine whether the Slider is still being dragged or has just been released.
+The event is sent continuously while the slider is dragged and once when released. Use `lv_slider_is_dragged` to determine whether the Slider is still being dragged or has just been released.
 - `LV_EVENT_DRAW_PART_BEGIN` and `LV_EVENT_DRAW_PART_END` are sent for the following parts. 
     - `LV_SLIDER_DRAW_PART_KNOB` The main (right) knob of the slider
         - `part`: `LV_PART_KNOB` 

--- a/docs/widgets/extra/chart.md
+++ b/docs/widgets/extra/chart.md
@@ -39,7 +39,7 @@ You can specify the display type with `lv_chart_set_type(chart, LV_CHART_TYPE_..
 
 
 ### Data series
-You can add any number of series to the charts by `lv_chart_add_series(chart, color, axis)`. This will allocates a `lv_chart_series_t` structure which contains the chosen `color` and an array for the data points.
+You can add any number of series to the charts by `lv_chart_add_series(chart, color, axis)`. This allocates an `lv_chart_series_t` structure which contains the chosen `color` and an array for the data points.
 `axis` can have the following values:
 - `LV_CHART_AXIS_PRIMARY_Y` Left axis
 - `LV_CHART_AXIS_SECONDARY_Y` Right axis
@@ -73,7 +73,7 @@ For `LV_CHART_TYPE_SCATTER` type  `lv_chart_set_value_by_id2(chart, ser, id, val
 ### Update modes
 `lv_chart_set_next_value` can behave in two ways depending on *update mode*:
 - `LV_CHART_UPDATE_MODE_SHIFT` Shift old data to the left and add the new one to the right.
-- `LV_CHART_UPDATE_MODE_CIRCULAR` - Add the new data in circular fashion, like an ECG diagram).
+- `LV_CHART_UPDATE_MODE_CIRCULAR` - Add the new data in circular fashion, like an ECG diagram.
 
 The update mode can be changed with `lv_chart_set_update_mode(chart, LV_CHART_UPDATE_MODE_...)`.
 
@@ -82,7 +82,7 @@ The number of points in the series can be modified by `lv_chart_set_point_count(
 Note: this also affects the number of points processed when an external buffer is assigned to a series, so you need to be sure the external array is large enough. 
 
 #### Handling large number of points
-On line charts if the number of points is greater than the pixels horizontally, the Chart will draw only vertical lines to make the drawing of large amount of data effective. 
+On line charts, if the number of points is greater than the pixels horizontally, the Chart will draw only vertical lines to make the drawing of large amount of data effective. 
 If there are, let's say, 10 points to a pixel, LVGL searches the smallest and the largest value and draws a vertical lines between them to ensure no peaks are missed.
 
 ### Vertical range

--- a/docs/widgets/extra/colorwheel.md
+++ b/docs/widgets/extra/colorwheel.md
@@ -36,7 +36,7 @@ Learn more about [Events](/overview/event).
 
 ## Keys
 - `LV_KEY_UP`, `LV_KEY_RIGHT` Increment the current parameter's value by 1
-- `LV_KEY_DOWN`, `LV_KEY_LEFT` Decrement the current parameter's by 1
+- `LV_KEY_DOWN`, `LV_KEY_LEFT` Decrement the current parameter's value by 1
 - `LV_KEY_ENTER` A long press will show the next mode. Double click to reset the current parameter.
 
 Learn more about [Keys](/overview/indev).

--- a/docs/widgets/extra/list.md
+++ b/docs/widgets/extra/list.md
@@ -21,7 +21,7 @@ See the [Button](/widgets/core/btn)'s and [Label](/widgets/core/label)'s documen
 ### Buttons
 `lv_list_add_btn(list, icon, text)` adds a full-width button with an icon - that can be an image or symbol - and a text.
 
-The text starts to scroll horizontally if its too long.
+The text starts to scroll horizontally if it's too long.
 
 ### Texts
 `lv_list_add_text(list, icon, text)` adds a text.

--- a/docs/widgets/extra/meter.md
+++ b/docs/widgets/extra/meter.md
@@ -32,13 +32,13 @@ Labels are added automatically on major ticks with `label_gap` distance from the
 
 ### Add indicators
 
-Indicators needs to be added to a Scale and their value is interpreted in the range of the Scale.
+Indicators need to be added to a Scale and their value is interpreted in the range of the Scale.
 
 All the indicator add functions return `lv_meter_indicator_t *`.
 
 #### Needle line
 
-`indic = lv_meter_add_needle_line(meter, scale, line_width, line_color, r_mod)` adds a needle line to a Scale. By default the length of the line is the same as the scale's radius but `r_mod` changes the length.
+`indic = lv_meter_add_needle_line(meter, scale, line_width, line_color, r_mod)` adds a needle line to a Scale. By default, the length of the line is the same as the scale's radius but `r_mod` changes the length.
 
 `lv_meter_set_indicator_value(meter, indic, value)` sets the value of the indicator.
 
@@ -50,7 +50,7 @@ All the indicator add functions return `lv_meter_indicator_t *`.
 `lv_meter_set_indicator_value(meter, inidicator, value)` sets the value of the indicator.
 
 #### Arc
-`indic = lv_meter_add_arc(meter, scale, arc_width, arc_color, r_mod)` adds and arc indicator. . By default the radius of the arc is the same as the scale's radius but `r_mod` changes the radius.
+`indic = lv_meter_add_arc(meter, scale, arc_width, arc_color, r_mod)` adds and arc indicator. . By default, the radius of the arc is the same as the scale's radius but `r_mod` changes the radius.
 
 `lv_meter_set_indicator_start_value(meter, indic, value)` and `lv_meter_set_indicator_end_value(meter, inidicator, value)` sets the value of the indicator. 
 

--- a/docs/widgets/extra/msgbox.md
+++ b/docs/widgets/extra/msgbox.md
@@ -13,7 +13,7 @@ The text will be broken into multiple lines automatically and the height will be
 The message box can be modal (blocking clicks on the rest of the screen) or not modal.
 
 ## Parts and Styles
-The mesasge box is built from other widgets so you can check these widget's documentation for details.
+The message box is built from other widgets, so you can check these widgets' documentation for details.
 - Background: [lv_obj](/widgets/obj)
 - Close button: [lv_btn](/widgets/core/btn)
 - Title and text: [lv_label](/widgets/core/label)

--- a/docs/widgets/extra/spinbox.md
+++ b/docs/widgets/extra/spinbox.md
@@ -28,7 +28,7 @@ The parts of the Spinbox are identical to the [Text area](/widgets/core/textarea
 `separator_position` is the number of digits before the decimal point. If 0, no decimal point is displayed.
 
 ### Rollover
-`lv_spinbox_set_rollover(spinbox, true/false)` enables/disabled rollover mode. If either the minimum or maximum value is reached with rollover enabled, the value will change to the other limit. If rollover is disabled the value will be remain at the minimum or maximum value. 
+`lv_spinbox_set_rollover(spinbox, true/false)` enables/disabled rollover mode. If either the minimum or maximum value is reached with rollover enabled, the value will change to the other limit. If rollover is disabled the value will remain at the minimum or maximum value. 
 
 ## Events
 - `LV_EVENT_VALUE_CHANGED` Sent when the value has changed.

--- a/docs/widgets/extra/spinner.md
+++ b/docs/widgets/extra/spinner.md
@@ -17,7 +17,7 @@ The parts are identical to the parts of [lv_arc](/widgets/core/arc).
 To create a spinner use `lv_spinner_create(parent, spin_time, arc_length)`. `spin time` sets the spin time in milliseconds, `arc_length` sets the length of the spinning arc in degrees.
 
 ## Events
-No special events are sent the the Spinner.
+No special events are sent to the Spinner.
 
 See the events of the [Arc](/widgets/core/arc) too.
 

--- a/docs/widgets/obj.md
+++ b/docs/widgets/obj.md
@@ -17,7 +17,7 @@ In object-oriented thinking, it is the base class from which all other objects i
 
 The functions and functionalities of the Base object can be used with other widgets too. For example `lv_obj_set_width(slider, 100)`
 
-The Base object can be directly used as a simple widget: it nothing else than a rectangle. In HTML terms, think of it as a `<div>`.
+The Base object can be directly used as a simple widget: it's nothing else than a rectangle. In HTML terms, think of it as a `<div>`.
 
 ### Coordinates
 
@@ -31,7 +31,7 @@ You can set the position relative to the parent with `lv_obj_set_x(obj, new_x)` 
 
 #### Alignment
 You can align the object on its parent with `lv_obj_set_align(obj, LV_ALIGN_...)`. After this every x and y setting will be ralitive to the set alignment mode. 
-For example a this will shift the object by 10;20 px from the center of its parent.
+For example, this will shift the object by 10;20 px from the center of its parent.
 ```c
 lv_obj_set_align(obj, LV_ALIGN_CENTER);
 lv_obj_set_pos(obj, 10, 20);


### PR DESCRIPTION
Fix a bunch of spelling errors in the documentation folder
