### PR TITLE
feat(fs): support multiple littlefs filesystems

### DIFF
--- a/src/libs/fsdrv/lv_fs_littlefs.c
+++ b/src/libs/fsdrv/lv_fs_littlefs.c
@@ -30,21 +30,18 @@ static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn, uint3
 /**
  * Register a drive for the LittleFS File System interface
  */
-lv_result_t lv_fs_littlefs_register_drive(lfs_t *lfs, char letter)
+lv_result_t lv_fs_littlefs_register_drive(lfs_t * lfs, char letter)
 {
 
-    if(lfs == NULL)
-    {
+    if(lfs == NULL) {
         return LV_RESULT_INVALID; /*Invalid LittleFS handle*/
     }   
 
-    if(LV_FS_IS_VALID_LETTER(letter) == false)
-    {
+    if(LV_FS_IS_VALID_LETTER(letter) == false) {
         return LV_RESULT_INVALID; /*Invalid letter*/
     }
 
-    if(lv_fs_get_drv(letter) != NULL)
-    {
+    if(lv_fs_get_drv(letter) != NULL) {
         return LV_RESULT_INVALID; /*Already registered*/
     }
 

--- a/src/libs/fsdrv/lv_fs_littlefs.c
+++ b/src/libs/fsdrv/lv_fs_littlefs.c
@@ -4,6 +4,10 @@
 #include "lfs.h"
 #include "../../core/lv_global.h"
 
+#if !LV_FS_IS_VALID_LETTER(LV_FS_LITTLEFS_LETTER)
+    #error "Invalid drive letter"
+#endif
+
 typedef struct LittleFile {
     lfs_file_t file;
 } LittleFile;
@@ -27,9 +31,34 @@ static lv_fs_res_t fs_dir_close(lv_fs_drv_t * drv, void * dir_p);
 static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn, uint32_t fn_len);
 
 
-/**
- * Register a drive for the LittleFS File System interface
- */
+
+
+void lv_littlefs_set_handler(lfs_t * lfs)
+{
+    lv_fs_drv_t * drv = lv_fs_get_drv(LV_FS_LITTLEFS_LETTER);
+    drv->user_data = lfs;
+}
+
+void lv_fs_littlefs_init(void)
+{
+    lv_fs_drv_t * fs_drv = &(LV_GLOBAL_DEFAULT()->littlefs_fs_drv);
+    lv_fs_drv_init(fs_drv);
+
+    fs_drv->letter = LV_FS_LITTLEFS_LETTER;
+    fs_drv->open_cb = fs_open;
+    fs_drv->close_cb = fs_close;
+    fs_drv->read_cb = fs_read;
+    fs_drv->write_cb = fs_write;
+    fs_drv->seek_cb = fs_seek;
+    fs_drv->tell_cb = fs_tell;
+
+    fs_drv->dir_open_cb = fs_dir_open;
+    fs_drv->dir_close_cb = fs_dir_close;
+    fs_drv->dir_read_cb = fs_dir_read;
+
+    lv_fs_drv_register(fs_drv);
+}
+
 lv_result_t lv_fs_littlefs_register_drive(lfs_t * lfs, char letter)
 {
 
@@ -65,6 +94,7 @@ lv_result_t lv_fs_littlefs_register_drive(lfs_t * lfs, char letter)
     fs_drv->user_data = lfs;
 
     lv_fs_drv_register(fs_drv);
+    return LV_RESULT_OK;
 }
 
 /**********************

--- a/src/libs/fsdrv/lv_fs_littlefs.c
+++ b/src/libs/fsdrv/lv_fs_littlefs.c
@@ -4,10 +4,6 @@
 #include "lfs.h"
 #include "../../core/lv_global.h"
 
-#if !LV_FS_IS_VALID_LETTER(LV_FS_LITTLEFS_LETTER)
-    #error "Invalid drive letter"
-#endif
-
 typedef struct LittleFile {
     lfs_file_t file;
 } LittleFile;
@@ -19,6 +15,7 @@ typedef struct LittleDirectory {
 /**********************
  *  STATIC PROTOTYPES
  **********************/
+static void fs_remove(lv_fs_drv_t * drv);
 static void * fs_open(lv_fs_drv_t * drv, const char * path, lv_fs_mode_t mode);
 static lv_fs_res_t fs_close(lv_fs_drv_t * drv, void * file_p);
 static lv_fs_res_t fs_read(lv_fs_drv_t * drv, void * file_p, void * buf, uint32_t btr, uint32_t * br);
@@ -29,21 +26,33 @@ static void * fs_dir_open(lv_fs_drv_t * drv, const char * path);
 static lv_fs_res_t fs_dir_close(lv_fs_drv_t * drv, void * dir_p);
 static lv_fs_res_t fs_dir_read(lv_fs_drv_t * drv, void * dir_p, char * fn, uint32_t fn_len);
 
-void lv_littlefs_set_handler(lfs_t * lfs)
-{
-    lv_fs_drv_t * drv = lv_fs_get_drv(LV_FS_LITTLEFS_LETTER);
-    drv->user_data = lfs;
-}
 
 /**
- * Register a driver for the LittleFS File System interface
+ * Register a drive for the LittleFS File System interface
  */
-void lv_fs_littlefs_init(void)
+lv_result_t lv_fs_littlefs_register_drive(lfs_t *lfs, char letter)
 {
-    lv_fs_drv_t * fs_drv = &(LV_GLOBAL_DEFAULT()->littlefs_fs_drv);
+
+    if(lfs == NULL)
+    {
+        return LV_RESULT_INVALID; /*Invalid LittleFS handle*/
+    }   
+
+    if(LV_FS_IS_VALID_LETTER(letter) == false)
+    {
+        return LV_RESULT_INVALID; /*Invalid letter*/
+    }
+
+    if(lv_fs_get_drv(letter) != NULL)
+    {
+        return LV_RESULT_INVALID; /*Already registered*/
+    }
+
+    lv_fs_drv_t * fs_drv = lv_malloc(sizeof(lv_fs_drv_t));
+    LV_ASSERT_MALLOC(fs_drv);
     lv_fs_drv_init(fs_drv);
 
-    fs_drv->letter = LV_FS_LITTLEFS_LETTER;
+    fs_drv->letter = letter;
     fs_drv->open_cb = fs_open;
     fs_drv->close_cb = fs_close;
     fs_drv->read_cb = fs_read;
@@ -55,12 +64,26 @@ void lv_fs_littlefs_init(void)
     fs_drv->dir_close_cb = fs_dir_close;
     fs_drv->dir_read_cb = fs_dir_read;
 
+    fs_drv->remove_cb = fs_remove; /*Optional*/
+    fs_drv->user_data = lfs;
+
     lv_fs_drv_register(fs_drv);
 }
 
 /**********************
  *   STATIC FUNCTIONS
  **********************/
+
+/**
+ * free the driver handle
+ * @param drv       pointer to a driver where this function belongs
+ */
+static void fs_remove(lv_fs_drv_t * drv)
+{
+    if(drv != NULL) {
+        lv_free(drv);
+    }
+}
 
 /**
  * Open a file

--- a/src/libs/fsdrv/lv_fs_littlefs.c
+++ b/src/libs/fsdrv/lv_fs_littlefs.c
@@ -136,6 +136,7 @@ static void * fs_open(lv_fs_drv_t * drv, const char * path, lv_fs_mode_t mode)
     lfs_t * lfs = drv->user_data;
     int err = lfs_file_open(lfs, &lf->file, buf, flags);
     if(err) {
+        lv_free(lf);
         return NULL;
     }
 

--- a/src/libs/fsdrv/lv_fs_littlefs.c
+++ b/src/libs/fsdrv/lv_fs_littlefs.c
@@ -35,7 +35,7 @@ lv_result_t lv_fs_littlefs_register_drive(lfs_t * lfs, char letter)
 
     if(lfs == NULL) {
         return LV_RESULT_INVALID; /*Invalid LittleFS handle*/
-    }   
+    }
 
     if(LV_FS_IS_VALID_LETTER(letter) == false) {
         return LV_RESULT_INVALID; /*Invalid letter*/

--- a/src/libs/fsdrv/lv_fs_littlefs.c
+++ b/src/libs/fsdrv/lv_fs_littlefs.c
@@ -59,19 +59,19 @@ void lv_fs_littlefs_init(void)
     lv_fs_drv_register(fs_drv);
 }
 
-lv_result_t lv_fs_littlefs_register_drive(lfs_t * lfs, char letter)
+lv_fs_res_t lv_fs_littlefs_register_drive(lfs_t * lfs, char letter)
 {
 
     if(lfs == NULL) {
-        return LV_RESULT_INVALID; /*Invalid LittleFS handle*/
+        return LV_FS_RES_INV_PARAM; /*Invalid LittleFS handle*/
     }
 
     if(LV_FS_IS_VALID_LETTER(letter) == false) {
-        return LV_RESULT_INVALID; /*Invalid letter*/
+        return LV_FS_RES_INV_PARAM; /*Invalid letter*/
     }
 
     if(lv_fs_get_drv(letter) != NULL) {
-        return LV_RESULT_INVALID; /*Already registered*/
+        return LV_FS_RES_DRIVE_LETTER_ALREADY_USED; /*Already registered*/
     }
 
     lv_fs_drv_t * fs_drv = lv_malloc(sizeof(lv_fs_drv_t));
@@ -94,7 +94,7 @@ lv_result_t lv_fs_littlefs_register_drive(lfs_t * lfs, char letter)
     fs_drv->user_data = lfs;
 
     lv_fs_drv_register(fs_drv);
-    return LV_RESULT_OK;
+    return LV_FS_RES_OK;
 }
 
 /**********************

--- a/src/libs/fsdrv/lv_fs_littlefs.c
+++ b/src/libs/fsdrv/lv_fs_littlefs.c
@@ -107,9 +107,7 @@ lv_result_t lv_fs_littlefs_register_drive(lfs_t * lfs, char letter)
  */
 static void fs_remove(lv_fs_drv_t * drv)
 {
-    if(drv != NULL) {
-        lv_free(drv);
-    }
+    lv_free(drv);
 }
 
 /**

--- a/src/libs/fsdrv/lv_fsdrv.h
+++ b/src/libs/fsdrv/lv_fsdrv.h
@@ -51,6 +51,24 @@ void lv_fs_memfs_init(void);
 
 #if LV_USE_FS_LITTLEFS
 #include "lfs.h"
+struct lfs;
+/**
+ * Set the default LittleFS handler to be used by LVGL
+ * @param  lfs     pointer to an initialized LittleFS filesystem structure
+ */
+void lv_littlefs_set_handler(struct lfs * lfs);
+
+/**
+ * Initialize LittleFS file system driver
+ */
+void lv_fs_littlefs_init(void);
+
+/**
+ * Register a LittleFS drive with LVGL
+ * @param  lfs     pointer to an initialized LittleFS filesystem structure
+ * @param  letter  driver letter to register (e.g. 'A')
+ * @return         LV_RESULT_OK: success; LV_RESULT_INVALID: failure
+ */
 lv_result_t lv_fs_littlefs_register_drive(lfs_t * lfs, char letter);
 #endif
 

--- a/src/libs/fsdrv/lv_fsdrv.h
+++ b/src/libs/fsdrv/lv_fsdrv.h
@@ -51,7 +51,7 @@ void lv_fs_memfs_init(void);
 
 #if LV_USE_FS_LITTLEFS
 #include "lfs.h"
-lv_result_t lv_fs_littlefs_register_drive(lfs_t *lfs, char letter);
+lv_result_t lv_fs_littlefs_register_drive(lfs_t * lfs, char letter);
 #endif
 
 #if LV_USE_FS_ARDUINO_ESP_LITTLEFS

--- a/src/libs/fsdrv/lv_fsdrv.h
+++ b/src/libs/fsdrv/lv_fsdrv.h
@@ -67,9 +67,10 @@ void lv_fs_littlefs_init(void);
  * Register a LittleFS drive with LVGL
  * @param  lfs     pointer to an initialized LittleFS filesystem structure
  * @param  letter  driver letter to register (e.g. 'A')
- * @return         LV_RESULT_OK: success; LV_RESULT_INVALID: failure
+ * @return         LV_FS_RESULT_OK: success, LV_FS_RES_INV_PARAM: lfs is NULL or letetr not in range A-Z,
+ *                 LV_FS_RES_DRIVE_LETTER_ALREADY_USED: A drive with this letter is already registered
  */
-lv_result_t lv_fs_littlefs_register_drive(lfs_t * lfs, char letter);
+lv_fs_res_t lv_fs_littlefs_register_drive(lfs_t * lfs, char letter);
 #endif
 
 #if LV_USE_FS_ARDUINO_ESP_LITTLEFS

--- a/src/libs/fsdrv/lv_fsdrv.h
+++ b/src/libs/fsdrv/lv_fsdrv.h
@@ -50,9 +50,8 @@ void lv_fs_memfs_init(void);
 #endif
 
 #if LV_USE_FS_LITTLEFS
-struct lfs;
-void lv_littlefs_set_handler(struct lfs *);
-void lv_fs_littlefs_init(void);
+#include "lfs.h"
+lv_result_t lv_fs_littlefs_register_drive(lfs_t *lfs, char letter);
 #endif
 
 #if LV_USE_FS_ARDUINO_ESP_LITTLEFS

--- a/src/libs/fsdrv/lv_fsdrv.h
+++ b/src/libs/fsdrv/lv_fsdrv.h
@@ -67,7 +67,7 @@ void lv_fs_littlefs_init(void);
  * Register a LittleFS drive with LVGL
  * @param  lfs     pointer to an initialized LittleFS filesystem structure
  * @param  letter  driver letter to register (e.g. 'A')
- * @return         LV_FS_RESULT_OK: success, LV_FS_RES_INV_PARAM: lfs is NULL or letetr not in range A-Z,
+ * @return         LV_FS_RES_OK: success, LV_FS_RES_INV_PARAM: lfs is NULL or letter not in range A-Z,
  *                 LV_FS_RES_DRIVE_LETTER_ALREADY_USED: A drive with this letter is already registered
  */
 lv_fs_res_t lv_fs_littlefs_register_drive(lfs_t * lfs, char letter);

--- a/src/lv_init.c
+++ b/src/lv_init.c
@@ -357,8 +357,34 @@ void lv_init(void)
     lv_fs_memfs_init();
 #endif
 
-#if LV_USE_FS_LITTLEFS
-    lv_fs_littlefs_init();
+#if LV_USE_FS_LITTLEFS && defined (LV_FS_LITTLEFS_BD_GET_DRIVER_DATA_FUNC)
+
+    extern void LV_FS_LITTLEFS_BD_GET_DRIVER_DATA_FUNC(lfs_t **out_lfs, struct lfs_config **out_config);
+
+    lfs_t *lfs;
+    struct lfs_config *config;
+    LV_FS_LITTLEFS_BD_GET_DRIVER_DATA_FUNC(&lfs, &config);
+
+    int lfs_err = lfs_mount(lfs, config);
+    if(lfs_err < 0)
+    {
+        //should only happen the first time
+       lfs_err = lfs_format(lfs, config);
+
+       if(lfs_err == 0)
+       {
+         lfs_err = lfs_mount(lfs, config);
+       }
+    }
+
+    if(lfs_err < 0)
+    {
+        LV_LOG_ERROR("lfs mount failed");
+    }
+    else
+    {
+        lv_fs_littlefs_register_drive(lfs, LV_FS_LITTLEFS_LETTER);
+    }
 #endif
 
 #if LV_USE_FS_ARDUINO_ESP_LITTLEFS

--- a/src/lv_init.c
+++ b/src/lv_init.c
@@ -357,31 +357,8 @@ void lv_init(void)
     lv_fs_memfs_init();
 #endif
 
-#if LV_USE_FS_LITTLEFS && defined (LV_FS_LITTLEFS_BD_GET_DRIVER_DATA_FUNC)
-
-    extern void LV_FS_LITTLEFS_BD_GET_DRIVER_DATA_FUNC(lfs_t ** out_lfs, struct lfs_config ** out_config);
-
-    lfs_t * lfs;
-    struct lfs_config * config;
-    LV_FS_LITTLEFS_BD_GET_DRIVER_DATA_FUNC(&lfs, &config);
-
-    int lfs_err = lfs_mount(lfs, config);
-
-    if(lfs_err < 0) {
-        //should only happen the first time
-        lfs_err = lfs_format(lfs, config);
-
-        if(lfs_err == 0) {
-            lfs_err = lfs_mount(lfs, config);
-        }
-    }
-
-    if(lfs_err < 0) {
-        LV_LOG_ERROR("lfs mount failed");
-    }
-    else {
-        lv_fs_littlefs_register_drive(lfs, LV_FS_LITTLEFS_LETTER);
-    }
+#if LV_USE_FS_LITTLEFS
+    lv_fs_littlefs_init();
 #endif
 
 #if LV_USE_FS_ARDUINO_ESP_LITTLEFS

--- a/src/lv_init.c
+++ b/src/lv_init.c
@@ -359,15 +359,15 @@ void lv_init(void)
 
 #if LV_USE_FS_LITTLEFS && defined (LV_FS_LITTLEFS_BD_GET_DRIVER_DATA_FUNC)
 
-    extern void LV_FS_LITTLEFS_BD_GET_DRIVER_DATA_FUNC(lfs_t **out_lfs, struct lfs_config **out_config);
+    extern void LV_FS_LITTLEFS_BD_GET_DRIVER_DATA_FUNC(lfs_t ** out_lfs, struct lfs_config ** out_config);
 
-    lfs_t *lfs;
-    struct lfs_config *config;
+    lfs_t * lfs;
+    struct lfs_config * config;
     LV_FS_LITTLEFS_BD_GET_DRIVER_DATA_FUNC(&lfs, &config);
 
     int lfs_err = lfs_mount(lfs, config);
-    if(lfs_err < 0)
-    {
+
+    if(lfs_err < 0) {
         //should only happen the first time
        lfs_err = lfs_format(lfs, config);
 
@@ -377,12 +377,10 @@ void lv_init(void)
        }
     }
 
-    if(lfs_err < 0)
-    {
+    if(lfs_err < 0) {
         LV_LOG_ERROR("lfs mount failed");
     }
-    else
-    {
+    else {
         lv_fs_littlefs_register_drive(lfs, LV_FS_LITTLEFS_LETTER);
     }
 #endif

--- a/src/lv_init.c
+++ b/src/lv_init.c
@@ -369,10 +369,9 @@ void lv_init(void)
 
     if(lfs_err < 0) {
         //should only happen the first time
-       lfs_err = lfs_format(lfs, config);
+        lfs_err = lfs_format(lfs, config);
 
-       if(lfs_err == 0)
-       {
+        if(lfs_err == 0) {
          lfs_err = lfs_mount(lfs, config);
        }
     }

--- a/src/lv_init.c
+++ b/src/lv_init.c
@@ -372,8 +372,8 @@ void lv_init(void)
         lfs_err = lfs_format(lfs, config);
 
         if(lfs_err == 0) {
-         lfs_err = lfs_mount(lfs, config);
-       }
+            lfs_err = lfs_mount(lfs, config);
+        }
     }
 
     if(lfs_err < 0) {

--- a/src/misc/lv_fs.c
+++ b/src/misc/lv_fs.c
@@ -515,6 +515,19 @@ void lv_fs_drv_register(lv_fs_drv_t * drv_p)
     *new_drv = drv_p;
 }
 
+void lv_fs_remove_drive(char letter)
+{
+    lv_fs_drv_t ** drv;
+    LV_LL_READ(fsdrv_ll_p, drv) {
+        if((*drv)->letter == letter) {
+            lv_ll_remove(fsdrv_ll_p, drv); // remove the drive from the list of registered drives
+            if((*drv)->remove_cb) {
+                (*drv)->remove_cb(*drv); // call the remove callback if available
+            }
+        }
+    }
+}
+
 lv_fs_drv_t * lv_fs_get_drv(char letter)
 {
     lv_fs_drv_t ** drv;

--- a/src/misc/lv_fs.c
+++ b/src/misc/lv_fs.c
@@ -524,7 +524,7 @@ void lv_fs_remove_drive(char letter)
             if((*drv)->remove_cb) {
                 (*drv)->remove_cb(*drv); /* call the remove callback if available */
             }
-            lv_free(*drv); /* free the drive structure */
+            lv_free(drv); /* free the list node*/
         }
     }
 }

