### PR TITLE
fix(qrcode): remove global variables and lv_qrcode_delete

### DIFF
--- a/docs/libs/qrcode.md
+++ b/docs/libs/qrcode.md
@@ -3,21 +3,13 @@
 
 QR code generation with LVGL. Uses [QR-Code-generator](https://github.com/nayuki/QR-Code-generator) by [nayuki](https://github.com/nayuki).
 
-## Get started
-- Download or clone this repository
-  - [Download](https://github.com/lvgl/lv_lib_qrcode.git) from GitHub
-  - Clone: git clone https://github.com/lvgl/lv_lib_qrcode.git
-- Include the library: `#include "lv_lib_qrcode/lv_qrcode.h"`
-- Test with the following code:
-```c
-const char * data = "Hello world";
+## Usage
 
-/*Create a 100x100 QR code*/
-lv_obj_t * qr = lv_qrcode_create(lv_scr_act(), 100, lv_color_hex3(0x33f), lv_color_hex3(0xeef));
+Enable `LV_USE_QRCODE` in `lv_conf.h`.
 
-/*Set data*/
-lv_qrcode_update(qr, data, strlen(data));
-```
+Use `lv_qrcode_create()` to create a qrcode object, and use `lv_qrcode_update()` to generate a QR code.
+
+If you need to re-modify the size and color, use `lv_qrcode_set_size()` and `lv_qrcode_set_dark/light_color()`, and call `lv_qrcode_update()` again to regenerate the QR code.
 
 ## Notes
 - QR codes with less data are smaller, but they scaled by an integer number to best fit to the given size.

--- a/examples/libs/qrcode/lv_example_qrcode_1.c
+++ b/examples/libs/qrcode/lv_example_qrcode_1.c
@@ -9,7 +9,10 @@ void lv_example_qrcode_1(void)
     lv_color_t bg_color = lv_palette_lighten(LV_PALETTE_LIGHT_BLUE, 5);
     lv_color_t fg_color = lv_palette_darken(LV_PALETTE_BLUE, 4);
 
-    lv_obj_t * qr = lv_qrcode_create(lv_scr_act(), 150, fg_color, bg_color);
+    lv_obj_t * qr = lv_qrcode_create(lv_scr_act());
+    lv_qrcode_set_size(qr, 150);
+    lv_qrcode_set_dark_color(qr, fg_color);
+    lv_qrcode_set_light_color(qr, bg_color);
 
     /*Set data*/
     const char * data = "https://lvgl.io";
@@ -22,11 +25,3 @@ void lv_example_qrcode_1(void)
 }
 
 #endif
-
-
-
-
-
-
-
-

--- a/examples/libs/qrcode/lv_example_qrcode_1.py
+++ b/examples/libs/qrcode/lv_example_qrcode_1.py
@@ -5,11 +5,16 @@ import display_driver
 bg_color = lv.palette_lighten(lv.PALETTE.LIGHT_BLUE, 5)
 fg_color = lv.palette_darken(lv.PALETTE.BLUE, 4)
 
-qr = lv.qrcode(lv.scr_act(), 150, fg_color, bg_color)
+qr = lv.qrcode(lv.scr_act())
+qr.set_size(150)
+qr.set_dark_color(fg_color)
+qr.set_light_color(bg_color)
+
 # Set data
 data = "https://lvgl.io"
 qr.update(data,len(data))
 qr.center()
+
 # Add a border with bg_color
 qr.set_style_border_color(bg_color, 0)
 qr.set_style_border_width(5, 0)

--- a/src/libs/qrcode/lv_qrcode.c
+++ b/src/libs/qrcode/lv_qrcode.c
@@ -48,18 +48,13 @@ const lv_obj_class_t lv_qrcode_class = {
 /**
  * Create an empty QR code (an `lv_canvas`) object.
  * @param parent point to an object where to create the QR code
- * @param size width and height of the QR code
- * @param dark_color dark color of the QR code
- * @param light_color light color of the QR code
  * @return pointer to the created QR code object
  */
-lv_obj_t * lv_qrcode_create(lv_obj_t * parent, lv_coord_t size, lv_color_t dark_color, lv_color_t light_color)
+lv_obj_t * lv_qrcode_create(lv_obj_t * parent)
 {
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(MY_CLASS, parent);
     lv_obj_class_init_obj(obj);
-    lv_qrcode_set_size(obj, size);
-    lv_qrcode_set_color(obj, dark_color, light_color);
     return obj;
 }
 
@@ -67,49 +62,60 @@ void lv_qrcode_set_size(lv_obj_t * obj, lv_coord_t size)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
-    lv_qrcode_t * qrcode = (lv_qrcode_t *)obj;
-    uint32_t buf_size = LV_CANVAS_BUF_SIZE_INDEXED_1BIT(size, size);
-    qrcode->buf = lv_realloc(qrcode->buf, buf_size);
-    LV_ASSERT_MALLOC(qrcode->buf);
-    if(qrcode->buf == NULL) return;
+    lv_img_dsc_t * img_dsc = lv_canvas_get_img(obj);
+    void * buf = (void *)img_dsc->data;
 
-    lv_canvas_set_buffer(obj, qrcode->buf, size, size, LV_IMG_CF_INDEXED_1BIT);
+    uint32_t buf_size = LV_CANVAS_BUF_SIZE_INDEXED_1BIT(size, size);
+    buf = lv_realloc(buf, buf_size);
+    LV_ASSERT_MALLOC(buf);
+    if(buf == NULL) {
+        LV_LOG_ERROR("malloc failed for canvas buffer");
+        return;
+    }
+
+    lv_canvas_set_buffer(obj, buf, size, size, LV_IMG_CF_INDEXED_1BIT);
 }
 
-void lv_qrcode_set_color(lv_obj_t * obj, lv_color_t dark_color, lv_color_t light_color)
+void lv_qrcode_set_dark_color(lv_obj_t * obj, lv_color_t color)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
-
-    lv_canvas_set_palette(obj, 0, dark_color);
-    lv_canvas_set_palette(obj, 1, light_color);
+    lv_qrcode_t * qrcode = (lv_qrcode_t *)obj;
+    qrcode->dark_color = color;
 }
 
