### PR TITLE
fix(span):eliminate the warning in lv_get_snippet_cnt()

### DIFF
--- a/src/extra/widgets/span/lv_span.c
+++ b/src/extra/widgets/span/lv_span.c
@@ -59,7 +59,7 @@ static bool lv_txt_get_snippet(const char * txt, const lv_font_t * font, lv_coor
                                uint32_t * end_ofs);
 
 static void lv_snippet_clear(void);
-static uint16_t lv_get_snippet_cnt();
+static uint16_t lv_get_snippet_cnt(void);
 static void lv_snippet_push(lv_snippet_t * item);
 static lv_snippet_t * lv_get_snippet(uint16_t index);
 
@@ -700,7 +700,7 @@ static void lv_snippet_push(lv_snippet_t * item)
     }
 }
 
-static uint16_t lv_get_snippet_cnt()
+static uint16_t lv_get_snippet_cnt(void)
 {
     return snippet_stack.index;
 }


### PR DESCRIPTION
### Description of the feature or fix

modfiy lv_get_snippet_cnt() to lv_get_snippet_cnt(void).

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
