### PR TITLE
fix compiler warnings due to integer type mismatch

### DIFF
--- a/examples/event/lv_example_event_1.c
+++ b/examples/event/lv_example_event_1.c
@@ -5,10 +5,10 @@ static void event_cb(lv_event_t * e)
 {
     LV_LOG_USER("Clicked");
 
-    static uint32_t cnt = 1;
+    static unsigned int cnt = 1;
     lv_obj_t * btn = lv_event_get_target(e);
     lv_obj_t * label = lv_obj_get_child(btn, 0);
-    lv_label_set_text_fmt(label, "%d", cnt);
+    lv_label_set_text_fmt(label, "%u", cnt);
     cnt++;
 }
 

--- a/examples/event/lv_example_event_3.c
+++ b/examples/event/lv_example_event_3.c
@@ -27,14 +27,14 @@ void lv_example_event_3(void)
     lv_obj_center(cont);
     lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_ROW_WRAP);
 
-    uint32_t i;
+    unsigned int i;
     for(i = 0; i < 30; i++) {
         lv_obj_t * btn = lv_btn_create(cont);
         lv_obj_set_size(btn, 80, 50);
         lv_obj_add_flag(btn, LV_OBJ_FLAG_EVENT_BUBBLE);
 
         lv_obj_t * label = lv_label_create(btn);
-        lv_label_set_text_fmt(label, "%d", i);
+        lv_label_set_text_fmt(label, "%u", i);
         lv_obj_center(label);
     }
 

--- a/examples/get_started/lv_example_get_started_3.c
+++ b/examples/get_started/lv_example_get_started_3.c
@@ -8,7 +8,7 @@ static void slider_event_cb(lv_event_t * e)
     lv_obj_t * slider = lv_event_get_target(e);
 
     /*Refresh the text*/
-    lv_label_set_text_fmt(label, "%d", lv_slider_get_value(slider));
+    lv_label_set_text_fmt(label, "%d", (int)lv_slider_get_value(slider));
     lv_obj_align_to(label, slider, LV_ALIGN_OUT_TOP_MID, 0, -15);    /*Align top of the slider*/
 }
 

--- a/examples/layouts/flex/lv_example_flex_1.c
+++ b/examples/layouts/flex/lv_example_flex_1.c
@@ -18,7 +18,7 @@ void lv_example_flex_1(void)
     lv_obj_align_to(cont_col, cont_row, LV_ALIGN_OUT_BOTTOM_MID, 0, 5);
     lv_obj_set_flex_flow(cont_col, LV_FLEX_FLOW_COLUMN);
 
-    uint32_t i;
+    unsigned int i;
     for(i = 0; i < 10; i++) {
         lv_obj_t * obj;
         lv_obj_t * label;
@@ -28,7 +28,7 @@ void lv_example_flex_1(void)
         lv_obj_set_size(obj, 100, LV_PCT(100));
 
         label = lv_label_create(obj);
-        lv_label_set_text_fmt(label, "Item: %d", i);
+        lv_label_set_text_fmt(label, "Item: %u", i);
         lv_obj_center(label);
 
         /*Add items to the column*/
@@ -36,7 +36,7 @@ void lv_example_flex_1(void)
         lv_obj_set_size(obj, LV_PCT(100), LV_SIZE_CONTENT);
 
         label = lv_label_create(obj);
-        lv_label_set_text_fmt(label, "Item: %d", i);
+        lv_label_set_text_fmt(label, "Item: %u", i);
         lv_obj_center(label);
     }
 }

--- a/examples/layouts/flex/lv_example_flex_2.c
+++ b/examples/layouts/flex/lv_example_flex_2.c
@@ -17,13 +17,13 @@ void lv_example_flex_2(void)
     lv_obj_center(cont);
     lv_obj_add_style(cont, &style, 0);
 
-    uint32_t i;
+    unsigned int i;
     for(i = 0; i < 8; i++) {
         lv_obj_t * obj = lv_obj_create(cont);
         lv_obj_set_size(obj, 70, LV_SIZE_CONTENT);
 
         lv_obj_t * label = lv_label_create(obj);
-        lv_label_set_text_fmt(label, "%d", i);
+        lv_label_set_text_fmt(label, "%u", i);
         lv_obj_center(label);
     }
 }

--- a/examples/layouts/flex/lv_example_flex_4.c
+++ b/examples/layouts/flex/lv_example_flex_4.c
@@ -12,13 +12,13 @@ void lv_example_flex_4(void)
     lv_obj_center(cont);
     lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_COLUMN_REVERSE);
 
-    uint32_t i;
+    unsigned int i;
     for(i = 0; i < 6; i++) {
         lv_obj_t * obj = lv_obj_create(cont);
         lv_obj_set_size(obj, 100, 50);
 
         lv_obj_t * label = lv_label_create(obj);
-        lv_label_set_text_fmt(label, "Item: %d", i);
+        lv_label_set_text_fmt(label, "Item: %u", i);
         lv_obj_center(label);
     }
 }

--- a/examples/layouts/flex/lv_example_flex_5.c
+++ b/examples/layouts/flex/lv_example_flex_5.c
@@ -21,13 +21,13 @@ void lv_example_flex_5(void)
     lv_obj_center(cont);
     lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_ROW_WRAP);
 
-    uint32_t i;
+    unsigned int i;
     for(i = 0; i < 9; i++) {
         lv_obj_t * obj = lv_obj_create(cont);
         lv_obj_set_size(obj, 70, LV_SIZE_CONTENT);
 
         lv_obj_t * label = lv_label_create(obj);
-        lv_label_set_text_fmt(label, "%d", i);
+        lv_label_set_text_fmt(label, "%u", i);
         lv_obj_center(label);
     }
 