-/**
- * Set the data of a QR code object
- * @param qrcode pointer to aQ code object
- * @param data data to display
- * @param data_len length of data in bytes
- * @return LV_RES_OK: if no error; LV_RES_INV: on error
- */
+void lv_qrcode_set_light_color(lv_obj_t * obj, lv_color_t color)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_qrcode_t * qrcode = (lv_qrcode_t *)obj;
+    qrcode->light_color = color;
+}
+
 lv_res_t lv_qrcode_update(lv_obj_t * obj, const void * data, uint32_t data_len)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_qrcode_t * qrcode = (lv_qrcode_t *)obj;
 
+    lv_img_dsc_t * img_dsc = lv_canvas_get_img(obj);
+    if(!img_dsc->data) {
+        LV_LOG_ERROR("canvas buffer is NULL");
+        return LV_RES_INV;
+    }
+
+    lv_canvas_set_palette(obj, 0, qrcode->dark_color);
+    lv_canvas_set_palette(obj, 1, qrcode->light_color);
     lv_color_t c;
     c.full = 1;
     lv_canvas_fill_bg(obj, c, LV_OPA_COVER);
 
     if(data_len > qrcodegen_BUFFER_LEN_MAX) return LV_RES_INV;
 
-    lv_img_dsc_t * imgdsc = lv_canvas_get_img(obj);
-
     int32_t qr_version = qrcodegen_getMinFitVersion(qrcodegen_Ecc_MEDIUM, data_len);
     if(qr_version <= 0) return LV_RES_INV;
     int32_t qr_size = qrcodegen_version2size(qr_version);
     if(qr_size <= 0) return LV_RES_INV;
-    int32_t scale = imgdsc->header.w / qr_size;
+    int32_t scale = img_dsc->header.w / qr_size;
     if(scale <= 0) return LV_RES_INV;
-    int32_t remain = imgdsc->header.w % qr_size;
+    int32_t remain = img_dsc->header.w % qr_size;
 
     /* The qr version is incremented by four point */
     uint32_t version_extend = remain / (scale << 2);
@@ -135,17 +141,17 @@ lv_res_t lv_qrcode_update(lv_obj_t * obj, const void * data, uint32_t data_len)
         return LV_RES_INV;
     }
 
-    lv_coord_t obj_w = imgdsc->header.w;
+    lv_coord_t obj_w = img_dsc->header.w;
     qr_size = qrcodegen_getSize(qr0);
     scale = obj_w / qr_size;
     int scaled = qr_size * scale;
     int margin = (obj_w - scaled) / 2;
