### PR TITLE
(trivial) expose LV_COLOR_DEPTH and LV_COLOR_16_SWAP in micropython

### DIFF
--- a/src/misc/lv_color.h
+++ b/src/misc/lv_color.h
@@ -35,6 +35,8 @@ extern "C" {
 /*********************
  *      DEFINES
  *********************/
+LV_EXPORT_CONST_INT(LV_COLOR_DEPTH);
+LV_EXPORT_CONST_INT(LV_COLOR_16_SWAP);
 
 /**
  * Opacity percentages.


### PR DESCRIPTION
### Description of the feature or fix

Export color settings to micropython so that they can be used in python-based display drivers. I don't think it warrants a mention in the CHANGELOG.md, TBH.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
