### PR TITLE
perf(blend): fix loop unrolling condition

### DIFF
--- a/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888.c
@@ -257,7 +257,7 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_argb8888(lv_draw_sw_blend_f
             uint32_t color32 = lv_color_to_u32(dsc->color);
             uint32_t * dest_buf = dsc->dest_buf;
             for(y = 0; y < h; y++) {
-                for(x = 0; x < w - 16; x += 16) {
+                for(x = 0; x < w - 15; x += 16) {
                     dest_buf[x + 0] = color32;
                     dest_buf[x + 1] = color32;
                     dest_buf[x + 2] = color32;


### PR DESCRIPTION
Something i noticed while taking a look at this code

Take w == 16, x == 0, `x < w - 16` means we never enter this loop even thought it's safe to do so