### PR TITLE
fix(conf): make a better style alignment in lv_conf_internal.h

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2,20 +2,15 @@
 
 menu "LVGL configuration"
 
-    config LV_ATTRIBUTE_FAST_MEM_USE_IRAM
-        bool "Set IRAM as LV_ATTRIBUTE_FAST_MEM"
-        help
-            Set this option to configure IRAM as LV_ATTRIBUTE_FAST_MEM
-
-    config LV_CONF_MINIMAL
-        bool "LVGL minimal configuration."
-
     # Define CONFIG_LV_CONF_SKIP so we can use LVGL
     # without lv_conf.h file, the lv_conf_internal.h and
     # lv_conf_kconfig.h files are used instead.
     config LV_CONF_SKIP
         bool
         default y
+
+    config LV_CONF_MINIMAL
+        bool "LVGL minimal configuration."
 
     menu "Color settings"
         choice
@@ -97,12 +92,10 @@ menu "LVGL configuration"
             default 30
 
         config LV_TICK_CUSTOM
-            bool
-            prompt "Use a custom tick source"
+            bool "Use a custom tick source"
 
         config LV_TICK_CUSTOM_INCLUDE
-            string
-            prompt "Header for the system time function"
+            string "Header for the system time function"
             default "Arduino.h"
             depends on LV_TICK_CUSTOM
 
@@ -318,6 +311,11 @@ menu "LVGL configuration"
         menu "Compiler settings"
             config LV_BIG_ENDIAN_SYSTEM
                 bool "For big endian systems set to 1"
+
+            config LV_ATTRIBUTE_FAST_MEM_USE_IRAM
+                bool "Set IRAM as LV_ATTRIBUTE_FAST_MEM"
+                help
+                    Set this option to configure IRAM as LV_ATTRIBUTE_FAST_MEM
 
             config LV_USE_LARGE_COORD
                 bool "Extend the default -32k..32k coordinate range to -4M..4M by using int32_t for coordinates instead of int16_t"

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -24,68 +24,68 @@
  *====================*/
 
 /*Color depth: 1 (1 byte per pixel), 8 (RGB332), 16 (RGB565), 32 (ARGB8888)*/
-#define LV_COLOR_DEPTH     16
+#define LV_COLOR_DEPTH 16
 
 /*Swap the 2 bytes of RGB565 color. Useful if the display has an 8-bit interface (e.g. SPI)*/
-#define LV_COLOR_16_SWAP   0
+#define LV_COLOR_16_SWAP 0
 
 /*Enable more complex drawing routines to manage screens transparency.
  *Can be used if the UI is above another layer, e.g. an OSD menu or video player.
  *Requires `LV_COLOR_DEPTH = 32` colors and the screen's `bg_opa` should be set to non LV_OPA_COVER value*/
-#define LV_COLOR_SCREEN_TRANSP    0
+#define LV_COLOR_SCREEN_TRANSP 0
 
 /*Images pixels with this color will not be drawn if they are chroma keyed)*/
-#define LV_COLOR_CHROMA_KEY    lv_color_hex(0x00ff00)         /*pure green*/
+#define LV_COLOR_CHROMA_KEY lv_color_hex(0x00ff00)         /*pure green*/
 
 /*=========================
    MEMORY SETTINGS
  *=========================*/
 
 /*1: use custom malloc/free, 0: use the built-in `lv_mem_alloc()` and `lv_mem_free()`*/
-#define LV_MEM_CUSTOM      0
+#define LV_MEM_CUSTOM 0
 #if LV_MEM_CUSTOM == 0
 /*Size of the memory available for `lv_mem_alloc()` in bytes (>= 2kB)*/
-#  define LV_MEM_SIZE    (32U * 1024U)          /*[bytes]*/
+#  define LV_MEM_SIZE (32U * 1024U)          /*[bytes]*/
 
 /*Set an address for the memory pool instead of allocating it as a normal array. Can be in external SRAM too.*/
-#  define LV_MEM_ADR          0     /*0: unused*/
+#  define LV_MEM_ADR 0     /*0: unused*/
 /*Instead of an address give a memory allocator that will be called to get a memory pool for LVGL. E.g. my_malloc*/
 #if LV_MEM_ADR == 0
-//#define LV_MEM_POOL_INCLUDE   your_alloc_library  /* Uncomment if using an external allocator*/
-//#define LV_MEM_POOL_ALLOC     your_alloc          /* Uncomment if using an external allocator*/
+//#define LV_MEM_POOL_INCLUDE your_alloc_library  /* Uncomment if using an external allocator*/
+//#define LV_MEM_POOL_ALLOC   your_alloc          /* Uncomment if using an external allocator*/
 #endif
 
 #else       /*LV_MEM_CUSTOM*/
 #  define LV_MEM_CUSTOM_INCLUDE <stdlib.h>   /*Header for the dynamic memory function*/
-#  define LV_MEM_CUSTOM_ALLOC     malloc
-#  define LV_MEM_CUSTOM_FREE      free
-#  define LV_MEM_CUSTOM_REALLOC   realloc
+#  define LV_MEM_CUSTOM_ALLOC   malloc
+#  define LV_MEM_CUSTOM_FREE    free
+#  define LV_MEM_CUSTOM_REALLOC realloc
 #endif     /*LV_MEM_CUSTOM*/
 
 /*Use the standard `memcpy` and `memset` instead of LVGL's own functions. (Might or might not be faster).*/
-#define LV_MEMCPY_MEMSET_STD    0
+#define LV_MEMCPY_MEMSET_STD 0
 
 /*====================
    HAL SETTINGS
  *====================*/
 
 /*Default display refresh period. LVG will redraw changed areas with this period time*/
-#define LV_DISP_DEF_REFR_PERIOD     30      /*[ms]*/
+#define LV_DISP_DEF_REFR_PERIOD 30      /*[ms]*/
 
 /*Input device read period in milliseconds*/
-#define LV_INDEV_DEF_READ_PERIOD    30      /*[ms]*/
+#define LV_INDEV_DEF_READ_PERIOD 30     /*[ms]*/
 
 /*Use a custom tick source that tells the elapsed time in milliseconds.
  *It removes the need to manually update the tick with `lv_tick_inc()`)*/
-#define LV_TICK_CUSTOM     0
+#define LV_TICK_CUSTOM 0
 #if LV_TICK_CUSTOM
-#define LV_TICK_CUSTOM_INCLUDE  "Arduino.h"         /*Header for the system time function*/
-#define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())     /*Expression evaluating to current system time in ms*/
+#define LV_TICK_CUSTOM_INCLUDE "Arduino.h"         /*Header for the system time function*/
+#define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())    /*Expression evaluating to current system time in ms*/
 #endif   /*LV_TICK_CUSTOM*/
 
 /*Default Dot Per Inch. Used to initialize default sizes such as widgets sized, style paddings.
  *(Not so important, you can adjust it to modify default sizes and spaces)*/
-#define LV_DPI_DEF                  130     /*[px/inch]*/
+#define LV_DPI_DEF 130     /*[px/inch]*/
 
 /*=======================
  * FEATURE CONFIGURATION
@@ -103,13 +103,13 @@
 /*Allow buffering some shadow calculation.
  *LV_SHADOW_CACHE_SIZE is the max. shadow size to buffer, where shadow size is `shadow_width + radius`
  *Caching has LV_SHADOW_CACHE_SIZE^2 RAM cost*/
-#define LV_SHADOW_CACHE_SIZE    0
+#define LV_SHADOW_CACHE_SIZE 0
 
 /* Set number of maximally cached circle data.
  * The circumference of 1/4 circle are saved for anti-aliasing
  * radius * 4 bytes are used per circle (the most often used radiuses are saved)
  * 0: to disable caching */
-#define LV_CIRCLE_CACHE_SIZE    4
+#define LV_CIRCLE_CACHE_SIZE 4
 
 #endif /*LV_DRAW_COMPLEX*/
 
@@ -118,17 +118,17 @@
  *With complex image decoders (e.g. PNG or JPG) caching can save the continuous open/decode of images.
  *However the opened images might consume additional RAM.
  *0: to disable caching*/
-#define LV_IMG_CACHE_DEF_SIZE       0
+#define LV_IMG_CACHE_DEF_SIZE 0
 
 /*Maximum buffer size to allocate for rotation. Only used if software rotation is enabled in the display driver.*/
-#define LV_DISP_ROT_MAX_BUF         (10*1024)
+#define LV_DISP_ROT_MAX_BUF (10*1024)
 
 /*-------------
  * GPU
  *-----------*/
 
 /*Use STM32's DMA2D (aka Chrom Art) GPU*/
-#define LV_USE_GPU_STM32_DMA2D  0
+#define LV_USE_GPU_STM32_DMA2D 0
 #if LV_USE_GPU_STM32_DMA2D
 /*Must be defined to include path of CMSIS header of target processor
 e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
@@ -136,7 +136,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #endif
 
 /*Use NXP's PXP GPU iMX RTxxx platforms*/
-#define LV_USE_GPU_NXP_PXP      0
+#define LV_USE_GPU_NXP_PXP 0
 #if LV_USE_GPU_NXP_PXP
 /*1: Add default bare metal and FreeRTOS interrupt handling routines for PXP (lv_gpu_nxp_pxp_osa.c)
  *   and call lv_gpu_nxp_pxp_init() automatically during lv_init(). Note that symbol SDK_OS_FREE_RTOS
@@ -147,14 +147,14 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #endif
 
 /*Use NXP's VG-Lite GPU iMX RTxxx platforms*/
-#define LV_USE_GPU_NXP_VG_LITE   0
+#define LV_USE_GPU_NXP_VG_LITE 0
 
 /*Use SDL renderer API*/
 #ifndef LV_USE_GPU_SDL
 #  ifdef CONFIG_LV_USE_GPU_SDL
 #    define LV_USE_GPU_SDL CONFIG_LV_USE_GPU_SDL
 #  else
-#    define  LV_USE_GPU_SDL   0
+#    define  LV_USE_GPU_SDL 0
 #  endif
 #endif
 #if LV_USE_GPU_SDL
@@ -173,7 +173,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
  *-----------*/
 
 /*Enable the log module*/
-#define LV_USE_LOG      0
+#define LV_USE_LOG 0
 #if LV_USE_LOG
 
 /*How important log should be added:
@@ -183,21 +183,21 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
  *LV_LOG_LEVEL_ERROR       Only critical issue, when the system may fail
  *LV_LOG_LEVEL_USER        Only logs added by the user
  *LV_LOG_LEVEL_NONE        Do not log anything*/
-#  define LV_LOG_LEVEL    LV_LOG_LEVEL_WARN
+#  define LV_LOG_LEVEL LV_LOG_LEVEL_WARN
 
 /*1: Print the log with 'printf';
  *0: User need to register a callback with `lv_log_register_print_cb()`*/
-#  define LV_LOG_PRINTF   0
+#  define LV_LOG_PRINTF 0
 
 /*Enable/disable LV_LOG_TRACE in modules that produces a huge number of logs*/
