### PR TITLE
fix scroll example sqort types

### DIFF
--- a/examples/scroll/lv_example_scroll_6.c
+++ b/examples/scroll/lv_example_scroll_6.c
@@ -29,7 +29,7 @@ static void scroll_event_cb(lv_event_t * e)
             x = r;
         } else {
             /*Use Pythagoras theorem to get x from radius and y*/
-            lv_coord_t x_sqr = r * r - diff_y * diff_y;
+            uint32_t x_sqr = r * r - diff_y * diff_y;
             lv_sqrt_res_t res;
             lv_sqrt(x_sqr, &res, 0x8000);   /*Use lvgl's built in sqrt root function*/
             x = r - res.i;


### PR DESCRIPTION
line 32 of lv_example_scroll_6.c, if LV_USE_LARGE_COORD not configured,
x_sqr will overflow when r is greater than 256.

Signed-off-by: liushuai25 <liushuai25@xiaomi.com>