-    uint8_t * buf_u8 = (uint8_t *)imgdsc->data + 8;    /*+8 skip the palette*/
+    uint8_t * buf_u8 = (uint8_t *)img_dsc->data + 8;    /*+8 skip the palette*/
 
     /* Copy the qr code canvas:
      * A simple `lv_canvas_set_px` would work but it's slow for so many pixels.
      * So buffer 1 byte (8 px) from the qr code and set it in the canvas image */
-    uint32_t row_byte_cnt = (imgdsc->header.w + 7) >> 3;
+    uint32_t row_byte_cnt = (img_dsc->header.w + 7) >> 3;
     int y;
     for(y = margin; y < scaled + margin; y += scale) {
         uint8_t b = 0;
@@ -202,17 +208,28 @@ lv_res_t lv_qrcode_update(lv_obj_t * obj, const void * data, uint32_t data_len)
 static void lv_qrcode_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
 {
     LV_UNUSED(class_p);
-    LV_UNUSED(obj);
+
+    /*Set default size*/
+    lv_qrcode_set_size(obj, LV_DPI_DEF);
+
+    /*Set default color*/
+    lv_qrcode_set_dark_color(obj, lv_color_black());
+    lv_qrcode_set_light_color(obj, lv_color_white());
 }
 
 static void lv_qrcode_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
 {
     LV_UNUSED(class_p);
 
-    lv_img_dsc_t * img = lv_canvas_get_img(obj);
-    lv_img_cache_invalidate_src(img);
-    lv_free((void *)img->data);
-    img->data = NULL;
+    lv_img_dsc_t * img_dsc = lv_canvas_get_img(obj);
+    lv_img_cache_invalidate_src(img_dsc);
+
+    if(!img_dsc->data) {
+        return;
+    }
+
+    lv_free((void *)img_dsc->data);
+    img_dsc->data = NULL;
 }
 
 #endif /*LV_USE_QRCODE*/

--- a/src/libs/qrcode/lv_qrcode.c
+++ b/src/libs/qrcode/lv_qrcode.c
@@ -74,6 +74,9 @@ void lv_qrcode_set_size(lv_obj_t * obj, lv_coord_t size)
     }
 
     lv_canvas_set_buffer(obj, buf, size, size, LV_IMG_CF_INDEXED_1BIT);
+
+    /*Clear canvas buffer*/
+    lv_canvas_fill_bg(obj, lv_color_white(), LV_OPA_COVER);
 }
 
 void lv_qrcode_set_dark_color(lv_obj_t * obj, lv_color_t color)

