### PR TITLE
perf(snapshot): render from the top object when taking snapshot.

### DIFF
--- a/src/core/lv_refr_private.h
+++ b/src/core/lv_refr_private.h
@@ -58,6 +58,14 @@ lv_display_t * lv_refr_get_disp_refreshing(void);
  */
 void lv_refr_set_disp_refreshing(lv_display_t * disp);
 
+/**
+ * Search the most top object which fully covers an area
+ * @param area_p pointer to an area
+ * @param obj the first object to start the searching (typically a screen)
+ * @return
+ */
+lv_obj_t * lv_refr_get_top_obj(const lv_area_t * area_p, lv_obj_t * obj);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/others/snapshot/lv_snapshot.c
+++ b/src/others/snapshot/lv_snapshot.c
@@ -98,15 +98,19 @@ lv_result_t lv_snapshot_take_to_draw_buf(lv_obj_t * obj, lv_color_format_t cf, l
     res = lv_snapshot_reshape_draw_buf(obj, draw_buf);
     if(res != LV_RESULT_OK) return res;
 
-    /* clear draw buffer*/
-    lv_draw_buf_clear(draw_buf, NULL);
-
     lv_area_t snapshot_area;
     int32_t w = draw_buf->header.w;
     int32_t h = draw_buf->header.h;
     int32_t ext_size = lv_obj_get_ext_draw_size(obj);
     lv_obj_get_coords(obj, &snapshot_area);
     lv_area_increase(&snapshot_area, ext_size, ext_size);
+
+    lv_obj_t * top_obj = lv_refr_get_top_obj(&snapshot_area, obj);
+    if(top_obj == NULL) {
+        /* Clear draw buffer when no top object*/
+        lv_draw_buf_clear(draw_buf, NULL);
+        top_obj = obj;
+    }
 
     lv_layer_t layer;
     lv_layer_init(&layer);
@@ -126,7 +130,7 @@ lv_result_t lv_snapshot_take_to_draw_buf(lv_obj_t * obj, lv_color_format_t cf, l
     disp_new->layer_head = &layer;
 
     lv_refr_set_disp_refreshing(disp_new);
-    lv_obj_redraw(&layer, obj);
+    lv_obj_redraw(&layer, top_obj);
 
     while(layer.draw_task_head) {
         lv_draw_dispatch_wait_for_request();


### PR DESCRIPTION
render from the top object when taking snapshot. Improving snapshot efficiency<!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