--- a/src/misc/lv_fs.c
+++ b/src/misc/lv_fs.c
@@ -524,6 +524,7 @@ void lv_fs_remove_drive(char letter)
             if((*drv)->remove_cb) {
                 (*drv)->remove_cb(*drv); /* call the remove callback if available */
             }
+            lv_free(*drv); /* free the drive structure */
         }
     }
 }

--- a/src/misc/lv_fs.c
+++ b/src/misc/lv_fs.c
@@ -520,9 +520,9 @@ void lv_fs_remove_drive(char letter)
     lv_fs_drv_t ** drv;
     LV_LL_READ(fsdrv_ll_p, drv) {
         if((*drv)->letter == letter) {
-            lv_ll_remove(fsdrv_ll_p, drv); // remove the drive from the list of registered drives
+            lv_ll_remove(fsdrv_ll_p, drv); /* remove the drive from the list of registered drives */
             if((*drv)->remove_cb) {
-                (*drv)->remove_cb(*drv); // call the remove callback if available
+                (*drv)->remove_cb(*drv); /* call the remove callback if available */
             }
         }
     }

--- a/src/misc/lv_fs.h
+++ b/src/misc/lv_fs.h
@@ -71,6 +71,8 @@ struct _lv_fs_drv_t {
     uint32_t cache_size;
     bool (*ready_cb)(lv_fs_drv_t * drv);
 
+    void(*remove_cb)(lv_fs_drv_t * drv); /*Optional*/
+
     void * (*open_cb)(lv_fs_drv_t * drv, const char * path, lv_fs_mode_t mode);
     lv_fs_res_t (*close_cb)(lv_fs_drv_t * drv, void * file_p);
     lv_fs_res_t (*read_cb)(lv_fs_drv_t * drv, void * file_p, void * buf, uint32_t btr, uint32_t * br);
@@ -130,6 +132,13 @@ void lv_fs_drv_register(lv_fs_drv_t * drv);
  * @return          pointer to a driver or NULL if not found
  */
 lv_fs_drv_t * lv_fs_get_drv(char letter);
+
+/**
+ * @brief Remove a drive and call its remove function if available
+ * 
+ * @param letter letter identifier of the drive to remove
+ */
+void lv_fs_remove_drive(char letter);
 
 /**
  * Test if a drive is ready or not. If the `ready` function was not initialized `true` will be

--- a/src/misc/lv_fs.h
+++ b/src/misc/lv_fs.h
@@ -44,7 +44,7 @@ typedef enum {
     LV_FS_RES_NOT_IMP,    /*Requested function is not implemented*/
     LV_FS_RES_OUT_OF_MEM, /*Not enough memory for an internal operation*/
     LV_FS_RES_INV_PARAM,  /*Invalid parameter among arguments*/
-    LV_FS_RES_DRIVE_LETTER_ALREADY_USED, /*A drive with this letter is already registed*/
+    LV_FS_RES_DRIVE_LETTER_ALREADY_USED, /*A drive with this letter is already registered*/
     LV_FS_RES_UNKNOWN,    /*Other unknown error*/
 } lv_fs_res_t;
 

