### PR TITLE
feat(lv_animimg): add stop and delete function

### DIFF
--- a/examples/widgets/animimg/lv_example_animimg_1.c
+++ b/examples/widgets/animimg/lv_example_animimg_1.c
@@ -18,6 +18,15 @@ void lv_example_animimg_1(void)
     lv_animimg_set_duration(animimg0, 1000);
     lv_animimg_set_repeat_count(animimg0, LV_ANIM_REPEAT_INFINITE);
     lv_animimg_start(animimg0);
+
+    /*Stop the animation image and hide the image*/
+    // lv_animimg_stop(animimg0, true);
+
+    /*Stop the animation image and don't hide the image*/
+    // lv_animimg_stop(animimg0, false);
+
+    /*Delete the animation image*/
+    // lv_animimg_del(animimg0);
 }
 
 #endif

--- a/src/extra/widgets/animimg/lv_animimg.c
+++ b/src/extra/widgets/animimg/lv_animimg.c
@@ -77,7 +77,28 @@ void lv_animimg_start(lv_obj_t * obj)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_animimg_t * animimg = (lv_animimg_t *)obj;
+    if(lv_obj_has_flag(&animimg->img.obj, LV_OBJ_FLAG_HIDDEN)) {
+        lv_obj_clear_flag(&animimg->img.obj, LV_OBJ_FLAG_HIDDEN);
+    }
     lv_anim_start(&animimg->anim);
+}
+
+void lv_animimg_stop(lv_obj_t * obj, bool hidden)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_animimg_t * animimg = (lv_animimg_t *)obj;
+    lv_anim_del(animimg->anim.var, animimg->anim.exec_cb);
+    if(hidden) {
+        lv_obj_add_flag(&animimg->img.obj, LV_OBJ_FLAG_HIDDEN);
+    }
+}
+
+void lv_animimg_del(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_animimg_t * animimg = (lv_animimg_t *)obj;
+    lv_anim_del(animimg->anim.var, animimg->anim.exec_cb);
+    lv_obj_del((lv_obj_t *)animimg);
 }
 
 /*=====================

--- a/src/extra/widgets/animimg/lv_animimg.h
+++ b/src/extra/widgets/animimg/lv_animimg.h
@@ -79,6 +79,19 @@ void lv_animimg_set_src(lv_obj_t * img,  lv_img_dsc_t * dsc[], uint8_t num);
 void lv_animimg_start(lv_obj_t * obj);
 
 /**
+ * Stop the image animation.
+ * @param obj pointer to an animation image object
+ * @param hidden hide the animation image object
+ */
+void lv_animimg_stop(lv_obj_t * obj, bool hidden);
+
+/**
+ * Delete the image animation.
+ * @param obj pointer to an animation image object
+ */
+void lv_animimg_del(lv_obj_t * obj);
+
+/**
  * Set the  image animation duration time. unit:ms
  * @param img pointer to an animation image object
  */


### PR DESCRIPTION
1. add lv_animimg_stop function with hidden param
2. add lv_animimg_del function

### Description of the feature

#### WHY
I need to use these two methods in a project, so I added these two methods. :)

lv_animimg_stop is function to stop and hide the animation image.
lv_animimg_del is function to delete the animation image.

#### Test Video
https://user-images.githubusercontent.com/26544331/138559507-8a58ea74-2eb3-43ac-b71e-e22f561f93bf.mp4

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [x] Update the documentation
