### PR TITLE
fix(lv_printf.h): to eliminate the errors in Keil and IAR

### DIFF
--- a/src/misc/lv_printf.h
+++ b/src/misc/lv_printf.h
@@ -34,13 +34,17 @@
 #ifndef _LV_PRINTF_H_
 #define _LV_PRINTF_H_
 
-#if defined(__has_include) && __has_include(<inttypes.h>)
-    #include<inttypes.h>
-    /* platform-specific printf format for int32_t, usually "d" or "ld" */
-    #define LV_PRId32 PRId32
+#if defined(__has_include)
+#  if __has_include(<inttypes.h>)
+#    include <inttypes.h>
+     /* platform-specific printf format for int32_t, usually "d" or "ld" */
+#    define LV_PRId32 PRId32
+#  else
+#    define LV_PRId32 "d"
+#  endif
 #else
-    /* hope this is correct for ports without __has_include or without inttypes.h */
-    #define LV_PRId32 "d"
+   /* hope this is correct for ports without __has_include or without inttypes.h */
+#  define LV_PRId32 "d"
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Description of the feature or fix

This PR will fix the problem when we are using IAR or Keil IDE to compile LVGL source code. There is a one-line source code that IAR or Keil can not recognize. This PR will fix this grammar error, and let LVGL can be compiled in GCC, IAR and KEIL.

Meanwhile, I took a video to show how to use LVGL official software package in a RT-Thread project. Because the file size is over than 10MB, so I send to your gmail. Thank you.

Meco

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
