### PR TITLE
feat(DMA2D): encoded images

### DIFF
--- a/src/draw/dma2d/lv_draw_dma2d.c
+++ b/src/draw/dma2d/lv_draw_dma2d.c
@@ -346,23 +346,11 @@ static int32_t dispatch_cb(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
             return LV_DRAW_UNIT_IDLE;
         }
 
-        void * dest = lv_draw_layer_go_to_xy(layer,
-                                             clipped_coords.x1 - layer->buf_area.x1,
-                                             clipped_coords.y1 - layer->buf_area.y1);
-
         if(dsc->opa >= LV_OPA_MAX) {
-            lv_draw_dma2d_opaque_image(
-                t,
-                dest,
-                &clipped_coords,
-                lv_draw_buf_width_to_stride(lv_area_get_width(&layer->buf_area), dsc->base.layer->color_format));
+            lv_draw_dma2d_opaque_image(t, dsc, &t->area);
         }
         else {
-            lv_draw_dma2d_image(
-                t,
-                dest,
-                &clipped_coords,
-                lv_draw_buf_width_to_stride(lv_area_get_width(&layer->buf_area), dsc->base.layer->color_format));
+            lv_draw_dma2d_image(t, dsc, &t->area);
         }
     }
 

--- a/src/draw/dma2d/lv_draw_dma2d_img.c
+++ b/src/draw/dma2d/lv_draw_dma2d_img.c
@@ -10,6 +10,10 @@
 #include "lv_draw_dma2d_private.h"
 #if LV_USE_DRAW_DMA2D
 
+#include "../lv_draw_image_private.h"
+#include "../lv_image_decoder_private.h"
+#include "../../misc/lv_area_private.h"
+
 /*********************
  *      DEFINES
  *********************/
