### PR TITLE
Nxp patches v9.3

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -421,25 +421,35 @@ menu "LVGL configuration"
 			bool "Enable PXP asserts"
 			depends on LV_USE_DRAW_PXP
 
-		config LV_USE_DRAW_G2D
+		config LV_USE_G2D
 			bool "Use NXP's G2D on MPU platforms"
+			default n
+		
+		config LV_USE_DRAW_G2D
+			bool "Use G2D for drawing."
+			depends on LV_USE_G2D
+			default y
+		
+		config LV_USE_ROTATE_G2D
+			bool "Use G2D to rotate display."
+			depends on LV_USE_G2D
 			default n
 
 		config LV_G2D_HASH_TABLE_SIZE
 			bool "Maximum number of buffers that can be stored for G2D draw unit."
 			default 50
-			depends on LV_USE_DRAW_G2D
+			depends on LV_USE_G2D
 			help
 				Includes the frame buffers and assets.
 
 		config LV_USE_G2D_DRAW_THREAD
 			bool "Use additional draw thread for G2D processing"
-			depends on LV_USE_DRAW_G2D && !LV_OS_NONE
+			depends on LV_USE_G2D && !LV_OS_NONE
 			default y
 
 		config LV_USE_G2D_ASSERT
 			bool "Enable G2D asserts"
-			depends on LV_USE_DRAW_G2D
+			depends on LV_USE_G2D
 			default n
 
 		config LV_USE_DRAW_DAVE2D

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -294,9 +294,15 @@
 #endif
 
 /** Use NXP's G2D on MPU platforms. */
-#define LV_USE_DRAW_G2D 0
+#define LV_USE_G2D 0
 
-#if LV_USE_DRAW_G2D
+#if LV_USE_G2D
+    /** Use G2D for drawing. **/
+    #define LV_USE_DRAW_G2D 1
+
+    /** Use G2D to rotate display. **/
+    #define LV_USE_ROTATE_G2D 0
+
     /** Maximum number of buffers that can be stored for G2D draw unit.
      *  Includes the frame buffers and assets. */
     #define LV_G2D_HASH_TABLE_SIZE 50

--- a/src/draw/nxp/g2d/lv_draw_buf_g2d.c
+++ b/src/draw/nxp/g2d/lv_draw_buf_g2d.c
@@ -15,7 +15,8 @@
 
 #include "lv_draw_g2d.h"
 
-#if LV_USE_DRAW_G2D
+#if LV_USE_G2D
+#if LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D
 #include "../../lv_draw_buf_private.h"
 #include "g2d.h"
 #include "lv_g2d_buf_map.h"
@@ -89,4 +90,5 @@ static void _invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * 
     g2d_cache_op(buf, G2D_CACHE_FLUSH);
 }
 
-#endif /*LV_USE_DRAW_G2D*/
+#endif /*LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D*/
+#endif /*LV_USE_G2D*/

--- a/src/draw/nxp/g2d/lv_draw_g2d.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d.c
@@ -57,6 +57,8 @@ static void _g2d_execute_drawing(lv_draw_task_t * t);
  *  STATIC VARIABLES
  **********************/
 
+static int32_t is_hw_pxp = 0;
+
 /**********************
  *      MACROS
  **********************/
@@ -78,6 +80,8 @@ void lv_draw_g2d_init(void)
     if(g2d_open(&draw_g2d_unit->g2d_handle)) {
         LV_LOG_ERROR("g2d_open fail.\n");
     }
+    g2d_query_hardware(draw_g2d_unit->g2d_handle, G2D_HARDWARE_PXP, &is_hw_pxp);
+
 #if LV_USE_G2D_DRAW_THREAD
     lv_draw_sw_thread_dsc_t * thread_dsc = &draw_g2d_unit->thread_dsc;
     thread_dsc->idx = 0;
@@ -105,6 +109,12 @@ static inline bool _g2d_dest_cf_supported(lv_color_format_t cf)
         case LV_COLOR_FORMAT_XRGB8888:
             is_cf_supported = true;
             break;
+        case LV_COLOR_FORMAT_RGB565: {
+                if(!is_hw_pxp) {
+                    is_cf_supported = true;
+                }
+            }
+            break;
         default:
             break;
     }
