### PR TITLE
fix(fsdrv): remove the seek call in fs_open

### DIFF
--- a/src/extra/libs/fsdrv/lv_fs_fatfs.c
+++ b/src/extra/libs/fsdrv/lv_fs_fatfs.c
@@ -109,7 +109,6 @@ static void * fs_open(lv_fs_drv_t * drv, const char * path, lv_fs_mode_t mode)
 
     FRESULT res = f_open(f, path, flags);
     if(res == FR_OK) {
-        f_lseek(f, 0);
         return f;
     } else {
         lv_mem_free(f);

--- a/src/extra/libs/fsdrv/lv_fs_posix.c
+++ b/src/extra/libs/fsdrv/lv_fs_posix.c
@@ -112,9 +112,6 @@ static void * fs_open(lv_fs_drv_t * drv, const char * path, lv_fs_mode_t mode)
 #endif
     if(f < 0) return NULL;
 
-    /*Be sure we are the beginning of the file*/
-    lseek(f, 0, SEEK_SET);
-
     return (void *)(lv_uintptr_t)f;
 }
 

--- a/src/extra/libs/fsdrv/lv_fs_stdio.c
+++ b/src/extra/libs/fsdrv/lv_fs_stdio.c
@@ -107,16 +107,10 @@ static void * fs_open(lv_fs_drv_t * drv, const char * path, lv_fs_mode_t mode)
     char buf[256];
     sprintf(buf, LV_FS_STDIO_PATH "%s", path);
 
-    FILE * f = fopen(buf, flags);
+    return fopen(buf, flags);
 #else
-    FILE * f = fopen(path, flags);
+    return fopen(path, flags);
 #endif
-    if(f == NULL) return NULL;
-
-    /*Be sure we are the beginning of the file*/
-    fseek(f, 0, SEEK_SET);
-
-    return f;
 }
 
 /**


### PR DESCRIPTION
### Description of the feature or fix

since the file should be located at zero after open

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
