### PR TITLE
add target_include_directories for lvgl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,11 +53,13 @@ else()
         # 29316 | STATIC int32_t lv_style_transition_dsc_t_path_xcb_callback(const struct _lv_anim_t * arg0)
         #       |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         target_compile_options(lvgl_interface INTERFACE -Wno-unused-function)
+        target_include_directories(lvgl_interface INTERFACE  ${CMAKE_CURRENT_SOURCE_DIR})
     else(MICROPY_DIR)
         # without micropython, build lvgl and examples libs normally
         # default linux build uses this scope
         add_library(lvgl STATIC ${SOURCES})
         add_library(lvgl_examples STATIC ${EXAMPLE_SOURCES})
+        target_include_directories(lvgl INTERFACE  ${CMAKE_CURRENT_SOURCE_DIR})
 
         include_directories(${CMAKE_SOURCE_DIR})
 


### PR DESCRIPTION
### Description of the feature or fix

Better cmake integration for projects that use lvgl.
With target_include_directories, the lvgl path is emitted as include for compilers in projects that use lvgl. Otherwise, the projects must define where lvgl includes are located.
This follows https://gist.github.com/mbinna/c61dbb39bca0e4fb7d1f73b0d66a4fd1#declare-include-directories-with-target_include_directories
and is also use by zephyr already.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