@@ -122,10 +132,7 @@ static inline bool _g2d_src_cf_supported(lv_draw_unit_t * drawunit, lv_color_for
             is_cf_supported = true;
             break;
         case LV_COLOR_FORMAT_RGB565: {
-                int32_t hw_pxp = 0;
-                lv_draw_g2d_unit_t * u = (lv_draw_g2d_unit_t *)drawunit;
-                g2d_query_hardware(u->g2d_handle, G2D_HARDWARE_PXP, &hw_pxp);
-                if(!hw_pxp) {
+                if(!is_hw_pxp) {
                     is_cf_supported = true;
                 }
             }

--- a/src/draw/nxp/g2d/lv_draw_g2d.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d.c
@@ -152,10 +152,13 @@ static bool _g2d_draw_img_supported(const lv_draw_image_dsc_t * draw_dsc)
         return false;
 
     bool has_recolor = (draw_dsc->recolor_opa > LV_OPA_MIN);
-    bool has_rotation = (draw_dsc->rotation != 0);
+    /* Recolor is not supported. */
+    if(has_recolor)
+        return false;
 
-    /* Recolor or rotation are not supported. */
-    if(has_recolor || has_rotation)
+    bool has_rotation = (draw_dsc->rotation != 0);
+    /* Rotation is not supported for PXP hardware. */
+    if(has_rotation && is_hw_pxp)
         return false;
 
     return true;

--- a/src/draw/nxp/g2d/lv_draw_g2d.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d.c
@@ -80,7 +80,7 @@ void lv_draw_g2d_init(void)
     if(g2d_open(&draw_g2d_unit->g2d_handle)) {
         LV_LOG_ERROR("g2d_open fail.\n");
     }
-    g2d_query_hardware(draw_g2d_unit->g2d_handle, G2D_HARDWARE_PXP, &is_hw_pxp);
+    g2d_query_hardware(draw_g2d_unit->g2d_handle, G2D_HARDWARE_PXP_V1, &is_hw_pxp);
 
 #if LV_USE_G2D_DRAW_THREAD
     lv_draw_sw_thread_dsc_t * thread_dsc = &draw_g2d_unit->thread_dsc;

--- a/src/draw/nxp/g2d/lv_draw_g2d.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d.c
@@ -150,11 +150,6 @@ static inline bool _g2d_src_cf_supported(lv_draw_unit_t * drawunit, lv_color_for
 
 static bool _g2d_draw_img_supported(const lv_draw_image_dsc_t * draw_dsc)
 {
-    bool is_tiled = draw_dsc->tile;
-    /* Tiled image (repeat image) is currently not supported. */
-    if(is_tiled)
-        return false;
-
     bool has_recolor = (draw_dsc->recolor_opa > LV_OPA_MIN);
     /* Recolor is not supported. */
     if(has_recolor)

--- a/src/draw/nxp/g2d/lv_draw_g2d.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d.c
@@ -11,10 +11,11 @@
 
 #include "lv_draw_g2d.h"
 
-#if LV_USE_DRAW_G2D
+#if LV_USE_G2D
 #include "../../../misc/lv_area_private.h"
 #include "g2d.h"
 #include "lv_g2d_buf_map.h"
+#include "lv_g2d_utils.h"
 
 /*********************
  *      DEFINES
@@ -70,17 +71,12 @@ static int32_t is_hw_pxp = 0;
 void lv_draw_g2d_init(void)
 {
     lv_draw_buf_g2d_init_handlers();
-
+#if LV_USE_DRAW_G2D
     lv_draw_g2d_unit_t * draw_g2d_unit = lv_draw_create_unit(sizeof(lv_draw_g2d_unit_t));
     draw_g2d_unit->base_unit.evaluate_cb = _g2d_evaluate;
     draw_g2d_unit->base_unit.dispatch_cb = _g2d_dispatch;
     draw_g2d_unit->base_unit.delete_cb = _g2d_delete;
     draw_g2d_unit->base_unit.name = "G2D";
-    g2d_create_buf_map();
-    if(g2d_open(&draw_g2d_unit->g2d_handle)) {
-        LV_LOG_ERROR("g2d_open fail.\n");
-    }
-    g2d_query_hardware(draw_g2d_unit->g2d_handle, G2D_HARDWARE_PXP_V1, &is_hw_pxp);
 
 #if LV_USE_G2D_DRAW_THREAD
     lv_draw_sw_thread_dsc_t * thread_dsc = &draw_g2d_unit->thread_dsc;
@@ -89,6 +85,14 @@ void lv_draw_g2d_init(void)
     lv_thread_init(&thread_dsc->thread, "g2ddraw", LV_DRAW_THREAD_PRIO, _g2d_render_thread_cb, LV_DRAW_THREAD_STACK_SIZE,
                    thread_dsc);
 #endif
+#endif
+    g2d_create_buf_map();
+    void * handle;
+    if(g2d_open(&handle)) {
+        LV_LOG_ERROR("g2d_open fail.\n");
+    }
+    g2d_query_hardware(handle, G2D_HARDWARE_PXP_V1, &is_hw_pxp);
+    g2d_set_handle(handle);
 }
 
 void lv_draw_g2d_deinit(void)
@@ -99,7 +103,7 @@ void lv_draw_g2d_deinit(void)
 /**********************
  *   STATIC FUNCTIONS
  **********************/
-
+#if LV_USE_DRAW_G2D
 static inline bool _g2d_dest_cf_supported(lv_color_format_t cf)
 {
     bool is_cf_supported = false;
@@ -278,7 +282,7 @@ static int32_t _g2d_delete(lv_draw_unit_t * draw_unit)
 
     res = lv_thread_delete(&thread_dsc->thread);
 #endif
-    g2d_close(draw_g2d_unit->g2d_handle);
+    g2d_close(g2d_get_handle());
 
     return res;
 }
@@ -343,4 +347,5 @@ static void _g2d_render_thread_cb(void * ptr)
 }
 #endif
 
-#endif /*LV_USE_DRAW_G2D*/
+#endif /*LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D*/
+#endif /*LV_USE_G2D*/

--- a/src/draw/nxp/g2d/lv_draw_g2d.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d.c
@@ -160,9 +160,8 @@ static bool _g2d_draw_img_supported(const lv_draw_image_dsc_t * draw_dsc)
     if(has_recolor)
         return false;
 
-    bool has_rotation = (draw_dsc->rotation != 0);
-    /* Rotation is not supported for PXP hardware. */
-    if(has_rotation && is_hw_pxp)
+    /* G2D can only rotate at 90x angles. */
+    if(draw_dsc->rotation % 900)
         return false;
 
     return true;

--- a/src/draw/nxp/g2d/lv_draw_g2d.h
+++ b/src/draw/nxp/g2d/lv_draw_g2d.h
@@ -22,7 +22,8 @@ extern "C" {
 
 #include "../../../lv_conf_internal.h"
 
-#if LV_USE_DRAW_G2D
+#if LV_USE_G2D
+#if LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D
 #include "../../sw/lv_draw_sw_private.h"
 
 /*********************
@@ -40,8 +41,6 @@ typedef struct lv_draw_g2d_unit {
 #else
     lv_draw_task_t * task_act;
 #endif
-
-    void * g2d_handle;
 } lv_draw_g2d_unit_t;
 
 /**********************
@@ -62,7 +61,8 @@ void lv_draw_g2d_img(lv_draw_task_t * t);
  *      MACROS
  **********************/
 
-#endif /*LV_USE_DRAW_G2D*/
+#endif /*LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D*/
+#endif /*LV_USE_G2D*/
 
 #ifdef __cplusplus
 } /*extern "C"*/

--- a/src/draw/nxp/g2d/lv_draw_g2d_fill.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d_fill.c
@@ -39,10 +39,10 @@ static void _g2d_fill(void * g2d_handle, struct g2d_surface * dst_surf);
 static void _g2d_fill_with_opa(void * g2d_handle, struct g2d_surface * dst_surf, struct g2d_surface * src_surf);
 
 static void _g2d_set_src_surf(struct g2d_surface * src_surf, struct g2d_buf * buf, const lv_area_t * area,
-                              lv_color_t color, lv_opa_t opa);
+                              lv_color_t color, lv_opa_t opa, lv_color_format_t cf);
 
 static void _g2d_set_dst_surf(struct g2d_surface * dst_surf, struct g2d_buf * buf, const lv_area_t * area,
-                              int32_t stride, lv_color_t color);
+                              int32_t stride, lv_color_t color, lv_color_format_t cf);
 
 /**********************
  *  STATIC VARIABLES
@@ -88,14 +88,14 @@ void lv_draw_g2d_fill(lv_draw_task_t * t)
 
     bool has_opa = (dsc->opa < (lv_opa_t)LV_OPA_MAX);
     struct g2d_surface dst_surf;
-    _g2d_set_dst_surf(&dst_surf, dst_buf, &blend_area, stride, dsc->color);
+    _g2d_set_dst_surf(&dst_surf, dst_buf, &blend_area, stride, dsc->color, draw_buf->header.cf);
 
     if(has_opa) {
         struct g2d_buf * tmp_buf = g2d_alloc(lv_area_get_width(&blend_area) * lv_area_get_height(&blend_area) * sizeof(
                                                  lv_color32_t), 1);
         G2D_ASSERT_MSG(tmp_buf, "Failed to alloc temporary buffer.");
         struct g2d_surface src_surf;
-        _g2d_set_src_surf(&src_surf, tmp_buf, &blend_area, dsc->color, dsc->opa);
+        _g2d_set_src_surf(&src_surf, tmp_buf, &blend_area, dsc->color, dsc->opa, draw_buf->header.cf);
         _g2d_fill_with_opa(u->g2d_handle, &dst_surf, &src_surf);
         g2d_free(tmp_buf);
     }
@@ -109,12 +109,12 @@ void lv_draw_g2d_fill(lv_draw_task_t * t)
  **********************/
 
 static void _g2d_set_src_surf(struct g2d_surface * src_surf, struct g2d_buf * buf, const lv_area_t * area,
-                              lv_color_t color, lv_opa_t opa)
+                              lv_color_t color, lv_opa_t opa, lv_color_format_t cf)
 {
     int32_t width  = lv_area_get_width(area);
     int32_t height = lv_area_get_height(area);
 
-    src_surf->format = G2D_RGBA8888;
+    src_surf->format = g2d_get_buf_format(cf);
 
     src_surf->left   = 0;
     src_surf->top    = 0;
@@ -133,12 +133,12 @@ static void _g2d_set_src_surf(struct g2d_surface * src_surf, struct g2d_buf * bu
 }
 
 static void _g2d_set_dst_surf(struct g2d_surface * dst_surf, struct g2d_buf * buf, const lv_area_t * area,
-                              int32_t stride, lv_color_t color)
+                              int32_t stride, lv_color_t color, lv_color_format_t cf)
 {
     int32_t width  = lv_area_get_width(area);
     int32_t height = lv_area_get_height(area);
 
-    dst_surf->format = G2D_RGBA8888;
+    dst_surf->format = g2d_get_buf_format(cf);
 
     dst_surf->left   = area->x1;
     dst_surf->top    = area->y1;

--- a/src/draw/nxp/g2d/lv_draw_g2d_fill.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d_fill.c
@@ -15,6 +15,7 @@
 
 #include "lv_draw_g2d.h"
 
+#if LV_USE_G2D
 #if LV_USE_DRAW_G2D
 #include <stdlib.h>
 #include "g2d.h"
@@ -35,8 +36,8 @@
  **********************/
 
 /* Blit simple w/ opa and alpha channel */
-static void _g2d_fill(void * g2d_handle, struct g2d_surface * dst_surf);
-static void _g2d_fill_with_opa(void * g2d_handle, struct g2d_surface * dst_surf, struct g2d_surface * src_surf);
+static void _g2d_fill(void * handle, struct g2d_surface * dst_surf);
+static void _g2d_fill_with_opa(void * handle, struct g2d_surface * dst_surf, struct g2d_surface * src_surf);
 
 static void _g2d_set_src_surf(struct g2d_surface * src_surf, struct g2d_buf * buf, const lv_area_t * area,
                               lv_color_t color, lv_opa_t opa, lv_color_format_t cf);
@@ -90,17 +91,19 @@ void lv_draw_g2d_fill(lv_draw_task_t * t)
     struct g2d_surface dst_surf;
     _g2d_set_dst_surf(&dst_surf, dst_buf, &blend_area, stride, dsc->color, draw_buf->header.cf);
 
+    void * handle = g2d_get_handle();
+
     if(has_opa) {
         struct g2d_buf * tmp_buf = g2d_alloc(lv_area_get_width(&blend_area) * lv_area_get_height(&blend_area) * sizeof(
                                                  lv_color32_t), 1);
         G2D_ASSERT_MSG(tmp_buf, "Failed to alloc temporary buffer.");
         struct g2d_surface src_surf;
         _g2d_set_src_surf(&src_surf, tmp_buf, &blend_area, dsc->color, dsc->opa, draw_buf->header.cf);
-        _g2d_fill_with_opa(u->g2d_handle, &dst_surf, &src_surf);
+        _g2d_fill_with_opa(handle, &dst_surf, &src_surf);
         g2d_free(tmp_buf);
     }
     else {
-        _g2d_fill(u->g2d_handle, &dst_surf);
+        _g2d_fill(handle, &dst_surf);
     }
 }
 
