### PR TITLE
fix(span): opt span ellipsis more precise in omitting text

### DIFF
--- a/src/widgets/span/lv_span.c
+++ b/src/widgets/span/lv_span.c
@@ -1233,8 +1233,8 @@ static void lv_draw_span(lv_obj_t * obj, lv_layer_t * layer)
             lv_snippet_t * pinfo = lv_get_snippet(i_item);
             if(ellipsis_valid && i_item == item_cnt - 1) {
                 uint32_t n_ofs = 0;
-                lv_text_get_snippet(pinfo->txt, pinfo->font, pinfo->letter_space, max_width - txts_w,
-                                    LV_TEXT_FLAG_BREAK_ALL, &pinfo->txt_w, &n_ofs);
+                ellipsis_valid = lv_text_get_snippet(pinfo->txt, pinfo->font, pinfo->letter_space, max_width - txts_w,
+                                                     LV_TEXT_FLAG_BREAK_ALL, &pinfo->txt_w, &n_ofs);
                 pinfo->bytes = n_ofs;
             }
             txts_w = txts_w + pinfo->txt_w;


### PR DESCRIPTION
When there is `only one` line and the width of the last character is `greater` than the width of three ellipses

before
![iShot_2025-09-11_17 04 45](https://github.com/user-attachments/assets/2c76b82c-961b-4ce7-ab0b-78b47ae1710f)

after
![iShot_2025-09-11_17 05 10](https://github.com/user-attachments/assets/e3173291-83cf-4954-ab0d-908b9ddcb332)


<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
