### PR TITLE
fix(lv_png) fix compile error when LV_COLOR_DEPTH == 8

### DIFF
--- a/src/extra/libs/png/lv_png.c
+++ b/src/extra/libs/png/lv_png.c
@@ -225,9 +225,9 @@ static void convert_color_depth(uint8_t * img, uint32_t px_cnt)
        lv_color_t c;
        uint32_t i;
        for(i = 0; i < px_cnt; i++) {
-           c = lv_color_make(img_argb[i].red, img_argb[i].green, img_argb[i].blue);
-           img[i*2 + 1] = img_argb[i].alpha;
-           img[i*2 + 0] = c.full
+           c = lv_color_make(img_argb[i].ch.red, img_argb[i].ch.green, img_argb[i].ch.blue);
+           img[i*2 + 1] = img_argb[i].ch.alpha;
+           img[i*2 + 0] = c.full;
        }
 #endif
 }


### PR DESCRIPTION
### Description of the feature or fix

lv_png fails to compile if LV_COLOR_DEPTH == 8.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
