### PR TITLE
fix(font loader): overflow error when calculating ids size

### DIFF
--- a/src/font/lv_binfont_loader.c
+++ b/src/font/lv_binfont_loader.c
@@ -407,6 +407,7 @@ static int32_t load_glyph(lv_fs_file_t * fp, lv_font_fmt_txt_dsc_t * font_dsc,
     }
 
     uint8_t * glyph_bmp = (uint8_t *)lv_malloc(sizeof(uint8_t) * cur_bmp_size);
+    LV_ASSERT_MALLOC(glyph_bmp);
 
     font_dsc->glyph_bitmap = glyph_bmp;
 

--- a/src/font/lv_binfont_loader.c
+++ b/src/font/lv_binfont_loader.c
@@ -253,7 +253,7 @@ static bool load_cmaps_tables(lv_fs_file_t * fp, lv_font_fmt_txt_dsc_t * font_ds
 
         switch(cmap_table[i].format_type) {
             case LV_FONT_FMT_TXT_CMAP_FORMAT0_FULL: {
-                    uint8_t ids_size = (uint8_t)(sizeof(uint8_t) * cmap_table[i].data_entries_count);
+                    uint32_t ids_size = (uint32_t)(sizeof(uint8_t) * cmap_table[i].data_entries_count);
                     uint8_t * glyph_id_ofs_list = lv_malloc(ids_size);
 
                     cmap->glyph_id_ofs_list = glyph_id_ofs_list;


### PR DESCRIPTION
Related to #8400
That issue is related to v8.3 but I realized the issue still exists for the master branch

```c
	lv_font_t *font = lv_binfont_create("A:NotoSansJP-Regular-12px-4bpp.bin");
	lv_obj_t *label = lv_label_create(lv_screen_active());
	lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
	lv_obj_set_style_text_font(lv_screen_active(), font, LV_PART_MAIN | LV_STATE_DEFAULT);
	lv_label_set_text(label, "歌録");
```

Before:
<img width="480" height="270" alt="Screenshot From 2025-07-25 12-01-55" src="https://github.com/user-attachments/assets/a51269dd-726b-46f4-8f58-2c7112067b4b" />
After:
<img width="480" height="270" alt="Screenshot From 2025-07-25 12-01-35" src="https://github.com/user-attachments/assets/6256e6da-93b0-4313-90c0-53da8578410e" />