### PR TITLE
feat(wayland): Restore the touchscreen support

### DIFF
--- a/src/drivers/wayland/lv_wayland_private.h
+++ b/src/drivers/wayland/lv_wayland_private.h
@@ -106,6 +106,11 @@ struct input {
     lv_indev_touch_data_t touches[10];
     uint8_t touch_event_cnt;
     uint8_t primary_id;
+#else
+    struct {
+        lv_point_t point;
+        lv_indev_state_t state;
+    } touch;
 #endif
 };
 

--- a/src/drivers/wayland/lv_wl_seat.c
+++ b/src/drivers/wayland/lv_wl_seat.c
@@ -85,12 +85,10 @@ static void seat_handle_capabilities(void * data, struct wl_seat * wl_seat, enum
         seat->wl_keyboard = NULL;
     }
 
-#if LV_USE_GESTURE_RECOGNITION
     if((caps & WL_SEAT_CAPABILITY_TOUCH) && !seat->wl_touch) {
         seat->wl_touch = wl_seat_get_touch(wl_seat);
         wl_touch_add_listener(seat->wl_touch, lv_wayland_touch_get_listener(), app);
     }
-#endif
     else if(!(caps & WL_SEAT_CAPABILITY_TOUCH) && seat->wl_touch) {
         wl_touch_destroy(seat->wl_touch);
         seat->wl_touch = NULL;

--- a/src/drivers/wayland/lv_wl_touch.c
+++ b/src/drivers/wayland/lv_wl_touch.c
@@ -5,7 +5,7 @@
 
 #include "lv_wl_touch.h"
 
-#if LV_USE_WAYLAND && LV_USE_GESTURE_RECOGNITION
+#if LV_USE_WAYLAND
 
 #include "lv_wayland_private.h"
 
@@ -103,6 +103,7 @@ static void _lv_wayland_touch_read(lv_indev_t * drv, lv_indev_data_t * data)
         return;
     }
 
+#if LV_USE_GESTURE_RECOGNITION
     /* Collect touches if there are any - send them to the gesture recognizer */
     lv_indev_gesture_recognizers_update(drv, &window->body->input.touches[0], window->body->input.touch_event_cnt);
 
@@ -121,13 +122,20 @@ static void _lv_wayland_touch_read(lv_indev_t * drv, lv_indev_data_t * data)
         data->point.x = 0;
         data->point.y = 0;
     }