@@ -156,23 +159,24 @@ static void _g2d_set_dst_surf(struct g2d_surface * dst_surf, struct g2d_buf * bu
     dst_surf->blendfunc = G2D_ONE_MINUS_SRC_ALPHA | G2D_PRE_MULTIPLIED_ALPHA;
 }
 
-static void _g2d_fill_with_opa(void * g2d_handle, struct g2d_surface * dst_surf, struct g2d_surface * src_surf)
+static void _g2d_fill_with_opa(void * handle, struct g2d_surface * dst_surf, struct g2d_surface * src_surf)
 {
-    g2d_clear(g2d_handle, src_surf);
+    g2d_clear(handle, src_surf);
 
-    g2d_enable(g2d_handle, G2D_BLEND);
-    g2d_enable(g2d_handle, G2D_GLOBAL_ALPHA);
-    g2d_blit(g2d_handle, src_surf, dst_surf);
-    g2d_finish(g2d_handle);
-    g2d_disable(g2d_handle, G2D_GLOBAL_ALPHA);
-    g2d_disable(g2d_handle, G2D_BLEND);
+    g2d_enable(handle, G2D_BLEND);
+    g2d_enable(handle, G2D_GLOBAL_ALPHA);
+    g2d_blit(handle, src_surf, dst_surf);
+    g2d_finish(handle);
+    g2d_disable(handle, G2D_GLOBAL_ALPHA);
+    g2d_disable(handle, G2D_BLEND);
 }
 
-static void _g2d_fill(void * g2d_handle, struct g2d_surface * dst_surf)
+static void _g2d_fill(void * handle, struct g2d_surface * dst_surf)
 {
-    g2d_clear(g2d_handle, dst_surf);
+    g2d_clear(handle, dst_surf);
 
-    g2d_finish(g2d_handle);
+    g2d_finish(handle);
 }
 
 #endif /*LV_USE_DRAW_G2D*/
+#endif /*LV_USE_G2D*/

