### PR TITLE
fix(draw/dave2d): prevent deadlock by avoid to flush the GPU buffer when empty.

### DIFF
--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -267,7 +267,7 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
 
 #if LV_USE_OS
     #if (LV_USE_FREETYPE || LV_USE_THORVG) && LV_DRAW_THREAD_STACK_SIZE < (32 * 1024)
-        #warning "Increase LV_DRAW_THREAD_STACK_SIZE to at least 32KB for FreeType or ThorVG."
+        #error "Increase LV_DRAW_THREAD_STACK_SIZE to at least 32KB for FreeType or ThorVG."
     #endif
 
     #if defined(LV_DRAW_THREAD_STACKSIZE) && !defined(LV_DRAW_THREAD_STACK_SIZE)

--- a/src/draw/renesas/dave2d/lv_draw_dave2d.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d.c
@@ -455,7 +455,7 @@ static int32_t _dave2d_wait_finish(lv_draw_unit_t * draw_unit)
 
     if(!draw_pressure) {
         /* It reached here because Dave2D Draw Unit was not suitable to take a task
-         * While there is nothing being rendered, prevent the dead lock 
+         * While there is nothing being rendered, prevent the dead lock
          * by flushing the GPU command buffer empty and just return.
          */
         return 0;

--- a/src/draw/renesas/dave2d/lv_draw_dave2d.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d.c
@@ -452,6 +452,14 @@ static int32_t _dave2d_wait_finish(lv_draw_unit_t * draw_unit)
      * Dave and wait for its interrupt. (Dave2D driver is RTOS aware, no need for semaphores);
      */
     lv_draw_dave2d_unit_t * draw_dave2d_unit = (lv_draw_dave2d_unit_t *) draw_unit;
+
+    if(!draw_pressure) {
+        /* It reached here because Dave2D Draw Unit was not suitable to take a task
+         * While there is nothing being rendered, prevent the dead lock 
+         * by flushing the GPU command buffer empty and just return.
+         */
+        return 0;
+    }
     dave2d_execute_dlist_and_flush();
     draw_pressure = 0;
 

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -4817,7 +4817,7 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
 
 #if LV_USE_OS
     #if (LV_USE_FREETYPE || LV_USE_THORVG) && LV_DRAW_THREAD_STACK_SIZE < (32 * 1024)
-        #warning "Increase LV_DRAW_THREAD_STACK_SIZE to at least 32KB for FreeType or ThorVG."
+        #error "Increase LV_DRAW_THREAD_STACK_SIZE to at least 32KB for FreeType or ThorVG."
     #endif
 
     #if defined(LV_DRAW_THREAD_STACKSIZE) && !defined(LV_DRAW_THREAD_STACK_SIZE)


### PR DESCRIPTION
As the title says.

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
