### PR TITLE
Reduce the stack usage in log function

### DIFF
--- a/src/misc/lv_log.c
+++ b/src/misc/lv_log.c
@@ -72,9 +72,6 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line, const char *
     if(level >= LV_LOG_LEVEL) {
         va_list args;
         va_start(args, format);
-        char msg[256];
-        lv_vsnprintf(msg, sizeof(msg), format, args);
-        va_end(args);
 
         /*Use only the file name not the path*/
         size_t p;
@@ -85,13 +82,27 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line, const char *
             }
         }
 
-        char buf[512];
         uint32_t t = lv_tick_get();
         static const char * lvl_prefix[] = {"Trace", "Info", "Warn", "Error", "User"};
-        lv_snprintf(buf, sizeof(buf), "[%s]\t(%" LV_PRId32 ".%03" LV_PRId32 ", +%" LV_PRId32 ")\t %s: %s \t(in %s line #%d)\n",
-                    lvl_prefix[level], t / 1000, t % 1000, t - last_log_time, func, msg, &file[p], line);
+
+#if LV_LOG_PRINTF
+        printf("[%s]\t(%" LV_PRId32 ".%03" LV_PRId32 ", +%" LV_PRId32 ")\t %s: ",
+               lvl_prefix[level], t / 1000, t % 1000, t - last_log_time, func);
+        vprintf(format, args);
+        printf(" \t(in %s line #%d)\n", &file[p], line);
+#else
+        if (custom_print_cb) {
+            char buf[512];
+            char msg[256];
+            lv_vsnprintf(msg, sizeof(msg), format, args);
+            lv_snprintf(buf, sizeof(buf), "[%s]\t(%" LV_PRId32 ".%03" LV_PRId32 ", +%" LV_PRId32 ")\t %s: %s \t(in %s line #%d)\n",
+                        lvl_prefix[level], t / 1000, t % 1000, t - last_log_time, func, msg, &file[p], line);
+            custom_print_cb(buf);
+        }
+#endif
+
         last_log_time = t;
-        lv_log(buf);
+        va_end(args);
     }
 }
 

--- a/src/misc/lv_log.c
+++ b/src/misc/lv_log.c
@@ -93,10 +93,16 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line, const char *
 #else
         if (custom_print_cb) {
             char buf[512];
+#if LV_SPRINTF_CUSTOM
             char msg[256];
             lv_vsnprintf(msg, sizeof(msg), format, args);
             lv_snprintf(buf, sizeof(buf), "[%s]\t(%" LV_PRId32 ".%03" LV_PRId32 ", +%" LV_PRId32 ")\t %s: %s \t(in %s line #%d)\n",
                         lvl_prefix[level], t / 1000, t % 1000, t - last_log_time, func, msg, &file[p], line);
+#else
+            lv_vaformat_t vaf = {format, &args};
+            lv_snprintf(buf, sizeof(buf), "[%s]\t(%" LV_PRId32 ".%03" LV_PRId32 ", +%" LV_PRId32 ")\t %s: %pV \t(in %s line #%d)\n",
+                        lvl_prefix[level], t / 1000, t % 1000, t - last_log_time, func, &vaf, &file[p], line);
+#endif
             custom_print_cb(buf);
         }
 #endif

--- a/src/misc/lv_log.c
+++ b/src/misc/lv_log.c
@@ -99,9 +99,9 @@ void lv_log(const char * buf)
 {
 #if LV_LOG_PRINTF
     puts(buf);
-#endif
+#else
     if(custom_print_cb) custom_print_cb(buf);
-
+#endif
 }
 
 /**********************

--- a/src/misc/lv_log.c
+++ b/src/misc/lv_log.c
@@ -98,7 +98,7 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line, const char *
 void lv_log(const char * buf)
 {
 #if LV_LOG_PRINTF
-    fwrite(buf, 1, strlen(buf), stdout);
+    puts(buf);
 #endif
     if(custom_print_cb) custom_print_cb(buf);
 

--- a/src/misc/lv_printf.c
+++ b/src/misc/lv_printf.c
@@ -699,6 +699,9 @@ static int _vsnprintf(out_fct_type out, char * buffer, const size_t maxlen, cons
                         else
 #endif
                             flags |= FLAGS_LONG;
+
+                        if(*(format + 1) == 'V')
+                            format++;
                     }
                     else if(*format == 'o') {
                         base =  8U;
@@ -746,6 +749,14 @@ static int _vsnprintf(out_fct_type out, char * buffer, const size_t maxlen, cons
                             idx = _ntoa_long(out, buffer, idx, maxlen, (unsigned int)(value > 0 ? value : 0 - value), value < 0, base, precision,
                                              width, flags);
                         }
+                    }
+                    else if (*format == 'V') {
+                        lv_vaformat_t * vaf = va_arg(va, lv_vaformat_t *);
+                        va_list copy;
+
+                        va_copy(copy, *vaf->va);
+                        idx += _vsnprintf(out, buffer + idx, maxlen - idx, vaf->fmt, copy);
+                        va_end(copy);
                     }
                     else {
                         // unsigned

--- a/src/misc/lv_printf.h
+++ b/src/misc/lv_printf.h
@@ -54,6 +54,11 @@ extern "C" {
 #include <stdarg.h>
 #include <stddef.h>
 
+typedef struct {
+  const char * fmt;
+  va_list * va;
+} lv_vaformat_t;
+
 /**
  * Tiny snprintf/vsnprintf implementation
  * \param buffer A pointer to the buffer where to store the formatted string


### PR DESCRIPTION
### Description of the feature or fix

- feat(printf): support %pV format specifier
- fix(log): remove 768B temp buffer if LV_LOG_PRINTF == 1
- fix(log): save 256B temp buffer if LV_LOG_PRINTF == 0

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