-#  define LV_LOG_TRACE_MEM            1
-#  define LV_LOG_TRACE_TIMER          1
-#  define LV_LOG_TRACE_INDEV          1
-#  define LV_LOG_TRACE_DISP_REFR      1
-#  define LV_LOG_TRACE_EVENT          1
-#  define LV_LOG_TRACE_OBJ_CREATE     1
-#  define LV_LOG_TRACE_LAYOUT         1
-#  define LV_LOG_TRACE_ANIM           1
+#  define LV_LOG_TRACE_MEM        1
+#  define LV_LOG_TRACE_TIMER      1
+#  define LV_LOG_TRACE_INDEV      1
+#  define LV_LOG_TRACE_DISP_REFR  1
+#  define LV_LOG_TRACE_EVENT      1
+#  define LV_LOG_TRACE_OBJ_CREATE 1
+#  define LV_LOG_TRACE_LAYOUT     1
+#  define LV_LOG_TRACE_ANIM       1
 
 #endif  /*LV_USE_LOG*/
 
@@ -214,34 +214,34 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #define LV_USE_ASSERT_OBJ           0   /*Check the object's type and existence (e.g. not deleted). (Slow)*/
 
 /*Add a custom handler when assert happens e.g. to restart the MCU*/
-#define LV_ASSERT_HANDLER_INCLUDE   <stdint.h>
-#define LV_ASSERT_HANDLER   while(1);   /*Halt by default*/
+#define LV_ASSERT_HANDLER_INCLUDE <stdint.h>
+#define LV_ASSERT_HANDLER while(1);   /*Halt by default*/
 
 /*-------------
  * Others
  *-----------*/
 
 /*1: Show CPU usage and FPS count in the right bottom corner*/
-#define LV_USE_PERF_MONITOR     0
+#define LV_USE_PERF_MONITOR 0
 
 /*1: Show the used memory and the memory fragmentation in the left bottom corner
  * Requires LV_MEM_CUSTOM = 0*/
-#define LV_USE_MEM_MONITOR      0
+#define LV_USE_MEM_MONITOR 0
 
 /*1: Draw random colored rectangles over the redrawn areas*/
-#define LV_USE_REFR_DEBUG       0
+#define LV_USE_REFR_DEBUG 0
 
 /*Change the built in (v)snprintf functions*/
-#define LV_SPRINTF_CUSTOM   0
+#define LV_SPRINTF_CUSTOM 0
 #if LV_SPRINTF_CUSTOM
 #  define LV_SPRINTF_INCLUDE <stdio.h>
-#  define lv_snprintf     snprintf
-#  define lv_vsnprintf    vsnprintf
+#  define lv_snprintf  snprintf
+#  define lv_vsnprintf vsnprintf
 #else   /*LV_SPRINTF_CUSTOM*/
 #  define LV_SPRINTF_USE_FLOAT 0
 #endif  /*LV_SPRINTF_CUSTOM*/
 
-#define LV_USE_USER_DATA      1
+#define LV_USE_USER_DATA 1
 
 /*Garbage Collector settings
  *Used if lvgl is bound to higher level language and the memory is managed by that language*/
@@ -251,14 +251,14 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #endif /*LV_ENABLE_GC*/
 
 /*1: Enable API to take snapshot for object*/
-#define LV_USE_SNAPSHOT         1
+#define LV_USE_SNAPSHOT 1
 
 /*=====================
  *  COMPILER SETTINGS
  *====================*/
 
 /*For big endian systems set to 1*/
-#define LV_BIG_ENDIAN_SYSTEM    0
+#define LV_BIG_ENDIAN_SYSTEM 0
 
 /*Define a custom attribute to `lv_tick_inc` function*/
 #define LV_ATTRIBUTE_TICK_INC
@@ -293,7 +293,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #define LV_EXPORT_CONST_INT(int_value) struct _silence_gcc_warning /*The default value just prevents GCC warning*/
 
 /*Extend the default -32k..32k coordinate range to -4M..4M by using int32_t for coordinates instead of int16_t*/
-#define LV_USE_LARGE_COORD  0
+#define LV_USE_LARGE_COORD 0
 
 /*==================
  *   FONT USAGE
@@ -301,27 +301,27 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 
 /*Montserrat fonts with ASCII range and some symbols using bpp = 4
  *https://fonts.google.com/specimen/Montserrat*/
-#define LV_FONT_MONTSERRAT_8     0
-#define LV_FONT_MONTSERRAT_10    0
-#define LV_FONT_MONTSERRAT_12    0
-#define LV_FONT_MONTSERRAT_14    1
-#define LV_FONT_MONTSERRAT_16    0
-#define LV_FONT_MONTSERRAT_18    0
-#define LV_FONT_MONTSERRAT_20    0
-#define LV_FONT_MONTSERRAT_22    0
-#define LV_FONT_MONTSERRAT_24    0
-#define LV_FONT_MONTSERRAT_26    0
-#define LV_FONT_MONTSERRAT_28    0
-#define LV_FONT_MONTSERRAT_30    0
-#define LV_FONT_MONTSERRAT_32    0
-#define LV_FONT_MONTSERRAT_34    0
-#define LV_FONT_MONTSERRAT_36    0
-#define LV_FONT_MONTSERRAT_38    0
-#define LV_FONT_MONTSERRAT_40    0
-#define LV_FONT_MONTSERRAT_42    0
-#define LV_FONT_MONTSERRAT_44    0
-#define LV_FONT_MONTSERRAT_46    0
-#define LV_FONT_MONTSERRAT_48    0
+#define LV_FONT_MONTSERRAT_8  0
+#define LV_FONT_MONTSERRAT_10 0
+#define LV_FONT_MONTSERRAT_12 0
+#define LV_FONT_MONTSERRAT_14 1
+#define LV_FONT_MONTSERRAT_16 0
+#define LV_FONT_MONTSERRAT_18 0
+#define LV_FONT_MONTSERRAT_20 0
+#define LV_FONT_MONTSERRAT_22 0
+#define LV_FONT_MONTSERRAT_24 0
+#define LV_FONT_MONTSERRAT_26 0
+#define LV_FONT_MONTSERRAT_28 0
+#define LV_FONT_MONTSERRAT_30 0
+#define LV_FONT_MONTSERRAT_32 0
+#define LV_FONT_MONTSERRAT_34 0
+#define LV_FONT_MONTSERRAT_36 0
+#define LV_FONT_MONTSERRAT_38 0
+#define LV_FONT_MONTSERRAT_40 0
+#define LV_FONT_MONTSERRAT_42 0
+#define LV_FONT_MONTSERRAT_44 0
+#define LV_FONT_MONTSERRAT_46 0
+#define LV_FONT_MONTSERRAT_48 0
 
 /*Demonstrate special features*/
 #define LV_FONT_MONTSERRAT_12_SUBPX      0
@@ -330,8 +330,8 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #define LV_FONT_SIMSUN_16_CJK            0  /*1000 most common CJK radicals*/
 
 /*Pixel perfect monospace fonts*/
-#define LV_FONT_UNSCII_8        0
-#define LV_FONT_UNSCII_16       0
+#define LV_FONT_UNSCII_8  0
+#define LV_FONT_UNSCII_16 0
 
 /*Optionally declare custom fonts here.
  *You can use these fonts as default font too and they will be available globally.
@@ -344,16 +344,16 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 /*Enable handling large font and/or fonts with a lot of characters.
  *The limit depends on the font size, font face and bpp.
  *Compiler error will be triggered if a font needs it.*/
-#define LV_FONT_FMT_TXT_LARGE   0
+#define LV_FONT_FMT_TXT_LARGE 0
 
 /*Enables/disables support for compressed fonts.*/
-#define LV_USE_FONT_COMPRESSED  0
+#define LV_USE_FONT_COMPRESSED 0
 
 /*Enable subpixel rendering*/
-#define LV_USE_FONT_SUBPX       0
+#define LV_USE_FONT_SUBPX 0
 #if LV_USE_FONT_SUBPX
 /*Set the pixel order of the display. Physical order of RGB channels. Doesn't matter with "normal" fonts.*/
-#define LV_FONT_SUBPX_BGR       0  /*0: RGB; 1:BGR order*/
+#define LV_FONT_SUBPX_BGR 0  /*0: RGB; 1:BGR order*/
 #endif
 
 /*=================
@@ -369,15 +369,15 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #define LV_TXT_ENC LV_TXT_ENC_UTF8
 
  /*Can break (wrap) texts on these chars*/
-#define LV_TXT_BREAK_CHARS                  " ,.;:-_"
+#define LV_TXT_BREAK_CHARS " ,.;:-_"
 
 /*If a word is at least this long, will break wherever "prettiest"
  *To disable, set to a value <= 0*/
-#define LV_TXT_LINE_BREAK_LONG_LEN          0
+#define LV_TXT_LINE_BREAK_LONG_LEN 0
 
 /*Minimum number of characters in a long word to put on a line before a break.
  *Depends on LV_TXT_LINE_BREAK_LONG_LEN.*/
-#define LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN  3
+#define LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN 3
 
 /*Minimum number of characters in a long word to put on a line after a break.
  *Depends on LV_TXT_LINE_BREAK_LONG_LEN.*/
@@ -389,13 +389,13 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 /*Support bidirectional texts. Allows mixing Left-to-Right and Right-to-Left texts.
  *The direction will be processed according to the Unicode Bidirectional Algorithm:
  *https://www.w3.org/International/articles/inline-bidi-markup/uba-basics*/
-#define LV_USE_BIDI         0
+#define LV_USE_BIDI 0
 #if LV_USE_BIDI
 /*Set the default direction. Supported values:
  *`LV_BASE_DIR_LTR` Left-to-Right
  *`LV_BASE_DIR_RTL` Right-to-Left
  *`LV_BASE_DIR_AUTO` detect texts base direction*/
-#define LV_BIDI_BASE_DIR_DEF  LV_BASE_DIR_AUTO
+#define LV_BIDI_BASE_DIR_DEF LV_BASE_DIR_AUTO
 #endif
 
 /*Enable Arabic/Persian processing
@@ -408,47 +408,47 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 
 /*Documentation of the widgets: https://docs.lvgl.io/latest/en/html/widgets/index.html*/
 
-#define LV_USE_ARC          1
+#define LV_USE_ARC        1
 
-#define LV_USE_ANIMIMG	    1
+#define LV_USE_ANIMIMG	  1
 
-#define LV_USE_BAR          1
+#define LV_USE_BAR        1
 
-#define LV_USE_BTN          1
+#define LV_USE_BTN        1
 
-#define LV_USE_BTNMATRIX    1
+#define LV_USE_BTNMATRIX  1
 
-#define LV_USE_CANVAS       1
+#define LV_USE_CANVAS     1
 
-#define LV_USE_CHECKBOX     1
+#define LV_USE_CHECKBOX   1
 
-#define LV_USE_DROPDOWN     1   /*Requires: lv_label*/
+#define LV_USE_DROPDOWN   1   /*Requires: lv_label*/
 
-#define LV_USE_IMG          1   /*Requires: lv_label*/
+#define LV_USE_IMG        1   /*Requires: lv_label*/
 