@@ -21,6 +25,14 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
+
+static void lv_draw_dma2d_opaque_image_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
+                                            const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
+                                            const lv_area_t * img_coords, const lv_area_t * clipped_img_area);
+
+static void lv_draw_dma2d_image_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
+                                     const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
+                                     const lv_area_t * img_coords, const lv_area_t * clipped_img_area);
 
 /**********************
  *  STATIC VARIABLES
@@ -34,25 +46,60 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_dma2d_opaque_image(lv_draw_task_t * t, void * dest_first_pixel, lv_area_t * clipped_coords,
-                                int32_t dest_stride)
+void lv_draw_dma2d_opaque_image(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
+                                const lv_area_t * coords)
 {
-    int32_t w = lv_area_get_width(clipped_coords);
-    int32_t h = lv_area_get_height(clipped_coords);
+    if(!draw_dsc->tile) {
+        lv_draw_image_normal_helper(t, draw_dsc, coords, lv_draw_dma2d_opaque_image_core);
+    }
+    else {
+        lv_draw_image_tiled_helper(t, draw_dsc, coords, lv_draw_dma2d_opaque_image_core);
+    }
+}
 
-    lv_draw_image_dsc_t * dsc = t->draw_dsc;
-    lv_color_format_t output_cf = dsc->base.layer->color_format;
-    lv_color_format_t image_cf = dsc->header.cf;
+void lv_draw_dma2d_image(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
+                         const lv_area_t * coords)
+{
+    if(!draw_dsc->tile) {
+        lv_draw_image_normal_helper(t, draw_dsc, coords, lv_draw_dma2d_image_core);
+    }
+    else {
+        lv_draw_image_tiled_helper(t, draw_dsc, coords, lv_draw_dma2d_image_core);
+    }
+}
 
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static void lv_draw_dma2d_opaque_image_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
+                                            const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
+                                            const lv_area_t * img_coords, const lv_area_t * clipped_img_area)
+{
+    LV_UNUSED(sup);
+    LV_UNUSED(img_coords);
+
+    lv_layer_t * layer = t->target_layer;
+
+    void * dest_first_pixel = lv_draw_layer_go_to_xy(layer,
+                                                     clipped_img_area->x1 - layer->buf_area.x1,
+                                                     clipped_img_area->y1 - layer->buf_area.y1);
+    int32_t dest_stride = lv_draw_buf_width_to_stride(lv_area_get_width(&layer->buf_area), layer->color_format);
+
+    int32_t w = lv_area_get_width(clipped_img_area);
+    int32_t h = lv_area_get_height(clipped_img_area);
+
+    lv_color_format_t output_cf = layer->color_format;
+    uint32_t output_cf_size = lv_color_format_get_size(output_cf);
     lv_draw_dma2d_output_cf_t output_cf_dma2d = lv_draw_dma2d_cf_to_dma2d_output_cf(output_cf);
-    uint32_t output_cf_size = LV_COLOR_FORMAT_GET_SIZE(output_cf);
 
+    const lv_draw_buf_t * decoded = decoder_dsc->decoded;
+    const uint8_t * src_buf = decoded->data;
+    uint32_t image_stride = decoded->header.stride;
+    lv_color_format_t image_cf = decoded->header.cf;
     lv_draw_dma2d_fgbg_cf_t image_cf_dma2d = (lv_draw_dma2d_fgbg_cf_t) lv_draw_dma2d_cf_to_dma2d_output_cf(image_cf);
     uint32_t image_cf_size = LV_COLOR_FORMAT_GET_SIZE(image_cf);
-
-    const lv_image_dsc_t * img_dsc = dsc->src;
-    uint32_t image_stride = img_dsc->header.stride;
-    if(image_stride == 0) image_stride = image_cf_size * img_dsc->header.w;
+    if(image_stride == 0) image_stride = image_cf_size * decoded->header.w;
 
 #if LV_DRAW_DMA2D_CACHE
     lv_draw_dma2d_cache_area_t dest_area = {
@@ -69,9 +116,9 @@ void lv_draw_dma2d_opaque_image(lv_draw_task_t * t, void * dest_first_pixel, lv_
     }
 #endif
 
-    const void * image_first_byte = img_dsc->data
-                                    + (image_stride * (clipped_coords->y1 - dsc->image_area.y1))
-                                    + (image_cf_size * (clipped_coords->x1 - dsc->image_area.x1));
+    const void * image_first_byte = src_buf
+                                    + (image_stride * (clipped_img_area->y1 - draw_dsc->image_area.y1))
+                                    + (image_cf_size * (clipped_img_area->x1 - draw_dsc->image_area.x1));
 
 #if LV_DRAW_DMA2D_CACHE
     lv_draw_dma2d_cache_area_t src_area = {
@@ -121,26 +168,35 @@ void lv_draw_dma2d_opaque_image(lv_draw_task_t * t, void * dest_first_pixel, lv_
     lv_draw_dma2d_configure_and_start_transfer(&conf);
 }
 
-void lv_draw_dma2d_image(lv_draw_task_t * t, void * dest_first_pixel, lv_area_t * clipped_coords,
-                         int32_t dest_stride)
+static void lv_draw_dma2d_image_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
+                                     const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
+                                     const lv_area_t * img_coords, const lv_area_t * clipped_img_area)
 {
-    int32_t w = lv_area_get_width(clipped_coords);
-    int32_t h = lv_area_get_height(clipped_coords);
+    LV_UNUSED(sup);
+    LV_UNUSED(img_coords);
 
-    lv_draw_image_dsc_t * dsc = t->draw_dsc;
-    lv_color_format_t output_cf = dsc->base.layer->color_format;
-    lv_color_format_t image_cf = dsc->header.cf;
-    lv_opa_t opa = dsc->opa;
+    lv_layer_t * layer = t->target_layer;
 
+    void * dest_first_pixel = lv_draw_layer_go_to_xy(layer,
+                                                     clipped_img_area->x1 - layer->buf_area.x1,
+                                                     clipped_img_area->y1 - layer->buf_area.y1);
+    int32_t dest_stride = lv_draw_buf_width_to_stride(lv_area_get_width(&layer->buf_area), layer->color_format);
+
+    int32_t w = lv_area_get_width(clipped_img_area);
+    int32_t h = lv_area_get_height(clipped_img_area);
+
+    lv_color_format_t output_cf = layer->color_format;
+    uint32_t output_cf_size = lv_color_format_get_size(output_cf);
     lv_draw_dma2d_output_cf_t output_cf_dma2d = lv_draw_dma2d_cf_to_dma2d_output_cf(output_cf);
-    uint32_t output_cf_size = LV_COLOR_FORMAT_GET_SIZE(output_cf);
 
+    const lv_draw_buf_t * decoded = decoder_dsc->decoded;
+    const uint8_t * src_buf = decoded->data;
+    uint32_t image_stride = decoded->header.stride;
+    lv_color_format_t image_cf = decoded->header.cf;
+    lv_opa_t opa = draw_dsc->opa;
     lv_draw_dma2d_fgbg_cf_t image_cf_dma2d = (lv_draw_dma2d_fgbg_cf_t) lv_draw_dma2d_cf_to_dma2d_output_cf(image_cf);
     uint32_t image_cf_size = LV_COLOR_FORMAT_GET_SIZE(image_cf);
-
-    const lv_image_dsc_t * img_dsc = dsc->src;
-    uint32_t image_stride = img_dsc->header.stride;
-    if(image_stride == 0) image_stride = image_cf_size * img_dsc->header.w;
+    if(image_stride == 0) image_stride = image_cf_size * decoded->header.w;
 
 #if LV_DRAW_DMA2D_CACHE
     lv_draw_dma2d_cache_area_t dest_area = {
@@ -155,9 +211,9 @@ void lv_draw_dma2d_image(lv_draw_task_t * t, void * dest_first_pixel, lv_area_t 
     lv_draw_dma2d_clean_cache(&dest_area);
 #endif
 
-    const void * image_first_byte = img_dsc->data
-                                    + (image_stride * (clipped_coords->y1 - dsc->image_area.y1))
-                                    + (image_cf_size * (clipped_coords->x1 - dsc->image_area.x1));
+    const void * image_first_byte = src_buf
+                                    + (image_stride * (clipped_img_area->y1 - draw_dsc->image_area.y1))
+                                    + (image_cf_size * (clipped_img_area->x1 - draw_dsc->image_area.x1));
 
 #if LV_DRAW_DMA2D_CACHE
     lv_draw_dma2d_cache_area_t src_area = {
@@ -202,9 +258,5 @@ void lv_draw_dma2d_image(lv_draw_task_t * t, void * dest_first_pixel, lv_area_t 
 
     lv_draw_dma2d_configure_and_start_transfer(&conf);
 }
-
-/**********************
- *   STATIC FUNCTIONS
- **********************/
 
 #endif /*LV_USE_DRAW_DMA2D*/

