### PR TITLE
fix(draw border):border draw error if border width > radius

### DIFF
--- a/src/draw/lv_draw_rect.c
+++ b/src/draw/lv_draw_rect.c
@@ -1080,7 +1080,7 @@ void draw_border_generic(const lv_area_t * clip_area, const lv_area_t * outer_ar
 {
     opa = opa >= LV_OPA_COVER ? LV_OPA_COVER : opa;
 
-    if(rout == 0 || rin == 0) {
+    if(rout == 0 && rin == 0) {
         draw_border_simple(clip_area, outer_area, inner_area, color, opa);
         return;
     }


### PR DESCRIPTION
### Description of the feature or fix

fix(draw border):border draw error if border width > radius

test code:
```c
lv_obj_t *child = lv_obj_create(par);
lv_obj_set_style_radius(child, 10, 0);
lv_obj_set_style_border_width(child, 20, 0);
```

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
