### PR TITLE
fix: mark unused variable with LV_UNUSED(xxx) instead of (void)xxx

### DIFF
--- a/src/draw/lv_img_decoder.c
+++ b/src/draw/lv_img_decoder.c
@@ -272,7 +272,7 @@ void lv_img_decoder_set_close_cb(lv_img_decoder_t * decoder, lv_img_decoder_clos
  */
 lv_res_t lv_img_decoder_built_in_info(lv_img_decoder_t * decoder, const void * src, lv_img_header_t * header)
 {
-    (void)decoder; /*Unused*/
+    LV_UNUSED(decoder); /*Unused*/
 
     lv_img_src_t src_type = lv_img_src_get_type(src);
     if(src_type == LV_IMG_SRC_VARIABLE) {

--- a/src/extra/libs/png/lodepng.c
+++ b/src/extra/libs/png/lodepng.c
@@ -2310,7 +2310,7 @@ static unsigned zlib_compress(unsigned char** out, size_t* outsize, const unsign
 static unsigned zlib_decompress(unsigned char** out, size_t* outsize, size_t expected_size,
                                 const unsigned char* in, size_t insize, const LodePNGDecompressSettings* settings) {
   if(!settings->custom_zlib) return 87; /*no custom zlib function provided */
-  (void)expected_size;
+  LV_UNUSED(expected_size);
   return settings->custom_zlib(out, outsize, in, insize, settings);
 }
 #endif /*LODEPNG_COMPILE_DECODER*/

--- a/src/extra/libs/png/lv_png.c
+++ b/src/extra/libs/png/lv_png.c
@@ -185,7 +185,7 @@ static lv_res_t decoder_open(lv_img_decoder_t * decoder, lv_img_decoder_dsc_t * 
  */
 static void decoder_close(lv_img_decoder_t *decoder, lv_img_decoder_dsc_t *dsc)
 {
-    (void)decoder; /*Unused*/
+    LV_UNUSED(decoder); /*Unused*/
     if (dsc->img_data) {
         lv_mem_free((uint8_t *)dsc->img_data);
         dsc->img_data = NULL;

--- a/src/misc/lv_printf.c
+++ b/src/misc/lv_printf.c
@@ -133,10 +133,10 @@ static inline void _out_buffer(char character, void * buffer, size_t idx, size_t
 // internal null output
 static inline void _out_null(char character, void * buffer, size_t idx, size_t maxlen)
 {
-    (void)character;
-    (void)buffer;
-    (void)idx;
-    (void)maxlen;
+    LV_UNUSED(character);
+    LV_UNUSED(buffer);
+    LV_UNUSED(idx);
+    LV_UNUSED(maxlen);
 }
 
 // internal secure strlen

--- a/src/misc/lv_tlsf.c
+++ b/src/misc/lv_tlsf.c
@@ -827,7 +827,7 @@ static void integrity_walker(void * ptr, size_t size, int used, void * user)
     const size_t this_block_size = block_size(block);
 
     int status = 0;
-    (void)used;
+    LV_UNUSED(used);
     tlsf_insist(integ->prev_status == this_prev_status && "prev status incorrect");
     tlsf_insist(size == this_block_size && "block size incorrect");
 

--- a/src/misc/lv_txt.c
+++ b/src/misc/lv_txt.c
@@ -743,7 +743,7 @@ static uint32_t lv_txt_utf8_get_length(const char * txt)
  */
 static uint8_t lv_txt_iso8859_1_size(const char * str)
 {
-    (void)str; /*Unused*/
+    LV_UNUSED(str); /*Unused*/
     return 1;
 }
 

--- a/src/widgets/lv_label.c
+++ b/src/widgets/lv_label.c
@@ -238,8 +238,8 @@ void lv_label_set_text_sel_start(lv_obj_t * obj, uint32_t index)
     label->sel_start   = index;
     lv_obj_invalidate(obj);
 #else
-    (void)obj;    /*Unused*/
-    (void)index;    /*Unused*/
+    LV_UNUSED(obj);    /*Unused*/
+    LV_UNUSED(index);  /*Unused*/
 #endif
 }
 

--- a/src/widgets/lv_textarea.c
+++ b/src/widgets/lv_textarea.c
@@ -714,7 +714,7 @@ void lv_textarea_clear_selection(lv_obj_t * obj)
         lv_label_set_text_sel_end(ta->label, LV_DRAW_LABEL_NO_TXT_SEL);
     }
 #else
-    (void)obj; /*Unused*/
+    LV_UNUSED(obj); /*Unused*/
 #endif
 }
 


### PR DESCRIPTION
### Description of the feature or fix


### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
