### PR TITLE
fix(chart): fix overflow constant

### DIFF
--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -880,13 +880,20 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
     /*If there are at least as many points as pixels then draw only vertical lines*/
     bool crowded_mode = (int32_t)chart->point_cnt >= w;
 
-    line_dsc.base.id1 = lv_ll_get_len(&chart->series_ll) - 1;
+    uint32_t ser_cnt = lv_ll_get_len(&chart->series_ll);
+    if(ser_cnt == 0) {
+        return;
+    }
+
+    line_dsc.base.id1 = ser_cnt - 1;
     point_dsc_default.base.id1 = line_dsc.base.id1;
     /*Go through all data lines*/
     LV_LL_READ_BACK(&chart->series_ll, ser) {
         if(ser->hidden) {
-            line_dsc.base.id1--;
-            point_dsc_default.base.id1--;
+            if(line_dsc.base.id1 > 0) {
+                line_dsc.base.id1--;
+                point_dsc_default.base.id1--;
+            }
             continue;
         }
         line_dsc.color = ser->color;
@@ -983,8 +990,10 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
             }
         }
 
-        point_dsc_default.base.id1--;
-        line_dsc.base.id1--;
+        if(line_dsc.base.id1 > 0) {
+            point_dsc_default.base.id1--;
+            line_dsc.base.id1--;
+        }
     }
 
     layer->_clip_area = clip_area_ori;


### PR DESCRIPTION
Fixes overflow constant
where _lv_ll_get_len(&chart->series_ll) is known to be equal to 0, underflows the type that receives it, base.id1 is an unsigned integer 32 bits wide.

 <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