--- a/examples/layouts/flex/lv_example_flex_6.c
+++ b/examples/layouts/flex/lv_example_flex_6.c
@@ -13,13 +13,13 @@ void lv_example_flex_6(void)
     lv_obj_center(cont);
     lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_ROW_WRAP);
 
-    uint32_t i;
+    unsigned int i;
     for(i = 0; i < 20; i++) {
         lv_obj_t * obj = lv_obj_create(cont);
         lv_obj_set_size(obj, 70, LV_SIZE_CONTENT);
 
         lv_obj_t * label = lv_label_create(obj);
-        lv_label_set_text_fmt(label, "%d", i);
+        lv_label_set_text_fmt(label, "%u", i);
         lv_obj_center(label);
     }
 }

--- a/examples/scroll/lv_example_scroll_2.c
+++ b/examples/scroll/lv_example_scroll_2.c
@@ -25,17 +25,17 @@ void lv_example_scroll_2(void)
     lv_obj_set_flex_flow(panel, LV_FLEX_FLOW_ROW);
     lv_obj_align(panel, LV_ALIGN_CENTER, 0, 20);
 
-    uint32_t i;
+    unsigned int i;
     for(i = 0; i < 10; i++) {
         lv_obj_t * btn = lv_btn_create(panel);
         lv_obj_set_size(btn, 150, lv_pct(100));
 
         lv_obj_t * label = lv_label_create(btn);
         if(i == 3) {
-            lv_label_set_text_fmt(label, "Panel %d\nno snap", i);
+            lv_label_set_text_fmt(label, "Panel %u\nno snap", i);
             lv_obj_clear_flag(btn, LV_OBJ_FLAG_SNAPPABLE);
         } else {
-            lv_label_set_text_fmt(label, "Panel %d", i);
+            lv_label_set_text_fmt(label, "Panel %u", i);
         }
 
         lv_obj_center(label);

--- a/examples/scroll/lv_example_scroll_6.c
+++ b/examples/scroll/lv_example_scroll_6.c
@@ -60,13 +60,13 @@ void lv_example_scroll_6(void)
     lv_obj_set_scroll_snap_y(cont, LV_SCROLL_SNAP_CENTER);
     lv_obj_set_scrollbar_mode(cont, LV_SCROLLBAR_MODE_OFF);
 
-    uint32_t i;
+    unsigned int i;
     for(i = 0; i < 20; i++) {
         lv_obj_t * btn = lv_btn_create(cont);
         lv_obj_set_width(btn, lv_pct(100));
 
         lv_obj_t * label = lv_label_create(btn);
-        lv_label_set_text_fmt(label, "Button %d", i);
+        lv_label_set_text_fmt(label, "Button %u", i);
     }
 
     /*Update the buttons position manually for first*/

--- a/examples/widgets/table/lv_example_table_2.c
+++ b/examples/widgets/table/lv_example_table_2.c
@@ -86,13 +86,13 @@ void lv_example_table_2(void)
     lv_mem_monitor_t mon2;
     lv_mem_monitor(&mon2);
 
-    uint32_t mem_used = mon1.free_size - mon2.free_size;
+    long unsigned int mem_used = mon1.free_size - mon2.free_size;
 
-    uint32_t elaps = lv_tick_elaps(t);
+    unsigned int elaps = lv_tick_elaps(t);
 
     lv_obj_t * label = lv_label_create(lv_scr_act());
-    lv_label_set_text_fmt(label, "%d items were created in %d ms\n"
-                                  "using %d bytes of memory",
+    lv_label_set_text_fmt(label, "%d items were created in %u ms\n"
+                                  "using %lu bytes of memory",
                                   ITEM_CNT, elaps, mem_used);
 
     lv_obj_align(label, LV_ALIGN_BOTTOM_MID, 0, -10);

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -268,7 +268,7 @@ void _lv_disp_refr_timer(lv_timer_t * tmr)
     else {
         perf_last_time = lv_tick_get();
         uint32_t fps_limit = 1000 / disp_refr->refr_timer->period;
-        uint32_t fps;
+        unsigned int fps;
 
         if(elaps_sum == 0) elaps_sum = 1;
         if(frame_cnt == 0) fps = fps_limit;
@@ -279,8 +279,8 @@ void _lv_disp_refr_timer(lv_timer_t * tmr)
 
         fps_sum_all += fps;
         fps_sum_cnt ++;
-        uint32_t cpu = 100 - lv_timer_get_idle();
-        lv_label_set_text_fmt(perf_label, "%d FPS\n%d%% CPU", fps, cpu);
+        unsigned int cpu = 100 - lv_timer_get_idle();
+        lv_label_set_text_fmt(perf_label, "%u FPS\n%u%% CPU", fps, cpu);
     }
 #endif
 


### PR DESCRIPTION
### Description of the feature or fix

This PR will silence the warning:
```
lv_refr.c:283:43: warning: format '%d' expects argument of type 'int', but argument 3 has type 'uint32_t {aka long unsigned int}'

lv_refr.c:283:43: warning: format '%d' expects argument of type 'int', but argument 4 has type 'uint32_t {aka long unsigned int}'
```

This is an awkward situation: some compilers think that uint32_t is `long unsigned int` (which means %lu should be used), and some of those think that uint32_t is `unsigned int` (which means %u should be used).

Thus, I think the best solution is to use `unsigned int` to replace `uint32_t`, and use `%u` to replace `%d`. Every compiler is happy.😂

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
