### PR TITLE
don't squash: ci(perf/build/hw): multiple fixes

### DIFF
--- a/.github/workflows/build_hardware.yml
+++ b/.github/workflows/build_hardware.yml
@@ -14,6 +14,11 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install Dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y libfontconfig-dev
+
       - name: Install EJ dispatcher tool
         run: |
           cargo install ejlv

--- a/.github/workflows/build_hardware.yml
+++ b/.github/workflows/build_hardware.yml
@@ -1,8 +1,8 @@
 name: Hardware Build Test
 
+# No point on running this on pushes to master
+# as we already dispatch a run job for that event
 on:
-  push:
-    branches: 'master'
   pull_request:
     branches: 'master'
 

--- a/.github/workflows/build_hardware.yml
+++ b/.github/workflows/build_hardware.yml
@@ -32,4 +32,4 @@ jobs:
             --socket /ejd/ejd.sock \
             --commit-hash $COMMIT_REF \
             --remote-url $REPO_URL \
-            --seconds 600
+            --seconds 1800

--- a/.github/workflows/build_hardware.yml
+++ b/.github/workflows/build_hardware.yml
@@ -11,11 +11,6 @@ jobs:
     runs-on: self-hosted
     name: Hardware Build Test
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/perf_hardware.yml
+++ b/.github/workflows/perf_hardware.yml
@@ -18,6 +18,11 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install Dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y libfontconfig-dev
+
       - name: Install EJ dispatcher tool
         run: |
           cargo install ejlv

--- a/.github/workflows/perf_hardware.yml
+++ b/.github/workflows/perf_hardware.yml
@@ -37,7 +37,7 @@ jobs:
             --comment-path comment.md \
             --commit-hash $COMMIT_REF \
             --remote-url $REPO_URL \
-            --seconds 900
+            --seconds 1800
 
       - name: Upload Comment
         uses: actions/upload-artifact@v4

--- a/.github/workflows/perf_hardware.yml
+++ b/.github/workflows/perf_hardware.yml
@@ -15,11 +15,6 @@ jobs:
 
     name: Hardware Performance Benchmark
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/perf_hardware_comment_pr.yml
+++ b/.github/workflows/perf_hardware_comment_pr.yml
@@ -45,7 +45,7 @@ jobs:
           ejlv comment-pr \
             --comment-path comment.md \
             --pr-number $(cat pr_number) \
-            --gh-token $GITHUB_TOKEN \
+            --gh-token "${{ secrets.GITHUB_TOKEN }}" \
             --signature "hw_performance_tests"
 
       - name: Remove trigger label

--- a/.github/workflows/perf_hardware_comment_pr.yml
+++ b/.github/workflows/perf_hardware_comment_pr.yml
@@ -36,6 +36,11 @@ jobs:
           mv artifacts/pr_number/pr_number .
           mv artifacts/comment/comment.md .
 
+      - name: Install Dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y libfontconfig-dev
+
       - name: Install EJ dispatcher tool
         run: |
           cargo install ejlv


### PR DESCRIPTION
[e8ac192](https://github.com/lvgl/lvgl/pull/8581/commits/e8ac192d5dc5781bb9ccb32bb2fa369366103bb7): Noticed that when we push to master we dispatch two jobs, one `build` job and a `run` job which is unnecessary as the `run` job has to `build` first so this addresses that to save CPU cycles

[7b9b328](https://github.com/lvgl/lvgl/pull/8581/commits/7b9b328ea7d7e7cf4b71e95a810b518b961d768c) the $GITHUB_TOKEN isn't passed to the shell env so I need to use special github actions syntax to pass it to CLI

