### PR TITLE
fix(tjpgd): Fixed memory leak if opening JPEG image failed.

### DIFF
--- a/src/libs/tjpgd/lv_tjpgd.c
+++ b/src/libs/tjpgd/lv_tjpgd.c
@@ -167,6 +167,10 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
                 return LV_RESULT_INVALID;
             }
         }
+        else {
+            lv_free(f);
+            return LV_RESULT_INVALID;
+        }
 #else
         LV_LOG_WARN("LV_USE_FS_MEMFS needs to enabled to decode from data");
         lv_free(f);
@@ -183,6 +187,14 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
                 return LV_RESULT_INVALID;
             }
         }
+        else {
+            lv_free(f);
+            return LV_RESULT_INVALID;
+        }
+    }
+    else {
+        lv_free(f);
+        return LV_RESULT_INVALID;
     }
 
     uint8_t * workb_temp = lv_malloc(TJPGD_WORKBUFF_SIZE);

--- a/src/libs/tjpgd/lv_tjpgd.c
+++ b/src/libs/tjpgd/lv_tjpgd.c
@@ -153,11 +153,13 @@ static size_t input_func(JDEC * jd, uint8_t * buff, size_t ndata)
 static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc)
 {
     LV_UNUSED(decoder);
-    lv_fs_file_t * f = lv_malloc(sizeof(lv_fs_file_t));
+    lv_fs_file_t * f = NULL;
     if(dsc->src_type == LV_IMAGE_SRC_VARIABLE) {
 #if LV_USE_FS_MEMFS
         const lv_image_dsc_t * img_dsc = dsc->src;
         if(is_jpg(img_dsc->data, img_dsc->data_size) == true) {
+            f = lv_malloc(sizeof(lv_fs_file_t));
+            if(f == NULL) return LV_RESULT_INVALID;
             lv_fs_path_ex_t path;
             lv_fs_make_path_from_buffer(&path, LV_FS_MEMFS_LETTER, img_dsc->data, img_dsc->data_size);
             lv_fs_res_t res;
@@ -167,19 +169,15 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
                 return LV_RESULT_INVALID;
             }
         }
-        else {
-            lv_free(f);
-            return LV_RESULT_INVALID;
-        }
 #else
         LV_LOG_WARN("LV_USE_FS_MEMFS needs to enabled to decode from data");
-        lv_free(f);
-        return LV_RESULT_INVALID;
 #endif
     }
     else if(dsc->src_type == LV_IMAGE_SRC_FILE) {
         const char * fn = dsc->src;
         if((lv_strcmp(lv_fs_get_ext(fn), "jpg") == 0) || (lv_strcmp(lv_fs_get_ext(fn), "jpeg") == 0)) {
+            f = lv_malloc(sizeof(lv_fs_file_t));
+            if(f == NULL) return LV_RESULT_INVALID;
             lv_fs_res_t res;
             res = lv_fs_open(f, fn, LV_FS_MODE_RD);
             if(res != LV_FS_RES_OK) {
@@ -187,19 +185,16 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
                 return LV_RESULT_INVALID;
             }
         }
-        else {
-            lv_free(f);
-            return LV_RESULT_INVALID;
-        }
     }
-    else {
-        lv_free(f);
-        return LV_RESULT_INVALID;
-    }
+    if(f == NULL) return LV_RESULT_INVALID;
 
     uint8_t * workb_temp = lv_malloc(TJPGD_WORKBUFF_SIZE);
     JDEC * jd = lv_malloc(sizeof(JDEC));
-    JRESULT rc = jd_prepare(jd, input_func, workb_temp, (size_t)TJPGD_WORKBUFF_SIZE, f);
+    JRESULT rc = JDR_MEM1;
+
+    if(workb_temp != NULL && jd != NULL)
+        rc = jd_prepare(jd, input_func, workb_temp, (size_t)TJPGD_WORKBUFF_SIZE, f);
+
     if(rc != JDR_OK) {
         lv_fs_close(f);
         lv_free(f);

--- a/src/libs/tjpgd/lv_tjpgd.c
+++ b/src/libs/tjpgd/lv_tjpgd.c
@@ -169,6 +169,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
         }
 #else
         LV_LOG_WARN("LV_USE_FS_MEMFS needs to enabled to decode from data");
+        lv_free(f);
         return LV_RESULT_INVALID;
 #endif
     }
@@ -186,20 +187,20 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
 
     uint8_t * workb_temp = lv_malloc(TJPGD_WORKBUFF_SIZE);
     JDEC * jd = lv_malloc(sizeof(JDEC));
-    dsc->user_data = jd;
     JRESULT rc = jd_prepare(jd, input_func, workb_temp, (size_t)TJPGD_WORKBUFF_SIZE, f);
-    if(rc) return LV_RESULT_INVALID;
-
-    dsc->header.cf = LV_COLOR_FORMAT_RGB888;
-    dsc->header.w = jd->width;
-    dsc->header.h = jd->height;
-    dsc->header.stride = jd->width * 3;
-
     if(rc != JDR_OK) {
+        lv_fs_close(f);
+        lv_free(f);
         lv_free(workb_temp);
         lv_free(jd);
         return LV_RESULT_INVALID;
     }
+
+    dsc->user_data = jd;
+    dsc->header.cf = LV_COLOR_FORMAT_RGB888;
+    dsc->header.w = jd->width;
+    dsc->header.h = jd->height;
+    dsc->header.stride = jd->width * 3;
 
     return LV_RESULT_OK;
 }


### PR DESCRIPTION
Fixes #8579

Fixes memory leak that occurs, if Tiny JPEG Decompressor (TJPGD)  failed to open JPEG image.
The code was missing memory release of allocated lv_fs_file_t structure and there was a premature return.