### PR TITLE
fix bug where multiple events with same callback couldn't be removed …

### DIFF
--- a/src/core/lv_obj_event.c
+++ b/src/core/lv_obj_event.c
@@ -144,6 +144,8 @@ uint32_t lv_obj_remove_event_cb(lv_obj_t * obj, lv_event_cb_t event_cb)
     uint32_t removed_count = 0;
     int32_t i;
     
+    if(event_cnt == 0) return 0;
+    
     for(i = event_cnt - 1; i >= 0; i--) {
         lv_event_dsc_t * dsc = lv_obj_get_event_dsc(obj, i);
         if(dsc && dsc->cb == event_cb) {

--- a/src/core/lv_obj_event.c
+++ b/src/core/lv_obj_event.c
@@ -142,8 +142,9 @@ uint32_t lv_obj_remove_event_cb(lv_obj_t * obj, lv_event_cb_t event_cb)
 
     uint32_t event_cnt = lv_obj_get_event_count(obj);
     uint32_t removed_count = 0;
-    uint32_t i;
-    for(i = 0; i < event_cnt; i++) {
+    int32_t i;
+    
+    for(i = event_cnt - 1; i >= 0; i--) {
         lv_event_dsc_t * dsc = lv_obj_get_event_dsc(obj, i);
         if(dsc && dsc->cb == event_cb) {
             lv_obj_remove_event(obj, i);


### PR DESCRIPTION

Fixes where multiple events with same callback couldn't be removed

## Problem
The lv_obj_remove_event_cb function has a bug where it can only remove one event per call when multiple events share the same callback function, due to index skipping during forward iteration.

## Solution
Fixed by changing from forward to reverse iteration, following the same implementation pattern as lv_obj_remove_event_cb_with_user_data .

### Changes
- Changed loop from for(i = 0; i < event_cnt; i++) to for(i = event_cnt - 1; i >= 0; i--)
- Changed index type from uint32_t to int32_t
- Added explanatory comment
### Why This Works
Reverse iteration prevents index skipping when elements are removed from the array, ensuring all matching events are found and removed in a single call.

Reference : This fix aligns the implementation with lv_obj_remove_event_cb_with_user_data , which already uses reverse iteration correctly.
