### PR TITLE
feat(draw/dave2d): improve performance using block processing

### DIFF
--- a/src/draw/renesas/dave2d/lv_draw_dave2d.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d.c
@@ -14,8 +14,15 @@
 /*********************
  *      DEFINES
  *********************/
-#define DRAW_UNIT_ID_DAVE2D     4
+#define DRAW_UNIT_ID_DAVE2D         4
+/* The amount of tasks exercising pressure to the currrent to get finished
+ * This one is used as the main signal to start to render a block of tasks.
+ */
+#define DAVE2D_MAX_DRAW_PRESSURE    256
 
+#if (DAVE2D_MAX_DRAW_PRESSURE < 256)
+    #error "DRAW Pressure should be at least 256 otherwise the Dave engine may crash!"
+#endif
 /**********************
  *      TYPEDEFS
  **********************/
@@ -23,12 +30,8 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-#if LV_USE_OS
-    static void _dave2d_render_thread_cb(void * ptr);
-#endif
 
 static void execute_drawing(lv_draw_dave2d_unit_t * u);
-
 #if defined(RENESAS_CORTEX_M85)
     #if (BSP_CFG_DCACHE_ENABLED)
         static void _dave2d_buf_invalidate_cache_cb(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
@@ -36,13 +39,12 @@ static void execute_drawing(lv_draw_dave2d_unit_t * u);
 #endif
 
 static int32_t _dave2d_evaluate(lv_draw_unit_t * draw_unit, lv_draw_task_t * task);
-
+static int32_t _dave2d_wait_finish(lv_draw_unit_t * draw_unit);
 static int32_t lv_draw_dave2d_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer);
 
 static d2_s32 lv_dave2d_init(void);
-
 static void lv_draw_buf_dave2d_init_handlers(void);
-
+static bool lv_draw_dave2d_image_color_format_supported(lv_color_format_t color_format);
 void dave2d_execute_dlist_and_flush(void);
 
 /**********************
@@ -53,11 +55,16 @@ void dave2d_execute_dlist_and_flush(void);
  *  STATIC VARIABLES
  **********************/
 
-d2_device * _d2_handle;
-d2_renderbuffer * _renderbuffer;
-d2_renderbuffer * _blit_renderbuffer;
+static d2_device * _d2_handle;
 
-lv_ll_t  _ll_Dave2D_Tasks;
+/* Main render buffer, used to carry the block of dave commands for any shape */
+static d2_renderbuffer * _renderbuffer;
+
+/* Label dedicated render buffer, used to carry only label related dave commands */
+static d2_renderbuffer * _label_renderbuffer;
+
+static lv_ll_t  draw_tasks_on_dlist;
+static uint32_t draw_pressure = 0;
 
 #if LV_USE_OS
     lv_mutex_t xd2Semaphore;
@@ -80,6 +87,7 @@ void lv_draw_dave2d_init(void)
     lv_draw_dave2d_unit_t * draw_dave2d_unit = lv_draw_create_unit(sizeof(lv_draw_dave2d_unit_t));
     draw_dave2d_unit->base_unit.dispatch_cb = lv_draw_dave2d_dispatch;
     draw_dave2d_unit->base_unit.evaluate_cb = _dave2d_evaluate;
+    draw_dave2d_unit->base_unit.wait_for_finish_cb = _dave2d_wait_finish;
     draw_dave2d_unit->base_unit.name = "DAVE2D";
     draw_dave2d_unit->idx = DRAW_UNIT_ID_DAVE2D;
 
@@ -90,19 +98,13 @@ void lv_draw_dave2d_init(void)
     lv_result_t res;
     res =  lv_mutex_init(&xd2Semaphore);
     LV_ASSERT(LV_RESULT_OK == res);
-
     draw_dave2d_unit->pd2Mutex    = &xd2Semaphore;
 #endif
 
     draw_dave2d_unit->d2_handle = _d2_handle;
     draw_dave2d_unit->renderbuffer = _renderbuffer;
