### PR TITLE
docs(mipi): align return type of callbacks in documentation with code

### DIFF
--- a/docs/src/details/integration/external_display_controllers/gen_mipi.rst
+++ b/docs/src/details/integration/external_display_controllers/gen_mipi.rst
@@ -51,13 +51,13 @@ You need to implement two platform-dependent functions:
 .. code-block:: c
 
 	/* Send short command to the LCD. This function shall wait until the transaction finishes. */
-	int32_t my_lcd_send_cmd(lv_display_t *disp, const uint8_t *cmd, size_t cmd_size, const uint8_t *param, size_t param_size)
+	void my_lcd_send_cmd(lv_display_t *disp, const uint8_t *cmd, size_t cmd_size, const uint8_t *param, size_t param_size)
 	{
 		...
 	}
 
 	/* Send large array of pixel data to the LCD. If necessary, this function has to do the byte-swapping. This function can do the transfer in the background. */
-	int32_t my_lcd_send_color(lv_display_t *disp, const uint8_t *cmd, size_t cmd_size, uint8_t *param, size_t param_size)
+	void my_lcd_send_color(lv_display_t *disp, const uint8_t *cmd, size_t cmd_size, uint8_t *param, size_t param_size)
 	{
 		...
 	}

--- a/docs/src/details/integration/external_display_controllers/ili9341.rst
+++ b/docs/src/details/integration/external_display_controllers/ili9341.rst
@@ -37,13 +37,13 @@ You need to implement two platform-dependent functions:
 .. code-block:: c
 
 	/* Send short command to the LCD. This function shall wait until the transaction finishes. */
-	int32_t my_lcd_send_cmd(lv_display_t *disp, const uint8_t *cmd, size_t cmd_size, const uint8_t *param, size_t param_size)
+	void my_lcd_send_cmd(lv_display_t *disp, const uint8_t *cmd, size_t cmd_size, const uint8_t *param, size_t param_size)
 	{
 		...
 	}
 
 	/* Send large array of pixel data to the LCD. If necessary, this function has to do the byte-swapping. This function can do the transfer in the background. */
-	int32_t my_lcd_send_color(lv_display_t *disp, const uint8_t *cmd, size_t cmd_size, uint8_t *param, size_t param_size)
+	void my_lcd_send_color(lv_display_t *disp, const uint8_t *cmd, size_t cmd_size, uint8_t *param, size_t param_size)
 	{
 		...
 	}

--- a/docs/src/details/integration/external_display_controllers/st7735.rst
+++ b/docs/src/details/integration/external_display_controllers/st7735.rst
@@ -39,13 +39,13 @@ You need to implement two platform-dependent functions:
 .. code-block:: c
 
 	/* Send short command to the LCD. This function shall wait until the transaction finishes. */
-	int32_t my_lcd_send_cmd(lv_display_t *disp, const uint8_t *cmd, size_t cmd_size, const uint8_t *param, size_t param_size)
+	void my_lcd_send_cmd(lv_display_t *disp, const uint8_t *cmd, size_t cmd_size, const uint8_t *param, size_t param_size)
 	{
 		...
 	}
 
 	/* Send large array of pixel data to the LCD. If necessary, this function has to do the byte-swapping. This function can do the transfer in the background. */
-	int32_t my_lcd_send_color(lv_display_t *disp, const uint8_t *cmd, size_t cmd_size, uint8_t *param, size_t param_size)
+	void my_lcd_send_color(lv_display_t *disp, const uint8_t *cmd, size_t cmd_size, uint8_t *param, size_t param_size)
 	{
 		...
 	}

--- a/docs/src/details/integration/external_display_controllers/st7789.rst
+++ b/docs/src/details/integration/external_display_controllers/st7789.rst
@@ -38,13 +38,13 @@ You need to implement two platform-dependent functions:
 .. code-block:: c
 
 	/* Send short command to the LCD. This function shall wait until the transaction finishes. */
-	int32_t my_lcd_send_cmd(lv_display_t *disp, const uint8_t *cmd, size_t cmd_size, const uint8_t *param, size_t param_size)
+	void my_lcd_send_cmd(lv_display_t *disp, const uint8_t *cmd, size_t cmd_size, const uint8_t *param, size_t param_size)
 	{
 		...
 	}
 
 	/* Send large array of pixel data to the LCD. If necessary, this function has to do the byte-swapping. This function can do the transfer in the background. */
-	int32_t my_lcd_send_color(lv_display_t *disp, const uint8_t *cmd, size_t cmd_size, uint8_t *param, size_t param_size)
+	void my_lcd_send_color(lv_display_t *disp, const uint8_t *cmd, size_t cmd_size, uint8_t *param, size_t param_size)
 	{
 		...
 	}

--- a/docs/src/details/integration/external_display_controllers/st7796.rst
+++ b/docs/src/details/integration/external_display_controllers/st7796.rst
@@ -39,13 +39,13 @@ You need to implement two platform-dependent functions:
 .. code-block:: c
 
 	/* Send short command to the LCD. This function shall wait until the transaction finishes. */
-	int32_t my_lcd_send_cmd(lv_display_t *disp, const uint8_t *cmd, size_t cmd_size, const uint8_t *param, size_t param_size)
+	void my_lcd_send_cmd(lv_display_t *disp, const uint8_t *cmd, size_t cmd_size, const uint8_t *param, size_t param_size)
 	{
 		...
 	}
 
 	/* Send large array of pixel data to the LCD. If necessary, this function has to do the byte-swapping. This function can do the transfer in the background. */
-	int32_t my_lcd_send_color(lv_display_t *disp, const uint8_t *cmd, size_t cmd_size, uint8_t *param, size_t param_size)
+	void my_lcd_send_color(lv_display_t *disp, const uint8_t *cmd, size_t cmd_size, uint8_t *param, size_t param_size)
 	{
 		...
 	}


### PR DESCRIPTION
https://github.com/lvgl/lvgl/issues/8802#issuecomment-3249236824

Functions are defined as:
```c
typedef void (*lv_lcd_send_cmd_cb_t)(lv_display_t * disp, const uint8_t * cmd, size_t cmd_size, const uint8_t * param,
                                     size_t param_size);

typedef void (*lv_lcd_send_color_cb_t)(lv_display_t * disp, const uint8_t * cmd, size_t cmd_size, uint8_t * param,
                                       size_t param_size);
```