### PR TITLE
Try out requiring all XML props without defaults

### DIFF
--- a/xmls/lv_buttonmatrix.xml
+++ b/xmls/lv_buttonmatrix.xml
@@ -38,8 +38,8 @@ Example
 
 	    <prop name="map"  type="string[NULL]" help=""/>
 	    <prop name="ctrl_map" type="enum:lv_buttonmatrix_ctrl[]+" help=""/>
-	    <prop name="one_checked" type="bool" help=""/>
-	    <prop name="selected_button" type="int" help=""/>
+	    <prop name="one_checked" type="bool" help="" default=""/>
+	    <prop name="selected_button" type="int" help=""  default=""/>
 
 
 	</api>

--- a/xmls/lv_chart.xml
+++ b/xmls/lv_chart.xml
@@ -28,12 +28,12 @@
 	        <enum name="secondary_y"/>
 	    </enumdef>
 
-	    <prop name="type" type="enum:lv_chart_type" help=""/>
+	    <prop name="type" type="enum:lv_chart_type" help="" default=""/>
 
-	    <prop name="point_count" type="int" help=""/>
-	    <prop name="update_mode" type="enum:lv_chart_update_mode" help=""/>
-	    <prop name="nor_div_line_count" help=""/>
-	    <prop name="ver_div_line_count" help=""/>
+	    <prop name="point_count" type="int" help="" default=""/>
+	    <prop name="update_mode" type="enum:lv_chart_update_mode" help="" default=""/>
+	    <prop name="nor_div_line_count" help="" default=""/>
+	    <prop name="ver_div_line_count" help="" default=""/>
 
 	    <element name="series" type="lv_chart_series" access="add">
 	        <arg name="color" type="color" help=""/>

--- a/xmls/lv_dropdown.xml
+++ b/xmls/lv_dropdown.xml
@@ -7,15 +7,15 @@ Example
 
 <widget>
 	<api>
-	    <prop name="text" type="string" help="Show it instead of the selected options"/>
-	    <prop name="options" type="string" help="The options as a \n separated string"/>
-	    <prop name="selected" help="The index of the selected option">
+	    <prop name="text" type="string" help="Show it instead of the selected options" default=""/>
+	    <prop name="options" type="string" help="The options as a \n separated string" default=""/>
+	    <prop name="selected" help="The index of the selected option" default="">
 	    	<param name="selected" type="int" help="The index of the selected option"/>
 	    	<param name="anim" type="bool" help="Move to the option with animation" default="false"/>
 	    </prop>
-	    <prop name="symbol" type="string" help="The symbol, usually a caret"/>
-	    <prop name="bind_value" type="subject" help=""/>
+	    <prop name="symbol" type="string" help="The symbol, usually a caret" default=""/>
+	    <prop name="bind_value" type="subject" help="" default=""/>
 
-	    <element name="list" access="get" type="lv_obj" help=""/>
+	    <element name="list" access="get" type="lv_obj" help="" default=""/>
 	</api>
 </widget>

--- a/xmls/lv_image.xml
+++ b/xmls/lv_image.xml
@@ -23,11 +23,11 @@ Example
 		</enumdef>
 
 	    <prop name="src" type="image" help=""/>
-	    <prop name="inner_align" type="enum:lv_image_align" help=""/>
-	    <prop name="rotation" type="int" help=""/>
-	    <prop name="scale_x" type="int" help=""/>
-	    <prop name="scale_y" type="int" help=""/>
-    	<prop name="pivot_x" type="int" help=""/>
-    	<prop name="pivot_y" type="int" help=""/>
+	    <prop name="inner_align" type="enum:lv_image_align" help="" default="default"/>
+	    <prop name="rotation" type="int" help="" default="0"/>
+	    <prop name="scale_x" type="int" help="" default="0"/>
+	    <prop name="scale_y" type="int" help="" default="0"/>
+    	<prop name="pivot_x" type="int" help="" default="0"/>
+    	<prop name="pivot_y" type="int" help="" default="0"/>
 	</api>
 </widget>

--- a/xmls/lv_label.xml
+++ b/xmls/lv_label.xml
@@ -13,10 +13,10 @@ Example
 	        <enum name="dots" help=""/>
 	    </enumdef>
 
-	    <prop name="text"  type="string" />
-	    <prop name="text-translated"  type="string" />
-	    <prop name="long_mode" type="enum:lv_label_long_mode" />
-	    <prop name="bind_text">
+	    <prop name="text" type="string" default="" />
+	    <prop name="text-translated"  type="string" default="" />
+	<prop name="long_mode" type="enum:lv_label_long_mode" default="" />
+	    <prop name="bind_text" default="NULL NULL">
 	    	<param name="bind_text" type="subject" />
 	    	<param name="fmt" type="string" default="NULL"/>
 	   	</prop>

--- a/xmls/lv_obj.xml
+++ b/xmls/lv_obj.xml
@@ -58,7 +58,7 @@ Example
             <arg name="ref_value" type="int"/>
         </element>
 
-        <element name="event_cb" access="add">
+        <element name="event_cb" access="add" type="void">
             <arg name="callback" type="event_cb"/>
             <arg name="trigger" type="lv_event" default="clicked"/>
             <arg name="user_data" type="string" default="NULL"/>

--- a/xmls/lv_slider.xml
+++ b/xmls/lv_slider.xml
@@ -11,21 +11,21 @@ Example
 	        <enum name="symmetrical" help="The indicaror is grwing from zero"/>
 	    </enumdef>
 
-        <prop name="min_value" type="int"/>
-        <prop name="max_value" type="int"/>
+        <prop name="min_value" type="int" default=""/>
+        <prop name="max_value" type="int" default=""/>
 
-	    <prop name="value">
+	    <prop name="value" default="0 false">
 	    	<param name="value" type="int"/>
 	    	<param name="anim" type="bool" default="false"/>
 	    </prop>
 
-	    <prop name="start_value">
+	    <prop name="start_value" default="0 false">
 	    	<param name="start_value" type="int"/>
 	    	<param name="anim" type="bool" default="false"/>
 	    </prop>
 
-	    <prop name="mode" type="enum:lv_slider_mode"/>
+	    <prop name="mode" type="enum:lv_slider_mode" default=""/>
 
-	    <prop name="bind_value" type="subject" />
+	    <prop name="bind_value" type="subject" default="" />
 	</api>
 </widget>

--- a/xmls/lv_tabview.xml
+++ b/xmls/lv_tabview.xml
@@ -9,8 +9,8 @@ Example
 
 <widget>
     <api>
-        <prop name="active" type="int" help="Zero based index of the tab to select"/>
-        <prop name="tab_bar_position" type="enum:lv_dir" help=""/>
+        <prop name="active" type="int" help="Zero based index of the tab to select" default=""/>
+        <prop name="tab_bar_position" type="enum:lv_dir" help="" default=""/>
         <element name="tab_bar" type="lv_obj" access="get">
         </element>
         <element name="tab" type="lv_obj" access="add">


### PR DESCRIPTION
Treating as required all props without defaults... creates quite a few errors. So, I'm trying out what it looks like to use `default="x"` to communicate if a prop is required.

This is not an exhaustive list - just the widgets I'm using in a test project.

I'm wondering if it'd be much better to add a `required="true/false"` attribute. It is non-intuitive when default is used to communicate if something is required, because there is often no sane default.

What do you think?