### PR TITLE
fix(log): replace printf with fwrite to save the stack size

### DIFF
--- a/src/misc/lv_log.c
+++ b/src/misc/lv_log.c
@@ -98,7 +98,7 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line, const char *
 void lv_log(const char * buf)
 {
 #if LV_LOG_PRINTF
-    printf("%s", buf);
+    fwrite(buf, 1, strlen(buf), stdout);
 #endif
     if(custom_print_cb) custom_print_cb(buf);
 


### PR DESCRIPTION
### Description of the feature or fix

since fwrite consume much small stack than printf

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
