### PR TITLE
fix(obj): readjust scroll after layout when child removed

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -702,6 +702,10 @@ static void lv_obj_event(const lv_obj_class_t * class_p, lv_event_t * e)
             lv_obj_mark_layout_as_dirty(obj);
         }
     }
+    else if(code == LV_EVENT_CHILD_DELETED) {
+        obj->readjust_scroll_after_layout = 1;
+        lv_obj_mark_layout_as_dirty(obj);
+    }
     else if(code == LV_EVENT_REFR_EXT_DRAW_SIZE) {
         int32_t d = lv_obj_calculate_ext_draw_size(obj, LV_PART_MAIN);
         lv_event_set_ext_draw_size(e, d);

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -237,6 +237,7 @@ typedef struct _lv_obj_t {
     lv_obj_flag_t flags;
     lv_state_t state;
     uint16_t layout_inv : 1;
+    uint16_t readjust_scroll_after_layout : 1;
     uint16_t scr_layout_inv : 1;
     uint16_t skip_trans : 1;
     uint16_t style_cnt  : 6;

--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -192,7 +192,7 @@ bool lv_obj_refr_size(lv_obj_t * obj)
     /*Invalidate the new area*/
     lv_obj_invalidate(obj);
 
-    lv_obj_readjust_scroll(obj, LV_ANIM_OFF);
+    obj->readjust_scroll_after_layout = 1;
 
     /*If the object was out of the parent invalidate the new scrollbar area too.
      *If it wasn't out of the parent but out now, also invalidate the scrollbars*/
@@ -1098,15 +1098,19 @@ static void layout_update_core(lv_obj_t * obj)
         layout_update_core(child);
     }
 
-    if(obj->layout_inv == 0) return;
+    if(obj->layout_inv) {
+        obj->layout_inv = 0;
+        lv_obj_refr_size(obj);
+        lv_obj_refr_pos(obj);
 
-    obj->layout_inv = 0;
+        if(child_cnt > 0) {
+            _lv_layout_apply(obj);
+        }
+    }
 
-    lv_obj_refr_size(obj);
-    lv_obj_refr_pos(obj);
-
-    if(child_cnt > 0) {
-        _lv_layout_apply(obj);
+    if(obj->readjust_scroll_after_layout) {
+        obj->readjust_scroll_after_layout = 0;
+        lv_obj_readjust_scroll(obj, LV_ANIM_OFF);
     }
 }
 

--- a/src/core/lv_obj_scroll.h
+++ b/src/core/lv_obj_scroll.h
@@ -298,7 +298,7 @@ void lv_obj_get_scrollbar_area(struct _lv_obj_t * obj, lv_area_t * hor, lv_area_
 void lv_obj_scrollbar_invalidate(struct _lv_obj_t * obj);
 
 /**
- * Checked if the content is scrolled "in" and adjusts it to a normal position.
+ * Checks if the content is scrolled "in" and adjusts it to a normal position.
  * @param obj       pointer to an object
  * @param anim_en   LV_ANIM_ON/OFF
  */

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -60,9 +60,6 @@ void lv_obj_delete(lv_obj_t * obj)
     lv_obj_invalidate(obj);
 
     lv_obj_t * par = lv_obj_get_parent(obj);
-    if(par && !par->is_deleting) {
-        lv_obj_scrollbar_invalidate(par);
-    }
 
     lv_display_t * disp = NULL;
     bool act_screen_del = false;
@@ -76,8 +73,6 @@ void lv_obj_delete(lv_obj_t * obj)
 
     /*Call the ancestor's event handler to the parent to notify it about the child delete*/
     if(par && !par->is_deleting) {
-        lv_obj_update_layout(par);
-        lv_obj_readjust_scroll(par, LV_ANIM_OFF);
         lv_obj_scrollbar_invalidate(par);
         lv_obj_send_event(par, LV_EVENT_CHILD_CHANGED, NULL);
         lv_obj_send_event(par, LV_EVENT_CHILD_DELETED, NULL);
@@ -190,7 +185,6 @@ void lv_obj_set_parent(lv_obj_t * obj, lv_obj_t * parent)
     obj->parent = parent;
 
     /*Notify the original parent because one of its children is lost*/
-    lv_obj_readjust_scroll(old_parent, LV_ANIM_OFF);
     lv_obj_scrollbar_invalidate(old_parent);
     lv_obj_send_event(old_parent, LV_EVENT_CHILD_CHANGED, obj);
     lv_obj_send_event(old_parent, LV_EVENT_CHILD_DELETED, NULL);


### PR DESCRIPTION
Removing a child element may cause the current scroll position of the parent to become invalid. This was reported and *partially* fixed in #3210.

Looking at the original reproducer, there's another way to remove `obj3` that still exhibits the bug:

```c
    if(code == LV_EVENT_CLICKED) {
        lv_obj_set_parent(obj0, obj2);
        lv_obj_set_parent(obj3, lv_scr_act()); // instead of lv_obj_del_async(obj3);
    }
```

To fix both, add a general mechanism to call `lv_obj_readjust_scroll()` after revalidating the layout. This also fixes (or at least significantly improves) the performance issue in #4908.