### PR TITLE
fix(hal tick): add precompile !LV_TICK_CUSTOM for global variables and lv_tick_inc()

### DIFF
--- a/src/hal/lv_hal_tick.c
+++ b/src/hal/lv_hal_tick.c
@@ -28,8 +28,10 @@
 /**********************
  *  STATIC VARIABLES
  **********************/
+#if !LV_TICK_CUSTOM
 static uint32_t sys_time = 0;
 static volatile uint8_t tick_irq_flag;
+#endif
 
 /**********************
  *      MACROS
@@ -39,6 +41,7 @@ static volatile uint8_t tick_irq_flag;
  *   GLOBAL FUNCTIONS
  **********************/
 
+#if !LV_TICK_CUSTOM
 /**
  * You have to call this function periodically
  * @param tick_period the call period of this function in milliseconds
@@ -48,6 +51,7 @@ LV_ATTRIBUTE_TICK_INC void lv_tick_inc(uint32_t tick_period)
     tick_irq_flag = 0;
     sys_time += tick_period;
 }
+#endif
 
 /**
  * Get the elapsed milliseconds since start up

--- a/src/hal/lv_hal_tick.h
+++ b/src/hal/lv_hal_tick.h
@@ -35,11 +35,13 @@ extern "C" {
 
 //! @cond Doxygen_Suppress
 
+#if !LV_TICK_CUSTOM
 /**
  * You have to call this function periodically
  * @param tick_period the call period of this function in milliseconds
  */
 LV_ATTRIBUTE_TICK_INC void lv_tick_inc(uint32_t tick_period);
+#endif
 
 //! @endcond
 


### PR DESCRIPTION
### Description of the feature or fix

When users enable the LV_TICK_CUSTOM, `sys_time` , `tick_irq_flag` and `lv_tick_inc()` are meaningless. Thus, they should be excluded from compiling.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
