### PR TITLE
fix(grid): fix uninitialized var warnings

### DIFF
--- a/src/layouts/grid/lv_grid.c
+++ b/src/layouts/grid/lv_grid.c
@@ -54,10 +54,10 @@ typedef struct {
  *  STATIC PROTOTYPES
  **********************/
 static void grid_update(lv_obj_t * cont, void * user_data);
-static void calc(lv_obj_t * obj, lv_grid_calc_t * calc);
+static lv_result_t calc(lv_obj_t * obj, lv_grid_calc_t * calc);
 static void calc_free(lv_grid_calc_t * calc);
-static void calc_cols(lv_obj_t * cont, lv_grid_calc_t * c);
-static void calc_rows(lv_obj_t * cont, lv_grid_calc_t * c);
+static lv_result_t calc_cols(lv_obj_t * cont, lv_grid_calc_t * c);
+static lv_result_t calc_rows(lv_obj_t * cont, lv_grid_calc_t * c);
 static void item_repos(lv_obj_t * item, lv_grid_calc_t * c, item_repos_hint_t * hint);
 static int32_t grid_align(int32_t cont_size, bool auto_size, lv_grid_align_t align, int32_t gap,
                           uint32_t track_num,
@@ -230,15 +230,21 @@ static void grid_update(lv_obj_t * cont, void * user_data)
  * @param calc store the calculated cells sizes here
  * @note `lv_grid_calc_free(calc_out)` needs to be called when `calc_out` is not needed anymore
  */
-static void calc(lv_obj_t * cont, lv_grid_calc_t * calc_out)
+static lv_result_t calc(lv_obj_t * cont, lv_grid_calc_t * calc_out)
 {
     if(lv_obj_get_child(cont, 0) == NULL) {
         lv_memzero(calc_out, sizeof(lv_grid_calc_t));
-        return;
+        return LV_RESULT_INVALID;
     }
 
-    calc_rows(cont, calc_out);
-    calc_cols(cont, calc_out);
+    if(calc_rows(cont, calc_out) == LV_RESULT_INVALID) {
+        /* Warning is already logged inside `calc_rows` */
+        return LV_RESULT_INVALID;
+    }
+    if(calc_cols(cont, calc_out) == LV_RESULT_INVALID) {
+        /* Warning is already logged inside `calc_cols` */
+        return LV_RESULT_INVALID;
+    }
 
     int32_t col_gap = lv_obj_get_style_pad_column(cont, LV_PART_MAIN);
     int32_t row_gap = lv_obj_get_style_pad_row(cont, LV_PART_MAIN);
@@ -258,6 +264,7 @@ static void calc(lv_obj_t * cont, lv_grid_calc_t * calc_out)
                                   calc_out->y, false);
 
     LV_ASSERT_MEM_INTEGRITY();
+    return LV_RESULT_OK;
 }
 
 /**
@@ -272,7 +279,7 @@ static void calc_free(lv_grid_calc_t * calc)
     lv_free(calc->h);
 }
 
-static void calc_cols(lv_obj_t * cont, lv_grid_calc_t * c)
+static lv_result_t calc_cols(lv_obj_t * cont, lv_grid_calc_t * c)
 {
 
     const int32_t * col_templ;
@@ -283,7 +290,7 @@ static void calc_cols(lv_obj_t * cont, lv_grid_calc_t * c)
         col_templ = get_col_dsc(parent);
         if(col_templ == NULL) {
             LV_LOG_WARN("No col descriptor found even on the parent");
-            return;
+            return LV_RESULT_INVALID;
         }
 
         int32_t pos = get_col_pos(cont);
@@ -363,9 +370,10 @@ static void calc_cols(lv_obj_t * cont, lv_grid_calc_t * c)
     if(subgrid) {
         lv_free((void *)col_templ);
     }
+    return LV_RESULT_OK;
 }
 
-static void calc_rows(lv_obj_t * cont, lv_grid_calc_t * c)
+static lv_result_t calc_rows(lv_obj_t * cont, lv_grid_calc_t * c)
 {
     const int32_t * row_templ;
     row_templ = get_row_dsc(cont);
@@ -375,7 +383,7 @@ static void calc_rows(lv_obj_t * cont, lv_grid_calc_t * c)
         row_templ = get_row_dsc(parent);
         if(row_templ == NULL) {
             LV_LOG_WARN("No row descriptor found even on the parent");
-            return;
+            return LV_RESULT_INVALID;
         }
 
         int32_t pos = get_row_pos(cont);
@@ -452,6 +460,7 @@ static void calc_rows(lv_obj_t * cont, lv_grid_calc_t * c)
     if(subgrid) {
         lv_free((void *)row_templ);
     }
+    return LV_RESULT_OK;
 }
 
 /**


### PR DESCRIPTION
While working on #8590 with full warnings and LTO enabled (Can be easily reproduces with [this repository](https://github.com/andreCostaaa/lv_neon_benchmark/))

I got these warnings at the linking stage:

```bash
/home/andre/dev/lvgl/neon_benchmark/lvgl/src/layouts/grid/lv_grid.c: In function ‘grid_update’:
/home/andre/dev/lvgl/neon_benchmark/lvgl/src/layouts/grid/lv_grid.c:252:24: warning: ‘c.x’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  252 |     calc_out->grid_w = grid_align(cont_w, auto_w, get_grid_col_align(cont), col_gap, calc_out->col_num, calc_out->w,
      |                        ^
/home/andre/dev/lvgl/neon_benchmark/lvgl/src/layouts/grid/lv_grid.c:252:24: warning: ‘c.col_num’ may be used uninitialized in this function [-Wmaybe-uninitialized]
/home/andre/dev/lvgl/neon_benchmark/lvgl/src/layouts/grid/lv_grid.c:252:24: warning: ‘c.w’ may be used uninitialized in this function [-Wmaybe-uninitialized]
```

This is because `calc_rows` and `calc_cols` can fail semi-silently and these variables won't be initialized anywhere