### PR TITLE
lv_obj_draw_part_dsc_t.text_length added (lv_demos issue #121)

### DIFF
--- a/src/core/lv_obj_draw.h
+++ b/src/core/lv_obj_draw.h
@@ -51,8 +51,8 @@ typedef struct {
     const lv_point_t *
     p1;              /**< A point calculated during drawing. E.g. a point of chart or the center of an arc.*/
     const lv_point_t * p2;              /**< A point calculated during drawing. E.g. a point of chart.*/
-    const char *
-    text;                  /**< A text calculated during drawing. Can be modified. E.g. tick labels on a chart axis.*/
+    const char * text;                  /**< A text calculated during drawing. Can be modified. E.g. tick labels on a chart axis.*/
+    uint32_t text_length;               /**< Size of the text buffer containing null-terminated text string calculated during drawing.*/
     uint32_t part;                      /**< The current part for which the event is sent*/
     uint32_t id;                        /**< The index of the part. E.g. a button's index on button matrix or table cell index.*/
     lv_coord_t radius;                  /**< E.g. the radius of an arc (not the corner radius).*/

--- a/src/extra/widgets/chart/lv_chart.c
+++ b/src/extra/widgets/chart/lv_chart.c
@@ -19,6 +19,7 @@
 #define LV_CHART_HDIV_DEF 3
 #define LV_CHART_VDIV_DEF 5
 #define LV_CHART_POINT_CNT_DEF 10
+#define LV_CHART_LABEL_MAX_TEXT_LENGTH 16
 
 /**********************
  *      TYPEDEFS
@@ -1426,10 +1427,11 @@ static void draw_y_ticks(lv_obj_t * obj, const lv_area_t * clip_area, lv_chart_a
 
         /*add text only to major tick*/
         if(major && t->label_en)  {
-            char buf[16];
+            char buf[LV_CHART_LABEL_MAX_TEXT_LENGTH];
             lv_snprintf(buf, sizeof(buf), "%" LV_PRId32, tick_value);
             part_draw_dsc.label_dsc = &label_dsc;
             part_draw_dsc.text = buf;
+            part_draw_dsc.text_length = LV_CHART_LABEL_MAX_TEXT_LENGTH;
             lv_event_send(obj, LV_EVENT_DRAW_PART_BEGIN, &part_draw_dsc);
 
             /*reserve appropriate area*/
@@ -1459,6 +1461,7 @@ static void draw_y_ticks(lv_obj_t * obj, const lv_area_t * clip_area, lv_chart_a
         else {
             part_draw_dsc.label_dsc = NULL;
             part_draw_dsc.text = NULL;
+            part_draw_dsc.text_length = 0;
             lv_event_send(obj, LV_EVENT_DRAW_PART_BEGIN, &part_draw_dsc);
         }
 
@@ -1560,10 +1563,11 @@ static void draw_x_ticks(lv_obj_t * obj, const lv_area_t * clip_area, lv_chart_a
         part_draw_dsc.value = tick_value;
 
         if(major && t->label_en) {
-            char buf[16];
+            char buf[LV_CHART_LABEL_MAX_TEXT_LENGTH];
             lv_snprintf(buf, sizeof(buf), "%" LV_PRId32, tick_value);
             part_draw_dsc.label_dsc = &label_dsc;
             part_draw_dsc.text = buf;
+            part_draw_dsc.text_length = LV_CHART_LABEL_MAX_TEXT_LENGTH;
 
             lv_event_send(obj, LV_EVENT_DRAW_PART_BEGIN, &part_draw_dsc);
 
@@ -1593,6 +1597,7 @@ static void draw_x_ticks(lv_obj_t * obj, const lv_area_t * clip_area, lv_chart_a
         else {
             part_draw_dsc.label_dsc = NULL;
             part_draw_dsc.text = NULL;
+            part_draw_dsc.text_length = 0;
             lv_event_send(obj, LV_EVENT_DRAW_PART_BEGIN, &part_draw_dsc);
         }
 


### PR DESCRIPTION
`lv_obj_draw_part_dsc_t` struct contains a pointer to the text buffer (`text`) used during drawing but no buffer length is available.
Fix: add `text_length` containing buffer length.
See [#121](/lvgl/lv_demos/issues/121)