--- a/src/misc/lv_fs.h
+++ b/src/misc/lv_fs.h
@@ -134,8 +134,7 @@ void lv_fs_drv_register(lv_fs_drv_t * drv);
 lv_fs_drv_t * lv_fs_get_drv(char letter);
 
 /**
- * @brief Remove a drive and call its remove function if available
- * 
+ * Remove a drive and call its remove function if available
  * @param letter letter identifier of the drive to remove
  */
 void lv_fs_remove_drive(char letter);

--- a/src/misc/lv_fs.h
+++ b/src/misc/lv_fs.h
@@ -44,6 +44,7 @@ typedef enum {
     LV_FS_RES_NOT_IMP,    /*Requested function is not implemented*/
     LV_FS_RES_OUT_OF_MEM, /*Not enough memory for an internal operation*/
     LV_FS_RES_INV_PARAM,  /*Invalid parameter among arguments*/
+    LV_FS_RES_DRIVE_LETTER_ALREADY_USED, /*A drive with this letter is already registed*/
     LV_FS_RES_UNKNOWN,    /*Other unknown error*/
 } lv_fs_res_t;
 


### PR DESCRIPTION
Support multiple littlefs filesystem simultanously and identify them by the unique drive letter.

For example A:/my_dir/myfile which is a parttion in flash memory and B:/my_dir/myfile which is on a sd card
