### PR TITLE
fix(calendar): allow setting years in ascending order

### DIFF
--- a/src/widgets/calendar/lv_calendar_header_dropdown.c
+++ b/src/widgets/calendar/lv_calendar_header_dropdown.c
@@ -145,17 +145,20 @@ static void year_event_cb(lv_event_t * e)
 
     uint32_t sel = lv_dropdown_get_selected(dropdown);
 
+    const char * year_p = lv_dropdown_get_options(dropdown);
+
+    LV_ASSERT(3 + sel * 5 < lv_strlen(year_p));
+
+    /* NOTE: Assumes YYYY format */
+    const uint32_t year = (year_p[0 + sel * 5] - '0') * 1000 +
+                          (year_p[1 + sel * 5] - '0') * 100 +
+                          (year_p[2 + sel * 5] - '0') * 10 +
+                          (year_p[3 + sel * 5] - '0');
+
     const lv_calendar_date_t * d;
     d = lv_calendar_get_showed_date(calendar);
-
-    /* Get the first year on the options list
-     * NOTE: Assumes the first 4 digits in the option list are numbers */
-    const char * year_p = lv_dropdown_get_options(dropdown);
-    const uint32_t year = (year_p[0] - '0') * 1000 + (year_p[1] - '0') * 100 + (year_p[2] - '0') * 10 +
-                          (year_p[3] - '0');
-
     lv_calendar_date_t newd = *d;
-    newd.year = year - sel;
+    newd.year = year;
 
     lv_calendar_set_month_shown(calendar, newd.year, newd.month);
 }
@@ -165,18 +168,14 @@ static void value_changed_event_cb(lv_event_t * e)
     lv_obj_t * header = lv_event_get_current_target(e);
     lv_obj_t * calendar = lv_obj_get_parent(header);
     const lv_calendar_date_t * cur_date = lv_calendar_get_showed_date(calendar);
-
     lv_obj_t * year_dd = lv_obj_get_child(header, 0);
-
-    /* Get the first year on the options list
-     * NOTE: Assumes the first 4 digits in the option list are numbers */
-    const char * year_p = lv_dropdown_get_options(year_dd);
-    const uint32_t year = (year_p[0] - '0') * 1000 + (year_p[1] - '0') * 100 + (year_p[2] - '0') * 10 +
-                          (year_p[3] - '0');
-
-    lv_dropdown_set_selected(year_dd, year - cur_date->year);
-
     lv_obj_t * month_dd = lv_obj_get_child(header, 1);
+    const char * year_p = lv_dropdown_get_options(year_dd);
+    /* NOTE: Assumes YYYY format */
+    const int32_t first_year = (year_p[0] - '0') * 1000 +
+                               (year_p[1] - '0') * 100 +
+                               (year_p[2] - '0') * 10 + (year_p[3] - '0');
+    lv_dropdown_set_selected(year_dd, LV_ABS(first_year - cur_date->year));
     lv_dropdown_set_selected(month_dd, cur_date->month - 1);
 }
 

--- a/tests/src/test_cases/widgets/test_calendar.c
+++ b/tests/src/test_cases/widgets/test_calendar.c
@@ -173,7 +173,7 @@ void test_calendar_header_dropdown_create_gui(void)
 
 void test_calendar_header_dropdown_ascending_year_order(void)
 {
-    const char *years =  "2020\n2021\n2022\n2023\n2024\n";
+    const char * years =  "2020\n2021\n2022\n2023\n2024\n";
     lv_calendar_header_dropdown_create(g_calendar);
     lv_calendar_header_dropdown_set_year_list(g_calendar, years);
     lv_calendar_set_month_shown(g_calendar, 2022, 9);
@@ -183,7 +183,7 @@ void test_calendar_header_dropdown_ascending_year_order(void)
 
 void test_calendar_header_dropdown_descending_year_order(void)
 {
-    const char *years =  "2024\n2023\n2022\n2021\n2020\n";
+    const char * years =  "2024\n2023\n2022\n2021\n2020\n";
     lv_calendar_header_dropdown_create(g_calendar);
     lv_calendar_header_dropdown_set_year_list(g_calendar, years);
     lv_calendar_set_month_shown(g_calendar, 2022, 9);

--- a/tests/src/test_cases/widgets/test_calendar.c
+++ b/tests/src/test_cases/widgets/test_calendar.c
@@ -171,6 +171,27 @@ void test_calendar_header_dropdown_create_gui(void)
     TEST_ASSERT_EQUAL_SCREENSHOT("widgets/calendar_05.png");
 }
 
+void test_calendar_header_dropdown_ascending_year_order(void)
+{
+    const char *years =  "2020\n2021\n2022\n2023\n2024\n";
+    lv_calendar_header_dropdown_create(g_calendar);
+    lv_calendar_header_dropdown_set_year_list(g_calendar, years);
+    lv_calendar_set_month_shown(g_calendar, 2022, 9);
+
+    TEST_ASSERT_EQUAL_SCREENSHOT("widgets/calendar_05.png");
+}
+
+void test_calendar_header_dropdown_descending_year_order(void)
+{
+    const char *years =  "2024\n2023\n2022\n2021\n2020\n";
+    lv_calendar_header_dropdown_create(g_calendar);
+    lv_calendar_header_dropdown_set_year_list(g_calendar, years);
+    lv_calendar_set_month_shown(g_calendar, 2022, 9);
+
+    TEST_ASSERT_EQUAL_SCREENSHOT("widgets/calendar_05.png");
+}
+
+
 void test_calendar_header_arrow_create_gui(void)
 {
     lv_calendar_add_header_arrow(g_calendar);


### PR DESCRIPTION
Fixes #8228 <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->


Testing code:

```c
const char *years =
"2025\n2024\n2023\n2022\n2021\n"
"2020\n2019\n2018\n2017\n2016\n2015\n2014\n2013\n2012\n2011\n2010\n2009\n2008\n2007\n2006\n2005\n2004\n2003\n2002\n2001\n"
"2000\n1999\n1998\n1997\n1996\n1995\n1994\n1993\n1992\n1991\n1990\n1989\n1988\n1987\n1986\n1985\n1984\n1983\n1982\n1981\n"
"1980\n1979\n1978\n1977\n1976\n1975\n1974\n1973\n1972\n1971\n1970\n1969\n1968\n1967\n1966\n1965\n1964\n1963\n1962\n1961\n"
"1960\n1959\n1958\n1957\n1956\n1955\n1954\n1953\n1952\n1951\n1950\n1949\n1948\n1947\n1946\n1945\n1944\n1943\n1942\n1941\n";
const char *years2 =
"2025\n2026\n2027\n2028\n2029\n2030\n2031\n2032\n2033\n2034\n2035\n2036\n2037\n"
"2038\n2039\n2040\n2041\n2042\n2043\n2044\n2045\n2046\n2047\n2048\n2049\n2050";

lv_obj_t *calendar = lv_calendar_create(lv_screen_active());
lv_obj_t *calendar2 = lv_calendar_create(lv_screen_active());
lv_calendar_header_dropdown_create(calendar);
lv_calendar_header_dropdown_create(calendar2);
lv_calendar_header_dropdown_set_year_list(calendar, years);
lv_calendar_header_dropdown_set_year_list(calendar2, years2);
lv_obj_align(calendar, LV_ALIGN_TOP_MID, 0, 0);
lv_obj_align(calendar2, LV_ALIGN_BOTTOM_MID, 0, 0);
```
