### PR TITLE
feat(anim): call start callback when animation restarts

### DIFF
--- a/src/misc/lv_anim.c
+++ b/src/misc/lv_anim.c
@@ -686,6 +686,7 @@ static void anim_completed_handler(lv_anim_t * a)
     else {
         /*Restart the animation. If the time is over a little compensate it.*/
         int32_t over_time = 0;
+        a->start_cb_called = 0;
         if(a->act_time > a->duration) over_time = a->act_time - a->duration;
         a->act_time = over_time - (int32_t)(a->repeat_delay);
         /*Swap start and end values in reverse-play mode*/

--- a/tests/src/test_cases/test_anim.c
+++ b/tests/src/test_cases/test_anim.c
@@ -18,6 +18,11 @@ void tearDown(void)
     lv_anim_enable_vsync_mode(false);
 }
 
+static void start_cb(lv_anim_t * anim)
+{
+    (*(int *)lv_anim_get_user_data(anim))++;
+}
+
 static void exec_cb(void * var, int32_t v)
 {
     int32_t * var_i32 = var;
@@ -192,6 +197,28 @@ void test_scroll_anim_delete(void)
     lv_obj_scroll_by(obj, 0, 100, LV_ANIM_ON);
 
     TEST_ASSERT_EQUAL(1, var);
+}
+void test_anim_start_cb_is_called(void)
+{
+    int32_t var;
+    int start_cb_call_count = 0;
+    lv_anim_t a;
+    lv_anim_init(&a);
+    lv_anim_set_var(&a, &var);
+    lv_anim_set_user_data(&a, (void *)&start_cb_call_count);
+    lv_anim_set_start_cb(&a, start_cb);
+    lv_anim_set_values(&a, 0, 100);
+    lv_anim_set_exec_cb(&a, exec_cb);
+    lv_anim_set_duration(&a, 100);
+    lv_anim_set_repeat_count(&a, 2);
+    lv_anim_start(&a);
+    lv_test_wait(50);
+    TEST_ASSERT_EQUAL(1, start_cb_call_count);
+    lv_test_wait(100);
+    TEST_ASSERT_EQUAL(2, start_cb_call_count);
+    lv_test_wait(50);
+    /*Delete the animation to avoid accessing it after return*/
+    lv_anim_delete(&var, exec_cb);
 }
 
 void test_anim_vsync_mode(void)

--- a/tests/src/test_cases/test_anim_timeline.c
+++ b/tests/src/test_cases/test_anim_timeline.c
@@ -584,6 +584,7 @@ void test_anim_timeline_without_exec_cb_but_anim_start_cb_and_completed_cb(void)
     anim_timeline = lv_anim_timeline_create();
     lv_anim_timeline_add(anim_timeline, 200, &anim1);
     lv_anim_timeline_set_progress(anim_timeline, 0);
+    lv_anim_timeline_set_repeat_count(anim_timeline, 2);
     lv_anim_timeline_start(anim_timeline);
 
     lv_refr_now(NULL);
@@ -605,6 +606,14 @@ void test_anim_timeline_without_exec_cb_but_anim_start_cb_and_completed_cb(void)
     lv_test_wait(300); /*Now we are at 520ms */
     TEST_ASSERT_EQUAL(1, anim1_start_called);
     TEST_ASSERT_EQUAL(1, anim1_completed_called);
+
+    lv_test_wait(200); /*Now we are at 720ms */
+    TEST_ASSERT_EQUAL(2, anim1_start_called);
+    TEST_ASSERT_EQUAL(1, anim1_completed_called);
+
+    lv_test_wait(300); /*Now we are at 1020ms */
+    TEST_ASSERT_EQUAL(2, anim1_start_called);
+    TEST_ASSERT_EQUAL(2, anim1_completed_called);
 }
 
 #endif


### PR DESCRIPTION
Fixes #8202 

Reset the `start_cb_called` flag when the animation is restarted so that the `start_cb` function is called after restarting
