### PR TITLE
fix(uefi): include configuration header instead of full LVGL header

### DIFF
--- a/src/drivers/uefi/lv_uefi_context.h
+++ b/src/drivers/uefi/lv_uefi_context.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lvgl.h"
+#include "../../lv_conf_internal.h"
 
 #if LV_USE_UEFI
 


### PR DESCRIPTION
Fixes #8379 

Including the full `lvgl.h` include creates an include cycle reported by tools like clang-tidy:

```
clang-tidy-18 -extra-arg-before=-I/opt/arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi/arm-none-eabi/include/ -p=./build src/widgets/page.c
ThirdParties/lvgl/src/drivers/uefi/../../lvgl.h:16:10: error: circular header file dependency detected while including 'lvgl.h', please check the include path [misc-header-include-cycle,-warnings-as-errors]
   16 | #include "../lvgl.h"
      |          ^
ThirdParties/lvgl/src/drivers/uefi/lv_uefi_context.h:17:10: note: 'lvgl.h' included from here
   17 | #include "../../lvgl.h"
      |          ^
ThirdParties/lvgl/src/drivers/lv_drivers.h:58:10: note: 'lv_uefi_context.h' included from here
   58 | #include "uefi/lv_uefi_context.h"
      |          ^
ThirdParties/lvgl/lvgl.h:128:10: note: 'lv_drivers.h' included from here
  128 | #include "src/drivers/lv_drivers.h"
      |          ^
src/widgets/page.c:2:10: note: 'lvgl.h' included from here
    2 | #include "lvgl.h"
      |          ^
974 warnings generated.
```

Including only `lv_conf_internal.h` should be enough to check for `LV_USE_UEFI`.
