### PR TITLE
[rt-thread] add support for rt-thread RTOS

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -1,0 +1,11 @@
+# RT-Thread building script for bridge
+
+import os
+from building import *
+
+objs = []
+cwd  = GetCurrentDir()
+
+objs = objs + SConscript(cwd + '/rt-thread/SConscript')
+
+Return('objs')

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,7 @@
 - feat(event) add add LV_EVENT_CHILD_CREATED/DELETED
 - feat(disp): Enable rendering to display subsection
 - feat(keyboard): add user-defined modes
+- Add support for RT-Thread RTOS
 
 ## v8.0.2 (16.07.2021)
 - fix(theme) improve button focus of keyboard
@@ -269,7 +270,7 @@ v8 is a major change and therefore it's not backward compatible with v7.
 - feat(img_cache) allow disabling image caching
 - calendar: make get_day_of_week() public
 - Added support for Zephyr integration
- 
+
 ### Bugfixes
 - fix(draw_rect) free buffer used for arabic processing
 - fix(win) arabic process the title of the window

--- a/rt-thread/SConscript
+++ b/rt-thread/SConscript
@@ -1,0 +1,15 @@
+# RT-Thread building script for bridge
+
+import os
+from building import *
+
+cwd = GetCurrentDir()
+objs = []
+list = os.listdir(cwd)
+
+for d in list:
+    path = os.path.join(cwd, d)
+    if os.path.isfile(os.path.join(path, 'SConscript')):
+        objs = objs + SConscript(os.path.join(d, 'SConscript'))
+
+Return('objs')


### PR DESCRIPTION
### Description of the feature or fix

Hi,

Thanks for your amazing project! This PR is for supporting RT-Thread Real-Time Operating System. Lvgl will be registered to the RT-Thread software packages center. RT-Thread has supported more than 200 boards (https://www.rt-thread.io/board.html). 

This PR includes two Sconscript files. RT-Thread uses Scons to organize files rather than CMake or Makefile, so it will not cause any conflicts with Lvgl CMake files.

I would be grateful if you consider about this PR. Thanks ahead.

Meco

https://github.com/RT-Thread/rt-thread
https://www.rt-thread.io

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