+#else
+    data->point.x = window->body->input.touch.point.x;
+    data->point.y = window->body->input.touch.point.y;
+    data->state = window->body->input.touch.state;
+#endif
 }
 
 static void touch_handle_down(void * data, struct wl_touch * wl_touch, uint32_t serial, uint32_t time,
                               struct wl_surface * surface, int32_t id, wl_fixed_t x_w, wl_fixed_t y_w)
 {
     struct lv_wayland_context * app = data;
+#if LV_USE_GESTURE_RECOGNITION
     uint8_t i;
+#endif
 
     LV_UNUSED(id);
     LV_UNUSED(time);
@@ -141,6 +149,8 @@ static void touch_handle_down(void * data, struct wl_touch * wl_touch, uint32_t 
 
     /* Create the touch down event */
     app->touch_obj = wl_surface_get_user_data(surface);
+
+#if LV_USE_GESTURE_RECOGNITION
     i              = app->touch_obj->input.touch_event_cnt;
 
     app->touch_obj->input.touches[i].point.x   = wl_fixed_to_int(x_w);
@@ -149,6 +159,11 @@ static void touch_handle_down(void * data, struct wl_touch * wl_touch, uint32_t 
     app->touch_obj->input.touches[i].timestamp = time;
     app->touch_obj->input.touches[i].state     = LV_INDEV_STATE_PRESSED;
     app->touch_obj->input.touch_event_cnt++;
+#else
+    app->touch_obj->input.touch.point.x = wl_fixed_to_int(x_w);
+    app->touch_obj->input.touch.point.y = wl_fixed_to_int(y_w);
+    app->touch_obj->input.touch.state = LV_INDEV_STATE_PRESSED;
+#endif
 
 #if LV_WAYLAND_WINDOW_DECORATIONS
     struct window * window = app->touch_obj->window;
@@ -176,15 +191,17 @@ static void touch_handle_down(void * data, struct wl_touch * wl_touch, uint32_t 
 static void touch_handle_up(void * data, struct wl_touch * wl_touch, uint32_t serial, uint32_t time, int32_t id)
 {
     struct lv_wayland_context * app = data;
+#if LV_USE_GESTURE_RECOGNITION
     uint8_t i;
+#endif
 
     LV_UNUSED(serial);
     LV_UNUSED(time);
     LV_UNUSED(id);
     LV_UNUSED(wl_touch);
 
-#if LV_USE_GESTURE_RECOGNITION
     /* Create a released event */
+#if LV_USE_GESTURE_RECOGNITION
     i = app->touch_obj->input.touch_event_cnt;
 
     app->touch_obj->input.touches[i].point.x   = 0;
@@ -194,6 +211,8 @@ static void touch_handle_up(void * data, struct wl_touch * wl_touch, uint32_t se
     app->touch_obj->input.touches[i].state     = LV_INDEV_STATE_RELEASED;
 
     app->touch_obj->input.touch_event_cnt++;
+#else
+    app->touch_obj->input.touch.state = LV_INDEV_STATE_RELEASED;
 #endif
 
 #if LV_WAYLAND_WINDOW_DECORATIONS
@@ -230,14 +249,17 @@ static void touch_handle_motion(void * data, struct wl_touch * wl_touch, uint32_
                                 wl_fixed_t y_w)
 {
     struct lv_wayland_context * app = data;
+#if LV_USE_GESTURE_RECOGNITION
     lv_indev_touch_data_t * touch;
     lv_indev_touch_data_t * cur;
     uint8_t i;
+#endif
 
     LV_UNUSED(time);
     LV_UNUSED(id);
     LV_UNUSED(wl_touch);
 
+#if LV_USE_GESTURE_RECOGNITION
     /* Update the contact point of the corresponding id with the latest coordinate */
     touch = &app->touch_obj->input.touches[0];
     cur   = NULL;
@@ -267,6 +289,10 @@ static void touch_handle_motion(void * data, struct wl_touch * wl_touch, uint32_
         cur->id        = id;
         cur->timestamp = time;
     }
+#else
+    app->touch_obj->input.touch.point.x = wl_fixed_to_int(x_w);
+    app->touch_obj->input.touch.point.y = wl_fixed_to_int(y_w);
+#endif
 }
 
 static void touch_handle_frame(void * data, struct wl_touch * wl_touch)
@@ -281,4 +307,4 @@ static void touch_handle_cancel(void * data, struct wl_touch * wl_touch)
     LV_UNUSED(data);
 }
 
-#endif /* LV_USE_WAYLAND && LV_USE_GESTURE_RECOGNITION */
+#endif /* LV_USE_WAYLAND */

--- a/src/drivers/wayland/lv_wl_touch.h
+++ b/src/drivers/wayland/lv_wl_touch.h
@@ -18,7 +18,7 @@ extern "C" {
 
 #include "../../indev/lv_indev.h"
 #include "../../indev/lv_indev_gesture.h"
-#if LV_USE_WAYLAND && LV_USE_GESTURE_RECOGNITION
+#if LV_USE_WAYLAND
 
 /*********************
  *      DEFINES

--- a/src/drivers/wayland/lv_wl_window.c
+++ b/src/drivers/wayland/lv_wl_window.c
@@ -153,16 +153,12 @@ lv_display_t * lv_wayland_window_create(uint32_t hor_res, uint32_t ver_res, char
         LV_LOG_ERROR("failed to register pointeraxis indev");
     }
 
-#if LV_USE_GESTURE_RECOGNITION
-
     window->lv_indev_touch = lv_wayland_touch_create();
     lv_indev_set_display(window->lv_indev_touch, window->lv_disp);
 
     if(!window->lv_indev_touch) {
         LV_LOG_ERROR("failed to register touch indev");
     }
-
-#endif /* END LV_USE_GESTURE_RECOGNITION */
 
     window->lv_indev_keyboard = lv_wayland_keyboard_create();
     lv_indev_set_display(window->lv_indev_keyboard, window->lv_disp);


### PR DESCRIPTION
The re-organization in commit 23bad412998b3de458e6ff45c26a3d1184ba738c disabled the touchscreen support, unless the LV_USE_GESTURE_RECOGNITION feature is enabled. Since a touchpad is also useful without multi-touch support enabled, restore the old code again.