### PR TITLE
Update lv_spinbox.h

### DIFF
--- a/src/extra/widgets/spinbox/lv_spinbox.h
+++ b/src/extra/widgets/spinbox/lv_spinbox.h
@@ -27,6 +27,9 @@ extern "C" {
  *********************/
 #define LV_SPINBOX_MAX_DIGIT_COUNT 10
 
+#define LV_SPINBOX_DIGIT_DIR_TO_RIGHT 0
+#define LV_SPINBOX_DIGIT_DIR_TO_LEFT 1
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -42,6 +45,7 @@ typedef struct {
     uint16_t digit_count : 4;
     uint16_t dec_point_pos : 4; /*if 0, there is no separator and the number is an integer*/
     uint16_t rollover : 1;   // Set to true for rollover functionality
+    uint8_t digit_step_dir : LV_SPINBOX_DIGIT_DIR_TO_RIGHT; // the direction the digit will step on encoder button press when editing
 } lv_spinbox_t;
 
 extern const lv_obj_class_t lv_spinbox_class;


### PR DESCRIPTION
* Added support for moving the Spinbox digit position from right-to-left when clicking the button on an encoder. The default behaviour is when clicking the encoder button, the digit is moved from left-to-right (MSB to LSB). 
* See also the spinbox.c file

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
