### PR TITLE
fix(indev): always assign data->point to the primary point instead of…

### DIFF
--- a/src/drivers/wayland/lv_wl_touch.c
+++ b/src/drivers/wayland/lv_wl_touch.c
@@ -112,6 +112,15 @@ static void _lv_wayland_touch_read(lv_indev_t * drv, lv_indev_data_t * data)
 
     /* Set the gesture information, before returning to LVGL */
     lv_indev_gesture_recognizers_set_data(drv, data);
+
+    if(window->body->input.touch_event_cnt > 0) {
+        data->point.x = window->body->input.touches[0].point.x;
+        data->point.y = window->body->input.touches[0].point.y;
+    }
+    else {
+        data->point.x = 0;
+        data->point.y = 0;
+    }
 }
 
 static void touch_handle_down(void * data, struct wl_touch * wl_touch, uint32_t serial, uint32_t time,

--- a/src/indev/lv_indev_gesture.c
+++ b/src/indev/lv_indev_gesture.c
@@ -221,19 +221,8 @@ void lv_indev_set_gesture_data(lv_indev_data_t * data, lv_indev_gesture_recogniz
                                lv_indev_gesture_type_t type)
 {
     bool is_active;
-    lv_point_t cur_pnt;
 
     if(recognizer == NULL) return;
-
-    /* If there is a single contact point use its coords,
-     * when there are no contact points it's set to 0,0
-     *
-     * Note: If a gesture was detected, the primary point is overwritten below
-     */
-
-    lv_indev_get_gesture_primary_point(recognizer, &cur_pnt);
-    data->point.x = cur_pnt.x;
-    data->point.y = cur_pnt.y;
 
     data->gesture_type[type] = LV_INDEV_GESTURE_NONE;
     data->gesture_data[type] = NULL;
@@ -251,9 +240,6 @@ void lv_indev_set_gesture_data(lv_indev_data_t * data, lv_indev_gesture_recogniz
 
     switch(recognizer->state) {
         case LV_INDEV_GESTURE_STATE_RECOGNIZED:
-            lv_indev_get_gesture_center_point(recognizer, &cur_pnt);
-            data->point.x = cur_pnt.x;
-            data->point.y = cur_pnt.y;
             data->gesture_type[type] = type;
             data->gesture_data[type] = (void *) recognizer;
             break;

--- a/src/others/test/lv_test_indev_gesture.c
+++ b/src/others/test/lv_test_indev_gesture.c
@@ -112,6 +112,15 @@ static void lv_test_gesture_read_cb(lv_indev_t * indev, lv_indev_data_t * data)
                                         _state.touch_data,
                                         _state.max_touch_cnt);
     lv_indev_gesture_recognizers_set_data(indev, data);
+    if(_state.touch_data != NULL && _state.max_touch_cnt > 0) {
+        data->point.x = _state.touch_data[0].point.x;
+        data->point.y = _state.touch_data[0].point.y;
+    }
+    else {
+        LV_LOG_ERROR("Invalid touch data or max touch count");
+        data->point.x = 0;
+        data->point.y = 0;
+    }
 }
 
 #endif /*LV_USE_TEST*/


### PR DESCRIPTION
… the center point

Fixes always assign data->point to the primary point instead of the center point <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

After detecting a two-finger pinch zoom, setting data->point as the center point causes discontinuous coordinates and interface jumping when one finger is lifted and data->point switches to the first finger's position.

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
