### PR TITLE
fix(kconfig): change CONFIG_LV_THEME_DEFAULT_FONT to CONFIG_LV_FONT_DEFAULT

### DIFF
--- a/src/lv_conf_kconfig.h
+++ b/src/lv_conf_kconfig.h
@@ -46,8 +46,8 @@ extern "C" {
  *******************/
 
 /**
- * NOTE: In Kconfig instead of `LV_THEME_DEFAULT_FONT`
- *       `CONFIG_LV_THEME_DEFAULT_FONT_<font_name>` is defined
+ * NOTE: In Kconfig instead of `LV_DEFAULT_FONT`
+ *       `CONFIG_LV_FONT_DEFAULT_<font_name>` is defined
  *       hence the large selection with if-s
  */
 
@@ -55,59 +55,59 @@ extern "C" {
  * DEFAULT FONT
  *-----------------*/
 #ifdef CONFIG_LV_FONT_DEFAULT_MONTSERRAT_8
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_8
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_8
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_10)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_10
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_10
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_12)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_12
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_12
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_14)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_14
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_14
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_16)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_16
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_16
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_18)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_18
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_18
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_20)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_20
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_20
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_22)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_22
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_22
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_24)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_24
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_24
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_26)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_26
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_26
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_28)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_28
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_28
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_30)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_30
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_30
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_32)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_32
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_32
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_34)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_34
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_34
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_36)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_36
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_36
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_38)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_38
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_38
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_40)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_40
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_40
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_42)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_42
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_42
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_44)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_44
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_44
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_46)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_46
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_46
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_48)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_48
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_48
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_12_SUBPX)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_12_subpx
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_12_subpx
 #elif defined(CONFIG_LV_FONT_DEFAULT_MONTSERRAT_28_COMPRESSED)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_montserrat_28_compressed
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_montserrat_28_compressed
 #elif defined(CONFIG_LV_FONT_DEFAULT_DEJAVU_16_PERSIAN_HEBREW)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_dejavu_16_persian_hebrew
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_dejavu_16_persian_hebrew
 #elif defined(CONFIG_LV_FONT_DEFAULT_SIMSUN_16_CJK)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_simsun_16_cjk
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_simsun_16_cjk
 #elif defined(CONFIG_LV_FONT_DEFAULT_UNSCII_8)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_unscii_8
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_unscii_8
 #elif defined(CONFIG_LV_FONT_DEFAULT_UNSCII_16)
-#  define CONFIG_LV_THEME_DEFAULT_FONT &lv_font_unscii_16
+#  define CONFIG_LV_FONT_DEFAULT &lv_font_unscii_16
 #endif
 
 /*------------------


### PR DESCRIPTION
### Description of the feature or fix

so the user can overwrite LV_FONT_DEFAULT

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
