### PR TITLE
fix(calendar): fixed macro comparing unsigned value to 0

### DIFF
--- a/src/widgets/calendar/lv_calendar_header_arrow.c
+++ b/src/widgets/calendar/lv_calendar_header_arrow.c
@@ -113,8 +113,8 @@ static void month_event_cb(lv_event_t * e)
     d = lv_calendar_get_showed_date(calendar);
     lv_calendar_date_t newd = *d;
 
-    LV_ASSERT_FORMAT_MSG(newd.year >= 0 && newd.month >= 1 && newd.month <= 12,
-                         "Invalid date: %d-%d", newd.year, newd.month);
+    LV_ASSERT_FORMAT_MSG(newd.month >= 1 && newd.month <= 12,
+                         "Invalid month: %d (expected 1-12)", newd.month);
 
     /*The last child is the right button*/
     if(lv_obj_get_child(header, 0) == btn) {
@@ -148,8 +148,8 @@ static void value_changed_event_cb(lv_event_t * e)
     lv_obj_t * calendar = lv_obj_get_parent(header);
 
     const lv_calendar_date_t * date = lv_calendar_get_showed_date(calendar);
-    LV_ASSERT_FORMAT_MSG(date->year >= 0 && date->month >= 1 && date->month <= 12,
-                         "Invalid date: %d-%d", date->year, date->month);
+    LV_ASSERT_FORMAT_MSG(date->month >= 1 && date->month <= 12,
+                         "Invalid month: %d (expected 1-12)", date->month);
 
     lv_obj_t * label = lv_obj_get_child(header, 1);
     lv_label_set_text_fmt(label, "%d %s", date->year, month_names_def[date->month - 1]);


### PR DESCRIPTION
Fixes macro comparing unsigned value to 0, date->year is always >= 0
 <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
