### PR TITLE
fix(lodepng): check that src is not null before calling memcpy

### DIFF
--- a/src/libs/lodepng/lodepng.c
+++ b/src/libs/lodepng/lodepng.c
@@ -3029,8 +3029,13 @@ static unsigned lodepng_chunk_createv(ucvector * out,
     unsigned char * chunk;
     CERROR_TRY_RETURN(lodepng_chunk_init(&chunk, out, length, type));
 
-    /*3: the data*/
-    lodepng_memcpy(chunk + 8, data, length);
+    /* 3: the data
+     * LVGL: In the upstream lodepng code, lodepng_memcpy doesn't use memcpy and instead uses a simple `for` loop to copy the data into its destination
+     * `lv_memcpy`, on the other hand, may call `memcpy` under the hood and `src` can't be NULL
+     * The function `addChunk_IEND` is an example of a function that calls this function with data == NULL*/
+    if(data) {
+    	lodepng_memcpy(chunk + 8, data, length);
+    }
 
     /*4: CRC (of the chunkname characters and the data)*/
     lodepng_chunk_generate_crc(chunk);


### PR DESCRIPTION
Fixes this runtime error when running tests locally:

```bash
lvgl/src/stdlib/clib/lv_string_clib.c:40:12: runtime error: null pointer passed as argument 2, which is declared to never be null
```