### PR TITLE
fix(draw): fix "blend_non_normal_pixel: Not supported blend mode" issue when using lv_demo_smartwatch which compiled by MSVC

### DIFF
--- a/src/draw/lv_draw_image.h
+++ b/src/draw/lv_draw_image.h
@@ -71,7 +71,7 @@ struct _lv_draw_image_dsc_t {
     /**Describes how to blend the pixels of the image to the background.
      * See `lv_blend_mode_t` for more details.
      */
-    lv_blend_mode_t blend_mode : 3;
+    uint16_t blend_mode : 4;
 
     /**1: perform the transformation with anti-alaising */
     uint16_t antialias          : 1;

--- a/src/draw/lv_draw_image.h
+++ b/src/draw/lv_draw_image.h
@@ -71,7 +71,7 @@ struct _lv_draw_image_dsc_t {
     /**Describes how to blend the pixels of the image to the background.
      * See `lv_blend_mode_t` for more details.
      */
-    uint16_t blend_mode : 4;
+    lv_blend_mode_t blend_mode : 4;
 
     /**1: perform the transformation with anti-alaising */
     uint16_t antialias          : 1;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ebb06266-988b-450d-ae46-014e3d8c9e3e)

In the recent days, one of LVGL Visual Studio repository users told me that there are some issues mentioned in the screenshot when he trying to use lv_demo_smartwatch.

This issue seems something familiar for me. So, I solve the issue for that user quickly. I think I should create a PR instead of an issue, and hope the issue can be fixed as soon as possible.

Kenji Mouri