-    lv_ll_init(&_ll_Dave2D_Tasks, 4);
-
-#if LV_USE_OS
-    lv_thread_init(&draw_dave2d_unit->thread, "dave2d", LV_DRAW_THREAD_PRIO, _dave2d_render_thread_cb, 8 * 1024,
-                   draw_dave2d_unit);
-#endif
-
+    draw_dave2d_unit->label_renderbuffer = _label_renderbuffer;
+    lv_ll_init(&draw_tasks_on_dlist, sizeof(uintptr_t));
 }
 
 /**********************
@@ -211,6 +213,26 @@ static void _dave2d_buf_copy(void * dest_buf, uint32_t dest_w, uint32_t dest_h, 
 }
 #endif
 
+static bool lv_draw_dave2d_image_color_format_supported(lv_color_format_t color_format)
+{
+    bool supported = false;
+
+    switch(color_format) {
+        case LV_COLOR_FORMAT_A8:
+        case LV_COLOR_FORMAT_RGB565:
+        case LV_COLOR_FORMAT_ARGB1555:
+        case LV_COLOR_FORMAT_ARGB4444:
+        case LV_COLOR_FORMAT_ARGB8888:
+        case LV_COLOR_FORMAT_XRGB8888:
+            supported = true;
+            break;
+        default:
+            break;
+    }
+
+    return supported;
+}
+
 #define USE_D2 (1)
 
 static int32_t _dave2d_evaluate(lv_draw_unit_t * u, lv_draw_task_t * t)
@@ -251,8 +273,7 @@ static int32_t _dave2d_evaluate(lv_draw_unit_t * u, lv_draw_task_t * t)
 
         case LV_DRAW_TASK_TYPE_IMAGE: {
                 lv_draw_image_dsc_t * dsc = t->draw_dsc;
-                if((dsc->header.cf >= LV_COLOR_FORMAT_PROPRIETARY_START) || (dsc->header.cf == LV_COLOR_FORMAT_RGB888) ||
-                   (dsc->header.cf == LV_COLOR_FORMAT_RGB565A8)) {
+                if(!lv_draw_dave2d_image_color_format_supported(dsc->header.cf)) {
                     ret = 0;
                     break;
                 }
@@ -345,103 +366,97 @@ static int32_t _dave2d_evaluate(lv_draw_unit_t * u, lv_draw_task_t * t)
     return ret;
 }
 
-#define DAVE2D_REFERRING_WATERMARK  10
 
 static int32_t lv_draw_dave2d_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 {
     lv_draw_dave2d_unit_t * draw_dave2d_unit = (lv_draw_dave2d_unit_t *) draw_unit;
-#if  (0 == D2_RENDER_EACH_OPERATION)
-    static uint32_t ref_count = 0;
-#endif
+    uint32_t deps = 0;
 
-    /*Return immediately if it's busy with draw task*/
-    if(draw_dave2d_unit->task_act) return 0;
+    if(draw_dave2d_unit->task_act) {
+        /* Return immediately if it's busy with draw task */
+        return LV_DRAW_UNIT_IDLE;
+    }
 
     lv_draw_task_t * t = NULL;
