### PR TITLE
feat(cmake-build): Add options to disable build of examples/demos

### DIFF
--- a/docs/get-started/platforms/cmake.md
+++ b/docs/get-started/platforms/cmake.md
@@ -7,7 +7,7 @@ LVGL supports integrating with [CMake](https://cmake.org/). It comes with precon
 
 On top of the preconfigured targets you can also use "plain" CMake to integrate LVGL into any custom C/C++ project.
 
-### Prerequisites
+## Prerequisites
 - CMake ( >= 3.12.4 )
 - Compatible build tool e.g.
   - [Make](https://www.gnu.org/software/make/)
@@ -41,41 +41,44 @@ target_link_libraries(MyFirmware PRIVATE lvgl::lvgl)
 This configuration declares a dependency between the two targets **MyFirmware** and **lvgl**. Upon building the target **MyFirmware** this dependency will be resolved and **lvgl** will be built and linked with it. Since LVGL requires a config header called [lv_conf.h](https://github.com/lvgl/lvgl/blob/master/lv_conf_template.h) to be includable by its sources we also set the option `LV_CONF_PATH` to point to our own copy of it.
 
 ### Additional CMake options
-Besides `LV_CONF_PATH` there are two additional CMake options to specify include paths.
+Besides `LV_CONF_PATH` there are few additional CMake options available.
 
-`LV_LVGL_H_INCLUDE_SIMPLE` which specifies whether to `#include "lvgl.h"` absolut or relative
+#### Include paths options
 
-| ON (default) | OFF            |
-| ------------ | -------------- |
-| "lvgl.h"     | "../../lvgl.h" |
+- `LV_LVGL_H_INCLUDE_SIMPLE`: which specifies whether to `#include "lvgl.h"` absolut or relative
 
-`LV_CONF_INCLUDE_SIMPLE` which specifies whether to `#include "lv_conf.h"` and `"lv_drv_conf.h"` absolut or relative
+    | ON (default) | OFF            |
+    | ------------ | -------------- |
+    | "lvgl.h"     | "../../lvgl.h" |
 
-| ON (default)    | OFF                   |
-| --------------- | --------------------- |
-| "lv_conf.h"     | "../../lv_conf.h"     |
-| "lv_drv_conf.h" | "../../lv_drv_conf.h" |
+- `LV_CONF_INCLUDE_SIMPLE`: which specifies whether to `#include "lv_conf.h"` and `"lv_drv_conf.h"` absolut or relative
 
-I do not recommend disabling those options unless your folder layout makes it absolutely necessary.
+    | ON (default)    | OFF                   |
+    | --------------- | --------------------- |
+    | "lv_conf.h"     | "../../lv_conf.h"     |
+    | "lv_drv_conf.h" | "../../lv_drv_conf.h" |
 
-## Building LVGL examples with CMake
-LVGL [examples](https://docs.lvgl.io/master/examples.html) have their own CMake target. If you want to build the examples simply add them to your dependencies.
+> We do not recommend disabling those options unless your folder layout makes it absolutely necessary.
 
-```cmake
-# The target "MyFirmware" depends on LVGL and examples
-target_link_libraries(MyFirmware PRIVATE lvgl::lvgl lvgl::examples)
-```
+#### Examples/demos options
 
-## Building LVGL drivers and demos with CMake
-Exactly the same goes for the [drivers](https://github.com/lvgl/lv_drivers) and the [demos](https://github.com/lvgl/lvgl/demos).
+LVGL [examples](https://docs.lvgl.io/master/examples.html) and [demos](https://github.com/lvgl/lvgl/demos) are built by default in the main CMake file.  
+To disable their built, use:
+
+- `LV_CONF_BUILD_DISABLE_EXAMPLES`: Set to `1` to disable _examples_ build
+- `LV_CONF_BUILD_DISABLE_DEMOS`: Set to `1` to disable _demos_ build
+
+## Building LVGL drivers
+
+To build [LVGL drivers](https://github.com/lvgl/lv_drivers), you can use:
 
 ```cmake
 FetchContent_Declare(lv_drivers
                      GIT_REPOSITORY https://github.com/lvgl/lv_drivers)
 FetchContent_MakeAvailable(lv_drivers)
 
-# The target "MyFirmware" depends on LVGL, drivers and demos
-target_link_libraries(MyFirmware PRIVATE lvgl::lvgl lvgl::drivers lvgl::examples)
+# The target "MyFirmware" depends on LVGL and drivers
+target_link_libraries(MyFirmware PRIVATE lvgl::lvgl lvgl::drivers)
 ```
 
 # Build shared libraries with CMake

--- a/env_support/cmake/custom.cmake
+++ b/env_support/cmake/custom.cmake
@@ -14,16 +14,14 @@ get_filename_component(LV_CONF_DIR ${LV_CONF_PATH} DIRECTORY)
 # Option to build shared libraries (as opposed to static), default: OFF
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 
+# Set sources used for LVGL components
 file(GLOB_RECURSE SOURCES ${LVGL_ROOT_DIR}/src/*.c)
 file(GLOB_RECURSE EXAMPLE_SOURCES ${LVGL_ROOT_DIR}/examples/*.c)
 file(GLOB_RECURSE DEMO_SOURCES ${LVGL_ROOT_DIR}/demos/*.c)
 
+# Build LVGL library
 add_library(lvgl ${SOURCES})
 add_library(lvgl::lvgl ALIAS lvgl)
-add_library(lvgl_examples ${EXAMPLE_SOURCES})
-add_library(lvgl::examples ALIAS lvgl_examples)
-add_library(lvgl_demos ${DEMO_SOURCES})
-add_library(lvgl::demos ALIAS lvgl_demos)
 
 target_compile_definitions(
   lvgl PUBLIC $<$<BOOL:${LV_LVGL_H_INCLUDE_SIMPLE}>:LV_LVGL_H_INCLUDE_SIMPLE>
@@ -37,14 +35,23 @@ endif()
 # Include root and optional parent path of LV_CONF_PATH
 target_include_directories(lvgl SYSTEM PUBLIC ${LVGL_ROOT_DIR} ${LV_CONF_DIR})
 
-# Include /examples folder
-target_include_directories(lvgl_examples SYSTEM
-                           PUBLIC ${LVGL_ROOT_DIR}/examples)
-target_include_directories(lvgl_demos SYSTEM
-                           PUBLIC ${LVGL_ROOT_DIR}/demos)
+# Build LVGL example library
+if(NOT LV_CONF_BUILD_DISABLE_EXAMPLES)
+    add_library(lvgl_examples ${EXAMPLE_SOURCES})
+    add_library(lvgl::examples ALIAS lvgl_examples)
 
-target_link_libraries(lvgl_examples PUBLIC lvgl)
-target_link_libraries(lvgl_demos PUBLIC lvgl)
+    target_include_directories(lvgl_examples SYSTEM PUBLIC ${LVGL_ROOT_DIR}/examples)
+    target_link_libraries(lvgl_examples PUBLIC lvgl)
+endif()
+
+# Build LVGL demos library
+if(NOT LV_CONF_BUILD_DISABLE_DEMOS)
+    add_library(lvgl_demos ${DEMO_SOURCES})
+    add_library(lvgl::demos ALIAS lvgl_demos)
+
+    target_include_directories(lvgl_demos SYSTEM PUBLIC ${LVGL_ROOT_DIR}/demos)
+    target_link_libraries(lvgl_demos PUBLIC lvgl)
+endif()
 
 # Lbrary and headers can be installed to system using make install
 file(GLOB LVGL_PUBLIC_HEADERS "${CMAKE_SOURCE_DIR}/lv_conf.h"


### PR DESCRIPTION
### Description of the feature or fix

When building LVGL with examples and demos disabled in `lv.conf`, those are still build by [cmake.custom](https://github.com/lvgl/lvgl/blob/master/env_support/cmake/custom.cmake) (in a light version but they are still build: `liblvgl_examples.a` -> 209,6 Ko and `liblvgl_demos.a` -> 96,2 Ko).  

Introduce new CMake options `LV_CONF_BUILD_DISABLE_EXAMPLES` and `LV_CONF_BUILD_DISABLE_DEMOS` to allow  to disable build of those components.  
Usage:
```
cd build/
cmake "-DLV_CONF_PATH=/path/custom_lvgl_conf.h" "-DLV_CONF_BUILD_DISABLE_EXAMPLES=1" "-DLV_CONF_BUILD_DISABLE_DEMOS=1" ..
cmake --build .
```
> Only **lvgl** library will be built.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
