### PR TITLE
fix(thorvg): include alloca on zephyr

### DIFF
--- a/src/libs/thorvg/tvgXmlParser.cpp
+++ b/src/libs/thorvg/tvgXmlParser.cpp
@@ -29,7 +29,7 @@
 
 #ifdef _WIN32
     #include <malloc.h>
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__ZEPHYR__)
     #include <alloca.h>
 #else
     #include <stdlib.h>


### PR DESCRIPTION
On zephyr you must include alloca.h. This small MR just fixes that.