### PR TITLE
Adds a null check in lv_vg_lite_pending_array_clear

### DIFF
--- a/src/draw/vg_lite/lv_vg_lite_pending.c
+++ b/src/draw/vg_lite/lv_vg_lite_pending.c
@@ -19,19 +19,20 @@
  *      TYPEDEFS
  **********************/
 
-struct _lv_vg_lite_pending_t {
-    lv_array_t * arr_act;
+struct _lv_vg_lite_pending_t
+{
+    lv_array_t *arr_act;
     lv_array_t arr_1;
     lv_array_t arr_2;
     lv_vg_lite_pending_free_cb_t free_cb;
-    void * user_data;
+    void *user_data;
 };
 
 /**********************
  *  STATIC PROTOTYPES
  **********************/
 
-static inline void lv_vg_lite_pending_array_clear(lv_vg_lite_pending_t * pending, lv_array_t * arr);
+static inline void lv_vg_lite_pending_array_clear(lv_vg_lite_pending_t *pending, lv_array_t *arr);
 
 /**********************
  *  STATIC VARIABLES
@@ -45,9 +46,9 @@ static inline void lv_vg_lite_pending_array_clear(lv_vg_lite_pending_t * pending
  *   GLOBAL FUNCTIONS
  **********************/
 
-lv_vg_lite_pending_t * lv_vg_lite_pending_create(size_t obj_size, uint32_t capacity_default)
+lv_vg_lite_pending_t *lv_vg_lite_pending_create(size_t obj_size, uint32_t capacity_default)
 {
-    lv_vg_lite_pending_t * pending = lv_malloc_zeroed(sizeof(lv_vg_lite_pending_t));
+    lv_vg_lite_pending_t *pending = lv_malloc_zeroed(sizeof(lv_vg_lite_pending_t));
     LV_ASSERT_MALLOC(pending);
     lv_array_init(&pending->arr_1, capacity_default, obj_size);
     lv_array_init(&pending->arr_2, capacity_default, obj_size);
@@ -55,7 +56,7 @@ lv_vg_lite_pending_t * lv_vg_lite_pending_create(size_t obj_size, uint32_t capac
     return pending;
 }
 
-void lv_vg_lite_pending_destroy(lv_vg_lite_pending_t * pending)
+void lv_vg_lite_pending_destroy(lv_vg_lite_pending_t *pending)
 {
     LV_ASSERT_NULL(pending);
     lv_vg_lite_pending_remove_all(pending);
@@ -65,8 +66,8 @@ void lv_vg_lite_pending_destroy(lv_vg_lite_pending_t * pending)
     lv_free(pending);
 }
 
-void lv_vg_lite_pending_set_free_cb(lv_vg_lite_pending_t * pending, lv_vg_lite_pending_free_cb_t free_cb,
-                                    void * user_data)
+void lv_vg_lite_pending_set_free_cb(lv_vg_lite_pending_t *pending, lv_vg_lite_pending_free_cb_t free_cb,
+                                    void *user_data)
 {
     LV_ASSERT_NULL(pending);
     LV_ASSERT_NULL(free_cb);
@@ -74,14 +75,14 @@ void lv_vg_lite_pending_set_free_cb(lv_vg_lite_pending_t * pending, lv_vg_lite_p
     pending->user_data = user_data;
 }
 
-void lv_vg_lite_pending_add(lv_vg_lite_pending_t * pending, void * obj)
+void lv_vg_lite_pending_add(lv_vg_lite_pending_t *pending, void *obj)
 {
     LV_ASSERT_NULL(pending);
     LV_ASSERT_NULL(obj);
     lv_array_push_back(pending->arr_act, obj);
 }
 
-void lv_vg_lite_pending_remove_all(lv_vg_lite_pending_t * pending)
+void lv_vg_lite_pending_remove_all(lv_vg_lite_pending_t *pending)
 {
     LV_ASSERT_NULL(pending);
 
@@ -89,7 +90,7 @@ void lv_vg_lite_pending_remove_all(lv_vg_lite_pending_t * pending)
     lv_vg_lite_pending_array_clear(pending, &pending->arr_2);
 }
 
-void lv_vg_lite_pending_swap(lv_vg_lite_pending_t * pending)
+void lv_vg_lite_pending_swap(lv_vg_lite_pending_t *pending)
 {
     pending->arr_act = (pending->arr_act == &pending->arr_1) ? &pending->arr_2 : &pending->arr_1;
     lv_vg_lite_pending_array_clear(pending, pending->arr_act);
@@ -99,17 +100,20 @@ void lv_vg_lite_pending_swap(lv_vg_lite_pending_t * pending)
  *   STATIC FUNCTIONS
  **********************/
 
-static inline void lv_vg_lite_pending_array_clear(lv_vg_lite_pending_t * pending, lv_array_t * arr)
+static inline void lv_vg_lite_pending_array_clear(lv_vg_lite_pending_t *pending, lv_array_t *arr)
 {
-    if (!pending->free_cb) return; // fail-safe
+    if (!pending->free_cb)
+        return; // fail-safe
 
     uint32_t size = lv_array_size(arr);
-    if(size == 0) {
+    if (size == 0)
+    {
         return;
     }
 
     /* remove all the pending objects */
-    for(uint32_t i = 0; i < size; i++) {
+    for (uint32_t i = 0; i < size; i++)
+    {
         pending->free_cb(lv_array_at(arr, i), pending->user_data);
     }
 

--- a/src/draw/vg_lite/lv_vg_lite_pending.c
+++ b/src/draw/vg_lite/lv_vg_lite_pending.c
@@ -101,7 +101,7 @@ void lv_vg_lite_pending_swap(lv_vg_lite_pending_t * pending)
 
 static inline void lv_vg_lite_pending_array_clear(lv_vg_lite_pending_t * pending, lv_array_t * arr)
 {
-    LV_ASSERT_NULL(pending->free_cb);
+    if (!pending->free_cb) return; // fail-safe
 
     uint32_t size = lv_array_size(arr);
     if(size == 0) {


### PR DESCRIPTION
Adds a null check in lv_vg_lite_pending_array_clear to prevent a potential crash when free_cb is not set.

Bug Fix in Source Code:
In src/draw/vg_lite/lv_vg_lite_pending.c, the following line was added to prevent a potential crash when no cleanup callback is configured:

if (!pending->free_cb) return; // fail-safe

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
