### PR TITLE
perf(draw): do not refresh invisible object

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ LVGL provides everything you need to create an embedded GUI with easy-to-use gra
 <a href="https://docs.lvgl.io/master/examples.html">Interactive examples</a>
 </h4>
 
-
 **English** | [中文](./README_zh.md) | [Português do Brasil](./README_pt_BR.md)
-
 
 ---
 

--- a/src/core/lv_event.c
+++ b/src/core/lv_event.c
@@ -20,7 +20,7 @@
 typedef struct _lv_event_dsc_t {
     lv_event_cb_t cb;
     void * user_data;
-    lv_event_code_t filter : 8;
+    uint8_t filter;
 } lv_event_dsc_t;
 
 /**********************

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -965,6 +965,10 @@ void refr_obj(lv_draw_ctx_t * draw_ctx, lv_obj_t * obj)
 {
     /*Do not refresh hidden objects*/
     if(lv_obj_has_flag(obj, LV_OBJ_FLAG_HIDDEN)) return;
+
+    /*Do not refresh invisible objects */
+    if(lv_obj_get_style_opa(obj, LV_PART_MAIN) <= LV_OPA_MIN) return;
+
     lv_layer_type_t layer_type = _lv_obj_get_layer_type(obj);
     if(layer_type == LV_LAYER_TYPE_NONE) {
         lv_obj_redraw(draw_ctx, obj);


### PR DESCRIPTION
This commit is to improve performance while refreshing object.

If screen's object structure becomes complex and object's visibility is controlled by OPA style, then computational overhead for calculating styles and refreshing the children becomes significant.
Therefore, as current object's opa style is set as invisible(i.e <= LV_OPA_MIN), the refresh can be improved by avoiding refreshing children and it's drawing attempt.

Change-Id: I5271fac3f8f0f3b3e3d2dad3d9351fb0a1d4218d



<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
