### PR TITLE
feat(display): add ability to get current screen being loaded

### DIFF
--- a/docs/src/details/main-modules/display/screen_layers.rst
+++ b/docs/src/details/main-modules/display/screen_layers.rst
@@ -40,7 +40,9 @@ You can get pointers to each of these screens on a specified display by using
 To set a Screen you create to be the :ref:`active_screen`, call
 :cpp:func:`lv_screen_load` or :cpp:func:`lv_screen_load_anim`.
 
-
+Calling :cpp:expr:`lv_display_get_screen_loading(disp)` will return the screen that is
+being loaded. A Screen is considered "being loaded" until the loading animation finishes.
+If no Screen is being loaded, this function will return ``NULL``.
 
 .. _layers_top_and_sys:
 

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -636,6 +636,17 @@ lv_obj_t * lv_display_get_screen_active(lv_display_t * disp)
     return disp->act_scr;
 }
 
+lv_obj_t * lv_display_get_screen_loading(lv_display_t * disp)
+{
+    if(!disp) disp = lv_display_get_default();
+    if(!disp) {
+        LV_LOG_WARN("no display registered to get the current screen being loaded");
+        return NULL;
+    }
+
+    return disp->scr_to_load;
+}
+
 lv_obj_t * lv_display_get_screen_prev(lv_display_t * disp)
 {
     if(!disp) disp = lv_display_get_default();

--- a/src/display/lv_display.h
+++ b/src/display/lv_display.h
@@ -409,6 +409,13 @@ lv_obj_t * lv_display_get_screen_active(lv_display_t * disp);
 lv_obj_t * lv_display_get_screen_prev(lv_display_t * disp);
 
 /**
+ * Return the screen that is currently being loaded by the display
+ * @param disp      pointer to a display object (NULL to use the default screen)
+ * @return          pointer to the screen being loaded or NULL if no screen is currently being loaded
+ */
+lv_obj_t * lv_display_get_screen_loading(lv_display_t * disp);
+
+/**
  * Return the top layer. The top layer is the same on all screens and it is above the normal screen layer.
  * @param disp      pointer to display which top layer should be get. (NULL to use the default screen)
  * @return          pointer to the top layer object


### PR DESCRIPTION
Fixes #8635 <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

This can also be done with some flags and events but I agree with @bryghtlabs-richard that it can be cumbersome
