### PR TITLE
fix(obj):use content coords as draw mask of child obj

### DIFF
--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -707,7 +707,7 @@ static void lv_refr_obj(lv_obj_t * obj, const lv_area_t * mask_ori_p)
         lv_draw_rect(&obj_ext_mask, &obj_ext_mask, &draw_dsc);
 #endif
         /*Create a new 'obj_mask' without 'ext_size' because the children can't be visible there*/
-        lv_obj_get_coords(obj, &obj_area);
+        lv_obj_get_content_coords(obj, &obj_area);
         union_ok = _lv_area_intersect(&obj_mask, mask_ori_p, &obj_area);
         if(union_ok != false) {
             lv_area_t mask_child; /*Mask from obj and its child*/


### PR DESCRIPTION
### Description of the feature or fix

According to the box model， The drawing field of the child obj should be the content field of the parent obj.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