-#define LV_USE_LABEL        1
+#define LV_USE_LABEL      1
 #if LV_USE_LABEL
-#  define LV_LABEL_TEXT_SELECTION         1   /*Enable selecting text of the label*/
-#  define LV_LABEL_LONG_TXT_HINT    1   /*Store some extra info in labels to speed up drawing of very long texts*/
+#  define LV_LABEL_TEXT_SELECTION 1 /*Enable selecting text of the label*/
+#  define LV_LABEL_LONG_TXT_HINT 1  /*Store some extra info in labels to speed up drawing of very long texts*/
 #endif
 
-#define LV_USE_LINE         1
+#define LV_USE_LINE       1
 
-#define LV_USE_ROLLER       1   /*Requires: lv_label*/
+#define LV_USE_ROLLER     1   /*Requires: lv_label*/
 #if LV_USE_ROLLER
-#  define LV_ROLLER_INF_PAGES       7   /*Number of extra "pages" when the roller is infinite*/
+#  define LV_ROLLER_INF_PAGES 7 /*Number of extra "pages" when the roller is infinite*/
 #endif
 
-#define LV_USE_SLIDER       1   /*Requires: lv_bar*/
+#define LV_USE_SLIDER     1   /*Requires: lv_bar*/
 
-#define LV_USE_SWITCH    1
+#define LV_USE_SWITCH     1
 
-#define LV_USE_TEXTAREA   1     /*Requires: lv_label*/
+#define LV_USE_TEXTAREA   1   /*Requires: lv_label*/
 #if LV_USE_TEXTAREA != 0
-#  define LV_TEXTAREA_DEF_PWD_SHOW_TIME     1500    /*ms*/
+#  define LV_TEXTAREA_DEF_PWD_SHOW_TIME 1500    /*ms*/
 #endif
 
-#define LV_USE_TABLE  1
+#define LV_USE_TABLE      1
 
 /*==================
  * EXTRA COMPONENTS
@@ -457,7 +457,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 /*-----------
  * Widgets
  *----------*/
-#define LV_USE_CALENDAR     1
+#define LV_USE_CALENDAR   1
 #if LV_USE_CALENDAR
 # define LV_CALENDAR_WEEK_STARTS_MONDAY 0
 # if LV_CALENDAR_WEEK_STARTS_MONDAY
@@ -467,40 +467,40 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 # endif
 
 # define LV_CALENDAR_DEFAULT_MONTH_NAMES {"January", "February", "March",  "April", "May",  "June", "July", "August", "September", "October", "November", "December"}
-# define LV_USE_CALENDAR_HEADER_ARROW       1
-# define LV_USE_CALENDAR_HEADER_DROPDOWN    1
+# define LV_USE_CALENDAR_HEADER_ARROW 1
+# define LV_USE_CALENDAR_HEADER_DROPDOWN 1
 #endif  /*LV_USE_CALENDAR*/
 
-#define LV_USE_CHART        1
+#define LV_USE_CHART      1
 
-#define LV_USE_COLORWHEEL   1
+#define LV_USE_COLORWHEEL 1
 
-#define LV_USE_IMGBTN       1
+#define LV_USE_IMGBTN     1
 
-#define LV_USE_KEYBOARD     1
+#define LV_USE_KEYBOARD   1
 
-#define LV_USE_LED          1
+#define LV_USE_LED        1
 
-#define LV_USE_LIST         1
+#define LV_USE_LIST       1
 
-#define LV_USE_METER        1
+#define LV_USE_METER      1
 
-#define LV_USE_MSGBOX       1
+#define LV_USE_MSGBOX     1
 
-#define LV_USE_SPINBOX      1
+#define LV_USE_SPINBOX    1
 
-#define LV_USE_SPINNER      1
+#define LV_USE_SPINNER    1
 
-#define LV_USE_TABVIEW      1
+#define LV_USE_TABVIEW    1
 
-#define LV_USE_TILEVIEW     1
+#define LV_USE_TILEVIEW   1
 
-#define LV_USE_WIN          1
+#define LV_USE_WIN        1
 
-#define LV_USE_SPAN         1
+#define LV_USE_SPAN       1
 #if LV_USE_SPAN
 /*A line text can contain maximum num of span descriptor */
-#  define LV_SPAN_SNIPPET_STACK_SIZE   64
+#  define LV_SPAN_SNIPPET_STACK_SIZE 64
 #endif
 
 /*-----------
@@ -508,34 +508,34 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
  *----------*/
 
 /*A simple, impressive and very complete theme*/
-#define LV_USE_THEME_DEFAULT    1
+#define LV_USE_THEME_DEFAULT 1
 #if LV_USE_THEME_DEFAULT
 
 /*0: Light mode; 1: Dark mode*/
-# define LV_THEME_DEFAULT_DARK     0
+# define LV_THEME_DEFAULT_DARK 0
 
 /*1: Enable grow on press*/
-# define LV_THEME_DEFAULT_GROW              1
+# define LV_THEME_DEFAULT_GROW 1
 
 /*Default transition time in [ms]*/
-# define LV_THEME_DEFAULT_TRANSITON_TIME    80
+# define LV_THEME_DEFAULT_TRANSITON_TIME 80
 #endif /*LV_USE_THEME_DEFAULT*/
 
 /*A very simple theme that is a good starting point for a custom theme*/
- #define LV_USE_THEME_BASIC    1
+ #define LV_USE_THEME_BASIC 1
 
 /*A theme designed for monochrome displays*/
-#define LV_USE_THEME_MONO       1
+#define LV_USE_THEME_MONO 1
 
 /*-----------
  * Layouts
  *----------*/
 
 /*A layout similar to Flexbox in CSS.*/
-#define LV_USE_FLEX     1
+#define LV_USE_FLEX 1
 
 /*A layout similar to Grid in CSS.*/
-#define LV_USE_GRID     1
+#define LV_USE_GRID 1
 
 /*---------------------
  * 3rd party libraries
@@ -552,26 +552,26 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #define LV_USE_FS_FATFS '\0'        /*Uses f_open, f_read, etc*/
 
 /*PNG decoder library*/
-#define LV_USE_PNG      0
+#define LV_USE_PNG 0
 
 /*BMP decoder library*/
-#define LV_USE_BMP      0
+#define LV_USE_BMP 0
 
 /* JPG + split JPG decoder library.
  * Split JPG is a custom format optimized for embedded systems. */
-#define LV_USE_SJPG     0
+#define LV_USE_SJPG 0
 
 /*GIF decoder library*/
-#define LV_USE_GIF      0
+#define LV_USE_GIF 0
 
 /*QR code library*/
-#define LV_USE_QRCODE   0
+#define LV_USE_QRCODE 0
 
 /*FreeType library*/
 #define LV_USE_FREETYPE 0
 #if LV_USE_FREETYPE
 /*Memory used by FreeType to cache characters [bytes] (-1: no caching)*/
-# define LV_FREETYPE_CACHE_SIZE  (16 * 1024)
+# define LV_FREETYPE_CACHE_SIZE (16 * 1024)
 #endif
 
 
@@ -580,7 +580,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 *==================*/
 
 /*Enable the examples to be built with the library*/
-#define LV_BUILD_EXAMPLES   1
+#define LV_BUILD_EXAMPLES 1
 
 /*--END OF LV_CONF_H--*/
 

