### PR TITLE
fix(draw/dave2d): redefine fixed point macros

### DIFF
--- a/src/draw/renesas/dave2d/lv_draw_dave2d.h
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d.h
@@ -19,6 +19,35 @@ extern "C" {
 #include "../../lv_draw_private.h"
 #include "bsp_api.h"
 #include "dave_driver.h"
+
+#if LV_USE_FLOAT
+
+/* We need to redefine some of D2 fixed point math macros to deal with lv_precise_t being float now */
+#undef D2_FIX4
+#undef D2_INT4
+#undef D2_FLOOR4
+#undef D2_CEIL4
+#undef D2_FRAC4
+#undef D2_FIX16
+#undef D2_INT16
+#undef D2_FLOOR16
+#undef D2_CEIL16
+#undef D2_FRAC16
+
+#define D2_FIX4(x)      (((int32_t)(x)) << 4)
+#define D2_INT4(x)      (((int32_t)(x))(x) >> 4)
+#define D2_FLOOR4(x)    (((int32_t)(x))((d2_u32)(x)) & ~15u)
+#define D2_CEIL4(x)     ((((d2_u32)(x)) + 15u) & ~15u)
+#define D2_FRAC4(x)     (((d2_u32)(x)) & 15u)
+#define D2_FIX16(x)     (((int32_t)(x)) << 16)
+#define D2_INT16(x)     (((int32_t)(x)) >> 16)
+#define D2_FLOOR16(x)   (((d2_u32)(x)) & ~65535u)
+#define D2_CEIL16(x)    ((((d2_u32)(x)) + 65535u) & ~65535u)
+#define D2_FRAC16(x)    (((d2_u32)(x)) & 65535u)
+
+/* It also should be included here before the other LVGL Dave2D files */
+#endif
+
 #include "lv_draw_dave2d_utils.h"
 #include "../../lv_draw_rect.h"
 #include "../../lv_draw_line.h"


### PR DESCRIPTION
To avoid breaking the compilation when LV_FLOAT is enabled which makes the lv_precise_t as float that breaks the original D2 fixed point macros on the Dave driver.

Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
