### PR TITLE
fix(display): load screen from matching display

### DIFF
--- a/src/core/lv_disp.c
+++ b/src/core/lv_disp.c
@@ -222,7 +222,7 @@ void lv_scr_load_anim(lv_obj_t * new_scr, lv_scr_load_anim_t anim_type, uint32_t
 {
 
     lv_disp_t * d = lv_obj_get_disp(new_scr);
-    lv_obj_t * act_scr = lv_scr_act();
+    lv_obj_t * act_scr = d->act_scr;
 
     if(act_scr == new_scr || d->scr_to_load == new_scr) {
         return;
@@ -492,7 +492,7 @@ static void scr_load_anim_start(lv_anim_t * a)
 {
     lv_disp_t * d = lv_obj_get_disp(a->var);
 
-    d->prev_scr = lv_scr_act();
+    d->prev_scr = d->act_scr;
     d->act_scr = a->var;
 
     lv_event_send(d->act_scr, LV_EVENT_SCREEN_LOAD_START, NULL);


### PR DESCRIPTION
Backport of #6189 to v8.4 with one less change from as in the meantime there were some fixes to this part of the code.

Fixes #8665 <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