--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -29,24 +29,24 @@ fout.write(
 
 /* Handle special Kconfig options */
 #ifndef LV_KCONFIG_IGNORE
-#   include "lv_conf_kconfig.h"
-#   ifdef CONFIG_LV_CONF_SKIP
-#       define LV_CONF_SKIP
-#   endif
+#  include "lv_conf_kconfig.h"
+#  ifdef CONFIG_LV_CONF_SKIP
+#    define LV_CONF_SKIP
+#  endif
 #endif
 
 /*If "lv_conf.h" is available from here try to use it later.*/
-#if defined __has_include
+#ifdef __has_include
 #  if __has_include("lv_conf.h")
-#   ifndef LV_CONF_INCLUDE_SIMPLE
-#    define LV_CONF_INCLUDE_SIMPLE
-#   endif
+#    ifndef LV_CONF_INCLUDE_SIMPLE
+#      define LV_CONF_INCLUDE_SIMPLE
+#    endif
 #  endif
 #endif
 
 /*If lv_conf.h is not skipped include it*/
-#if !defined(LV_CONF_SKIP)
-#  if defined(LV_CONF_PATH)											/*If there is a path defined for lv_conf.h use it*/
+#ifndef LV_CONF_SKIP
+#  ifdef LV_CONF_PATH                           /*If there is a path defined for lv_conf.h use it*/
 #    define __LV_TO_STR_AUX(x) #x
 #    define __LV_TO_STR(x) __LV_TO_STR_AUX(x)
 #    include __LV_TO_STR(LV_CONF_PATH)
@@ -80,11 +80,11 @@ for i in fin.read().splitlines():
 
   r = re.search(r'^ *# *define ([^\s]+).*$', i)
 
-#ifndef LV_USE_BTN               /*Only if not defined in lv_conf.h*/
+#ifndef LV_USE_BTN            /*Only if not defined in lv_conf.h*/
 #  ifdef CONFIG_LV_USE_BTN    /*Use KConfig value if set*/
-#    define LV_USE_BTN  CONFIG_LV_USE_BTN
+#    define LV_USE_BTN CONFIG_LV_USE_BTN
 #  else
-#    define LV_USE_BTN      1      /*Use default value*/
+#    define LV_USE_BTN 1      /*Use default value*/
 #  endif
 #endif
 
@@ -117,12 +117,10 @@ fout.write(
 LV_EXPORT_CONST_INT(LV_DPI_DEF);
 
 /*If running without lv_conf.h add typdesf with default value*/
-#if defined(LV_CONF_SKIP)
-
-# if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)    /*Disable warnings for Visual Studio*/
-#  define _CRT_SECURE_NO_WARNINGS
-# endif
-
+#ifdef LV_CONF_SKIP
+#  if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)    /*Disable warnings for Visual Studio*/
+#    define _CRT_SECURE_NO_WARNINGS
+#  endif
 #endif  /*defined(LV_CONF_SKIP)*/
 
 #endif  /*LV_CONF_INTERNAL_H*/

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -12,24 +12,24 @@
 
 /* Handle special Kconfig options */
 #ifndef LV_KCONFIG_IGNORE
-#   include "lv_conf_kconfig.h"
-#   ifdef CONFIG_LV_CONF_SKIP
-#       define LV_CONF_SKIP
-#   endif
+#  include "lv_conf_kconfig.h"
+#  ifdef CONFIG_LV_CONF_SKIP
+#    define LV_CONF_SKIP
+#  endif
 #endif
 
 /*If "lv_conf.h" is available from here try to use it later.*/
-#if defined __has_include
+#ifdef __has_include
 #  if __has_include("lv_conf.h")
-#   ifndef LV_CONF_INCLUDE_SIMPLE
-#    define LV_CONF_INCLUDE_SIMPLE
-#   endif
+#    ifndef LV_CONF_INCLUDE_SIMPLE
+#      define LV_CONF_INCLUDE_SIMPLE
+#    endif
 #  endif
 #endif
 
 /*If lv_conf.h is not skipped include it*/
-#if !defined(LV_CONF_SKIP)
-#  if defined(LV_CONF_PATH)											/*If there is a path defined for lv_conf.h use it*/
+#ifndef LV_CONF_SKIP
+#  ifdef LV_CONF_PATH                           /*If there is a path defined for lv_conf.h use it*/
 #    define __LV_TO_STR_AUX(x) #x
 #    define __LV_TO_STR(x) __LV_TO_STR_AUX(x)
 #    include __LV_TO_STR(LV_CONF_PATH)
@@ -58,7 +58,7 @@
 #  ifdef CONFIG_LV_COLOR_DEPTH
 #    define LV_COLOR_DEPTH CONFIG_LV_COLOR_DEPTH
 #  else
-#    define LV_COLOR_DEPTH     16
+#    define LV_COLOR_DEPTH 16
 #  endif
 #endif
 
@@ -67,7 +67,7 @@
 #  ifdef CONFIG_LV_COLOR_16_SWAP
 #    define LV_COLOR_16_SWAP CONFIG_LV_COLOR_16_SWAP
 #  else
-#    define LV_COLOR_16_SWAP   0
+#    define LV_COLOR_16_SWAP 0
 #  endif
 #endif
 
@@ -78,7 +78,7 @@
 #  ifdef CONFIG_LV_COLOR_SCREEN_TRANSP
 #    define LV_COLOR_SCREEN_TRANSP CONFIG_LV_COLOR_SCREEN_TRANSP
 #  else
-#    define LV_COLOR_SCREEN_TRANSP    0
+#    define LV_COLOR_SCREEN_TRANSP 0
 #  endif
 #endif
 
@@ -87,7 +87,7 @@
 #  ifdef CONFIG_LV_COLOR_CHROMA_KEY
 #    define LV_COLOR_CHROMA_KEY CONFIG_LV_COLOR_CHROMA_KEY
 #  else
-#    define LV_COLOR_CHROMA_KEY    lv_color_hex(0x00ff00)         /*pure green*/
+#    define LV_COLOR_CHROMA_KEY lv_color_hex(0x00ff00)         /*pure green*/
 #  endif
 #endif
 
@@ -100,7 +100,7 @@
 #  ifdef CONFIG_LV_MEM_CUSTOM
 #    define LV_MEM_CUSTOM CONFIG_LV_MEM_CUSTOM
 #  else
-#    define LV_MEM_CUSTOM      0
+#    define LV_MEM_CUSTOM 0
 #  endif
 #endif
 #if LV_MEM_CUSTOM == 0
@@ -109,7 +109,7 @@
 #  ifdef CONFIG_LV_MEM_SIZE
 #    define LV_MEM_SIZE CONFIG_LV_MEM_SIZE
 #  else
-#    define LV_MEM_SIZE    (32U * 1024U)          /*[bytes]*/
+#    define LV_MEM_SIZE (32U * 1024U)          /*[bytes]*/
 #  endif
 #endif
 
@@ -118,13 +118,13 @@
 #  ifdef CONFIG_LV_MEM_ADR
 #    define LV_MEM_ADR CONFIG_LV_MEM_ADR
 #  else
-#    define LV_MEM_ADR          0     /*0: unused*/
+#    define LV_MEM_ADR 0     /*0: unused*/
 #  endif
 #endif
 /*Instead of an address give a memory allocator that will be called to get a memory pool for LVGL. E.g. my_malloc*/
 #if LV_MEM_ADR == 0
-//#define LV_MEM_POOL_INCLUDE   your_alloc_library  /* Uncomment if using an external allocator*/
-//#define LV_MEM_POOL_ALLOC     your_alloc          /* Uncomment if using an external allocator*/
+//#define LV_MEM_POOL_INCLUDE your_alloc_library  /* Uncomment if using an external allocator*/
+//#define LV_MEM_POOL_ALLOC   your_alloc          /* Uncomment if using an external allocator*/
 #endif
 
 #else       /*LV_MEM_CUSTOM*/
@@ -139,21 +139,21 @@
 #  ifdef CONFIG_LV_MEM_CUSTOM_ALLOC
 #    define LV_MEM_CUSTOM_ALLOC CONFIG_LV_MEM_CUSTOM_ALLOC
 #  else
-#    define LV_MEM_CUSTOM_ALLOC     malloc
+#    define LV_MEM_CUSTOM_ALLOC   malloc
 #  endif
 #endif
 #ifndef LV_MEM_CUSTOM_FREE
 #  ifdef CONFIG_LV_MEM_CUSTOM_FREE
 #    define LV_MEM_CUSTOM_FREE CONFIG_LV_MEM_CUSTOM_FREE
 #  else
-#    define LV_MEM_CUSTOM_FREE      free
+#    define LV_MEM_CUSTOM_FREE    free
 #  endif
 #endif
 #ifndef LV_MEM_CUSTOM_REALLOC
 #  ifdef CONFIG_LV_MEM_CUSTOM_REALLOC
 #    define LV_MEM_CUSTOM_REALLOC CONFIG_LV_MEM_CUSTOM_REALLOC
 #  else
-#    define LV_MEM_CUSTOM_REALLOC   realloc
+#    define LV_MEM_CUSTOM_REALLOC realloc
 #  endif
 #endif
 #endif     /*LV_MEM_CUSTOM*/
@@ -163,7 +163,7 @@
 #  ifdef CONFIG_LV_MEMCPY_MEMSET_STD
 #    define LV_MEMCPY_MEMSET_STD CONFIG_LV_MEMCPY_MEMSET_STD
 #  else
-#    define LV_MEMCPY_MEMSET_STD    0
+#    define LV_MEMCPY_MEMSET_STD 0
 #  endif
 #endif
 
@@ -176,7 +176,7 @@
 #  ifdef CONFIG_LV_DISP_DEF_REFR_PERIOD
 #    define LV_DISP_DEF_REFR_PERIOD CONFIG_LV_DISP_DEF_REFR_PERIOD
 #  else
-#    define LV_DISP_DEF_REFR_PERIOD     30      /*[ms]*/
+#    define LV_DISP_DEF_REFR_PERIOD 30      /*[ms]*/
 #  endif
 #endif
 
@@ -185,7 +185,7 @@
 #  ifdef CONFIG_LV_INDEV_DEF_READ_PERIOD
 #    define LV_INDEV_DEF_READ_PERIOD CONFIG_LV_INDEV_DEF_READ_PERIOD
 #  else
-#    define LV_INDEV_DEF_READ_PERIOD    30      /*[ms]*/
+#    define LV_INDEV_DEF_READ_PERIOD 30     /*[ms]*/
 #  endif
 #endif
 
@@ -195,7 +195,7 @@
 #  ifdef CONFIG_LV_TICK_CUSTOM
 #    define LV_TICK_CUSTOM CONFIG_LV_TICK_CUSTOM
 #  else
-#    define LV_TICK_CUSTOM     0
+#    define LV_TICK_CUSTOM 0
 #  endif
 #endif
 #if LV_TICK_CUSTOM
@@ -203,14 +203,14 @@
 #  ifdef CONFIG_LV_TICK_CUSTOM_INCLUDE
 #    define LV_TICK_CUSTOM_INCLUDE CONFIG_LV_TICK_CUSTOM_INCLUDE
 #  else
-#    define LV_TICK_CUSTOM_INCLUDE  "Arduino.h"         /*Header for the system time function*/
+#    define LV_TICK_CUSTOM_INCLUDE "Arduino.h"         /*Header for the system time function*/
 #  endif
 #endif
 #ifndef LV_TICK_CUSTOM_SYS_TIME_EXPR
 #  ifdef CONFIG_LV_TICK_CUSTOM_SYS_TIME_EXPR
 #    define LV_TICK_CUSTOM_SYS_TIME_EXPR CONFIG_LV_TICK_CUSTOM_SYS_TIME_EXPR
 #  else
-#    define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())     /*Expression evaluating to current system time in ms*/
+#    define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())    /*Expression evaluating to current system time in ms*/
 #  endif
 #endif
 #endif   /*LV_TICK_CUSTOM*/
@@ -221,7 +221,7 @@
 #  ifdef CONFIG_LV_DPI_DEF
 #    define LV_DPI_DEF CONFIG_LV_DPI_DEF
 #  else
-#    define LV_DPI_DEF                  130     /*[px/inch]*/
+#    define LV_DPI_DEF 130     /*[px/inch]*/
 #  endif
 #endif
 
@@ -251,7 +251,7 @@
 #  ifdef CONFIG_LV_SHADOW_CACHE_SIZE
 #    define LV_SHADOW_CACHE_SIZE CONFIG_LV_SHADOW_CACHE_SIZE
 #  else
-#    define LV_SHADOW_CACHE_SIZE    0
+#    define LV_SHADOW_CACHE_SIZE 0
 #  endif
 #endif
 
@@ -263,7 +263,7 @@
 #  ifdef CONFIG_LV_CIRCLE_CACHE_SIZE
 #    define LV_CIRCLE_CACHE_SIZE CONFIG_LV_CIRCLE_CACHE_SIZE
 #  else
-#    define LV_CIRCLE_CACHE_SIZE    4
+#    define LV_CIRCLE_CACHE_SIZE 4
 #  endif
 #endif
 
@@ -278,7 +278,7 @@
 #  ifdef CONFIG_LV_IMG_CACHE_DEF_SIZE
 #    define LV_IMG_CACHE_DEF_SIZE CONFIG_LV_IMG_CACHE_DEF_SIZE
 #  else
-#    define LV_IMG_CACHE_DEF_SIZE       0
+#    define LV_IMG_CACHE_DEF_SIZE 0
 #  endif
 #endif
 
@@ -287,7 +287,7 @@
 #  ifdef CONFIG_LV_DISP_ROT_MAX_BUF
 #    define LV_DISP_ROT_MAX_BUF CONFIG_LV_DISP_ROT_MAX_BUF
 #  else
-#    define LV_DISP_ROT_MAX_BUF         (10*1024)
+#    define LV_DISP_ROT_MAX_BUF (10*1024)
 #  endif
 #endif
 
@@ -300,7 +300,7 @@
 #  ifdef CONFIG_LV_USE_GPU_STM32_DMA2D
 #    define LV_USE_GPU_STM32_DMA2D CONFIG_LV_USE_GPU_STM32_DMA2D
 #  else
-#    define LV_USE_GPU_STM32_DMA2D  0
+#    define LV_USE_GPU_STM32_DMA2D 0
 #  endif
 #endif
 #if LV_USE_GPU_STM32_DMA2D
@@ -320,7 +320,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_GPU_NXP_PXP
 #    define LV_USE_GPU_NXP_PXP CONFIG_LV_USE_GPU_NXP_PXP
 #  else
-#    define LV_USE_GPU_NXP_PXP      0
+#    define LV_USE_GPU_NXP_PXP 0
 #  endif
 #endif
 #if LV_USE_GPU_NXP_PXP
@@ -343,7 +343,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_GPU_NXP_VG_LITE
 #    define LV_USE_GPU_NXP_VG_LITE CONFIG_LV_USE_GPU_NXP_VG_LITE
 #  else
-#    define LV_USE_GPU_NXP_VG_LITE   0
+#    define LV_USE_GPU_NXP_VG_LITE 0
 #  endif
 #endif
 
@@ -358,7 +358,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  endif
 #endif
 #  else
-#    define  LV_USE_GPU_SDL   0
+#    define  LV_USE_GPU_SDL 0
 #  endif
 #endif
 #if LV_USE_GPU_SDL
@@ -399,7 +399,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_LOG
 #    define LV_USE_LOG CONFIG_LV_USE_LOG
 #  else
-#    define LV_USE_LOG      0
+#    define LV_USE_LOG 0
 #  endif
 #endif
 #if LV_USE_LOG
@@ -415,7 +415,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_LOG_LEVEL
 #    define LV_LOG_LEVEL CONFIG_LV_LOG_LEVEL
 #  else
-#    define LV_LOG_LEVEL    LV_LOG_LEVEL_WARN
+#    define LV_LOG_LEVEL LV_LOG_LEVEL_WARN
 #  endif
 #endif
 
@@ -425,7 +425,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_LOG_PRINTF
 #    define LV_LOG_PRINTF CONFIG_LV_LOG_PRINTF
 #  else
-#    define LV_LOG_PRINTF   0
+#    define LV_LOG_PRINTF 0
 #  endif
 #endif
 
@@ -434,56 +434,56 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_LOG_TRACE_MEM
 #    define LV_LOG_TRACE_MEM CONFIG_LV_LOG_TRACE_MEM
 #  else
-#    define LV_LOG_TRACE_MEM            1
+#    define LV_LOG_TRACE_MEM        1
 #  endif
 #endif
 #ifndef LV_LOG_TRACE_TIMER
 #  ifdef CONFIG_LV_LOG_TRACE_TIMER
 #    define LV_LOG_TRACE_TIMER CONFIG_LV_LOG_TRACE_TIMER
 #  else
-#    define LV_LOG_TRACE_TIMER          1
+#    define LV_LOG_TRACE_TIMER      1
 #  endif
 #endif
 #ifndef LV_LOG_TRACE_INDEV
 #  ifdef CONFIG_LV_LOG_TRACE_INDEV
 #    define LV_LOG_TRACE_INDEV CONFIG_LV_LOG_TRACE_INDEV
 #  else
-#    define LV_LOG_TRACE_INDEV          1
+#    define LV_LOG_TRACE_INDEV      1
 #  endif
 #endif
 #ifndef LV_LOG_TRACE_DISP_REFR
 #  ifdef CONFIG_LV_LOG_TRACE_DISP_REFR
 #    define LV_LOG_TRACE_DISP_REFR CONFIG_LV_LOG_TRACE_DISP_REFR
 #  else
-#    define LV_LOG_TRACE_DISP_REFR      1
+#    define LV_LOG_TRACE_DISP_REFR  1
 #  endif
 #endif
 #ifndef LV_LOG_TRACE_EVENT
 #  ifdef CONFIG_LV_LOG_TRACE_EVENT
 #    define LV_LOG_TRACE_EVENT CONFIG_LV_LOG_TRACE_EVENT
 #  else
-#    define LV_LOG_TRACE_EVENT          1
+#    define LV_LOG_TRACE_EVENT      1
 #  endif
 #endif
 #ifndef LV_LOG_TRACE_OBJ_CREATE
 #  ifdef CONFIG_LV_LOG_TRACE_OBJ_CREATE
 #    define LV_LOG_TRACE_OBJ_CREATE CONFIG_LV_LOG_TRACE_OBJ_CREATE
 #  else
-#    define LV_LOG_TRACE_OBJ_CREATE     1
+#    define LV_LOG_TRACE_OBJ_CREATE 1
 #  endif
 #endif
 #ifndef LV_LOG_TRACE_LAYOUT
 #  ifdef CONFIG_LV_LOG_TRACE_LAYOUT
 #    define LV_LOG_TRACE_LAYOUT CONFIG_LV_LOG_TRACE_LAYOUT
 #  else
-#    define LV_LOG_TRACE_LAYOUT         1
+#    define LV_LOG_TRACE_LAYOUT     1
 #  endif
 #endif
 #ifndef LV_LOG_TRACE_ANIM
 #  ifdef CONFIG_LV_LOG_TRACE_ANIM
 #    define LV_LOG_TRACE_ANIM CONFIG_LV_LOG_TRACE_ANIM
 #  else
-#    define LV_LOG_TRACE_ANIM           1
+#    define LV_LOG_TRACE_ANIM       1
 #  endif
 #endif
 
@@ -536,14 +536,14 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_ASSERT_HANDLER_INCLUDE
 #    define LV_ASSERT_HANDLER_INCLUDE CONFIG_LV_ASSERT_HANDLER_INCLUDE
 #  else
-#    define LV_ASSERT_HANDLER_INCLUDE   <stdint.h>
+#    define LV_ASSERT_HANDLER_INCLUDE <stdint.h>
 #  endif
 #endif
 #ifndef LV_ASSERT_HANDLER
 #  ifdef CONFIG_LV_ASSERT_HANDLER
 #    define LV_ASSERT_HANDLER CONFIG_LV_ASSERT_HANDLER
 #  else
-#    define LV_ASSERT_HANDLER   while(1);   /*Halt by default*/
+#    define LV_ASSERT_HANDLER while(1);   /*Halt by default*/
 #  endif
 #endif
 
@@ -556,7 +556,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_PERF_MONITOR
 #    define LV_USE_PERF_MONITOR CONFIG_LV_USE_PERF_MONITOR
 #  else
-#    define LV_USE_PERF_MONITOR     0
+#    define LV_USE_PERF_MONITOR 0
 #  endif
 #endif
 
@@ -566,7 +566,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_MEM_MONITOR
 #    define LV_USE_MEM_MONITOR CONFIG_LV_USE_MEM_MONITOR
 #  else
-#    define LV_USE_MEM_MONITOR      0
+#    define LV_USE_MEM_MONITOR 0
 #  endif
 #endif
 
@@ -575,7 +575,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_REFR_DEBUG
 #    define LV_USE_REFR_DEBUG CONFIG_LV_USE_REFR_DEBUG
 #  else
-#    define LV_USE_REFR_DEBUG       0
+#    define LV_USE_REFR_DEBUG 0
 #  endif
 #endif
 
@@ -584,7 +584,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_SPRINTF_CUSTOM
 #    define LV_SPRINTF_CUSTOM CONFIG_LV_SPRINTF_CUSTOM
 #  else
-#    define LV_SPRINTF_CUSTOM   0
+#    define LV_SPRINTF_CUSTOM 0
 #  endif
 #endif
 #if LV_SPRINTF_CUSTOM
@@ -599,14 +599,14 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_SNPRINTF
 #    define lv_snprintf CONFIG_LV_SNPRINTF
 #  else
-#    define lv_snprintf     snprintf
+#    define lv_snprintf  snprintf
 #  endif
 #endif
 #ifndef lv_vsnprintf
 #  ifdef CONFIG_LV_VSNPRINTF
 #    define lv_vsnprintf CONFIG_LV_VSNPRINTF
 #  else
-#    define lv_vsnprintf    vsnprintf
+#    define lv_vsnprintf vsnprintf
 #  endif
 #endif
 #else   /*LV_SPRINTF_CUSTOM*/
@@ -623,7 +623,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_USER_DATA
 #    define LV_USE_USER_DATA CONFIG_LV_USE_USER_DATA
 #  else
-#    define LV_USE_USER_DATA      1
+#    define LV_USE_USER_DATA 1
 #  endif
 #endif
 
@@ -651,7 +651,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_SNAPSHOT
 #    define LV_USE_SNAPSHOT CONFIG_LV_USE_SNAPSHOT
 #  else
-#    define LV_USE_SNAPSHOT         1
+#    define LV_USE_SNAPSHOT 1
 #  endif
 #endif
 
@@ -664,7 +664,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_BIG_ENDIAN_SYSTEM
 #    define LV_BIG_ENDIAN_SYSTEM CONFIG_LV_BIG_ENDIAN_SYSTEM
 #  else
-#    define LV_BIG_ENDIAN_SYSTEM    0
+#    define LV_BIG_ENDIAN_SYSTEM 0
 #  endif
 #endif
 
@@ -765,7 +765,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_LARGE_COORD
 #    define LV_USE_LARGE_COORD CONFIG_LV_USE_LARGE_COORD
 #  else
-#    define LV_USE_LARGE_COORD  0
+#    define LV_USE_LARGE_COORD 0
 #  endif
 #endif
 
@@ -779,147 +779,147 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_8
 #    define LV_FONT_MONTSERRAT_8 CONFIG_LV_FONT_MONTSERRAT_8
 #  else
-#    define LV_FONT_MONTSERRAT_8     0
+#    define LV_FONT_MONTSERRAT_8  0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_10
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_10
 #    define LV_FONT_MONTSERRAT_10 CONFIG_LV_FONT_MONTSERRAT_10
 #  else
-#    define LV_FONT_MONTSERRAT_10    0
+#    define LV_FONT_MONTSERRAT_10 0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_12
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_12
 #    define LV_FONT_MONTSERRAT_12 CONFIG_LV_FONT_MONTSERRAT_12
 #  else
-#    define LV_FONT_MONTSERRAT_12    0
+#    define LV_FONT_MONTSERRAT_12 0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_14
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_14
 #    define LV_FONT_MONTSERRAT_14 CONFIG_LV_FONT_MONTSERRAT_14
 #  else
-#    define LV_FONT_MONTSERRAT_14    1
+#    define LV_FONT_MONTSERRAT_14 1
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_16
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_16
 #    define LV_FONT_MONTSERRAT_16 CONFIG_LV_FONT_MONTSERRAT_16
 #  else
-#    define LV_FONT_MONTSERRAT_16    0
+#    define LV_FONT_MONTSERRAT_16 0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_18
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_18
 #    define LV_FONT_MONTSERRAT_18 CONFIG_LV_FONT_MONTSERRAT_18
 #  else
-#    define LV_FONT_MONTSERRAT_18    0
+#    define LV_FONT_MONTSERRAT_18 0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_20
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_20
 #    define LV_FONT_MONTSERRAT_20 CONFIG_LV_FONT_MONTSERRAT_20
 #  else
-#    define LV_FONT_MONTSERRAT_20    0
+#    define LV_FONT_MONTSERRAT_20 0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_22
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_22
 #    define LV_FONT_MONTSERRAT_22 CONFIG_LV_FONT_MONTSERRAT_22
 #  else
-#    define LV_FONT_MONTSERRAT_22    0
+#    define LV_FONT_MONTSERRAT_22 0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_24
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_24
 #    define LV_FONT_MONTSERRAT_24 CONFIG_LV_FONT_MONTSERRAT_24
 #  else
-#    define LV_FONT_MONTSERRAT_24    0
+#    define LV_FONT_MONTSERRAT_24 0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_26
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_26
 #    define LV_FONT_MONTSERRAT_26 CONFIG_LV_FONT_MONTSERRAT_26
 #  else
-#    define LV_FONT_MONTSERRAT_26    0
+#    define LV_FONT_MONTSERRAT_26 0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_28
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_28
 #    define LV_FONT_MONTSERRAT_28 CONFIG_LV_FONT_MONTSERRAT_28
 #  else
-#    define LV_FONT_MONTSERRAT_28    0
+#    define LV_FONT_MONTSERRAT_28 0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_30
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_30
 #    define LV_FONT_MONTSERRAT_30 CONFIG_LV_FONT_MONTSERRAT_30
 #  else
-#    define LV_FONT_MONTSERRAT_30    0
+#    define LV_FONT_MONTSERRAT_30 0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_32
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_32
 #    define LV_FONT_MONTSERRAT_32 CONFIG_LV_FONT_MONTSERRAT_32
 #  else
-#    define LV_FONT_MONTSERRAT_32    0
+#    define LV_FONT_MONTSERRAT_32 0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_34
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_34
 #    define LV_FONT_MONTSERRAT_34 CONFIG_LV_FONT_MONTSERRAT_34
 #  else
-#    define LV_FONT_MONTSERRAT_34    0
+#    define LV_FONT_MONTSERRAT_34 0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_36
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_36
 #    define LV_FONT_MONTSERRAT_36 CONFIG_LV_FONT_MONTSERRAT_36
 #  else
-#    define LV_FONT_MONTSERRAT_36    0
+#    define LV_FONT_MONTSERRAT_36 0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_38
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_38
 #    define LV_FONT_MONTSERRAT_38 CONFIG_LV_FONT_MONTSERRAT_38
 #  else
-#    define LV_FONT_MONTSERRAT_38    0
+#    define LV_FONT_MONTSERRAT_38 0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_40
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_40
 #    define LV_FONT_MONTSERRAT_40 CONFIG_LV_FONT_MONTSERRAT_40
 #  else
-#    define LV_FONT_MONTSERRAT_40    0
+#    define LV_FONT_MONTSERRAT_40 0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_42
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_42
 #    define LV_FONT_MONTSERRAT_42 CONFIG_LV_FONT_MONTSERRAT_42
 #  else
-#    define LV_FONT_MONTSERRAT_42    0
+#    define LV_FONT_MONTSERRAT_42 0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_44
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_44
 #    define LV_FONT_MONTSERRAT_44 CONFIG_LV_FONT_MONTSERRAT_44
 #  else
-#    define LV_FONT_MONTSERRAT_44    0
+#    define LV_FONT_MONTSERRAT_44 0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_46
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_46
 #    define LV_FONT_MONTSERRAT_46 CONFIG_LV_FONT_MONTSERRAT_46
 #  else
-#    define LV_FONT_MONTSERRAT_46    0
+#    define LV_FONT_MONTSERRAT_46 0
 #  endif
 #endif
 #ifndef LV_FONT_MONTSERRAT_48
 #  ifdef CONFIG_LV_FONT_MONTSERRAT_48
 #    define LV_FONT_MONTSERRAT_48 CONFIG_LV_FONT_MONTSERRAT_48
 #  else
-#    define LV_FONT_MONTSERRAT_48    0
+#    define LV_FONT_MONTSERRAT_48 0
 #  endif
 #endif
 
@@ -958,14 +958,14 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_FONT_UNSCII_8
 #    define LV_FONT_UNSCII_8 CONFIG_LV_FONT_UNSCII_8
 #  else
-#    define LV_FONT_UNSCII_8        0
+#    define LV_FONT_UNSCII_8  0
 #  endif
 #endif
 #ifndef LV_FONT_UNSCII_16
 #  ifdef CONFIG_LV_FONT_UNSCII_16
 #    define LV_FONT_UNSCII_16 CONFIG_LV_FONT_UNSCII_16
 #  else
-#    define LV_FONT_UNSCII_16       0
+#    define LV_FONT_UNSCII_16 0
 #  endif
 #endif
 
@@ -996,7 +996,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_FONT_FMT_TXT_LARGE
 #    define LV_FONT_FMT_TXT_LARGE CONFIG_LV_FONT_FMT_TXT_LARGE
 #  else
-#    define LV_FONT_FMT_TXT_LARGE   0
+#    define LV_FONT_FMT_TXT_LARGE 0
 #  endif
 #endif
 
@@ -1005,7 +1005,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_FONT_COMPRESSED
 #    define LV_USE_FONT_COMPRESSED CONFIG_LV_USE_FONT_COMPRESSED
 #  else
-#    define LV_USE_FONT_COMPRESSED  0
+#    define LV_USE_FONT_COMPRESSED 0
 #  endif
 #endif
 
@@ -1014,7 +1014,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_FONT_SUBPX
 #    define LV_USE_FONT_SUBPX CONFIG_LV_USE_FONT_SUBPX
 #  else
-#    define LV_USE_FONT_SUBPX       0
+#    define LV_USE_FONT_SUBPX 0
 #  endif
 #endif
 #if LV_USE_FONT_SUBPX
@@ -1023,7 +1023,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_FONT_SUBPX_BGR
 #    define LV_FONT_SUBPX_BGR CONFIG_LV_FONT_SUBPX_BGR
 #  else
-#    define LV_FONT_SUBPX_BGR       0  /*0: RGB; 1:BGR order*/
+#    define LV_FONT_SUBPX_BGR 0  /*0: RGB; 1:BGR order*/
 #  endif
 #endif
 #endif
@@ -1051,7 +1051,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_TXT_BREAK_CHARS
 #    define LV_TXT_BREAK_CHARS CONFIG_LV_TXT_BREAK_CHARS
 #  else
-#    define LV_TXT_BREAK_CHARS                  " ,.;:-_"
+#    define LV_TXT_BREAK_CHARS " ,.;:-_"
 #  endif
 #endif
 
@@ -1061,7 +1061,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_TXT_LINE_BREAK_LONG_LEN
 #    define LV_TXT_LINE_BREAK_LONG_LEN CONFIG_LV_TXT_LINE_BREAK_LONG_LEN
 #  else
-#    define LV_TXT_LINE_BREAK_LONG_LEN          0
+#    define LV_TXT_LINE_BREAK_LONG_LEN 0
 #  endif
 #endif
 
@@ -1071,7 +1071,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN
 #    define LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN CONFIG_LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN
 #  else
-#    define LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN  3
+#    define LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN 3
 #  endif
 #endif
 
@@ -1101,7 +1101,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_BIDI
 #    define LV_USE_BIDI CONFIG_LV_USE_BIDI
 #  else
-#    define LV_USE_BIDI         0
+#    define LV_USE_BIDI 0
 #  endif
 #endif
 #if LV_USE_BIDI
@@ -1113,7 +1113,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_BIDI_BASE_DIR_DEF
 #    define LV_BIDI_BASE_DIR_DEF CONFIG_LV_BIDI_BASE_DIR_DEF
 #  else
-#    define LV_BIDI_BASE_DIR_DEF  LV_BASE_DIR_AUTO
+#    define LV_BIDI_BASE_DIR_DEF LV_BASE_DIR_AUTO
 #  endif
 #endif
 #endif
@@ -1138,7 +1138,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_ARC
 #    define LV_USE_ARC CONFIG_LV_USE_ARC
 #  else
-#    define LV_USE_ARC          1
+#    define LV_USE_ARC        1
 #  endif
 #endif
 
@@ -1146,7 +1146,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_ANIMIMG
 #    define LV_USE_ANIMIMG CONFIG_LV_USE_ANIMIMG
 #  else
-#    define LV_USE_ANIMIMG	    1
+#    define LV_USE_ANIMIMG	  1
 #  endif
 #endif
 
@@ -1154,7 +1154,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_BAR
 #    define LV_USE_BAR CONFIG_LV_USE_BAR
 #  else
-#    define LV_USE_BAR          1
+#    define LV_USE_BAR        1
 #  endif
 #endif
 
@@ -1162,7 +1162,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_BTN
 #    define LV_USE_BTN CONFIG_LV_USE_BTN
 #  else
-#    define LV_USE_BTN          1
+#    define LV_USE_BTN        1
 #  endif
 #endif
 
@@ -1170,7 +1170,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_BTNMATRIX
 #    define LV_USE_BTNMATRIX CONFIG_LV_USE_BTNMATRIX
 #  else
-#    define LV_USE_BTNMATRIX    1
+#    define LV_USE_BTNMATRIX  1
 #  endif
 #endif
 
@@ -1178,7 +1178,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_CANVAS
 #    define LV_USE_CANVAS CONFIG_LV_USE_CANVAS
 #  else
-#    define LV_USE_CANVAS       1
+#    define LV_USE_CANVAS     1
 #  endif
 #endif
 
@@ -1186,7 +1186,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_CHECKBOX
 #    define LV_USE_CHECKBOX CONFIG_LV_USE_CHECKBOX
 #  else
-#    define LV_USE_CHECKBOX     1
+#    define LV_USE_CHECKBOX   1
 #  endif
 #endif
 
@@ -1194,7 +1194,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_DROPDOWN
 #    define LV_USE_DROPDOWN CONFIG_LV_USE_DROPDOWN
 #  else
-#    define LV_USE_DROPDOWN     1   /*Requires: lv_label*/
+#    define LV_USE_DROPDOWN   1   /*Requires: lv_label*/
 #  endif
 #endif
 
@@ -1202,7 +1202,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_IMG
 #    define LV_USE_IMG CONFIG_LV_USE_IMG
 #  else
-#    define LV_USE_IMG          1   /*Requires: lv_label*/
+#    define LV_USE_IMG        1   /*Requires: lv_label*/
 #  endif
 #endif
 
@@ -1210,7 +1210,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_LABEL
 #    define LV_USE_LABEL CONFIG_LV_USE_LABEL
 #  else
-#    define LV_USE_LABEL        1
+#    define LV_USE_LABEL      1
 #  endif
 #endif
 #if LV_USE_LABEL
@@ -1218,14 +1218,14 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_LABEL_TEXT_SELECTION
 #    define LV_LABEL_TEXT_SELECTION CONFIG_LV_LABEL_TEXT_SELECTION
 #  else
-#    define LV_LABEL_TEXT_SELECTION         1   /*Enable selecting text of the label*/
+#    define LV_LABEL_TEXT_SELECTION 1 /*Enable selecting text of the label*/
 #  endif
 #endif
 #ifndef LV_LABEL_LONG_TXT_HINT
 #  ifdef CONFIG_LV_LABEL_LONG_TXT_HINT
 #    define LV_LABEL_LONG_TXT_HINT CONFIG_LV_LABEL_LONG_TXT_HINT
 #  else
-#    define LV_LABEL_LONG_TXT_HINT    1   /*Store some extra info in labels to speed up drawing of very long texts*/
+#    define LV_LABEL_LONG_TXT_HINT 1  /*Store some extra info in labels to speed up drawing of very long texts*/
 #  endif
 #endif
 #endif
@@ -1234,7 +1234,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_LINE
 #    define LV_USE_LINE CONFIG_LV_USE_LINE
 #  else
-#    define LV_USE_LINE         1
+#    define LV_USE_LINE       1
 #  endif
 #endif
 
@@ -1242,7 +1242,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_ROLLER
 #    define LV_USE_ROLLER CONFIG_LV_USE_ROLLER
 #  else
-#    define LV_USE_ROLLER       1   /*Requires: lv_label*/
+#    define LV_USE_ROLLER     1   /*Requires: lv_label*/
 #  endif
 #endif
 #if LV_USE_ROLLER
@@ -1250,7 +1250,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_ROLLER_INF_PAGES
 #    define LV_ROLLER_INF_PAGES CONFIG_LV_ROLLER_INF_PAGES
 #  else
-#    define LV_ROLLER_INF_PAGES       7   /*Number of extra "pages" when the roller is infinite*/
+#    define LV_ROLLER_INF_PAGES 7 /*Number of extra "pages" when the roller is infinite*/
 #  endif
 #endif
 #endif
@@ -1259,7 +1259,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_SLIDER
 #    define LV_USE_SLIDER CONFIG_LV_USE_SLIDER
 #  else
-#    define LV_USE_SLIDER       1   /*Requires: lv_bar*/
+#    define LV_USE_SLIDER     1   /*Requires: lv_bar*/
 #  endif
 #endif
 
@@ -1267,7 +1267,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_SWITCH
 #    define LV_USE_SWITCH CONFIG_LV_USE_SWITCH
 #  else
-#    define LV_USE_SWITCH    1
+#    define LV_USE_SWITCH     1
 #  endif
 #endif
 
@@ -1275,7 +1275,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_TEXTAREA
 #    define LV_USE_TEXTAREA CONFIG_LV_USE_TEXTAREA
 #  else
-#    define LV_USE_TEXTAREA   1     /*Requires: lv_label*/
+#    define LV_USE_TEXTAREA   1   /*Requires: lv_label*/
 #  endif
 #endif
 #if LV_USE_TEXTAREA != 0
@@ -1283,7 +1283,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_TEXTAREA_DEF_PWD_SHOW_TIME
 #    define LV_TEXTAREA_DEF_PWD_SHOW_TIME CONFIG_LV_TEXTAREA_DEF_PWD_SHOW_TIME
 #  else
-#    define LV_TEXTAREA_DEF_PWD_SHOW_TIME     1500    /*ms*/
+#    define LV_TEXTAREA_DEF_PWD_SHOW_TIME 1500    /*ms*/
 #  endif
 #endif
 #endif
@@ -1292,7 +1292,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_TABLE
 #    define LV_USE_TABLE CONFIG_LV_USE_TABLE
 #  else
-#    define LV_USE_TABLE  1
+#    define LV_USE_TABLE      1
 #  endif
 #endif
 
@@ -1307,7 +1307,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_CALENDAR
 #    define LV_USE_CALENDAR CONFIG_LV_USE_CALENDAR
 #  else
-#    define LV_USE_CALENDAR     1
+#    define LV_USE_CALENDAR   1
 #  endif
 #endif
 #if LV_USE_CALENDAR
@@ -1347,14 +1347,14 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_CALENDAR_HEADER_ARROW
 #    define LV_USE_CALENDAR_HEADER_ARROW CONFIG_LV_USE_CALENDAR_HEADER_ARROW
 #  else
-#    define LV_USE_CALENDAR_HEADER_ARROW       1
+#    define LV_USE_CALENDAR_HEADER_ARROW 1
 #  endif
 #endif
 #ifndef LV_USE_CALENDAR_HEADER_DROPDOWN
 #  ifdef CONFIG_LV_USE_CALENDAR_HEADER_DROPDOWN
 #    define LV_USE_CALENDAR_HEADER_DROPDOWN CONFIG_LV_USE_CALENDAR_HEADER_DROPDOWN
 #  else
-#    define LV_USE_CALENDAR_HEADER_DROPDOWN    1
+#    define LV_USE_CALENDAR_HEADER_DROPDOWN 1
 #  endif
 #endif
 #endif  /*LV_USE_CALENDAR*/
@@ -1363,7 +1363,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_CHART
 #    define LV_USE_CHART CONFIG_LV_USE_CHART
 #  else
-#    define LV_USE_CHART        1
+#    define LV_USE_CHART      1
 #  endif
 #endif
 
@@ -1371,7 +1371,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_COLORWHEEL
 #    define LV_USE_COLORWHEEL CONFIG_LV_USE_COLORWHEEL
 #  else
-#    define LV_USE_COLORWHEEL   1
+#    define LV_USE_COLORWHEEL 1
 #  endif
 #endif
 
@@ -1379,7 +1379,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_IMGBTN
 #    define LV_USE_IMGBTN CONFIG_LV_USE_IMGBTN
 #  else
-#    define LV_USE_IMGBTN       1
+#    define LV_USE_IMGBTN     1
 #  endif
 #endif
 
@@ -1387,7 +1387,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_KEYBOARD
 #    define LV_USE_KEYBOARD CONFIG_LV_USE_KEYBOARD
 #  else
-#    define LV_USE_KEYBOARD     1
+#    define LV_USE_KEYBOARD   1
 #  endif
 #endif
 
@@ -1395,7 +1395,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_LED
 #    define LV_USE_LED CONFIG_LV_USE_LED
 #  else
-#    define LV_USE_LED          1
+#    define LV_USE_LED        1
 #  endif
 #endif
 
@@ -1403,7 +1403,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_LIST
 #    define LV_USE_LIST CONFIG_LV_USE_LIST
 #  else
-#    define LV_USE_LIST         1
+#    define LV_USE_LIST       1
 #  endif
 #endif
 
@@ -1411,7 +1411,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_METER
 #    define LV_USE_METER CONFIG_LV_USE_METER
 #  else
-#    define LV_USE_METER        1
+#    define LV_USE_METER      1
 #  endif
 #endif
 
@@ -1419,7 +1419,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_MSGBOX
 #    define LV_USE_MSGBOX CONFIG_LV_USE_MSGBOX
 #  else
-#    define LV_USE_MSGBOX       1
+#    define LV_USE_MSGBOX     1
 #  endif
 #endif
 
@@ -1427,7 +1427,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_SPINBOX
 #    define LV_USE_SPINBOX CONFIG_LV_USE_SPINBOX
 #  else
-#    define LV_USE_SPINBOX      1
+#    define LV_USE_SPINBOX    1
 #  endif
 #endif
 
@@ -1435,7 +1435,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_SPINNER
 #    define LV_USE_SPINNER CONFIG_LV_USE_SPINNER
 #  else
-#    define LV_USE_SPINNER      1
+#    define LV_USE_SPINNER    1
 #  endif
 #endif
 
@@ -1443,7 +1443,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_TABVIEW
 #    define LV_USE_TABVIEW CONFIG_LV_USE_TABVIEW
 #  else
-#    define LV_USE_TABVIEW      1
+#    define LV_USE_TABVIEW    1
 #  endif
 #endif
 
@@ -1451,7 +1451,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_TILEVIEW
 #    define LV_USE_TILEVIEW CONFIG_LV_USE_TILEVIEW
 #  else
-#    define LV_USE_TILEVIEW     1
+#    define LV_USE_TILEVIEW   1
 #  endif
 #endif
 
@@ -1459,7 +1459,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_WIN
 #    define LV_USE_WIN CONFIG_LV_USE_WIN
 #  else
-#    define LV_USE_WIN          1
+#    define LV_USE_WIN        1
 #  endif
 #endif
 
@@ -1467,7 +1467,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_SPAN
 #    define LV_USE_SPAN CONFIG_LV_USE_SPAN
 #  else
-#    define LV_USE_SPAN         1
+#    define LV_USE_SPAN       1
 #  endif
 #endif
 #if LV_USE_SPAN
@@ -1476,7 +1476,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_SPAN_SNIPPET_STACK_SIZE
 #    define LV_SPAN_SNIPPET_STACK_SIZE CONFIG_LV_SPAN_SNIPPET_STACK_SIZE
 #  else
-#    define LV_SPAN_SNIPPET_STACK_SIZE   64
+#    define LV_SPAN_SNIPPET_STACK_SIZE 64
 #  endif
 #endif
 #endif
@@ -1490,7 +1490,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_THEME_DEFAULT
 #    define LV_USE_THEME_DEFAULT CONFIG_LV_USE_THEME_DEFAULT
 #  else
-#    define LV_USE_THEME_DEFAULT    1
+#    define LV_USE_THEME_DEFAULT 1
 #  endif
 #endif
 #if LV_USE_THEME_DEFAULT
@@ -1500,7 +1500,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_THEME_DEFAULT_DARK
 #    define LV_THEME_DEFAULT_DARK CONFIG_LV_THEME_DEFAULT_DARK
 #  else
-#    define LV_THEME_DEFAULT_DARK     0
+#    define LV_THEME_DEFAULT_DARK 0
 #  endif
 #endif
 
@@ -1509,7 +1509,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_THEME_DEFAULT_GROW
 #    define LV_THEME_DEFAULT_GROW CONFIG_LV_THEME_DEFAULT_GROW
 #  else
-#    define LV_THEME_DEFAULT_GROW              1
+#    define LV_THEME_DEFAULT_GROW 1
 #  endif
 #endif
 
@@ -1518,7 +1518,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_THEME_DEFAULT_TRANSITON_TIME
 #    define LV_THEME_DEFAULT_TRANSITON_TIME CONFIG_LV_THEME_DEFAULT_TRANSITON_TIME
 #  else
-#    define LV_THEME_DEFAULT_TRANSITON_TIME    80
+#    define LV_THEME_DEFAULT_TRANSITON_TIME 80
 #  endif
 #endif
 #endif /*LV_USE_THEME_DEFAULT*/
@@ -1528,7 +1528,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_THEME_BASIC
 #    define LV_USE_THEME_BASIC CONFIG_LV_USE_THEME_BASIC
 #  else
-#    define LV_USE_THEME_BASIC    1
+#    define LV_USE_THEME_BASIC 1
 #  endif
 #endif
 
@@ -1537,7 +1537,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_THEME_MONO
 #    define LV_USE_THEME_MONO CONFIG_LV_USE_THEME_MONO
 #  else
-#    define LV_USE_THEME_MONO       1
+#    define LV_USE_THEME_MONO 1
 #  endif
 #endif
 
@@ -1550,7 +1550,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_FLEX
 #    define LV_USE_FLEX CONFIG_LV_USE_FLEX
 #  else
-#    define LV_USE_FLEX     1
+#    define LV_USE_FLEX 1
 #  endif
 #endif
 
@@ -1559,7 +1559,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_GRID
 #    define LV_USE_GRID CONFIG_LV_USE_GRID
 #  else
-#    define LV_USE_GRID     1
+#    define LV_USE_GRID 1
 #  endif
 #endif
 
@@ -1573,7 +1573,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_FS_STDIO
 #    define LV_USE_FS_STDIO CONFIG_LV_USE_FS_STDIO
 #  else
-#    define  LV_USE_FS_STDIO '\0'        /*Uses fopen, fread, etc*/
+#    define LV_USE_FS_STDIO '\0'        /*Uses fopen, fread, etc*/
 #  endif
 #endif
 //#define LV_FS_STDIO_PATH "/home/john/"    /*Set the working directory. If commented it will be "./" */
@@ -1582,7 +1582,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_FS_POSIX
 #    define LV_USE_FS_POSIX CONFIG_LV_USE_FS_POSIX
 #  else
-#    define  LV_USE_FS_POSIX '\0'        /*Uses open, read, etc*/
+#    define LV_USE_FS_POSIX '\0'        /*Uses open, read, etc*/
 #  endif
 #endif
 //#define LV_FS_POSIX_PATH "/home/john/"    /*Set the working directory. If commented it will be "./" */
@@ -1591,7 +1591,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_FS_FATFS
 #    define LV_USE_FS_FATFS CONFIG_LV_USE_FS_FATFS
 #  else
-#    define  LV_USE_FS_FATFS '\0'        /*Uses f_open, f_read, etc*/
+#    define LV_USE_FS_FATFS '\0'        /*Uses f_open, f_read, etc*/
 #  endif
 #endif
 
@@ -1600,7 +1600,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_PNG
 #    define LV_USE_PNG CONFIG_LV_USE_PNG
 #  else
-#    define  LV_USE_PNG      0
+#    define LV_USE_PNG 0
 #  endif
 #endif
 
@@ -1609,7 +1609,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_BMP
 #    define LV_USE_BMP CONFIG_LV_USE_BMP
 #  else
-#    define  LV_USE_BMP      0
+#    define LV_USE_BMP 0
 #  endif
 #endif
 
@@ -1619,7 +1619,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_SJPG
 #    define LV_USE_SJPG CONFIG_LV_USE_SJPG
 #  else
-#    define  LV_USE_SJPG     0
+#    define LV_USE_SJPG 0
 #  endif
 #endif
 
@@ -1628,7 +1628,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_GIF
 #    define LV_USE_GIF CONFIG_LV_USE_GIF
 #  else
-#    define  LV_USE_GIF      0
+#    define LV_USE_GIF 0
 #  endif
 #endif
 
@@ -1637,7 +1637,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_QRCODE
 #    define LV_USE_QRCODE CONFIG_LV_USE_QRCODE
 #  else
-#    define  LV_USE_QRCODE   0
+#    define LV_USE_QRCODE 0
 #  endif
 #endif
 
@@ -1646,16 +1646,16 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_USE_FREETYPE
 #    define LV_USE_FREETYPE CONFIG_LV_USE_FREETYPE
 #  else
-#    define  LV_USE_FREETYPE 0
+#    define LV_USE_FREETYPE 0
 #  endif
 #endif
 #if LV_USE_FREETYPE
-/*Memory used by FreeType to cache characters [bytes]*/
+/*Memory used by FreeType to cache characters [bytes] (-1: no caching)*/
 #ifndef LV_FREETYPE_CACHE_SIZE
 #  ifdef CONFIG_LV_FREETYPE_CACHE_SIZE
 #    define LV_FREETYPE_CACHE_SIZE CONFIG_LV_FREETYPE_CACHE_SIZE
 #  else
-#    define  LV_FREETYPE_CACHE_SIZE  (16 * 1024)
+#    define LV_FREETYPE_CACHE_SIZE (16 * 1024)
 #  endif
 #endif
 #endif
@@ -1670,7 +1670,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 #  ifdef CONFIG_LV_BUILD_EXAMPLES
 #    define LV_BUILD_EXAMPLES CONFIG_LV_BUILD_EXAMPLES
 #  else
-#    define LV_BUILD_EXAMPLES   1
+#    define LV_BUILD_EXAMPLES 1
 #  endif
 #endif
 
@@ -1683,12 +1683,10 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 LV_EXPORT_CONST_INT(LV_DPI_DEF);
 
 /*If running without lv_conf.h add typdesf with default value*/
-#if defined(LV_CONF_SKIP)
-
-# if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)    /*Disable warnings for Visual Studio*/
-#  define _CRT_SECURE_NO_WARNINGS
-# endif
-
+#ifdef LV_CONF_SKIP
+#  if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)    /*Disable warnings for Visual Studio*/
+#    define _CRT_SECURE_NO_WARNINGS
+#  endif
 #endif  /*defined(LV_CONF_SKIP)*/
 
 #endif  /*LV_CONF_INTERNAL_H*/

--- a/src/lv_conf_kconfig.h
+++ b/src/lv_conf_kconfig.h
@@ -11,7 +11,7 @@ extern "C" {
 #  include LV_CONF_KCONFIG_EXTERNAL_INCLUDE
 #else
 
-#  if defined ESP_PLATFORM
+#  ifdef ESP_PLATFORM
 #    include "sdkconfig.h"
 #    include "esp_attr.h"
 #  endif
@@ -23,25 +23,19 @@ extern "C" {
 #endif /*LV_CONF_KCONFIG_EXTERNAL_INCLUDE*/
 
 /*******************
- * LV_MEM_SIZE
- *******************/
-
-#ifndef LV_MEM_SIZE
-#if defined (CONFIG_LV_MEM_SIZE_KILOBYTES)
-#define CONFIG_LV_MEM_SIZE    (CONFIG_LV_MEM_SIZE_KILOBYTES * 1024U)
-#endif
-#endif
-
-/*******************
  * LV COLOR CHROMA KEY
  *******************/
 
-#ifndef LV_COLOR_CHROMA_KEY
-#if defined (CONFIG_LV_COLOR_CHROMA_KEY_HEX)
-#define CONFIG_LV_COLOR_CHROMA_KEY  lv_color_hex(CONFIG_LV_COLOR_CHROMA_KEY_HEX)
-#else
-#define CONFIG_LV_COLOR_CHROMA_KEY  lv_color_hex(0x00ff00)  /* pure green */
+#ifdef CONFIG_LV_COLOR_CHROMA_KEY_HEX
+#  define CONFIG_LV_COLOR_CHROMA_KEY lv_color_hex(CONFIG_LV_COLOR_CHROMA_KEY_HEX)
 #endif
+
+/*******************
+ * LV_MEM_SIZE
+ *******************/
+
+#ifdef CONFIG_LV_MEM_SIZE_KILOBYTES
+#  define CONFIG_LV_MEM_SIZE (CONFIG_LV_MEM_SIZE_KILOBYTES * 1024U)
 #endif
 
 /********************
@@ -57,87 +51,81 @@ extern "C" {
 /*------------------
  * DEFAULT FONT
  *-----------------*/
-#ifndef LV_THEME_DEFAULT_FONT
-#if defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT_8
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_8
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT_10
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_10
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT_12
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_12
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT_14
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_14
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT_16
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_16
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT_18
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_18
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT_20
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_20
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT_22
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_22
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT_24
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_24
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT_26
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_26
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT_28
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_28
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT_30
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_30
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT_32
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_32
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT_34
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_34
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT_36
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_36
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT_38
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_38
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT_40
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_40
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT_42
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_42
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT_44
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_44
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT_46
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_46
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT_48
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_48
-#elif defined CONFIG_LV_FONT_DEFAULT_UNSCII_8
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_unscii_8
-#elif defined CONFIG_LV_FONT_DEFAULT_UNSCII_16
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_unscii_16
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT12SUBPX
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_12_subpx
-#elif defined CONFIG_LV_FONT_DEFAULT_MONTSERRAT28COMPRESSED
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_montserrat_28_compressed
-#elif defined CONFIG_LV_FONT_DEFAULT_DEJAVU_16_PERSIAN_HEBREW
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_dejavu_16_persian_hebrew
-#elif defined CONFIG_LV_FONT_DEFAULT_SIMSUN_16_CJK
-#define CONFIG_LV_THEME_DEFAULT_FONT         &lv_font_simsun_16_cjk
-#endif
+#ifdef CONFIG_LV_FONT_DEFAULT_MONTSERRAT_8
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_8
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_10)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_10
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_12)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_12
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_14)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_14
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_16)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_16
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_18)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_18
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_20)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_20
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_22)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_22
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_24)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_24
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_26)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_26
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_28)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_28
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_30)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_30
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_32)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_32
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_34)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_34
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_36)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_36
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_38)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_38
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_40)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_40
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_42)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_42
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_44)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_44
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_46)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_46
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_48)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_48
+#elif defined(CONFIG_LV_FONT_DEFAULT_UNSCII_8)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_unscii_8
+#elif defined(CONFIG_LV_FONT_DEFAULT_UNSCII_16)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_unscii_16
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT12SUBPX)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_12_subpx
+#elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT28COMPRESSED)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_28_compressed
+#elif defined(CONFIG_LV_FONT_DEFAULT_DEJAVU_16_PERSIAN_HEBREW)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_dejavu_16_persian_hebrew
+#elif defined(CONFIG_LV_FONT_DEFAULT_SIMSUN_16_CJK)
+#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_simsun_16_cjk
 #endif
 
 /*------------------
  * TEXT ENCODING
  *-----------------*/