--- a/src/draw/nxp/g2d/lv_draw_g2d_img.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d_img.c
@@ -176,6 +176,38 @@ static void _g2d_set_dst_surf(struct g2d_surface * dst_surf, struct g2d_buf * bu
     int32_t dest_w;
     int32_t dest_h;
 
+    bool has_rotation = (dsc->rotation != 0);
+    enum g2d_rotation g2d_angle = G2D_ROTATION_0;
+
+    if(has_rotation) {
+        switch(dsc->rotation) {
+            case 0:
+                g2d_angle = G2D_ROTATION_0;
+                piv_offset_x = 0;
+                piv_offset_y = 0;
+                break;
+            case 900:
+                g2d_angle = G2D_ROTATION_90;
+                piv_offset_x = pivot.x + pivot.y - height;
+                piv_offset_y = pivot.y - pivot.x;
+                break;
+            case 1800:
+                g2d_angle = G2D_ROTATION_180;
+                piv_offset_x = 2 * pivot.x - width;
+                piv_offset_y = 2 * pivot.y - height;
+                break;
+            case 2700:
+                g2d_angle = G2D_ROTATION_270;
+                piv_offset_x = pivot.x - pivot.y;
+                piv_offset_y = pivot.x + pivot.y - width;
+                break;
+            default:
+                g2d_angle = G2D_ROTATION_0;
+                piv_offset_x = 0;
+                piv_offset_y = 0;
+        }
+    }
+
     float fp_scale_x = (float)dsc->scale_x / LV_SCALE_NONE;
     float fp_scale_y = (float)dsc->scale_y / LV_SCALE_NONE;
     int32_t int_scale_x = (int32_t)fp_scale_x;
@@ -203,7 +235,7 @@ static void _g2d_set_dst_surf(struct g2d_surface * dst_surf, struct g2d_buf * bu
     dst_surf->height = dest_h - trim_y;
 
     dst_surf->planes[0] = buf->buf_paddr;
-    dst_surf->rot = G2D_ROTATION_0;
+    dst_surf->rot = g2d_angle;
 
     dst_surf->clrcolor = g2d_rgba_to_u32(lv_color_black());
     dst_surf->global_alpha = 0xff;

--- a/src/draw/nxp/g2d/lv_draw_g2d_img.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d_img.c
@@ -21,6 +21,7 @@
 #include "g2d.h"
 #include "../../../misc/lv_area_private.h"
 #include "../../lv_draw_image_private.h"
+#include "../../lv_image_decoder_private.h"
 #include "lv_g2d_utils.h"
 #include "lv_g2d_buf_map.h"
 
@@ -40,7 +41,7 @@ static void _g2d_draw_core_cb(lv_draw_task_t * t, const lv_draw_image_dsc_t * dr
                               const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup, const lv_area_t * img_coords,
                               const lv_area_t * clipped_img_area);
 
-static struct g2d_buf * _g2d_handle_src_buf(const lv_image_dsc_t * data);
+static struct g2d_buf * _g2d_handle_src_buf(const lv_draw_buf_t * data);
 
 static void _g2d_set_src_surf(struct g2d_surface * src_surf, struct g2d_buf * buf, const lv_area_t * area,
                               int32_t stride, lv_color_format_t cf, const lv_draw_image_dsc_t * dsc);
@@ -80,12 +81,10 @@ void lv_draw_g2d_img(lv_draw_task_t * t)
 
     bool is_tiled = (dsc->tile != 0);
 
-    if(is_tiled) {
+    if(is_tiled)
         lv_draw_image_tiled_helper(t, dsc, coords, _g2d_draw_core_cb);
-    }
-    else {
+    else
         lv_draw_image_normal_helper(t, dsc, coords, _g2d_draw_core_cb);
-    }
 }
 
 /**********************
@@ -98,6 +97,8 @@ static void _g2d_draw_core_cb(lv_draw_task_t * t, const lv_draw_image_dsc_t * dr
 {
     LV_UNUSED(sup);
     lv_draw_buf_t * draw_buf = t->target_layer->draw_buf;
+
+    const lv_draw_buf_t * decoded = decoder_dsc->decoded;
 
     lv_area_t rel_clip_area;
     lv_area_copy(&rel_clip_area, clipped_img_area);
@@ -124,7 +125,7 @@ static void _g2d_draw_core_cb(lv_draw_task_t * t, const lv_draw_image_dsc_t * dr
 
 
     /* Source image */
-    struct g2d_buf * src_buf = _g2d_handle_src_buf(img_dsc);
+    struct g2d_buf * src_buf = _g2d_handle_src_buf(decoded);
 
     /* Destination buffer */
     struct g2d_buf * dst_buf = g2d_search_buf_map(draw_buf->data);
@@ -159,7 +160,7 @@ static void _g2d_draw_core_cb(lv_draw_task_t * t, const lv_draw_image_dsc_t * dr
     }
 }
 
-static struct g2d_buf * _g2d_handle_src_buf(const lv_image_dsc_t * img_dsc)
+static struct g2d_buf * _g2d_handle_src_buf(const lv_draw_buf_t * img_dsc)
 {
     struct g2d_buf * src_buf = g2d_search_buf_map((void *)img_dsc->data);
 

--- a/src/draw/nxp/g2d/lv_draw_g2d_img.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d_img.c
@@ -15,6 +15,7 @@
 
 #include "lv_draw_g2d.h"
 
+#if LV_USE_G2D
 #if LV_USE_DRAW_G2D
 #include <math.h>
 #include "g2d.h"
@@ -43,7 +44,7 @@ static void _g2d_set_dst_surf(struct g2d_surface * dst_surf, struct g2d_buf * bu
                               int32_t stride, lv_color_format_t cf, const lv_draw_image_dsc_t * dsc);
 
 /* Blit simple w/ opa and alpha channel */
-static void _g2d_blit(void * g2d_handle, struct g2d_surface * dst_surf, struct g2d_surface * src_surf);
+static void _g2d_blit(void * handle, struct g2d_surface * dst_surf, struct g2d_surface * src_surf);
 
 /**********************
  *  STATIC VARIABLES
@@ -112,13 +113,15 @@ void lv_draw_g2d_img(lv_draw_task_t * t)
     int32_t dest_stride = draw_buf->header.stride / (lv_color_format_get_bpp(draw_buf->header.cf) / 8);
     lv_color_format_t dest_cf = draw_buf->header.cf;
 
+    void * handle = g2d_get_handle();
+
     struct g2d_surface src_surf;
     struct g2d_surface dst_surf;
 
     _g2d_set_src_surf(&src_surf, src_buf, &src_area, src_stride, src_cf, dsc->opa);
     _g2d_set_dst_surf(&dst_surf, dst_buf, &blend_area, dest_stride, dest_cf, dsc);
 
-    _g2d_blit(u->g2d_handle, &dst_surf, &src_surf);
+    _g2d_blit(handle, &dst_surf, &src_surf);
 }
 
 /**********************
@@ -242,13 +245,14 @@ static void _g2d_set_dst_surf(struct g2d_surface * dst_surf, struct g2d_buf * bu
     dst_surf->blendfunc = G2D_ONE_MINUS_SRC_ALPHA | G2D_PRE_MULTIPLIED_ALPHA;
 }
 
-static void _g2d_blit(void * g2d_handle, struct g2d_surface * dst_surf, struct g2d_surface * src_surf)
+static void _g2d_blit(void * handle, struct g2d_surface * dst_surf, struct g2d_surface * src_surf)
 {
-    g2d_enable(g2d_handle, G2D_BLEND);
-    g2d_enable(g2d_handle, G2D_GLOBAL_ALPHA);
-    g2d_blit(g2d_handle, src_surf, dst_surf);
-    g2d_finish(g2d_handle);
-    g2d_disable(g2d_handle, G2D_GLOBAL_ALPHA);
-    g2d_disable(g2d_handle, G2D_BLEND);
+    g2d_enable(handle, G2D_BLEND);
+    g2d_enable(handle, G2D_GLOBAL_ALPHA);
+    g2d_blit(handle, src_surf, dst_surf);
+    g2d_finish(handle);
+    g2d_disable(handle, G2D_GLOBAL_ALPHA);
+    g2d_disable(handle, G2D_BLEND);
 }
 #endif /*LV_USE_DRAW_G2D*/
+#endif /*LV_USE_G2D*/

--- a/src/draw/nxp/g2d/lv_draw_g2d_img.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d_img.c
@@ -20,6 +20,7 @@
 #include <math.h>
 #include "g2d.h"
 #include "../../../misc/lv_area_private.h"
+#include "../../lv_draw_image_private.h"
 #include "lv_g2d_utils.h"
 #include "lv_g2d_buf_map.h"
 
@@ -35,6 +36,10 @@
  *  STATIC PROTOTYPES
  **********************/
 
+static void _g2d_draw_core_cb(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
+                              const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup, const lv_area_t * img_coords,
+                              const lv_area_t * clipped_img_area);
+
 static struct g2d_buf * _g2d_handle_src_buf(const lv_image_dsc_t * data);
 
 static void _g2d_set_src_surf(struct g2d_surface * src_surf, struct g2d_buf * buf, const lv_area_t * area,
@@ -44,7 +49,7 @@ static void _g2d_set_tmp_surf(struct g2d_surface * tmp_surf, struct g2d_buf * bu
                               lv_color_format_t cf);
 
 static void _g2d_set_dst_surf(struct g2d_surface * dst_surf, struct g2d_buf * buf, const lv_area_t * area,
-                              lv_draw_buf_t * draw_buf, const lv_draw_image_dsc_t * dsc);
+                              lv_draw_buf_t * draw_buf);
 
 /* Blit simple w/ opa and alpha channel */
 static void _g2d_blit(void * handle, struct g2d_surface * dst_surf, struct g2d_surface * src_surf);
@@ -71,32 +76,42 @@ void lv_draw_g2d_img(lv_draw_task_t * t)
     if(dsc->opa <= (lv_opa_t)LV_OPA_MIN)
         return;
 
-    lv_layer_t * layer = t->target_layer;
-    lv_draw_buf_t * draw_buf = layer->draw_buf;
-    const lv_image_dsc_t * img_dsc = dsc->src;
     lv_area_t * coords = &t->area;
 
-    lv_area_t rel_coords;
-    lv_area_copy(&rel_coords, coords);
-    lv_area_move(&rel_coords, -layer->buf_area.x1, -layer->buf_area.y1);
+    bool is_tiled = (dsc->tile != 0);
 
-    lv_area_t clip_area;
-    lv_area_copy(&clip_area, &t->clip_area);
-    lv_area_move(&clip_area, -layer->buf_area.x1, -layer->buf_area.y1);
+    if(is_tiled) {
+        lv_draw_image_tiled_helper(t, dsc, coords, _g2d_draw_core_cb);
+    }
+    else {
+        lv_draw_image_normal_helper(t, dsc, coords, _g2d_draw_core_cb);
+    }
+}
 
