### PR TITLE
feat(lv_spinbox): support both right-to-left and left-to-right digit steps when clicking encoder button

### DIFF
--- a/docs/widgets/extra/spinbox.md
+++ b/docs/widgets/extra/spinbox.md
@@ -22,6 +22,8 @@ The parts of the Spinbox are identical to the [Text area](/widgets/core/textarea
 
 `lv_spinbox_set_pos(spinbox, 1)` sets the cursor to a specific digit to change on increment/decrement. For example position '0' sets the cursor to the least significant digit.
 
+If an encoder is used as input device, the selected digit is shifted to the right by default whenever the encoder button is clicked. To change this behaviour to shifting to the left, the `lv_spinbox_set_digit_step_direction(spinbox, LV_DIR_LEFT)` can be used
+
 ### Format
 
 `lv_spinbox_set_digit_format(spinbox, digit_count, separator_position)` sets the number format. `digit_count` is the number of digits excluding the decimal separator and the sign.

--- a/src/extra/widgets/spinbox/lv_spinbox.c
+++ b/src/extra/widgets/spinbox/lv_spinbox.c
@@ -169,6 +169,15 @@ void lv_spinbox_set_pos(lv_obj_t * obj, uint8_t pos)
 
     lv_spinbox_updatevalue(obj);
 }
+
+void lv_spinbox_set_digit_step_direction(lv_obj_t *obj, uint8_t direction)
+{
+    LV_ASSERT_OBJ(obj, MYCLASS);
+    lv_spinbox_t * spinbox = (lv_spinbox_t *)obj;
+    spinbox->digit_step_dir = direction;
+
+    lv_spinbox_updatevalue(obj);
+}
 /*=====================
  * Getter functions
  *====================*/
@@ -363,7 +372,7 @@ static void lv_spinbox_event(const lv_obj_class_t * class_p, lv_event_t * e)
                         }
                         else {
                             /*Restart from the MSB*/
-                            spinbox->step = Power10(spinbox->digit_count - 2)
+                            spinbox->step = Power10(spinbox->digit_count - 2);
                             lv_spinbox_step_prev(obj);
                         }
                     }

