### PR TITLE
fix(anim): remove time_orig from lv_anim_t

### DIFF
--- a/src/misc/lv_anim.c
+++ b/src/misc/lv_anim.c
@@ -95,7 +95,6 @@ lv_anim_t * lv_anim_start(const lv_anim_t * a)
     /*Initialize the animation descriptor*/
     lv_memcpy(new_anim, a, sizeof(lv_anim_t));
     if(a->var == a) new_anim->var = new_anim;
-    new_anim->time_orig = a->time;
     new_anim->run_round = anim_run_round;
 
     /*Set the start value*/
@@ -430,8 +429,10 @@ static void anim_ready_handler(lv_anim_t * a)
             tmp      = a->start_value;
             a->start_value = a->end_value;
             a->end_value   = tmp;
-
-            a->time = a->playback_now == 0 ? a->time_orig : a->playback_time;
+            /*Swap the time and playback_time*/
+            tmp = a->time;
+            a->time = a->playback_time;
+            a->playback_time = tmp;
         }
     }
 }

--- a/src/misc/lv_anim.h
+++ b/src/misc/lv_anim.h
@@ -88,7 +88,6 @@ typedef struct _lv_anim_t {
     uint8_t playback_now : 1; /**< Play back is in progress*/
     uint8_t run_round : 1;    /**< Indicates the animation has run in this round*/
     uint8_t start_cb_called : 1;    /**< Indicates that the `start_cb` was already called*/
-    uint32_t time_orig;
 } lv_anim_t;
 
 /**********************


### PR DESCRIPTION
### Description of the feature or fix

swap time and playback_time instead to save four bytes

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