-    t = lv_draw_get_available_task(layer, NULL, DRAW_UNIT_ID_DAVE2D);
-    while(t && t->preferred_draw_unit_id != DRAW_UNIT_ID_DAVE2D) {
-        t->state = LV_DRAW_TASK_STATE_FINISHED;
-        t = lv_draw_get_available_task(layer, NULL, DRAW_UNIT_ID_DAVE2D);
-    }
-
+    t = lv_draw_get_next_available_task(layer, NULL, DRAW_UNIT_ID_DAVE2D);
     if(t == NULL) {
-#if  (0 == D2_RENDER_EACH_OPERATION)
-        if(false == lv_ll_is_empty(&_ll_Dave2D_Tasks)) {
-            ref_count = 0;
+        /* No valid task, but there are tasks waiting to be rendered,
+         * start to draw then immediatelly.
+         */
+        if(false == lv_ll_is_empty(&draw_tasks_on_dlist)) {
+            draw_pressure = 0;
             dave2d_execute_dlist_and_flush();
         }
-#endif
-        return LV_DRAW_UNIT_IDLE;  /*Couldn't start rendering*/
+        return LV_DRAW_UNIT_IDLE;  /* This task is not for us. */
     }
 
-    /* Return if target buffer format is not supported. */
-    if(!lv_draw_dave2d_is_dest_cf_supported(layer->color_format)) {
-        return LV_DRAW_UNIT_IDLE; /*Couldn't start rendering*/
-    }
+    if((t->preferred_draw_unit_id != DRAW_UNIT_ID_DAVE2D)) return LV_DRAW_UNIT_IDLE;
+    if(!lv_draw_dave2d_is_dest_cf_supported(layer->color_format)) return LV_DRAW_UNIT_IDLE;
 
     void * buf = lv_draw_layer_alloc_buf(layer);
-    if(buf == NULL) {
-        return LV_DRAW_UNIT_IDLE;  /*Couldn't start rendering*/
-    }
+    if(buf == NULL) return LV_DRAW_UNIT_IDLE;
 
-#if  (0 == D2_RENDER_EACH_OPERATION)
-    ref_count += lv_draw_get_dependent_count(t);
+    deps = lv_draw_get_dependent_count(t);
+    if(deps > 0 || draw_pressure > 0) {
+        draw_pressure += deps;
+        if(draw_pressure < DAVE2D_MAX_DRAW_PRESSURE) {
+            /* No other tasks are pressuring to get the current block
+             * of tasks including the latest one, just accumulate it
+             * and tells the drawing pipeline to send a new one if there is any
+             */
+            lv_draw_task_t ** p_new_list_entry;
+            p_new_list_entry = lv_ll_ins_tail(&draw_tasks_on_dlist);
+            *p_new_list_entry = t;
 
-    if(DAVE2D_REFERRING_WATERMARK < ref_count) {
-        ref_count = 0;
-        dave2d_execute_dlist_and_flush();
-    }
+            draw_dave2d_unit->task_act = t;
+            draw_dave2d_unit->task_act->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
+            execute_drawing(draw_dave2d_unit);
 
-    lv_draw_task_t ** p_new_list_entry;
-    p_new_list_entry = lv_ll_ins_tail(&_ll_Dave2D_Tasks);
-    *p_new_list_entry = t;
-#endif
+            draw_dave2d_unit->task_act = NULL;
+            lv_draw_dispatch_request();
 
-    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
-    draw_dave2d_unit->task_act = t;
-
-#if LV_USE_OS
-    /*Let the render thread work*/
-    lv_thread_sync_signal(&draw_dave2d_unit->sync);
-#else
-    execute_drawing(draw_dave2d_unit);
-#if  (D2_RENDER_EACH_OPERATION)
-    draw_dave2d_unit->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
-#endif
-    draw_dave2d_unit->task_act = NULL;
-
-    /*The draw unit is free now. Request a new dispatching as it can get a new task*/
-    lv_draw_dispatch_request();
-
-#endif
-    return 1;
-}
-
-#if LV_USE_OS
-static void _dave2d_render_thread_cb(void * ptr)
-{
-    lv_draw_dave2d_unit_t * u = ptr;
-
-    lv_thread_sync_init(&u->sync);
-
-    while(1) {
-        while(u->task_act == NULL) {
-            lv_thread_sync_wait(&u->sync);
+            return 1;
         }
+        /* If the pressure for drawing value was maxed-out, it is time to render
+         * return IDLE to force the drawing pipeline to wait while the Dave
+         * draw the block of tasks in a single row
+         */
+        return LV_DRAW_UNIT_IDLE;
+    }
+    else {
+        /* Handles a special case when there is no sufficient draw pressure
+         * But the actual task did not carry any extra pressure to get drew
+         * in this case, the drawing pipeline have a few set of tasks that
+         * don't make sense to accumulate them, just do a run to completion
+         * here, that is it, render the incoming task immediately.
+         */
+        draw_dave2d_unit->task_act = t;
+        draw_dave2d_unit->task_act->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
+        d2_selectrenderbuffer(_d2_handle, _renderbuffer);
+        execute_drawing(draw_dave2d_unit);
+        d2_executerenderbuffer(_d2_handle, _renderbuffer, 0);
+        d2_flushframe(_d2_handle);
 
-        execute_drawing(u);
-
-        /*Cleanup*/
-#if  (D2_RENDER_EACH_OPERATION)
-        u->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
-#endif
-        u->task_act = NULL;
-
-        /*The draw unit is free now. Request a new dispatching as it can get a new task*/
+        draw_dave2d_unit->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
+        draw_dave2d_unit->task_act = NULL;
         lv_draw_dispatch_request();
+
+        return 1;
     }
 }
-#endif
+
+static int32_t _dave2d_wait_finish(lv_draw_unit_t * draw_unit)
+{
+    /* If the drawing pipeline is waiting it means the pressure for drawing
+     * has been maxed out, defer the block of tasks to be rendered by the
+     * Dave and wait for its interrupt. (Dave2D driver is RTOS aware, no need for semaphores);
+     */
+    lv_draw_dave2d_unit_t * draw_dave2d_unit = (lv_draw_dave2d_unit_t *) draw_unit;
+    dave2d_execute_dlist_and_flush();
+    draw_pressure = 0;
+
+    return 0;
+}
 
 static void execute_drawing(lv_draw_dave2d_unit_t * u)
 {
@@ -510,6 +525,11 @@ static void execute_drawing(lv_draw_dave2d_unit_t * u)
             break;
     }
 
+#if defined(RENESAS_CORTEX_M85)
+#if (BSP_CFG_DCACHE_ENABLED)
+    lv_draw_buf_invalidate_cache(layer->draw_buf, &clipped_area);
+#endif
+#endif
 }
 
 static d2_s32 lv_dave2d_init(void)
@@ -544,23 +564,23 @@ static d2_s32 lv_dave2d_init(void)
     result = d2_setlinejoin(_d2_handle, d2_lj_miter);
 
     /* set blocksize for default displaylist */
-    result = d2_setdlistblocksize(_d2_handle, 25);
+    result = d2_setdlistblocksize(_d2_handle, 20);
     if(D2_OK != result) {
         LV_LOG_ERROR("Could NOT d2_setdlistblocksize");
         d2_closedevice(_d2_handle);
         return result;
     }
 
-    _blit_renderbuffer = d2_newrenderbuffer(_d2_handle, 20, 20);
-    if(!_blit_renderbuffer) {
+    _renderbuffer = d2_newrenderbuffer(_d2_handle, 250, 25);
+    if(!_renderbuffer) {
         LV_LOG_ERROR("NO renderbuffer");
         d2_closedevice(_d2_handle);
 
         return D2_NOMEMORY;
     }
 
-    _renderbuffer = d2_newrenderbuffer(_d2_handle, 20, 20);
-    if(!_renderbuffer) {
+    _label_renderbuffer = d2_newrenderbuffer(_d2_handle, 250, 25);
+    if(!_label_renderbuffer) {
         LV_LOG_ERROR("NO renderbuffer");
         d2_closedevice(_d2_handle);
 
@@ -578,6 +598,10 @@ static d2_s32 lv_dave2d_init(void)
 
 void dave2d_execute_dlist_and_flush(void)
 {
+    d2_s32 result;
+    lv_draw_task_t ** p_list_entry;
+    lv_draw_task_t * p_list_entry1;
+
 #if LV_USE_OS
     lv_result_t  status;
 
@@ -585,11 +609,6 @@ void dave2d_execute_dlist_and_flush(void)
     LV_ASSERT(LV_RESULT_OK == status);
 #endif
 
-    d2_s32     result;
-    lv_draw_task_t ** p_list_entry;
-    lv_draw_task_t * p_list_entry1;
-
-    // Execute render operations
     result = d2_executerenderbuffer(_d2_handle, _renderbuffer, 0);
     LV_ASSERT(D2_OK == result);
 
@@ -599,11 +618,11 @@ void dave2d_execute_dlist_and_flush(void)
     result = d2_selectrenderbuffer(_d2_handle, _renderbuffer);
     LV_ASSERT(D2_OK == result);
 
-    while(false == lv_ll_is_empty(&_ll_Dave2D_Tasks)) {
-        p_list_entry = lv_ll_get_tail(&_ll_Dave2D_Tasks);
+    while(false == lv_ll_is_empty(&draw_tasks_on_dlist)) {
+        p_list_entry = lv_ll_get_tail(&draw_tasks_on_dlist);
         p_list_entry1 = *p_list_entry;
         p_list_entry1->state = LV_DRAW_TASK_STATE_FINISHED;
-        lv_ll_remove(&_ll_Dave2D_Tasks, p_list_entry);
+        lv_ll_remove(&draw_tasks_on_dlist, p_list_entry);
         lv_free(p_list_entry);
     }
 

--- a/src/draw/renesas/dave2d/lv_draw_dave2d.h
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d.h
@@ -17,7 +17,8 @@ extern "C" {
 #if LV_USE_DRAW_DAVE2D
 #include "../../lv_draw.h"
 #include "../../lv_draw_private.h"
-#include "hal_data.h"
+#include "bsp_api.h"
+#include "dave_driver.h"
 #include "lv_draw_dave2d_utils.h"
 #include "../../lv_draw_rect.h"
 #include "../../lv_draw_line.h"
@@ -33,8 +34,6 @@ extern "C" {
  *      DEFINES
  *********************/
 
-#define D2_RENDER_EACH_OPERATION      (1)
-
 /**********************
  *      TYPEDEFS
  **********************/
@@ -49,6 +48,8 @@ typedef struct {
     uint32_t idx;
     d2_device * d2_handle;
     d2_renderbuffer * renderbuffer;
+    d2_renderbuffer * label_renderbuffer;
+
 #if LV_USE_OS
     lv_mutex_t * pd2Mutex;
 #endif

--- a/src/draw/renesas/dave2d/lv_draw_dave2d_arc.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d_arc.c
@@ -46,10 +46,6 @@ void lv_draw_dave2d_arc(lv_draw_task_t * t, const lv_draw_arc_dsc_t * dsc, const
     LV_ASSERT(LV_RESULT_OK == status);
 #endif
 
-#if D2_RENDER_EACH_OPERATION
-    d2_selectrenderbuffer(u->d2_handle, u->renderbuffer);
-#endif
-
     //
     // Generate render operations
     //
@@ -170,15 +166,6 @@ void lv_draw_dave2d_arc(lv_draw_task_t * t, const lv_draw_arc_dsc_t * dsc, const
             }
         }
     }
-
-    //
-    // Execute render operations
-    //
-
-#if D2_RENDER_EACH_OPERATION
-    d2_executerenderbuffer(u->d2_handle, u->renderbuffer, 0);
-    d2_flushframe(u->d2_handle);
-#endif
 
 #if LV_USE_OS
     status = lv_mutex_unlock(u->pd2Mutex);

--- a/src/draw/renesas/dave2d/lv_draw_dave2d_border.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d_border.c
@@ -78,13 +78,6 @@ static void dave2d_draw_border_simple(lv_draw_task_t * t, const lv_area_t * oute
     lv_area_move(&local_outer_area, x, y);
     lv_area_move(&local_inner_area, x, y);
 
-#if D2_RENDER_EACH_OPERATION
-    d2_selectrenderbuffer(u->d2_handle, u->renderbuffer);
-#endif
-    //
-    // Generate render operations
-    //
-
     d2_framebuffer_from_layer(u->d2_handle, t->target_layer);
 
     d2_setcolor(u->d2_handle, 0, lv_draw_dave2d_lv_colour_to_d2_colour(color));
@@ -143,14 +136,6 @@ static void dave2d_draw_border_simple(lv_draw_task_t * t, const lv_area_t * oute
                      (d2_point)D2_FIX4(lv_area_get_height(&a)));
     }
 
-    //
-    // Execute render operations
-    //
-#if D2_RENDER_EACH_OPERATION
-    d2_executerenderbuffer(u->d2_handle, u->renderbuffer, 0);
-    d2_flushframe(u->d2_handle);
-#endif
-
 #if LV_USE_OS
     status = lv_mutex_unlock(u->pd2Mutex);
     LV_ASSERT(LV_RESULT_OK == status);
@@ -190,9 +175,6 @@ static void dave2d_draw_border_complex(lv_draw_task_t * t, const lv_area_t * ori
     lv_area_move(&outer_area, x, y);
     lv_area_move(&inner_area, x, y);
 
-#if D2_RENDER_EACH_OPERATION
-    d2_selectrenderbuffer(u->d2_handle, u->renderbuffer);
-#endif
     //
     // Generate render operations
     //
@@ -401,14 +383,6 @@ static void dave2d_draw_border_complex(lv_draw_task_t * t, const lv_area_t * ori
         }
         d2_setantialiasing(u->d2_handle, aa); //restore original setting
     }
-
-    //
-    // Execute render operations
-    //
-#if D2_RENDER_EACH_OPERATION
-    d2_executerenderbuffer(u->d2_handle, u->renderbuffer, 0);
-    d2_flushframe(u->d2_handle);
-#endif
 
 #if LV_USE_OS
     status = lv_mutex_unlock(u->pd2Mutex);

--- a/src/draw/renesas/dave2d/lv_draw_dave2d_fill.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d_fill.c
@@ -34,13 +34,6 @@ void lv_draw_dave2d_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc, con
     lv_area_move(&draw_area, x, y);
     lv_area_move(&coordinates, x, y);
 
-    //
-    // Generate render operations
-    //
-#if D2_RENDER_EACH_OPERATION
-    d2_selectrenderbuffer(u->d2_handle, u->renderbuffer);
-#endif
-
     d2_framebuffer_from_layer(u->d2_handle, t->target_layer);
 
     if(LV_GRAD_DIR_NONE != dsc->grad.dir) {
@@ -288,14 +281,6 @@ void lv_draw_dave2d_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc, con
             LV_ASSERT(D2_OK == result);
         }
     }
-
-    //
-    // Execute render operations
-    //
-#if D2_RENDER_EACH_OPERATION
-    d2_executerenderbuffer(u->d2_handle, u->renderbuffer, 0);
-    d2_flushframe(u->d2_handle);
-#endif
 
     if(LV_GRAD_DIR_NONE != dsc->grad.dir) {
         d2_setalphamode(u->d2_handle, current_alpha_mode);

--- a/src/draw/renesas/dave2d/lv_draw_dave2d_image.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d_image.c
@@ -102,11 +102,6 @@ static void img_draw_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_d
     lv_area_move(&buffer_area, x, y);
     lv_area_move(&clipped_area, x, y);
 
-    /* Generate render operations*/
-#if D2_RENDER_EACH_OPERATION
-    d2_selectrenderbuffer(u->d2_handle, u->renderbuffer);
-#endif
-
     current_fill_mode = d2_getfillmode(u->d2_handle);
     a_texture_op      = d2_gettextureoperationa(u->d2_handle);
     r_texture_op      = d2_gettextureoperationr(u->d2_handle);
@@ -301,14 +296,6 @@ static void img_draw_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_d
                   (d2_point)D2_FIX4(p[3].x),
                   (d2_point)D2_FIX4(p[3].y),
                   0);
-
-    //
-    // Execute render operations
-    //
-#if D2_RENDER_EACH_OPERATION
-    d2_executerenderbuffer(u->d2_handle, u->renderbuffer, 0);
-    d2_flushframe(u->d2_handle);
-#endif
 
     d2_setfillmode(u->d2_handle, current_fill_mode);
     d2_settextureoperation(u->d2_handle, a_texture_op, r_texture_op, g_texture_op, b_texture_op);

--- a/src/draw/renesas/dave2d/lv_draw_dave2d_line.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d_line.c
@@ -51,9 +51,6 @@ void lv_draw_dave2d_line(lv_draw_task_t * t, const lv_draw_line_dsc_t * dsc)
         LV_ASSERT(0);
     }
 
-#if D2_RENDER_EACH_OPERATION
-    d2_selectrenderbuffer(u->d2_handle, u->renderbuffer);
-#endif
     //
     // Generate render operations
     //
@@ -76,14 +73,6 @@ void lv_draw_dave2d_line(lv_draw_task_t * t, const lv_draw_line_dsc_t * dsc)
 
     d2_renderline(u->d2_handle, D2_FIX4(p1_x), D2_FIX4(p1_y), D2_FIX4(p2_x),
                   D2_FIX4(p2_y), D2_FIX4(dsc->width), d2_le_exclude_none);
-
-    //
-    // Execute render operations
-    //
-#if D2_RENDER_EACH_OPERATION
-    d2_executerenderbuffer(u->d2_handle, u->renderbuffer, 0);
-    d2_flushframe(u->d2_handle);
-#endif
 
 #if LV_USE_OS
     status = lv_mutex_unlock(u->pd2Mutex);

--- a/src/draw/renesas/dave2d/lv_draw_dave2d_mask_rectangle.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d_mask_rectangle.c
@@ -29,10 +29,6 @@ void lv_draw_dave2d_mask_rect(lv_draw_task_t * t, const lv_draw_mask_rect_dsc_t 
     LV_ASSERT(LV_RESULT_OK == status);
 #endif
 
-#ifdef D2_RENDER_EACH_OPERATION
-    d2_selectrenderbuffer(u->d2_handle, u->renderbuffer);
-#endif
-
     d2_framebuffer_from_layer(u->d2_handle, t->target_layer);
 
     d2_cliprect(u->d2_handle, (d2_border)clipped_area.x1, (d2_border)clipped_area.y1, (d2_border)clipped_area.x2,
@@ -43,14 +39,6 @@ void lv_draw_dave2d_mask_rect(lv_draw_task_t * t, const lv_draw_mask_rect_dsc_t 
                  (d2_point)        D2_FIX4(coordinates.y1),
                  (d2_width)        D2_FIX4(lv_area_get_width(&coordinates)),
                  (d2_width)        D2_FIX4(lv_area_get_height(&coordinates)));
-
-    //
-    // Execute render operations
-    //
-#ifdef D2_RENDER_EACH_OPERATION
-    d2_executerenderbuffer(u->d2_handle, u->renderbuffer, 0);
-    d2_flushframe(u->d2_handle);
-#endif
 
 #if LV_USE_OS
     status = lv_mutex_unlock(u->pd2Mutex);

--- a/src/draw/renesas/dave2d/lv_draw_dave2d_triangle.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d_triangle.c
@@ -31,10 +31,6 @@ void lv_draw_dave2d_triangle(lv_draw_task_t * t, const lv_draw_triangle_dsc_t * 
 
     lv_area_move(&clipped_area, x, y);
 
-#if D2_RENDER_EACH_OPERATION
-    d2_selectrenderbuffer(u->d2_handle, u->renderbuffer);
-#endif
-
     lv_point_precise_t p[3];
     p[0] = dsc->p[0];
     p[1] = dsc->p[1];
@@ -156,14 +152,6 @@ void lv_draw_dave2d_triangle(lv_draw_task_t * t, const lv_draw_triangle_dsc_t * 
                  (d2_point)      D2_FIX4(p[2].x),
                  (d2_point)      D2_FIX4(p[2].y),
                  flags);
-
-    //
-    // Execute render operations
-    //
-#if D2_RENDER_EACH_OPERATION
-    d2_executerenderbuffer(u->d2_handle, u->renderbuffer, 0);
-    d2_flushframe(u->d2_handle);
-#endif
 
     d2_setalphamode(u->d2_handle, current_alpha_mode);
 


### PR DESCRIPTION
* Remove the render each operation option.
* Improve the draw pressure algorithm.
* Add edge cases: no draw pressure, draw shape immediately.
* Remove lv_thread based rendering to save context switches latency
* Use the wait for finish callback as dlist flushing mechanism
* Also fix a long time present bug on the label drawing which corrupts the dlist in block processing


<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
