### PR TITLE
fix(draw_rect):bottom border lost if enable clip_corner

### DIFF
--- a/src/draw/lv_draw_rect.c
+++ b/src/draw/lv_draw_rect.c
@@ -1129,7 +1129,7 @@ void draw_border_generic(const lv_area_t * clip_area, const lv_area_t * outer_ar
     if(mask_any) {
         blend_area.x1 = draw_area.x1;
         blend_area.x2 = draw_area.x2;
-        for(h = draw_area.y1; h < draw_area.y2; h++) {
+        for(h = draw_area.y1; h <= draw_area.y2; h++) {
             if(!top_side && h < core_area.y1) continue;
             if(!bottom_side && h > core_area.y2) break;
 


### PR DESCRIPTION
### Description of the feature or fix

test code:
```c
    lv_obj_t *par = lv_obj_create(lv_scr_act());
    lv_obj_set_size(par, 400, 400);
    lv_obj_set_style_radius(par, 10, 0);
    lv_obj_set_style_clip_corner(par, true, 0);
    lv_obj_set_style_pad_all(par, 0, 0);
    lv_obj_set_style_border_width(par, 1, 0);
    lv_obj_set_style_border_color(par, lv_palette_main(LV_PALETTE_ORANGE), 0);
    lv_obj_set_scrollbar_mode(par, LV_SCROLLBAR_MODE_OFF);

    lv_obj_t *child = lv_obj_create(par);
    lv_obj_set_style_border_width(child, 1, 0);
    lv_obj_set_style_border_color(child, lv_palette_main(LV_PALETTE_RED), 0);
```

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