--- a/src/extra/widgets/spinbox/lv_spinbox.c
+++ b/src/extra/widgets/spinbox/lv_spinbox.c
@@ -332,7 +332,7 @@ static void lv_spinbox_constructor(const lv_obj_class_t * class_p, lv_obj_t * ob
     spinbox->range_max          = 99999;
     spinbox->range_min          = -99999;
     spinbox->rollover           = false;
-    spinbox->digit_step_dir     = LV_SPINBOX_DIGIT_DIR_TO_RIGHT;
+    spinbox->digit_step_dir     = LV_DIR_RIGHT;
 
     lv_textarea_set_one_line(obj, true);
     lv_textarea_set_cursor_click_pos(obj, true);

--- a/src/extra/widgets/spinbox/lv_spinbox.c
+++ b/src/extra/widgets/spinbox/lv_spinbox.c
@@ -173,9 +173,9 @@ void lv_spinbox_set_pos(lv_obj_t * obj, uint8_t pos)
 /**
  * Set direction of digit step when clicking an encoder button while in editing mode
  * @param spinbox pointer to spinbox
- * @param direction the direction (LV_SPINBOX_DIGIT_DIR_TO_RIGHT or LV_SPINBOX_DIGIT_DIR_TO_LEFT)
+ * @param direction the direction (LV_DIR_RIGHT or LV_DIR_LEFT)
  */
-void lv_spinbox_set_digit_step_direction(lv_obj_t *obj, uint8_t direction)
+void lv_spinbox_set_digit_step_direction(lv_obj_t *obj, lv_dir_t direction)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_spinbox_t * spinbox = (lv_spinbox_t *)obj;
@@ -361,7 +361,7 @@ static void lv_spinbox_event(const lv_obj_class_t * class_p, lv_event_t * e)
         if(lv_indev_get_type(indev) == LV_INDEV_TYPE_ENCODER) {
             if(lv_group_get_editing(lv_obj_get_group(obj))) {
                 if (spinbox->digit_count > 1) {
-                    if (spinbox->digit_step_dir == LV_SPINBOX_DIGIT_DIR_TO_RIGHT) {
+                    if (spinbox->digit_step_dir == LV_DIR_RIGHT) {
                         if(spinbox->step > 1) {
                            lv_spinbox_step_next(obj);
                         }

--- a/src/extra/widgets/spinbox/lv_spinbox.c
+++ b/src/extra/widgets/spinbox/lv_spinbox.c
@@ -177,7 +177,7 @@ void lv_spinbox_set_pos(lv_obj_t * obj, uint8_t pos)
  */
 void lv_spinbox_set_digit_step_direction(lv_obj_t *obj, uint8_t direction)
 {
-    LV_ASSERT_OBJ(obj, MYCLASS);
+    LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_spinbox_t * spinbox = (lv_spinbox_t *)obj;
     spinbox->digit_step_dir = direction;
 
@@ -345,16 +345,6 @@ static void lv_spinbox_constructor(const lv_obj_class_t * class_p, lv_obj_t * ob
 
 static void lv_spinbox_event(const lv_obj_class_t * class_p, lv_event_t * e)
 {
-	uint32_t Power10(uint8_t exp)
-	{
-		uint32_t res = 1;
-		for (uint8_t t = 0; t < exp; t++)
-		{
-			res = res * 10;
-		}
-		return res;
-	}
-	
     LV_UNUSED(class_p);
 
     /*Call the ancestor's event handler*/
@@ -377,12 +367,12 @@ static void lv_spinbox_event(const lv_obj_class_t * class_p, lv_event_t * e)
                         }
                         else {
                             /*Restart from the MSB*/
-                            spinbox->step = Power10(spinbox->digit_count - 2);
+                            spinbox->step = lv_pow(10, spinbox->digit_count - 2);
                             lv_spinbox_step_prev(obj);
                         }
                     }
                     else {
-                        if(spinbox->step < Power10(spinbox->digit_count - 1)) {
+                        if(spinbox->step < lv_pow(10, spinbox->digit_count - 1)) {
                             lv_spinbox_step_prev(obj);
                         }
                         else {

--- a/src/extra/widgets/spinbox/lv_spinbox.c
+++ b/src/extra/widgets/spinbox/lv_spinbox.c
@@ -170,6 +170,11 @@ void lv_spinbox_set_pos(lv_obj_t * obj, uint8_t pos)
     lv_spinbox_updatevalue(obj);
 }
 
+/**
+ * Set direction of digit step when clicking an encoder button while in editing mode
+ * @param spinbox pointer to spinbox
+ * @param direction the direction (LV_SPINBOX_DIGIT_DIR_TO_RIGHT or LV_SPINBOX_DIGIT_DIR_TO_LEFT)
+ */
 void lv_spinbox_set_digit_step_direction(lv_obj_t *obj, uint8_t direction)
 {
     LV_ASSERT_OBJ(obj, MYCLASS);

--- a/src/extra/widgets/spinbox/lv_spinbox.h
+++ b/src/extra/widgets/spinbox/lv_spinbox.h
@@ -27,9 +27,6 @@ extern "C" {
  *********************/
 #define LV_SPINBOX_MAX_DIGIT_COUNT 10
 
-#define LV_SPINBOX_DIGIT_DIR_TO_RIGHT 0
-#define LV_SPINBOX_DIGIT_DIR_TO_LEFT 1
-
 /**********************
  *      TYPEDEFS
  **********************/
@@ -45,7 +42,7 @@ typedef struct {
     uint16_t digit_count : 4;
     uint16_t dec_point_pos : 4; /*if 0, there is no separator and the number is an integer*/
     uint16_t rollover : 1;   // Set to true for rollover functionality
-    uint16_t digit_step_dir : 1; // the direction the digit will step on encoder button press when editing
+    uint16_t digit_step_dir : 2; // the direction the digit will step on encoder button press when editing
 } lv_spinbox_t;
 
 extern const lv_obj_class_t lv_spinbox_class;
@@ -113,9 +110,9 @@ void lv_spinbox_set_pos(lv_obj_t * obj, uint8_t pos);
 /**
  * Set direction of digit step when clicking an encoder button while in editing mode
  * @param spinbox pointer to spinbox
- * @param direction the direction (LV_SPINBOX_DIGIT_DIR_TO_RIGHT or LV_SPINBOX_DIGIT_DIR_TO_LEFT)
+ * @param direction the direction (LV_DIR_RIGHT or LV_DIR_LEFT)
  */
-void lv_spinbox_set_digit_step_direction(lv_obj_t * obj, uint8_t direction);
+void lv_spinbox_set_digit_step_direction(lv_obj_t * obj, lv_dir_t direction);
 
  /*=====================
  * Getter functions

--- a/src/extra/widgets/spinbox/lv_spinbox.h
+++ b/src/extra/widgets/spinbox/lv_spinbox.h
@@ -114,7 +114,7 @@ void lv_spinbox_set_pos(lv_obj_t * obj, uint8_t pos);
  */
 void lv_spinbox_set_digit_step_direction(lv_obj_t * obj, lv_dir_t direction);
 
- /*=====================
+/*=====================
  * Getter functions
  *====================*/
 

--- a/src/extra/widgets/spinbox/lv_spinbox.h
+++ b/src/extra/widgets/spinbox/lv_spinbox.h
@@ -113,15 +113,15 @@ void lv_spinbox_set_pos(lv_obj_t * obj, uint8_t pos);
 /**
  * Set direction of digit step when clicking an encoder button while in editing mode
  * @param spinbox pointer to spinbox
- * @param direction the direction
+ * @param direction the direction (LV_SPINBOX_DIGIT_DIR_TO_RIGHT or LV_SPINBOX_DIGIT_DIR_TO_LEFT)
  */
 void lv_spinbox_set_digit_step_direction(lv_obj_t * obj, uint8_t direction);
 
-    /*=====================
+ /*=====================
  * Getter functions
  *====================*/
 
-    /**
+ /**
  * Get spinbox rollover function status
  * @param spinbox pointer to spinbox
  */

--- a/src/extra/widgets/spinbox/lv_spinbox.h
+++ b/src/extra/widgets/spinbox/lv_spinbox.h
@@ -125,8 +125,8 @@ void lv_spinbox_set_digit_step_direction(lv_obj_t * obj, uint8_t direction);
  * Get spinbox rollover function status
  * @param spinbox pointer to spinbox
  */
-    bool
-    lv_spinbox_get_rollover(lv_obj_t *obj);
+bool
+lv_spinbox_get_rollover(lv_obj_t *obj);
 
 /**
  * Get the spinbox numeral value (user has to convert to float according to its digit format)

--- a/src/extra/widgets/spinbox/lv_spinbox.h
+++ b/src/extra/widgets/spinbox/lv_spinbox.h
@@ -122,8 +122,7 @@ void lv_spinbox_set_digit_step_direction(lv_obj_t * obj, lv_dir_t direction);
  * Get spinbox rollover function status
  * @param spinbox pointer to spinbox
  */
-bool
-lv_spinbox_get_rollover(lv_obj_t *obj);
+bool lv_spinbox_get_rollover(lv_obj_t *obj);
 
 /**
  * Get the spinbox numeral value (user has to convert to float according to its digit format)

--- a/src/extra/widgets/spinbox/lv_spinbox.h
+++ b/src/extra/widgets/spinbox/lv_spinbox.h
@@ -27,6 +27,9 @@ extern "C" {
  *********************/
 #define LV_SPINBOX_MAX_DIGIT_COUNT 10
 
+#define LV_SPINBOX_DIGIT_DIR_TO_RIGHT 0
+#define LV_SPINBOX_DIGIT_DIR_TO_LEFT 1
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -42,6 +45,7 @@ typedef struct {
     uint16_t digit_count : 4;
     uint16_t dec_point_pos : 4; /*if 0, there is no separator and the number is an integer*/
     uint16_t rollover : 1;   // Set to true for rollover functionality
+    uint16_t digit_step_dir : 1; // the direction the digit will step on encoder button press when editing
 } lv_spinbox_t;
 
 extern const lv_obj_class_t lv_spinbox_class;
@@ -105,15 +109,24 @@ void lv_spinbox_set_range(lv_obj_t * obj, int32_t range_min, int32_t range_max);
  * @param pos selected position in spinbox
  */
 void lv_spinbox_set_pos(lv_obj_t * obj, uint8_t pos);
-/*=====================
+
+/**
+ * Set direction of digit step when clicking an encoder button while in editing mode
+ * @param spinbox pointer to spinbox
+ * @param direction the direction
+ */
+void lv_spinbox_set_digit_step_direction(lv_obj_t * obj, uint8_t direction);
+
+    /*=====================
  * Getter functions
  *====================*/
 
-/**
+    /**
  * Get spinbox rollover function status
  * @param spinbox pointer to spinbox
  */
-bool lv_spinbox_get_rollover(lv_obj_t * obj);
+    bool
+    lv_spinbox_get_rollover(lv_obj_t *obj);
 
 /**
  * Get the spinbox numeral value (user has to convert to float according to its digit format)

--- a/src/extra/widgets/spinbox/lv_spinbox.h
+++ b/src/extra/widgets/spinbox/lv_spinbox.h
@@ -118,7 +118,7 @@ void lv_spinbox_set_digit_step_direction(lv_obj_t * obj, lv_dir_t direction);
  * Getter functions
  *====================*/
 
- /**
+/**
  * Get spinbox rollover function status
  * @param spinbox pointer to spinbox
  */


### PR DESCRIPTION
### Description of the feature or fix

Adding Spinbox support for moving the digitposition both from left-to-right and right-to-left when editing a spinbox and clicking the encoder button. The current behaviour is clicking the encoder button only moves the digitposition from right to left (from MSB to LSB)

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