-    lv_area_t blend_area;
-    bool has_transform = (dsc->rotation != 0 || dsc->scale_x != LV_SCALE_NONE || dsc->scale_y != LV_SCALE_NONE);
-    if(has_transform)
-        lv_area_copy(&blend_area, &rel_coords);
-    else if(!lv_area_intersect(&blend_area, &rel_coords, &clip_area))
-        return; /*Fully clipped, nothing to do*/
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static void _g2d_draw_core_cb(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
+                              const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup, const lv_area_t * img_coords,
+                              const lv_area_t * clipped_img_area)
+{
+    LV_UNUSED(sup);
+    lv_draw_buf_t * draw_buf = t->target_layer->draw_buf;
+
+    lv_area_t rel_clip_area;
+    lv_area_copy(&rel_clip_area, clipped_img_area);
+    lv_area_move(&rel_clip_area, -img_coords->x1, -img_coords->y1);
+
+    lv_area_t rel_img_coords;
+    lv_area_copy(&rel_img_coords, img_coords);
+    lv_area_move(&rel_img_coords, -img_coords->x1, -img_coords->y1);
 
     lv_area_t src_area;
-    src_area.x1 = blend_area.x1 - (coords->x1 - layer->buf_area.x1);
-    src_area.y1 = blend_area.y1 - (coords->y1 - layer->buf_area.y1);
-    src_area.x2 = src_area.x1 + lv_area_get_width(&blend_area);
-    src_area.y2 = src_area.y1 + lv_area_get_height(&blend_area);
-    lv_color_format_t src_cf = img_dsc->header.cf;
+    if(!lv_area_intersect(&src_area, &rel_clip_area, &rel_img_coords))
+        return;
+
+    lv_color_format_t src_cf = draw_dsc->header.cf;
 
     /* G2D takes stride in pixels. */
     const uint8_t pixel_size = lv_color_format_get_size(src_cf);
@@ -120,10 +135,10 @@ void lv_draw_g2d_img(lv_draw_task_t * t)
     struct g2d_surface src_surf;
     struct g2d_surface dst_surf;
 
-    _g2d_set_src_surf(&src_surf, src_buf, &src_area, src_stride, src_cf, dsc);
-    _g2d_set_dst_surf(&dst_surf, dst_buf, &blend_area, draw_buf, dsc);
+    _g2d_set_src_surf(&src_surf, src_buf, &src_area, src_stride, src_cf, draw_dsc);
+    _g2d_set_dst_surf(&dst_surf, dst_buf, clipped_img_area, draw_buf);
 
-    bool has_rotation = (dsc->rotation != 0);
+    bool has_rotation = (draw_dsc->rotation != 0);
 
     if(has_rotation) {
         /** If the image has rotation, then blit in two steps:
@@ -144,10 +159,6 @@ void lv_draw_g2d_img(lv_draw_task_t * t)
     }
 }
 
-/**********************
- *   STATIC FUNCTIONS
- **********************/
-
 static struct g2d_buf * _g2d_handle_src_buf(const lv_image_dsc_t * img_dsc)
 {
     struct g2d_buf * src_buf = g2d_search_buf_map((void *)img_dsc->data);
@@ -167,6 +178,9 @@ static void _g2d_set_src_surf(struct g2d_surface * src_surf, struct g2d_buf * bu
                               int32_t stride, lv_color_format_t cf, const lv_draw_image_dsc_t * dsc)
 {
     src_surf->format = g2d_get_buf_format(cf);
+
+    int32_t src_w = lv_area_get_width(area);
+    int32_t src_h = lv_area_get_height(area);
 
     bool has_rotation = (dsc->rotation != 0);
     enum g2d_rotation g2d_angle = G2D_ROTATION_0;
@@ -192,11 +206,11 @@ static void _g2d_set_src_surf(struct g2d_surface * src_surf, struct g2d_buf * bu
 
     src_surf->left   = area->x1;
     src_surf->top    = area->y1;
-    src_surf->right  = area->x2;
-    src_surf->bottom = area->y2;
+    src_surf->right  = area->x1 + src_w;
+    src_surf->bottom = area->y1 + src_h;
     src_surf->stride = stride;
-    src_surf->width  = area->x2 - area->x1;
-    src_surf->height = area->y2 - area->y1;
+    src_surf->width  = src_w;
+    src_surf->height = src_h;
 
     src_surf->planes[0] = buf->buf_paddr;
     src_surf->rot = g2d_angle;
@@ -211,8 +225,8 @@ static void _g2d_set_tmp_surf(struct g2d_surface * tmp_surf, struct g2d_buf * bu
 {
     tmp_surf->format = g2d_get_buf_format(cf);
 
-    int32_t dest_w = area->x2 - area->x1;
-    int32_t dest_h = area->y2 - area->y1;
+    int32_t dest_w = lv_area_get_width(area);
+    int32_t dest_h = lv_area_get_height(area);
 
     tmp_surf->left   = area->x1;
     tmp_surf->top    = area->y1;
@@ -230,7 +244,7 @@ static void _g2d_set_tmp_surf(struct g2d_surface * tmp_surf, struct g2d_buf * bu
 }
 
 static void _g2d_set_dst_surf(struct g2d_surface * dst_surf, struct g2d_buf * buf, const lv_area_t * area,
-                              lv_draw_buf_t * draw_buf, const lv_draw_image_dsc_t * dsc)
+                              lv_draw_buf_t * draw_buf)
 {
     int32_t stride = draw_buf->header.stride / (lv_color_format_get_bpp(draw_buf->header.cf) / 8);
     lv_color_format_t cf = draw_buf->header.cf;
@@ -240,63 +254,12 @@ static void _g2d_set_dst_surf(struct g2d_surface * dst_surf, struct g2d_buf * bu
     int32_t blend_w  = lv_area_get_width(area);
     int32_t blend_h = lv_area_get_height(area);
 
-    lv_point_t pivot = dsc->pivot;
-    /*The offsets are now relative to the transformation result with pivot ULC*/
-    int32_t piv_offset_x = 0;
-    int32_t piv_offset_y = 0;
-    int32_t trim_x = 0;
-    int32_t trim_y = 0;
-    int32_t dest_w;
-    int32_t dest_h;
-
-    bool has_rotation = (dsc->rotation != 0);
-
-    if(has_rotation) {
-        switch(dsc->rotation) {
-            case 0:
-                piv_offset_x = 0;
-                piv_offset_y = 0;
-                break;
-            case 900:
-                piv_offset_x = pivot.x + pivot.y - blend_h;
-                piv_offset_y = pivot.y - pivot.x;
-                break;
-            case 1800:
-                piv_offset_x = 2 * pivot.x - blend_w;
-                piv_offset_y = 2 * pivot.y - blend_h;
-                break;
-            case 2700:
-                piv_offset_x = pivot.x - pivot.y;
-                piv_offset_y = pivot.x + pivot.y - blend_w;
-                break;
-            default:
-                piv_offset_x = 0;
-                piv_offset_y = 0;
-        }
-    }
-
-    float fp_scale_x = (float)dsc->scale_x / LV_SCALE_NONE;
-    float fp_scale_y = (float)dsc->scale_y / LV_SCALE_NONE;
-    int32_t int_scale_x = (int32_t)fp_scale_x;
-    int32_t int_scale_y = (int32_t)fp_scale_y;
-
-    /*Any scale_factor in (k, k + 1] will result in a trim equal to k*/
-    trim_x = (fp_scale_x == int_scale_x) ? int_scale_x - 1 : int_scale_x;
-    trim_y = (fp_scale_y == int_scale_y) ? int_scale_y - 1 : int_scale_y;
-
-    dest_w = blend_w * fp_scale_x + trim_x;
-    dest_h = blend_h * fp_scale_y + trim_y;
-
-    /*Final pivot offset = scale_factor * rotation_pivot_offset + scaling_pivot_offset*/
-    piv_offset_x = floor(fp_scale_x * piv_offset_x) - floor((fp_scale_x - 1) * pivot.x);
-    piv_offset_y = floor(fp_scale_y * piv_offset_y) - floor((fp_scale_y - 1) * pivot.y);
-
     dst_surf->format = g2d_get_buf_format(cf);
 
-    dst_surf->left   = area->x1 + piv_offset_x;
-    dst_surf->top    = area->y1 + piv_offset_y;
-    dst_surf->right  = area->x1 + piv_offset_x + dest_w - trim_x;
-    dst_surf->bottom = area->y1 + piv_offset_y + dest_h - trim_y;
+    dst_surf->left   = area->x1;
+    dst_surf->top    = area->y1;
+    dst_surf->right  = area->x1 + blend_w;
+    dst_surf->bottom = area->y1 + blend_h;
     dst_surf->stride = stride;
     dst_surf->width  = width;
     dst_surf->height = height;

--- a/src/draw/nxp/g2d/lv_draw_g2d_img.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d_img.c
@@ -117,9 +117,9 @@ static void _g2d_draw_core_cb(lv_draw_task_t * t, const lv_draw_image_dsc_t * dr
     /* G2D takes stride in pixels. */
     const uint8_t pixel_size = lv_color_format_get_size(src_cf);
 
-    uint32_t src_stride = img_dsc->header.stride == 0 ?
-                          lv_color_format_get_size(img_dsc->header.cf) * img_dsc->header.w :
-                          img_dsc->header.stride;
+    uint32_t src_stride = draw_dsc->header.stride == 0 ?
+                          lv_color_format_get_size(draw_dsc->header.cf) * draw_dsc->header.w :
+                          draw_dsc->header.stride;
     LV_ASSERT(pixel_size != 0);
     src_stride /= pixel_size;
 

--- a/src/draw/nxp/g2d/lv_g2d_buf_map.c
+++ b/src/draw/nxp/g2d/lv_g2d_buf_map.c
@@ -11,7 +11,8 @@
 
 #include "lv_g2d_buf_map.h"
 
-#if LV_USE_DRAW_G2D
+#if LV_USE_G2D
+#if LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D
 #include <stdio.h>
 #include "lv_g2d_utils.h"
 #include "g2d.h"
@@ -244,4 +245,5 @@ static void _map_free_item(lv_map_item_t * item)
     item = NULL;
 }
 
-#endif /*LV_USE_DRAW_G2D*/
+#endif /*LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D*/
+#endif /*LV_USE_G2D*/

--- a/src/draw/nxp/g2d/lv_g2d_buf_map.c
+++ b/src/draw/nxp/g2d/lv_g2d_buf_map.c
@@ -156,6 +156,7 @@ void g2d_free_item(void * key)
         for(uint32_t i = 0; i < lv_array_size(list); i++) {
             item = (lv_map_item_t *)lv_array_at(list, i);
             if(item->key == key) {
+                g2d_free(item->value);
                 lv_array_remove(list, i);
                 return;
             }

--- a/src/draw/nxp/g2d/lv_g2d_buf_map.h
+++ b/src/draw/nxp/g2d/lv_g2d_buf_map.h
@@ -23,7 +23,8 @@ extern "C" {
 
 #include "../../../lv_conf_internal.h"
 
-#if LV_USE_DRAW_G2D
+#if LV_USE_G2D
+#if LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D
 
 #include "../../../misc/lv_array.h"
 #include <string.h>
@@ -72,7 +73,8 @@ void g2d_print_table(void);
  *      MACROS
  **********************/
 
-#endif /*LV_USE_DRAW_G2D*/
+#endif /*LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D*/
+#endif /*LV_USE_G2D*/
 
 #ifdef __cplusplus
 } /*extern "C"*/

--- a/src/draw/nxp/g2d/lv_g2d_utils.c
+++ b/src/draw/nxp/g2d/lv_g2d_utils.c
@@ -15,7 +15,8 @@
 
 #include "lv_g2d_utils.h"
 
-#if LV_USE_DRAW_G2D
+#if LV_USE_G2D
+#if LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D
 #include "lv_g2d_buf_map.h"
 #include "lv_draw_g2d.h"
 
@@ -30,7 +31,7 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-
+static void * g2d_handle;
 /**********************
 *      MACROS
 **********************/
@@ -90,8 +91,57 @@ int32_t g2d_get_buf_fd(const lv_draw_buf_t * draw_buf)
     return g2d_buf_export_fd(buf);
 }
 
+void g2d_set_handle(void * handle)
+{
+    g2d_handle = handle;
+}
+void * g2d_get_handle()
+{
+    return g2d_handle;
+}
+
+#if LV_USE_ROTATE_G2D
+void g2d_rotate(lv_draw_buf_t * buf1, lv_draw_buf_t * buf2, int32_t width, int32_t height, lv_color_format_t cf)
+{
+    struct g2d_surface src_surf, dst_surf;
+    struct g2d_buf * src_buf = g2d_search_buf_map(buf1->data);
+    struct g2d_buf * dst_buf = g2d_search_buf_map(buf2->data);
+
+    src_surf.format = g2d_get_buf_format(cf);
+
+    src_surf.left   = 0;
+    src_surf.top    = 0;
+    src_surf.right  = height;
+    src_surf.bottom = width;
+    src_surf.stride = height;
+    src_surf.width  = height;
+    src_surf.height = width;
+
+    src_surf.planes[0] = src_buf->buf_paddr;
+    src_surf.rot = G2D_ROTATION_0;
+
+    dst_surf.format = g2d_get_buf_format(cf);
+
+    dst_surf.left   = 0;
+    dst_surf.top    = 0;
+    dst_surf.right  = width;
+    dst_surf.bottom = height;
+    dst_surf.stride = width;
+    dst_surf.width  = width;
+    dst_surf.height = height;
+
+    dst_surf.planes[0] = dst_buf->buf_paddr;
+    dst_surf.rot = G2D_ROTATION_90;
+
+    void * handle = g2d_get_handle();
+    g2d_blit(handle, &src_surf, &dst_surf);
+    g2d_finish(handle);
+}
+#endif
+
 /**********************
 *   STATIC FUNCTIONS
 **********************/
 
-#endif /*LV_USE_DRAW_G2D*/
+#endif /*LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D*/
+#endif /*LV_USE_G2D*/

--- a/src/draw/nxp/g2d/lv_g2d_utils.h
+++ b/src/draw/nxp/g2d/lv_g2d_utils.h
@@ -21,7 +21,8 @@ extern "C" {
  *********************/
 #include "../../../lv_conf_internal.h"
 
-#if LV_USE_DRAW_G2D
+#if LV_USE_G2D
+#if LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D
 #include "../../sw/lv_draw_sw_private.h"
 #include "g2d.h"
 #include "g2dExt.h"
@@ -59,11 +60,20 @@ g2d_format_t g2d_get_buf_format(lv_color_format_t cf);
 uint32_t g2d_rgba_to_u32(lv_color_t color);
 
 int32_t g2d_get_buf_fd(const lv_draw_buf_t * draw_buf);
+
+void g2d_set_handle(void * handle);
+
+void * g2d_get_handle();
+
+#if LV_USE_ROTATE_G2D
+void g2d_rotate(lv_draw_buf_t * buf1, lv_draw_buf_t * buf2, int32_t width, int32_t height, lv_color_format_t cf);
+#endif
 /**********************
  *      MACROS
  **********************/
 
-#endif /*LV_USE_DRAW_G2D*/
+#endif /*LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D*/
+#endif /*LV_USE_G2D*/
 
 #ifdef __cplusplus
 } /*extern "C"*/

--- a/src/draw/nxp/pxp/lv_draw_pxp.c
+++ b/src/draw/nxp/pxp/lv_draw_pxp.c
@@ -210,11 +210,6 @@ static bool _pxp_draw_img_supported(const lv_draw_image_dsc_t * draw_dsc)
 {
     const lv_image_dsc_t * img_dsc = draw_dsc->src;
 
-    bool is_tiled = draw_dsc->tile;
-    /* Tiled image (repeat image) is currently not supported. */
-    if(is_tiled)
-        return false;
-
     bool has_recolor = (draw_dsc->recolor_opa > LV_OPA_MIN);
     bool has_transform = (draw_dsc->rotation != 0 || draw_dsc->scale_x != LV_SCALE_NONE ||
                           draw_dsc->scale_y != LV_SCALE_NONE);

--- a/src/draw/nxp/vglite/lv_draw_vglite_arc.c
+++ b/src/draw/nxp/vglite/lv_draw_vglite_arc.c
@@ -482,10 +482,10 @@ static void _add_arc_path(int32_t * arc_path, uint32_t * pidx, uint32_t radius,
 {
     /* set number of arcs to draw */
     vg_arc q_arc;
-    uint32_t start_arc_angle = start_angle % 90;
-    uint32_t end_arc_angle = end_angle % 90;
-    uint32_t inv_start_arc_angle = (start_arc_angle > 0) ? (90 - start_arc_angle) : 0;
-    uint32_t nbarc = (end_angle - start_angle - inv_start_arc_angle - end_arc_angle) / 90;
+    int32_t start_arc_angle = start_angle % 90;
+    int32_t end_arc_angle = end_angle % 90;
+    int32_t inv_start_arc_angle = (start_arc_angle > 0) ? (90 - start_arc_angle) : 0;
+    int32_t nbarc = (end_angle - start_angle - inv_start_arc_angle - end_arc_angle) / 90;
     q_arc.rad = radius;
 
     /* handle special case of start & end point in the same quarter */

--- a/src/drivers/wayland/lv_wayland.c
+++ b/src/drivers/wayland/lv_wayland.c
@@ -18,8 +18,14 @@
     #error "Wayland doesn't support more than 1 LV_WAYLAND_BUF_COUNT without DMABUF"
 #endif
 
-#if LV_WAYLAND_USE_DMABUF && !LV_USE_DRAW_G2D
-    #error "LV_WAYLAND_USE_DMABUF requires LV_USE_DRAW_G2D"
+#if LV_WAYLAND_USE_DMABUF && !LV_USE_G2D
+    #error "LV_WAYLAND_USE_DMABUF requires LV_USE_G2D"
+#endif
+
+#if LV_USE_G2D
+    #if LV_USE_ROTATE_G2D && !LV_WAYLAND_USE_DMABUF
+        #error "LV_USE_ROTATE_G2D is supported only with DMABUF"
+    #endif
 #endif
 
 #ifndef LV_DISPLAY_RENDER_MODE_PARTIAL

--- a/src/drivers/wayland/lv_wl_dmabuf.c
+++ b/src/drivers/wayland/lv_wl_dmabuf.c
@@ -615,18 +615,15 @@ struct buffer * dmabuf_acquire_pool_buffer(struct window * window, struct graphi
 {
     uint8_t id = decoration->type;
 
-    if(window->decorators_buf[id] == NULL || (window->decorators_buf[id]->width == (uint32_t)decoration->width &&
-                                              window->decorators_buf[id]->height == (uint32_t)decoration->height)) {
+    if(window->decorators_buf[id] == NULL) {
         create_decorators_buf(window, decoration);
-
-        return window->decorators_buf[id];
     }
-    else {
+    else if(window->decorators_buf[id]->width != (uint32_t)decoration->width ||
+            window->decorators_buf[id]->height != (uint32_t)decoration->height) {
         destroy_decorators_buf(window, decoration);
         create_decorators_buf(window, decoration);
-
-        return window->decorators_buf[id];
     }
+    return window->decorators_buf[id];
 }
 
 #endif /* LV_WAYLAND_DMABUF */

--- a/src/drivers/wayland/lv_wl_window.c
+++ b/src/drivers/wayland/lv_wl_window.c
@@ -83,6 +83,15 @@ lv_display_t * lv_wayland_window_create(uint32_t hor_res, uint32_t ver_res, char
     int32_t window_width;
     int32_t window_height;
 
+    uint32_t width = hor_res;
+    uint32_t height = ver_res;
+#if LV_USE_G2D
+#if LV_USE_ROTATE_G2D
+    width = ver_res;
+    height = hor_res;
+#endif
+#endif
+
     lv_wayland_init();
 
     window_width  = hor_res;
@@ -104,7 +113,7 @@ lv_display_t * lv_wayland_window_create(uint32_t hor_res, uint32_t ver_res, char
     window->close_cb = close_cb;
 
     /* Initialize display driver */
-    window->lv_disp = lv_display_create(hor_res, ver_res);
+    window->lv_disp = lv_display_create(width, height);
     if(window->lv_disp == NULL) {
         LV_LOG_ERROR("failed to create lvgl display");
         return NULL;
@@ -324,7 +333,11 @@ lv_result_t lv_wayland_window_resize(struct window * window, int width, int heig
 #endif
 
     if(window->lv_disp) {
+#if LV_USE_ROTATE_G2D
+        lv_display_set_resolution(window->lv_disp, height, width);
+#else
         lv_display_set_resolution(window->lv_disp, width, height);
+#endif
         window->body->input.pointer.x = LV_MIN((int32_t)window->body->input.pointer.x, (width - 1));
         window->body->input.pointer.y = LV_MIN((int32_t)window->body->input.pointer.y, (height - 1));
     }

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -827,15 +827,37 @@
 #endif
 
 /** Use NXP's G2D on MPU platforms. */
-#ifndef LV_USE_DRAW_G2D
-    #ifdef CONFIG_LV_USE_DRAW_G2D
-        #define LV_USE_DRAW_G2D CONFIG_LV_USE_DRAW_G2D
+#ifndef LV_USE_G2D
+    #ifdef CONFIG_LV_USE_G2D
+        #define LV_USE_G2D CONFIG_LV_USE_G2D
     #else
-        #define LV_USE_DRAW_G2D 0
+        #define LV_USE_G2D 0
     #endif
 #endif
 
-#if LV_USE_DRAW_G2D
+#if LV_USE_G2D
+    /** Use G2D for drawing. **/
+    #ifndef LV_USE_DRAW_G2D
+        #ifdef LV_KCONFIG_PRESENT
+            #ifdef CONFIG_LV_USE_DRAW_G2D
+                #define LV_USE_DRAW_G2D CONFIG_LV_USE_DRAW_G2D
+            #else
+                #define LV_USE_DRAW_G2D 0
+            #endif
+        #else
+            #define LV_USE_DRAW_G2D 1
+        #endif
+    #endif
+
+    /** Use G2D to rotate display. **/
+    #ifndef LV_USE_ROTATE_G2D
+        #ifdef CONFIG_LV_USE_ROTATE_G2D
+            #define LV_USE_ROTATE_G2D CONFIG_LV_USE_ROTATE_G2D
+        #else
+            #define LV_USE_ROTATE_G2D 0
+        #endif
+    #endif
+
     /** Maximum number of buffers that can be stored for G2D draw unit.
      *  Includes the frame buffers and assets. */
     #ifndef LV_G2D_HASH_TABLE_SIZE

--- a/src/lv_init.c
+++ b/src/lv_init.c
@@ -57,8 +57,10 @@
         #include "draw/nxp/pxp/lv_draw_pxp.h"
     #endif
 #endif
-#if LV_USE_DRAW_G2D
-    #include "draw/nxp/g2d/lv_draw_g2d.h"
+#if LV_USE_G2D
+    #if LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D
+        #include "draw/nxp/g2d/lv_draw_g2d.h"
+    #endif
 #endif
 #if LV_USE_DRAW_DAVE2D
     #include "draw/renesas/dave2d/lv_draw_dave2d.h"
@@ -247,8 +249,10 @@ void lv_init(void)
 #endif
 #endif
 
-#if LV_USE_DRAW_G2D
+#if LV_USE_G2D
+#if LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D
     lv_draw_g2d_init();
+#endif
 #endif
 
 #if LV_USE_DRAW_DAVE2D
@@ -478,8 +482,10 @@ void lv_deinit(void)
     lv_draw_vglite_deinit();
 #endif
 
-#if LV_USE_DRAW_G2D
+#if LV_USE_G2D
+#if LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D
     lv_draw_g2d_deinit();
+#endif
 #endif
 
 #if LV_USE_DRAW_VG_LITE


### PR DESCRIPTION
This PR adds patches related to VGLite, PXP and G2D.
VGLite: adds a fix for arc_path calculation.
G2D: adds features for image rotation, framebuffer rotation, tiled images and PNGs as sources.
PXP: adds feature for tiled images.

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
