### PR TITLE
Fix for documentation 'lv_colorwheel_colour_set_mode...'

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v8.1.0 (In progress)
+- fix(docs) API colorwheel reference from 'lv_colorwheel_colour_set_mode...' to 'lv_colorwheel_set_mode...'
 - Fixed lv_deinit declaration when LV_USE_GPU_SDL is enabled
 - added sample lv_example_list_2.py
 - lv_obj_move_up(obj) and lv_obj_move_down(obj) added. (#2461)

--- a/docs/widgets/extra/colorwheel.md
+++ b/docs/widgets/extra/colorwheel.md
@@ -25,9 +25,9 @@ The color can be set manually with `lv_colorwheel_set_hue/saturation/value(color
 
 ### Color mode
 
-The current color mode can be manually selected with `lv_colorwheel_set_color_mode(colorwheel, LV_COLORWHEEL_MODE_HUE/SATURATION/VALUE)`.
+The current color mode can be manually selected with `lv_colorwheel_set_mode(colorwheel, LV_COLORWHEEL_MODE_HUE/SATURATION/VALUE)`.
 
-The color mode can be fixed (so as to not change with long press) using `lv_colorwheel_set_color_mode_fixed(colorwheel, true)`
+The color mode can be fixed (so as to not change with long press) using `lv_colorwheel_set__mode_fixed(colorwheel, true)`
 
 ## Events
 - `LV_EVENT_VALUE_CHANGED` Sent if a new color is selected.

--- a/docs/widgets/extra/colorwheel.md
+++ b/docs/widgets/extra/colorwheel.md
@@ -27,7 +27,7 @@ The color can be set manually with `lv_colorwheel_set_hue/saturation/value(color
 
 The current color mode can be manually selected with `lv_colorwheel_set_mode(colorwheel, LV_COLORWHEEL_MODE_HUE/SATURATION/VALUE)`.
 
-The color mode can be fixed (so as to not change with long press) using `lv_colorwheel_set__mode_fixed(colorwheel, true)`
+The color mode can be fixed (so as to not change with long press) using `lv_colorwheel_set_mode_fixed(colorwheel, true)`
 
 ## Events
 - `LV_EVENT_VALUE_CHANGED` Sent if a new color is selected.


### PR DESCRIPTION
### Description of the feature or fix

The current (8.x) documentation API colorwheel reference incorrectly references 'lv_colorwheel_colour_set_mode...' - this commit updates it to 'lv_colorwheel_set_mode...'

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [x] Update the documentation
