### PR TITLE
fix(image_decoder): fix memory leaks caused by multi-threaded rendering

### DIFF
--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -122,6 +122,10 @@ typedef struct _lv_global_t {
                                                             * can be managed by image cache. */
 
     lv_ll_t img_decoder_ll;
+#if LV_USE_OS != LV_OS_NONE
+    lv_mutex_t img_decoder_info_lock;
+    lv_mutex_t img_decoder_open_lock;
+#endif
 
     lv_cache_t * img_cache;
     lv_cache_t * img_header_cache;

--- a/src/draw/lv_image_decoder.c
+++ b/src/draw/lv_image_decoder.c
@@ -21,6 +21,14 @@
 #define img_header_cache_p (LV_GLOBAL_DEFAULT()->img_header_cache)
 #define image_cache_draw_buf_handlers &(LV_GLOBAL_DEFAULT()->image_cache_draw_buf_handlers)
 
+#if LV_USE_OS != LV_OS_NONE
+    #define img_decoder_info_lock_p &(LV_GLOBAL_DEFAULT()->img_decoder_info_lock)
+    #define img_decoder_open_lock_p &(LV_GLOBAL_DEFAULT()->img_decoder_open_lock)
+#else
+    #define img_decoder_info_lock_p NULL
+    #define img_decoder_open_lock_p NULL
+#endif
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -63,6 +71,9 @@ void lv_image_decoder_init(uint32_t image_cache_size, uint32_t image_header_coun
     /*Initialize the cache*/
     lv_image_cache_init(image_cache_size);
     lv_image_header_cache_init(image_header_count);
+
+    lv_mutex_init(img_decoder_info_lock_p);
+    lv_mutex_init(img_decoder_open_lock_p);
 }
 
 /**
@@ -72,6 +83,9 @@ void lv_image_decoder_deinit(void)
 {
     lv_cache_destroy(img_cache_p, NULL);
     lv_cache_destroy(img_header_cache_p, NULL);
+
+    lv_mutex_delete(img_decoder_info_lock_p);
+    lv_mutex_delete(img_decoder_open_lock_p);
 
     lv_ll_clear(img_decoder_ll_p);
 }
@@ -83,7 +97,9 @@ lv_result_t lv_image_decoder_get_info(const void * src, lv_image_header_t * head
     dsc.src = src;
     dsc.src_type = lv_image_src_get_type(src);
 
+    lv_mutex_lock(img_decoder_info_lock_p);
     lv_image_decoder_t * decoder = image_decoder_get_info(&dsc, header);
+    lv_mutex_unlock(img_decoder_info_lock_p);
     if(decoder == NULL) return LV_RESULT_INVALID;
 
     return LV_RESULT_OK;
@@ -97,6 +113,8 @@ lv_result_t lv_image_decoder_open(lv_image_decoder_dsc_t * dsc, const void * src
     dsc->src = src;
     dsc->src_type = lv_image_src_get_type(src);
 
+    lv_mutex_lock(img_decoder_open_lock_p);
+
     if(lv_image_cache_is_enabled()) {
         dsc->cache = img_cache_p;
         /*Try cache first, unless we are told to ignore cache.*/
@@ -104,13 +122,19 @@ lv_result_t lv_image_decoder_open(lv_image_decoder_dsc_t * dsc, const void * src
             /*
             * Check the cache first
             * If the image is found in the cache, just return it.*/
-            if(try_cache(dsc) == LV_RESULT_OK) return LV_RESULT_OK;
+            if(try_cache(dsc) == LV_RESULT_OK) {
+                lv_mutex_unlock(img_decoder_open_lock_p);
+                return LV_RESULT_OK;
+            }
         }
     }
 
     /*Find the decoder that can open the image source, and get the header info in the same time.*/
     dsc->decoder = image_decoder_get_info(dsc, &dsc->header);
-    if(dsc->decoder == NULL) return LV_RESULT_INVALID;
+    if(dsc->decoder == NULL) {
+        lv_mutex_unlock(img_decoder_open_lock_p);
+        return LV_RESULT_INVALID;
+    }
 
     /*Make a copy of args*/
     dsc->args = args ? *args : (lv_image_decoder_args_t) {
@@ -144,6 +168,7 @@ lv_result_t lv_image_decoder_open(lv_image_decoder_dsc_t * dsc, const void * src
         }
     }
 
+    lv_mutex_unlock(img_decoder_open_lock_p);
     return res;
 }
 
@@ -158,14 +183,20 @@ lv_result_t lv_image_decoder_get_area(lv_image_decoder_dsc_t * dsc, const lv_are
 
 void lv_image_decoder_close(lv_image_decoder_dsc_t * dsc)
 {
-    if(dsc->decoder) {
-        if(dsc->decoder->close_cb) dsc->decoder->close_cb(dsc->decoder, dsc);
-
-        if(lv_image_cache_is_enabled() && dsc->cache && dsc->cache_entry) {
-            /*Decoded data is in cache, release it from cache's callback*/
-            lv_cache_release(dsc->cache, dsc->cache_entry, NULL);
-        }
+    if(!dsc->decoder) {
+        return;
     }
+
+    lv_mutex_lock(img_decoder_open_lock_p);
+
+    if(dsc->decoder->close_cb) dsc->decoder->close_cb(dsc->decoder, dsc);
+
+    if(lv_image_cache_is_enabled() && dsc->cache && dsc->cache_entry) {
+        /*Decoded data is in cache, release it from cache's callback*/
+        lv_cache_release(dsc->cache, dsc->cache_entry, NULL);
+    }
+
+    lv_mutex_unlock(img_decoder_open_lock_p);
 }
 
 /**


### PR DESCRIPTION
In multi-threaded mode, since the image_decoder function reentres, it may cause repeated decoding of the image when the cache misses, resulting in adding the same image to the cache system and causing memory leaks (because the cache will only retain one entry instance when the key is the same). To avoid problems, a locking mechanism needs to be added to eliminate the impact of function reentry.

cc @W-Mai
Related PR: https://github.com/lvgl/lvgl/pull/6665

However, when I enabled multi-threaded rendering in `lv_test_conf_full.h` (`#define LV_DRAW_SW_DRAW_UNIT_CNT 4`), many image rendering results were inconsistent with single-threaded results. I guess it might be due to trimming edge processing when splitting the images for rendering.
@kisvegabor Could you please take over and have a look?

```bash
...
Screenshot compare error
  - File: ref_imgs/widgets/image_stretch.png
  - At x:550, y:241.
  - Expected: 5461B2
  - Actual:   5252C6
  - Tolerance: 0

lvgl/tests/src/test_cases/widgets/test_image.c:290:test_image_stretch:FAIL: widgets/image_stretch.png
lvgl/tests/src/test_cases/widgets/test_image.c:52:test_image_contain:INFO: 
Screenshot compare error
  - File: ref_imgs/widgets/image_contain.png
  - At x:550, y:406.
  - Expected: 62BA71
  - Actual:   62BB70
  - Tolerance: 0

lvgl/tests/src/test_cases/widgets/test_image.c:319:test_image_contain:FAIL: widgets/image_contain.png
lvgl/tests/src/test_cases/widgets/test_image.c:52:test_image_cover:INFO: 
Screenshot compare error
  - File: ref_imgs/widgets/image_cover.png
  - At x:498, y:256.
  - Expected: 7DD578
  - Actual:   7CD578
  - Tolerance: 0
...
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
