### PR TITLE
Replace legacy v9.0 call

### DIFF
--- a/src/libs/lodepng/lodepng.c
+++ b/src/libs/lodepng/lodepng.c
@@ -5831,7 +5831,7 @@ unsigned lodepng_decode(unsigned char ** out, unsigned * w, unsigned * h,
             return 56; /*unsupported color mode conversion*/
         }
 
-        lv_draw_buf_t * new_buf = lv_draw_buf_create_user(image_cache_draw_buf_handlers,*w, *h, LV_COLOR_FORMAT_ARGB8888, 4 * *w);
+        lv_draw_buf_t * new_buf = lv_draw_buf_create_ex(image_cache_draw_buf_handlers,*w, *h, LV_COLOR_FORMAT_ARGB8888, 4 * *w);
         if(new_buf == NULL) {
             state->error = 83; /*alloc fail*/
         }


### PR DESCRIPTION
Fixes #8611

`lv_draw_buf_create_user()` (API v9.0) replaced with `lv_draw_buf_create_ex()`.