-#ifndef LV_TEXT_ENC
 #ifdef CONFIG_LV_TXT_ENC_UTF8
-#define CONFIG_LV_TXT_ENC LV_TXT_ENC_UTF8
-#elif defined CONFIG_LV_TXT_ENC_ASCII
-#define CONFIG_LV_TXT_ENC LV_TXT_ENC_ASCII
-#endif
+#  define CONFIG_LV_TXT_ENC LV_TXT_ENC_UTF8
+#elif defined(CONFIG_LV_TXT_ENC_ASCII)
+#  define CONFIG_LV_TXT_ENC LV_TXT_ENC_ASCII
 #endif
 
 /*------------------
  * BIDI DIRECTION
  *-----------------*/
 
-#ifndef LV_BIDI_BASE_DIR_DEF
 #ifdef CONFIG_LV_BASE_DIR_LTR
-#define CONFIG_LV_BIDI_BASE_DIR_DEF LV_BASE_DIR_LTR
-#elif defined CONFIG_LV_BASE_DIR_RTL
-#define CONFIG_LV_BIDI_BASE_DIR_DEF LV_BASE_DIR_RTL
-#elif defined CONFIG_LV_BASE_DIR_AUTO
-#define CONFIG_LV_BIDI_BASE_DIR_DEF LV_BASE_DIR_AUTO
-#endif
+#  define CONFIG_LV_BIDI_BASE_DIR_DEF LV_BASE_DIR_LTR
+#elif defined(CONFIG_LV_BASE_DIR_RTL)
+#  define CONFIG_LV_BIDI_BASE_DIR_DEF LV_BASE_DIR_RTL
+#elif defined(CONFIG_LV_BASE_DIR_AUTO)
+#  define CONFIG_LV_BIDI_BASE_DIR_DEF LV_BASE_DIR_AUTO
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Description of the feature or fix

and reorder Kconfig and src/lv_conf_kconfig.h as lv_conf_template.h.
Note: the behavior should be same as before.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
