### PR TITLE
Improve LV_FORMAT_ATTRIBUTE usage

### DIFF
--- a/src/core/lv_event.c
+++ b/src/core/lv_event.c
@@ -40,7 +40,7 @@ static lv_event_t * event_head;
  *      MACROS
  **********************/
 #if LV_LOG_TRACE_EVENT
-    #define EVENT_TRACE(...) LV_LOG_TRACE( __VA_ARGS__)
+    #define EVENT_TRACE(...) LV_LOG_TRACE(__VA_ARGS__)
 #else
     #define EVENT_TRACE(...)
 #endif
@@ -402,7 +402,7 @@ static lv_event_dsc_t * lv_obj_get_event_dsc(const lv_obj_t * obj, uint32_t id)
 
 static lv_res_t event_send_core(lv_event_t * e)
 {
-    EVENT_TRACE("Sending event %d to %p with %p param", e->code, e->current_target, e->param);
+    EVENT_TRACE("Sending event %d to %p with %p param", e->code, (void *)e->current_target, e->param);
 
     /*Call the input device's feedback callback if set*/
     lv_indev_t * indev_act = lv_indev_get_act();

--- a/src/core/lv_indev.c
+++ b/src/core/lv_indev.c
@@ -52,7 +52,7 @@ static lv_obj_t * indev_obj_act = NULL;
  *      MACROS
  **********************/
 #if LV_LOG_TRACE_INDEV
-    #define INDEV_TRACE(...) LV_LOG_TRACE( __VA_ARGS__)
+    #define INDEV_TRACE(...) LV_LOG_TRACE(__VA_ARGS__)
 #else
     #define INDEV_TRACE(...)
 #endif

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -388,7 +388,7 @@ static inline lv_coord_t lv_obj_dpx(const lv_obj_t * obj, lv_coord_t n)
 #endif
 
 #if LV_USE_LOG && LV_LOG_TRACE_OBJ_CREATE
-#  define LV_TRACE_OBJ_CREATE(...) LV_LOG_TRACE( __VA_ARGS__)
+#  define LV_TRACE_OBJ_CREATE(...) LV_LOG_TRACE(__VA_ARGS__)
 #else
 #  define LV_TRACE_OBJ_CREATE(...)
 #endif

--- a/src/core/lv_obj_class.c
+++ b/src/core/lv_obj_class.c
@@ -42,7 +42,7 @@ static uint32_t get_instance_size(const lv_obj_class_t * class_p);
 
 lv_obj_t * lv_obj_class_create_obj(const lv_obj_class_t * class_p, lv_obj_t * parent)
 {
-    LV_TRACE_OBJ_CREATE("Creating object with %p class on %p parent", class_p, parent);
+    LV_TRACE_OBJ_CREATE("Creating object with %p class on %p parent", (void *)class_p, (void *)parent);
     uint32_t s = get_instance_size(class_p);
     lv_obj_t * obj = lv_mem_alloc(s);
     if(obj == NULL) return NULL;

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -44,7 +44,7 @@ static lv_obj_tree_walk_res_t walk_core(lv_obj_t * obj, lv_obj_tree_walk_cb_t cb
 
 void lv_obj_del(lv_obj_t * obj)
 {
-    LV_LOG_TRACE("begin (delete %p)", obj);
+    LV_LOG_TRACE("begin (delete %p)", (void *)obj);
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_obj_invalidate(obj);
 
@@ -78,12 +78,12 @@ void lv_obj_del(lv_obj_t * obj)
     }
 
     LV_ASSERT_MEM_INTEGRITY();
-    LV_LOG_TRACE("finished (delete %p)", obj);
+    LV_LOG_TRACE("finished (delete %p)", (void *)obj);
 }
 
 void lv_obj_clean(lv_obj_t * obj)
 {
-    LV_LOG_TRACE("begin (delete %p)", obj);
+    LV_LOG_TRACE("begin (delete %p)", (void *)obj);
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
     lv_obj_invalidate(obj);
@@ -102,7 +102,7 @@ void lv_obj_clean(lv_obj_t * obj)
 
     LV_ASSERT_MEM_INTEGRITY();
 
-    LV_LOG_TRACE("finished (delete %p)", obj);
+    LV_LOG_TRACE("finished (delete %p)", (void *)obj);
 }
 
 void lv_obj_del_delayed(lv_obj_t * obj, uint32_t delay_ms)

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -57,9 +57,9 @@ static lv_disp_t * disp_refr; /*Display being refreshed*/
  *      MACROS
  **********************/
 #if LV_LOG_TRACE_DISP_REFR
-    #define TRACE_REFR(...) LV_LOG_TRACE( __VA_ARGS__)
+    #define REFR_TRACE(...) LV_LOG_TRACE(__VA_ARGS__)
 #else
-    #define TRACE_REFR(...)
+    #define REFR_TRACE(...)
 #endif
 
 /**********************
@@ -181,7 +181,7 @@ void _lv_refr_set_disp_refreshing(lv_disp_t * disp)
  */
 void _lv_disp_refr_timer(lv_timer_t * tmr)
 {
-    TRACE_REFR("begin");
+    REFR_TRACE("begin");
 
     uint32_t start = lv_tick_get();
     volatile uint32_t elaps = 0;
@@ -207,7 +207,7 @@ void _lv_disp_refr_timer(lv_timer_t * tmr)
     if(disp_refr->act_scr == NULL) {
         disp_refr->inv_p = 0;
         LV_LOG_WARN("there is no active screen");
-        TRACE_REFR("finished");
+        REFR_TRACE("finished");
         return;
     }
 
@@ -312,7 +312,7 @@ void _lv_disp_refr_timer(lv_timer_t * tmr)
     }
 #endif
 
-    TRACE_REFR("finished");
+    REFR_TRACE("finished");
 }
 
 #if LV_USE_PERF_MONITOR
@@ -962,8 +962,8 @@ static void draw_buf_flush(void)
 
 static void call_flush_cb(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_p)
 {
-    TRACE_REFR("Calling flush_cb on (%d;%d)(%d;%d) area with %p image pointer", area->x1, area->y1, area->x2, area->y2,
-               color_p);
+    REFR_TRACE("Calling flush_cb on (%d;%d)(%d;%d) area with %p image pointer", area->x1, area->y1, area->x2, area->y2,
+               (void *)color_p);
 
     lv_area_t offset_area = {
         .x1 = area->x1 + drv->offset_x,

--- a/src/extra/layouts/flex/lv_flex.c
+++ b/src/extra/layouts/flex/lv_flex.c
@@ -208,7 +208,7 @@ void lv_obj_set_style_flex_grow(lv_obj_t * obj, uint8_t value, lv_style_selector
 
 static void flex_update(lv_obj_t * cont, void * user_data)
 {
-    LV_LOG_INFO("update %p container", cont);
+    LV_LOG_INFO("update %p container", (void *)cont);
     LV_UNUSED(user_data);
 
     flex_t f;

--- a/src/extra/layouts/grid/lv_grid.c
+++ b/src/extra/layouts/grid/lv_grid.c
@@ -343,7 +343,7 @@ void lv_obj_set_style_grid_cell_y_align(lv_obj_t * obj, lv_coord_t value, lv_sty
 
 static void grid_update(lv_obj_t * cont, void * user_data)
 {
-    LV_LOG_INFO("update %p container", cont);
+    LV_LOG_INFO("update %p container", (void *)cont);
     LV_UNUSED(user_data);
 
     const lv_coord_t * col_templ = get_col_dsc(cont);

--- a/src/extra/layouts/lv_layouts.h
+++ b/src/extra/layouts/lv_layouts.h
@@ -32,7 +32,7 @@ extern "C" {
  *      MACROS
  **********************/
 #if LV_USE_LOG && LV_LOG_TRACE_LAYOUT
-#  define LV_TRACE_LAYOUT(...) LV_LOG_TRACE( __VA_ARGS__)
+#  define LV_TRACE_LAYOUT(...) LV_LOG_TRACE(__VA_ARGS__)
 #else
 #  define LV_TRACE_LAYOUT(...)
 #endif

--- a/src/extra/libs/lv_libs.h
+++ b/src/extra/libs/lv_libs.h
@@ -37,11 +37,6 @@ extern "C" {
 /**********************
  *      MACROS
  **********************/
-#if LV_USE_LOG && LV_LOG_TRACE_LAYOUT
-#  define LV_TRACE_LAYOUT(...) LV_LOG_TRACE( __VA_ARGS__)
-#else
-#  define LV_TRACE_LAYOUT(...)
-#endif
 
 #ifdef __cplusplus
 } /*extern "C"*/

--- a/src/hal/lv_hal_indev.c
+++ b/src/hal/lv_hal_indev.c
@@ -39,7 +39,7 @@
  *      MACROS
  **********************/
 #if LV_LOG_TRACE_INDEV
-    #define INDEV_TRACE(...) LV_LOG_TRACE( __VA_ARGS__)
+    #define INDEV_TRACE(...) LV_LOG_TRACE(__VA_ARGS__)
 #else
     #define INDEV_TRACE(...)
 #endif

--- a/src/misc/lv_anim.c
+++ b/src/misc/lv_anim.c
@@ -46,7 +46,7 @@ static lv_timer_t * _lv_anim_tmr;
  *      MACROS
  **********************/
 #if LV_LOG_TRACE_ANIM
-    #define TRACE_ANIM(...) LV_LOG_TRACE( __VA_ARGS__)
+    #define TRACE_ANIM(...) LV_LOG_TRACE(__VA_ARGS__)
 #else
     #define TRACE_ANIM(...)
 #endif

--- a/src/misc/lv_log.c
+++ b/src/misc/lv_log.c
@@ -101,7 +101,7 @@ void _lv_log_add(lv_log_level_t level, const char * file, int line, const char *
 #else
             lv_vaformat_t vaf = {format, &args};
             lv_snprintf(buf, sizeof(buf), "[%s]\t(%" LV_PRId32 ".%03" LV_PRId32 ", +%" LV_PRId32 ")\t %s: %pV \t(in %s line #%d)\n",
-                        lvl_prefix[level], t / 1000, t % 1000, t - last_log_time, func, &vaf, &file[p], line);
+                        lvl_prefix[level], t / 1000, t % 1000, t - last_log_time, func, (void *)&vaf, &file[p], line);
 #endif
             custom_print_cb(buf);
         }

--- a/src/misc/lv_log.h
+++ b/src/misc/lv_log.h
@@ -16,6 +16,8 @@ extern "C" {
 #include "../lv_conf_internal.h"
 #include <stdint.h>
 
+#include "lv_types.h"
+
 /*********************
  *      DEFINES
  *********************/
@@ -77,7 +79,8 @@ void lv_log(const char * buf);
  * @param format    printf-like format string
  * @param ...       parameters for `format`
  */
-void _lv_log_add(lv_log_level_t level, const char * file, int line, const char * func, const char * format, ...);
+void _lv_log_add(lv_log_level_t level, const char * file, int line,
+                 const char * func, const char * format, ...) LV_FORMAT_ATTRIBUTE(5, 6);
 
 /**********************
  *      MACROS

--- a/src/misc/lv_mem.c
+++ b/src/misc/lv_mem.c
@@ -63,7 +63,7 @@ static uint32_t zero_mem = ZERO_MEM_SENTINEL; /*Give the address of this variabl
  *      MACROS
  **********************/
 #if LV_LOG_TRACE_MEM
-    #define MEM_TRACE(...) LV_LOG_TRACE( __VA_ARGS__)
+    #define MEM_TRACE(...) LV_LOG_TRACE(__VA_ARGS__)
 #else
     #define MEM_TRACE(...)
 #endif
@@ -122,7 +122,7 @@ void lv_mem_deinit(void)
  */
 void * lv_mem_alloc(size_t size)
 {
-    MEM_TRACE("allocating %d bytes", size);
+    MEM_TRACE("allocating %lu bytes", (unsigned long)size);
     if(size == 0) {
         MEM_TRACE("using zero_mem");
         return &zero_mem;
@@ -139,7 +139,7 @@ void * lv_mem_alloc(size_t size)
 #endif
 
     if(alloc == NULL) {
-        LV_LOG_ERROR("couldn't allocate memory (%d bytes)", size);
+        LV_LOG_ERROR("couldn't allocate memory (%lu bytes)", (unsigned long)size);
         lv_mem_monitor_t mon;
         lv_mem_monitor(&mon);
         LV_LOG_ERROR("used: %6d (%3d %%), frag: %3d %%, biggest free: %6d",
@@ -180,7 +180,7 @@ void lv_mem_free(void * data)
  */
 void * lv_mem_realloc(void * data_p, size_t new_size)
 {
-    MEM_TRACE("reallocating %p with %d size", data_p, new_size);
+    MEM_TRACE("reallocating %p with %lu size", data_p, (unsigned long)new_size);
     if(new_size == 0) {
         MEM_TRACE("using zero_mem");
         lv_mem_free(data_p);

--- a/src/misc/lv_printf.h
+++ b/src/misc/lv_printf.h
@@ -58,6 +58,8 @@ extern "C" {
 #include <stdarg.h>
 #include <stddef.h>
 
+#include "lv_types.h"
+
 typedef struct {
   const char * fmt;
   va_list * va;
@@ -73,8 +75,8 @@ typedef struct {
  *         null character. A value equal or larger than count indicates truncation. Only when the returned value
  *         is non-negative and less than count, the string has been completely written.
  */
-int  lv_snprintf(char * buffer, size_t count, const char * format, ...);
-int lv_vsnprintf(char * buffer, size_t count, const char * format, va_list va);
+int  lv_snprintf(char * buffer, size_t count, const char * format, ...) LV_FORMAT_ATTRIBUTE(3, 4);
+int lv_vsnprintf(char * buffer, size_t count, const char * format, va_list va) LV_FORMAT_ATTRIBUTE(3, 0);
 
 #else
 #include LV_SPRINTF_INCLUDE

--- a/src/misc/lv_timer.c
+++ b/src/misc/lv_timer.c
@@ -39,7 +39,7 @@ static bool timer_created;
  *      MACROS
  **********************/
 #if LV_LOG_TRACE_TIMER
-    #define TIMER_TRACE(...) LV_LOG_TRACE( __VA_ARGS__)
+    #define TIMER_TRACE(...) LV_LOG_TRACE(__VA_ARGS__)
 #else
     #define TIMER_TRACE(...)
 #endif
@@ -308,16 +308,16 @@ static bool lv_timer_exec(lv_timer_t * timer)
         int32_t original_repeat_count = timer->repeat_count;
         if(timer->repeat_count > 0) timer->repeat_count--;
         timer->last_run = lv_tick_get();
-        TIMER_TRACE("calling timer callback: %p", timer->timer_cb);
+        TIMER_TRACE("calling timer callback: %p", *((void **)&timer->timer_cb));
         if(timer->timer_cb && original_repeat_count != 0) timer->timer_cb(timer);
-        TIMER_TRACE("timer callback %p finished", timer->timer_cb);
+        TIMER_TRACE("timer callback %p finished", *((void **)&timer->timer_cb));
         LV_ASSERT_MEM_INTEGRITY();
         exec = true;
     }
 
     if(timer_deleted == false) { /*The timer might be deleted by itself as well*/
         if(timer->repeat_count == 0) { /*The repeat count is over, delete the timer*/
-            TIMER_TRACE("deleting timer with %p callback because the repeat count is over", timer->timer_cb);
+            TIMER_TRACE("deleting timer with %p callback because the repeat count is over", *((void **)&timer->timer_cb));
             lv_timer_del(timer);
         }
     }

--- a/src/misc/lv_txt.c
+++ b/src/misc/lv_txt.c
@@ -433,7 +433,7 @@ void _lv_txt_cut(char * txt, uint32_t pos, uint32_t len)
     }
 }
 
-LV_FORMAT_ATTRIBUTE(1, 0) char * _lv_txt_set_text_vfmt(const char * fmt, va_list ap)
+char * _lv_txt_set_text_vfmt(const char * fmt, va_list ap)
 {
     /*Allocate space for the new text by using trick from C99 standard section 7.19.6.12*/
     va_list ap_copy;

--- a/src/widgets/lv_label.c
+++ b/src/widgets/lv_label.c
@@ -144,7 +144,7 @@ void lv_label_set_text(lv_obj_t * obj, const char * text)
     lv_label_refr_text(obj);
 }
 
-LV_FORMAT_ATTRIBUTE(2, 3) void lv_label_set_text_fmt(lv_obj_t * obj, const char * fmt, ...)
+void lv_label_set_text_fmt(lv_obj_t * obj, const char * fmt, ...)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
     LV_ASSERT_NULL(fmt);


### PR DESCRIPTION
### Description of the feature or fix

- fix(format): add LV_FORMAT_ATTRIBUTE to lv_snprintf and lv_log 
- fix(format): remove LV_FORMAT_ATTRIBUTE from the function body
- fix(log): always reference the arguments in all log level

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
