### PR TITLE
fix(rt-thread): include the rt-thread configuration header file

### DIFF
--- a/rt-thread/lv_rt_thread_conf.h
+++ b/rt-thread/lv_rt_thread_conf.h
@@ -16,22 +16,11 @@
 #define LV_RTTHREAD_INCLUDE <rtthread.h>
 #include LV_RTTHREAD_INCLUDE
 
-/*====================
-   COLOR SETTINGS
- *====================*/
-
-#ifdef PKG_LVGL_ENABLE_COLOR_16_SWAP
-#define LV_COLOR_16_SWAP 1
-#else
-#define LV_COLOR_16_SWAP 0
-#endif
-
 /*=========================
    MEMORY SETTINGS
  *=========================*/
 
 #ifdef RT_USING_HEAP
-/*1: use custom malloc/free, 0: use the built-in `lv_mem_alloc()` and `lv_mem_free()`*/
 #  define LV_MEM_CUSTOM 1
 #  define LV_MEM_CUSTOM_INCLUDE LV_RTTHREAD_INCLUDE
 #  define LV_MEM_CUSTOM_ALLOC   rt_malloc
@@ -43,8 +32,6 @@
    HAL SETTINGS
  *====================*/
 
-/*Use a custom tick source that tells the elapsed time in milliseconds.
- *It removes the need to manually update the tick with `lv_tick_inc()`)*/
 #define LV_TICK_CUSTOM 1
 #define LV_TICK_CUSTOM_INCLUDE LV_RTTHREAD_INCLUDE
 #define LV_TICK_CUSTOM_SYS_TIME_EXPR (rt_tick_get_millisecond())    /*Expression evaluating to current system time in ms*/
@@ -57,7 +44,6 @@
  * Logging
  *-----------*/
 
-/*Enable the log module*/
 #ifdef PKG_LVGL_ENABLE_LOG
 #  define LV_USE_LOG 1
 #  define LV_LOG_PRINTF 0
@@ -76,7 +62,6 @@
  * Others
  *-----------*/
 
-/*Change the built in (v)snprintf functions*/
 #define LV_SPRINTF_CUSTOM 1
 #define LV_SPRINTF_INCLUDE LV_RTTHREAD_INCLUDE
 #define lv_snprintf  rt_snprintf
@@ -87,14 +72,12 @@
  *  COMPILER SETTINGS
  *====================*/
 
-/*For big endian systems set to 1*/
 #ifdef RT_USING_BIG_ENDIAN
 #  define LV_BIG_ENDIAN_SYSTEM 1
 #else
 #  define LV_BIG_ENDIAN_SYSTEM 0
 #endif
 
-/*Will be added where memories needs to be aligned*/
 #define LV_ATTRIBUTE_MEM_ALIGN ALIGN(4)
 
 /*--END OF LV_RT_THREAD_CONF_H--*/

--- a/src/lv_conf_kconfig.h
+++ b/src/lv_conf_kconfig.h
@@ -19,7 +19,8 @@ extern "C" {
 #  ifdef __NuttX__
 #    include <nuttx/config.h>
 #  elif defined(__RTTHREAD__)
-#    define LV_CONF_SKIP
+#    define LV_CONF_INCLUDE_SIMPLE
+#    include <lv_rt_thread_conf.h>
 #  endif
 
 #endif /*LV_CONF_KCONFIG_EXTERNAL_INCLUDE*/


### PR DESCRIPTION
### Description of the feature or fix

Hi,

This PR fixed the header file's error.
Meanwhile, the structure is more reasonable. I leave `<lv_config.h>` to users so that they can add some definitions manually if they want, 

>All lvgl config needs to be converted to be Rt-thread compatible?

which also means the `lv_rt_thread_conf.h` just needs to transition only a few definitions, so you don't need to worry about this any more.

`lv_config.h` will take over the users' manual settings;
`lv_rt_thread_conf.h` will take over the RT-Thread OS related settings (such as systicks, memory) and users' settings that come from RT-Thread Kconfig side (only a few, not too many);
`lv_conf_internal.h` will handle the rest of them.

Meco

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