--- a/src/libs/qrcode/lv_qrcode.h
+++ b/src/libs/qrcode/lv_qrcode.h
@@ -20,11 +20,17 @@ extern "C" {
  *      DEFINES
  *********************/
 
-extern const lv_obj_class_t lv_qrcode_class;
-
 /**********************
  *      TYPEDEFS
  **********************/
+
+/*Data of qrcode*/
+typedef struct {
+    lv_canvas_t canvas;
+    void * buf;
+} lv_qrcode_t;
+
+extern const lv_obj_class_t lv_qrcode_class;
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -41,20 +47,28 @@ extern const lv_obj_class_t lv_qrcode_class;
 lv_obj_t * lv_qrcode_create(lv_obj_t * parent, lv_coord_t size, lv_color_t dark_color, lv_color_t light_color);
 
 /**
+ * Set QR code size.
+ * @param obj pointer to a QR code object
+ * @param size width and height of the QR code
+ */
+void lv_qrcode_set_size(lv_obj_t * obj, lv_coord_t size);
+
+/**
+ * Set QR code color.
+ * @param obj pointer to a QR code object
+ * @param dark_color dark color of the QR code
+ * @param light_color light color of the QR code
+ */
+void lv_qrcode_set_color(lv_obj_t * obj, lv_color_t dark_color, lv_color_t light_color);
+
+/**
  * Set the data of a QR code object
- * @param qrcode pointer to aQ code object
+ * @param obj pointer to a QR code object
  * @param data data to display
  * @param data_len length of data in bytes
  * @return LV_RES_OK: if no error; LV_RES_INV: on error
  */
-lv_res_t lv_qrcode_update(lv_obj_t * qrcode, const void * data, uint32_t data_len);
-
-/**
- * DEPRECATED: Use normal lv_obj_del instead
- * Delete a QR code object
- * @param qrcode pointer to a QR code object
- */
-void lv_qrcode_delete(lv_obj_t * qrcode);
+lv_res_t lv_qrcode_update(lv_obj_t * obj, const void * data, uint32_t data_len);
 
 /**********************
  *      MACROS

--- a/src/libs/qrcode/lv_qrcode.h
+++ b/src/libs/qrcode/lv_qrcode.h
@@ -27,7 +27,8 @@ extern "C" {
 /*Data of qrcode*/
 typedef struct {
     lv_canvas_t canvas;
-    void * buf;
+    lv_color_t dark_color;
+    lv_color_t light_color;
 } lv_qrcode_t;
 
 extern const lv_obj_class_t lv_qrcode_class;
@@ -39,12 +40,9 @@ extern const lv_obj_class_t lv_qrcode_class;
 /**
  * Create an empty QR code (an `lv_canvas`) object.
  * @param parent point to an object where to create the QR code
- * @param size width and height of the QR code
- * @param dark_color dark color of the QR code
- * @param light_color light color of the QR code
  * @return pointer to the created QR code object
  */
-lv_obj_t * lv_qrcode_create(lv_obj_t * parent, lv_coord_t size, lv_color_t dark_color, lv_color_t light_color);
+lv_obj_t * lv_qrcode_create(lv_obj_t * parent);
 
 /**
  * Set QR code size.
@@ -54,12 +52,18 @@ lv_obj_t * lv_qrcode_create(lv_obj_t * parent, lv_coord_t size, lv_color_t dark_
 void lv_qrcode_set_size(lv_obj_t * obj, lv_coord_t size);
 
 /**
- * Set QR code color.
+ * Set QR code dark color.
  * @param obj pointer to a QR code object
- * @param dark_color dark color of the QR code
- * @param light_color light color of the QR code
+ * @param color dark color of the QR code
  */
-void lv_qrcode_set_color(lv_obj_t * obj, lv_color_t dark_color, lv_color_t light_color);
+void lv_qrcode_set_dark_color(lv_obj_t * obj, lv_color_t color);
+
+/**
+ * Set QR code light color.
+ * @param obj pointer to a QR code object
+ * @param color light color of the QR code
+ */
+void lv_qrcode_set_light_color(lv_obj_t * obj, lv_color_t color);
 
 /**
  * Set the data of a QR code object


### PR DESCRIPTION
### Description of the feature or fix

1.Remove global variables
2.Remove the `size`, `dark_color`, `light_color` parameters in `lv_qrcode_create()`
3.Remove `lv_qrcode_delete()`

### Checkpoints
- [x] Run `code-format.py` from the scripts folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [x] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant. 
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- [ ] If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/release/v8.3/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/release/v8.3/Kconfig).
 
Be sure the following conventions are followed:
- [x] Follow the [Styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Prefer `enum`s instead of macros. If inevitable to use `define`s export them with `LV_EXPORT_CONST_INT(defined_value)` right after the `define`.
- [x] In function arguments prefer `type name[]` declaration for array parameters instead of `type * name`
- [x] Use typed pointers instead of `void *` pointers
- [x] Do not `malloc` into a static or global variables. Instead declare the variable in `LV_ITERATE_ROOTS` list in [`lv_gc.h`](https://github.com/lvgl/lvgl/blob/master/src/misc/lv_gc.h) and mark the variable with `GC_ROOT(variable)` when it's used.
- [x] Widget constructor must follow the `lv_<widget_name>_create(lv_obj_t * parent)` pattern.
- [x] Widget members function must start with `lv_<modul_name>` and should receive `lv_obj_t *` as first argument which is a pointer to widget object itself.  
- [x] `struct`s should be used via an API and not modified directly via their elements.
- [x] `struct` APIs should follow the widgets' conventions. That is to receive a pointer to the `struct` as the first argument, and the prefix of the `struct` name should be used as the prefix of the function name too (e.g.  `lv_disp_set_default(lv_disp_t * disp)`)
- [x] Functions and `struct`s which are not part of the public API must begin with underscore in order to mark them as "private".
- [x] Arguments must be named in H files too.
- [x] To register and use callbacks one of the followings needs to be followed: 
  - For both the registration function and the callback pass a pointer to a `struct` as the first argument. The `struct` must contain `void * user_data` field.
  - The last argument of the registration function must be `void * user_data` and the same `user_data` needs to be passed as the last argument of the callback.
  - Callback types not following these conventions should end with `xcb_t`.
