### PR TITLE
fix(opengles): fix memory leak when shader compilation fails

### DIFF
--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -386,7 +386,6 @@ static unsigned int lv_opengles_shader_compile(unsigned int type, const char * s
     GL_CALL(glGetShaderiv(id, GL_COMPILE_STATUS, &result));
     if(result == GL_FALSE) {
         LV_LOG_ERROR("Failed to compile %s shader!", type == GL_VERTEX_SHADER ? "vertex" : "fragment");
-        LV_LOG_ERROR("source:\n%s", source);
         int length = 0;
         GL_CALL(glGetShaderiv(id, GL_INFO_LOG_LENGTH, &length));
         if(length > 0) {

--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -385,12 +385,19 @@ static unsigned int lv_opengles_shader_compile(unsigned int type, const char * s
     int result;
     GL_CALL(glGetShaderiv(id, GL_COMPILE_STATUS, &result));
     if(result == GL_FALSE) {
-        int length;
-        GL_CALL(glGetShaderiv(id, GL_INFO_LOG_LENGTH, &length));
-        char * message = lv_malloc_zeroed(length * sizeof(char));
-        GL_CALL(glGetShaderInfoLog(id, length, &length, message));
         LV_LOG_ERROR("Failed to compile %s shader!", type == GL_VERTEX_SHADER ? "vertex" : "fragment");
-        LV_LOG_ERROR("%s", message);
+        LV_LOG_ERROR("source:\n%s", source);
+        int length = 0;
+        GL_CALL(glGetShaderiv(id, GL_INFO_LOG_LENGTH, &length));
+        if(length > 0) {
+            char * message = lv_malloc_zeroed(length * sizeof(char));
+            LV_ASSERT_MALLOCS(message);
+            GL_CALL(glGetShaderInfoLog(id, length, &length, message));
+
+            LV_LOG_ERROR("%s", message);
+            lv_free(message);
+        }
+
         GL_CALL(glDeleteShader(id));
         return 0;
     }

--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -390,7 +390,7 @@ static unsigned int lv_opengles_shader_compile(unsigned int type, const char * s
         GL_CALL(glGetShaderiv(id, GL_INFO_LOG_LENGTH, &length));
         if(length > 0) {
             char * message = lv_malloc_zeroed(length * sizeof(char));
-            LV_ASSERT_MALLOCS(message);
+            LV_ASSERT_MALLOC(message);
             GL_CALL(glGetShaderInfoLog(id, length, &length, message));
 
             LV_LOG_ERROR("%s", message);


### PR DESCRIPTION
1. Added support for length=0.
2. Fixed an issue where message memory was not freed after printing.
3. Added support for printing shader source code.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
