### PR TITLE
 fix(draw_sw): fix ARGB8888PM case where the color of dest and src is the same but opa is different.

### DIFF
--- a/demos/render/lv_demo_render.c
+++ b/demos/render/lv_demo_render.c
@@ -327,7 +327,6 @@ static lv_obj_t * image_obj_create(lv_obj_t * parent, int32_t col, int32_t row, 
     return obj;
 
 }
-#include <stdio.h>
 
 static void image_core_cb(lv_obj_t * parent, bool recolor, uint32_t startAt)
 {

--- a/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888_premultiplied.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend_to_argb8888_premultiplied.c
@@ -302,7 +302,8 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
                              *darker color when blending the same color to the background.*/
                             if(dest_buf_c32[x].red != color_argb.red ||
                                dest_buf_c32[x].green != color_argb.green ||
-                               dest_buf_c32[x].blue != color_argb.blue) {
+                               dest_buf_c32[x].blue != color_argb.blue ||
+                               dest_buf_c32[x].alpha != color_argb.alpha) {
 
                                 color_argb.red   = (color_argb.red   * color_argb.alpha) >> 8;
                                 color_argb.green = (color_argb.green * color_argb.alpha) >> 8;
@@ -334,7 +335,8 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
                              *darker color when blending the same color to the background.*/
                             if(dest_buf_c32[x].red != color_argb.red ||
                                dest_buf_c32[x].green != color_argb.green ||
-                               dest_buf_c32[x].blue != color_argb.blue) {
+                               dest_buf_c32[x].blue != color_argb.blue ||
+                               dest_buf_c32[x].alpha != color_argb.alpha) {
                                 color_argb.alpha = alpha;
                                 color_argb.red   = (color_argb.red   * color_argb.alpha) >> 8;
                                 color_argb.green = (color_argb.green * color_argb.alpha) >> 8;
@@ -366,7 +368,8 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
                              *darker color when blending the same color to the background.*/
                             if(dest_buf_c32[x].red != color_argb.red ||
                                dest_buf_c32[x].green != color_argb.green ||
-                               dest_buf_c32[x].blue != color_argb.blue) {
+                               dest_buf_c32[x].blue != color_argb.blue ||
+                               dest_buf_c32[x].alpha != color_argb.alpha) {
                                 color_argb.alpha = alpha;
                                 color_argb.red   = (color_argb.red   * color_argb.alpha) >> 8;
                                 color_argb.green = (color_argb.green * color_argb.alpha) >> 8;
@@ -399,7 +402,8 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
                              *darker color when blending the same color to the background.*/
                             if(dest_buf_c32[x].red != color_argb.red ||
                                dest_buf_c32[x].green != color_argb.green ||
-                               dest_buf_c32[x].blue != color_argb.blue) {
+                               dest_buf_c32[x].blue != color_argb.blue ||
+                               dest_buf_c32[x].alpha != color_argb.alpha) {
                                 color_argb.alpha = alpha;
                                 color_argb.red   = (color_argb.red   * color_argb.alpha) >> 8;
                                 color_argb.green = (color_argb.green * color_argb.alpha) >> 8;

--- a/tests/src/test_cases/draw/test_render_to_argb8888_premultiplied.c
+++ b/tests/src/test_cases/draw/test_render_to_argb8888_premultiplied.c
@@ -26,8 +26,12 @@ void test_render_to_argb8888_premultiplied(void)
         uint32_t i;
         for(i = 0; i < LV_DEMO_RENDER_SCENE_NUM; i++) {
 
-            /*Skip test with transformed indexed images if they are not loaded to RAM*/
-            if(LV_BIN_DECODER_RAM_LOAD == 0 &&
+            /*
+             * Skip test with transformed indexed images if they are not loaded to RAM
+             * also skip normal_3 and recolor_3 on VGLite
+             * because RGB565A8 and I8 are not supported
+             */
+            if((LV_BIN_DECODER_RAM_LOAD == 0 || LV_USE_DRAW_VGLITE == 0) &&
                (i == LV_DEMO_RENDER_SCENE_IMAGE_NORMAL_3 ||
                 i == LV_DEMO_RENDER_SCENE_IMAGE_RECOLOR_3)) continue;
 


### PR DESCRIPTION
Up streaming work done by @kisvegabor as for the one line change authored by me here is the demonstration sample code to test the problem: 
```

/*
 * Sample code that demonstrates a problem with the new pre-multiplied alpha
 * blending if the color of the dest buffer
 * is the same but the opacity is different - the rectangle
 * does NOT appear without the one line change
 */
#include "lvgl/lvgl.h"
#include "lvgl/src/draw/sw/lv_draw_sw.h"
#include "lvgl/src/draw/lv_draw.h"

#define BUF_H 100
#define BUF_W 100

static lv_draw_buf_t *draw_buf;

static void draw_cb(lv_event_t *e)
{
    lv_layer_t *layer = lv_event_get_layer(e);
    const lv_area_t area = {.x1 = 0, .x2 = BUF_W - 1, .y1 = 0, .y2 = BUF_H - 1};
    lv_draw_image_dsc_t img_dsc;

    lv_draw_image_dsc_init(&img_dsc);
    img_dsc.rotation = 0;
    img_dsc.scale_x = LV_SCALE_NONE;
    img_dsc.scale_y = LV_SCALE_NONE;
    img_dsc.opa = LV_OPA_100;
    img_dsc.src = draw_buf;

    lv_draw_image(layer, &img_dsc, &area);
}

/* Draw a black rectangle with 50% opa on top a transparent black background
 * same color but different opacity */
void demo_alpha_blending_problem(void)
{
    uint8_t *buf_end;
    uint8_t *buf;

    lv_display_set_color_format(NULL, LV_COLOR_FORMAT_ARGB8888_PREMULTIPLIED);
    draw_buf = lv_draw_buf_create(BUF_H, BUF_W, LV_COLOR_FORMAT_ARGB8888, BUF_W * 4);
    lv_memset(draw_buf->data, 0x0, BUF_H * BUF_W * 4);

    buf = draw_buf->data;
    buf_end = (uint8_t *) ((uint32_t *) draw_buf->data + BUF_H * BUF_W);

    while(buf < buf_end) {
        *(buf++) = 0x0;
        *(buf++) = 0x0;
        *(buf++) = 0x0;
        *(buf++) = LV_OPA_50;
    }

    lv_obj_t *scr = lv_scr_act();
    lv_obj_set_width(scr, LV_PCT(100));
    lv_obj_set_height(scr, LV_PCT(100));
    lv_obj_set_style_bg_color(scr, lv_color_hex(0x000000), LV_PART_MAIN);
    lv_obj_set_style_bg_opa(scr, LV_OPA_0, LV_PART_MAIN);

    lv_obj_add_event_cb(scr, draw_cb, LV_EVENT_DRAW_MAIN, NULL);
}
```
With fix:
![black_square](https://github.com/user-attachments/assets/1bcf5116-d16f-4645-84d2-c58c1d3b17f0)
Without fix: 
![nothing](https://github.com/user-attachments/assets/5408b41a-c12a-4bdd-b4f1-be8347120a4a)