--- a/src/draw/dma2d/lv_draw_dma2d_private.h
+++ b/src/draw/dma2d/lv_draw_dma2d_private.h
@@ -131,10 +131,10 @@ typedef struct {
 
 void lv_draw_dma2d_opaque_fill(lv_draw_task_t * t, void * first_pixel, int32_t w, int32_t h, int32_t stride);
 void lv_draw_dma2d_fill(lv_draw_task_t * t, void * first_pixel, int32_t w, int32_t h, int32_t stride);
-void lv_draw_dma2d_opaque_image(lv_draw_task_t * t, void * dest_first_pixel, lv_area_t * clipped_coords,
-                                int32_t dest_stride);
-void lv_draw_dma2d_image(lv_draw_task_t * t, void * dest_first_pixel, lv_area_t * clipped_coords,
-                         int32_t dest_stride);
+void lv_draw_dma2d_opaque_image(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
+                                const lv_area_t * coords);
+void lv_draw_dma2d_image(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
+                         const lv_area_t * coords);
 lv_draw_dma2d_output_cf_t lv_draw_dma2d_cf_to_dma2d_output_cf(lv_color_format_t cf);
 uint32_t lv_draw_dma2d_color_to_dma2d_color(lv_draw_dma2d_output_cf_t cf, lv_color_t color);
 void lv_draw_dma2d_configure_and_start_transfer(const lv_draw_dma2d_configuration_t * conf);


### PR DESCRIPTION
Addresses part of #8460. NemaGFX also needs to be updated in another PR.

Use `lv_draw_image_normal_helper` and `lv_draw_image_tiled_helper` in the DMA2D driver so that RLE and LZ4 encoded images can be automatically decoded and drawn.

cc @apedersen00

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
