### PR TITLE
Bugfix and improvement for the logging

### DIFF
--- a/src/misc/lv_log.c
+++ b/src/misc/lv_log.c
@@ -96,13 +96,6 @@ void lv_log_add(lv_log_level_t level, const char * file, int line, const char * 
 #endif
         static const char * lvl_prefix[] = {"Trace", "Info", "Warn", "Error", "User"};
 
-#if LV_LOG_PRINTF
-        printf("[%s]" LOG_TIMESTAMP_FMT " %s: ",
-               lvl_prefix[level], LOG_TIMESTAMP_EXPR func);
-        vprintf(format, args);
-        printf(LOG_FILE_LINE_FMT "\n" LOG_FILE_LINE_EXPR);
-        fflush(stdout);
-#else
         if(custom_print_cb) {
             char buf[512];
             char msg[256];
@@ -110,6 +103,14 @@ void lv_log_add(lv_log_level_t level, const char * file, int line, const char * 
             lv_snprintf(buf, sizeof(buf), "[%s]" LOG_TIMESTAMP_FMT " %s: %s" LOG_FILE_LINE_FMT "\n",
                         lvl_prefix[level], LOG_TIMESTAMP_EXPR func, msg LOG_FILE_LINE_EXPR);
             custom_print_cb(level, buf);
+        }
+#if LV_LOG_PRINTF
+        else {
+            printf("[%s]" LOG_TIMESTAMP_FMT " %s: ",
+                   lvl_prefix[level], LOG_TIMESTAMP_EXPR func);
+            vprintf(format, args);
+            printf(LOG_FILE_LINE_FMT "\n" LOG_FILE_LINE_EXPR);
+            fflush(stdout);
         }
 #endif
 
@@ -127,13 +128,14 @@ void lv_log(const char * format, ...)
     va_list args;
     va_start(args, format);
 
-#if LV_LOG_PRINTF
-    vprintf(format, args);
-#else
     if(custom_print_cb) {
         char buf[512];
         lv_vsnprintf(buf, sizeof(buf), format, args);
         custom_print_cb(LV_LOG_LEVEL_USER, buf);
+    }
+#if LV_LOG_PRINTF
+    else {
+        vprintf(format, args);
     }
 #endif
 

--- a/src/misc/lv_log.c
+++ b/src/misc/lv_log.c
@@ -102,7 +102,7 @@ void lv_log_add(lv_log_level_t level, const char * file, int line, const char * 
         vprintf(format, args);
         printf(LOG_FILE_LINE_FMT "\n" LOG_FILE_LINE_EXPR);
         fflush(stdout);
-#endif
+#else
         if(custom_print_cb) {
             char buf[512];
             char msg[256];
@@ -111,6 +111,7 @@ void lv_log_add(lv_log_level_t level, const char * file, int line, const char * 
                         lvl_prefix[level], LOG_TIMESTAMP_EXPR func, msg LOG_FILE_LINE_EXPR);
             custom_print_cb(level, buf);
         }
+#endif
 
 #if LV_LOG_USE_TIMESTAMP
         last_log_time = t;


### PR DESCRIPTION
The first commit fixes a crash in the log function when both LV_LOG_PRINTF is enabled and a log callback is registered. In that case the varargs are used twice, which results in a crash.

The second commit changes the logic to prefer the registered log function over LV_LOG_PRINTF to make it possible to replace the logging destination at runtime.

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
