### PR TITLE
perf(draw): skip drawing that does not intersect the clipping area

### DIFF
--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -99,6 +99,14 @@ void * lv_draw_create_unit(size_t size)
 lv_draw_task_t * lv_draw_add_task(lv_layer_t * layer, const lv_area_t * coords, lv_draw_task_type_t type)
 {
     LV_PROFILER_DRAW_BEGIN;
+
+    /* When the rendered content has no intersection with the clipping area, skip drawing */
+    lv_area_t cliped_area;
+    if(!lv_area_intersect(&cliped_area, coords, &layer->_clip_area)) {
+        LV_PROFILER_DRAW_END;
+        return NULL;
+    }
+
     size_t dsc_size = get_draw_dsc_size(type);
     LV_ASSERT_FORMAT_MSG(dsc_size > 0, "Draw task size is 0 for type %d", type);
     lv_draw_task_t * new_task = lv_malloc_zeroed(LV_ALIGN_UP(sizeof(lv_draw_task_t), 8) + dsc_size);

--- a/src/draw/lv_draw.h
+++ b/src/draw/lv_draw.h
@@ -193,7 +193,8 @@ void * lv_draw_create_unit(size_t size);
  * @param layer     pointer to a layer
  * @param coords    the coordinates of the draw task
  * @return          the created draw task which needs to be
- *                  further configured e.g. by added a draw descriptor
+ *                  further configured e.g. by added a draw descriptor.
+ *                  If NULL is returned, the drawing is skipped.
  */
 lv_draw_task_t * lv_draw_add_task(lv_layer_t * layer, const lv_area_t * coords, lv_draw_task_type_t type);
 

--- a/src/draw/lv_draw_3d.c
+++ b/src/draw/lv_draw_3d.c
@@ -56,6 +56,10 @@ void lv_draw_3d(lv_layer_t * layer, const lv_draw_3d_dsc_t * dsc, const lv_area_
     LV_PROFILER_DRAW_BEGIN;
 
     lv_draw_task_t * t = lv_draw_add_task(layer, coords, LV_DRAW_TASK_TYPE_3D);
+    if(!t) {
+        LV_PROFILER_DRAW_END;
+        return;
+    }
 
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
 

--- a/src/draw/lv_draw_arc.c
+++ b/src/draw/lv_draw_arc.c
@@ -63,6 +63,10 @@ void lv_draw_arc(lv_layer_t * layer, const lv_draw_arc_dsc_t * dsc)
     a.x2 = dsc->center.x + dsc->radius - 1;
     a.y2 = dsc->center.y + dsc->radius - 1;
     lv_draw_task_t * t = lv_draw_add_task(layer, &a, LV_DRAW_TASK_TYPE_ARC);
+    if(!t) {
+        LV_PROFILER_DRAW_END;
+        return;
+    }
 
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
 

--- a/src/draw/lv_draw_image.c
+++ b/src/draw/lv_draw_image.c
@@ -74,6 +74,11 @@ void lv_draw_layer(lv_layer_t * layer, const lv_draw_image_dsc_t * dsc, const lv
     LV_PROFILER_DRAW_BEGIN;
 
     lv_draw_task_t * t = lv_draw_add_task(layer, coords, LV_DRAW_TASK_TYPE_LAYER);
+    if(!t) {
+        LV_PROFILER_DRAW_END;
+        return;
+    }
+
     lv_draw_image_dsc_t * new_image_dsc = t->draw_dsc;
     lv_memcpy(new_image_dsc, dsc, sizeof(*dsc));
     t->state = LV_DRAW_TASK_STATE_BLOCKED;
@@ -127,6 +132,11 @@ void lv_draw_image(lv_layer_t * layer, const lv_draw_image_dsc_t * dsc, const lv
     /*Typical case, draw the image as bitmap*/
     if(!(new_image_dsc.header.flags & LV_IMAGE_FLAGS_CUSTOM_DRAW)) {
         lv_draw_task_t * t = lv_draw_add_task(layer, image_coords, LV_DRAW_TASK_TYPE_IMAGE);
+        if(!t) {
+            LV_PROFILER_DRAW_END;
+            return;
+        }
+
         lv_memcpy(t->draw_dsc, &new_image_dsc, sizeof(lv_draw_image_dsc_t));
 
         lv_image_buf_get_transformed_area(&t->_real_area, lv_area_get_width(image_coords), lv_area_get_height(image_coords),

--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -109,6 +109,10 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_label(lv_layer_t * layer, const lv_draw_label
 
     LV_PROFILER_DRAW_BEGIN;
     lv_draw_task_t * t = lv_draw_add_task(layer, coords, LV_DRAW_TASK_TYPE_LABEL);
+    if(!t) {
+        LV_PROFILER_DRAW_END;
+        return;
+    }
 
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
 
@@ -191,6 +195,10 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_letter(lv_layer_t * layer, lv_draw_letter_dsc
     dsc->pivot.y = font->line_height - font->base_line;
 
     lv_draw_task_t * t = lv_draw_add_task(layer, &a, LV_DRAW_TASK_TYPE_LETTER);
+    if(!t) {
+        LV_PROFILER_DRAW_END;
+        return;
+    }
 
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
 

--- a/src/draw/lv_draw_line.c
+++ b/src/draw/lv_draw_line.c
@@ -64,6 +64,10 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_line(lv_layer_t * layer, const lv_draw_line_d
     a.y2 = (int32_t)LV_MAX(dsc->p1.y, dsc->p2.y) + dsc->width;
 
     lv_draw_task_t * t = lv_draw_add_task(layer, &a, LV_DRAW_TASK_TYPE_LINE);
+    if(!t) {
+        LV_PROFILER_DRAW_END;
+        return;
+    }
 
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
 

--- a/src/draw/lv_draw_mask.c
+++ b/src/draw/lv_draw_mask.c
@@ -56,6 +56,10 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_mask_rect(lv_layer_t * layer, const lv_draw_m
     LV_PROFILER_DRAW_BEGIN;
 
     lv_draw_task_t * t = lv_draw_add_task(layer, &layer->buf_area, LV_DRAW_TASK_TYPE_MASK_RECTANGLE);
+    if(!t) {
+        LV_PROFILER_DRAW_END;
+        return;
+    }
 
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
 

--- a/src/draw/lv_draw_rect.c
+++ b/src/draw/lv_draw_rect.c
@@ -75,6 +75,10 @@ void lv_draw_fill(lv_layer_t * layer, const lv_draw_fill_dsc_t * dsc, const lv_a
 
     LV_PROFILER_DRAW_BEGIN;
     lv_draw_task_t * t = lv_draw_add_task(layer, coords, LV_DRAW_TASK_TYPE_FILL);
+    if(!t) {
+        LV_PROFILER_DRAW_END;
+        return;
+    }
 
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
 
@@ -101,6 +105,10 @@ void lv_draw_border(lv_layer_t * layer, const lv_draw_border_dsc_t * dsc, const 
 
     LV_PROFILER_DRAW_BEGIN;
     lv_draw_task_t * t = lv_draw_add_task(layer, coords, LV_DRAW_TASK_TYPE_BORDER);
+    if(!t) {
+        LV_PROFILER_DRAW_END;
+        return;
+    }
 
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
 
@@ -126,6 +134,10 @@ void lv_draw_box_shadow(lv_layer_t * layer, const lv_draw_box_shadow_dsc_t * dsc
 
     LV_PROFILER_DRAW_BEGIN;
     lv_draw_task_t * t = lv_draw_add_task(layer, coords, LV_DRAW_TASK_TYPE_BOX_SHADOW);
+    if(!t) {
+        LV_PROFILER_DRAW_END;
+        return;
+    }
 
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
 
@@ -186,22 +198,24 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
     if(has_shadow) {
         /*Check whether the shadow is visible*/
         t = lv_draw_add_task(layer, coords, LV_DRAW_TASK_TYPE_BOX_SHADOW);
-        lv_draw_box_shadow_dsc_t * shadow_dsc = t->draw_dsc;
+        if(t) {
+            lv_draw_box_shadow_dsc_t * shadow_dsc = t->draw_dsc;
 
-        lv_area_increase(&t->_real_area, dsc->shadow_spread, dsc->shadow_spread);
-        lv_area_increase(&t->_real_area, dsc->shadow_width, dsc->shadow_width);
-        lv_area_move(&t->_real_area, dsc->shadow_offset_x, dsc->shadow_offset_y);
-        shadow_dsc->base = dsc->base;
-        shadow_dsc->base.dsc_size = sizeof(lv_draw_box_shadow_dsc_t);
-        shadow_dsc->radius = dsc->radius;
-        shadow_dsc->color = dsc->shadow_color;
-        shadow_dsc->width = dsc->shadow_width;
-        shadow_dsc->spread = dsc->shadow_spread;
-        shadow_dsc->opa = dsc->shadow_opa;
-        shadow_dsc->ofs_x = dsc->shadow_offset_x;
-        shadow_dsc->ofs_y = dsc->shadow_offset_y;
-        shadow_dsc->bg_cover = bg_cover;
-        lv_draw_finalize_task_creation(layer, t);
+            lv_area_increase(&t->_real_area, dsc->shadow_spread, dsc->shadow_spread);
+            lv_area_increase(&t->_real_area, dsc->shadow_width, dsc->shadow_width);
+            lv_area_move(&t->_real_area, dsc->shadow_offset_x, dsc->shadow_offset_y);
+            shadow_dsc->base = dsc->base;
+            shadow_dsc->base.dsc_size = sizeof(lv_draw_box_shadow_dsc_t);
+            shadow_dsc->radius = dsc->radius;
+            shadow_dsc->color = dsc->shadow_color;
+            shadow_dsc->width = dsc->shadow_width;
+            shadow_dsc->spread = dsc->shadow_spread;
+            shadow_dsc->opa = dsc->shadow_opa;
+            shadow_dsc->ofs_x = dsc->shadow_offset_x;
+            shadow_dsc->ofs_y = dsc->shadow_offset_y;
+            shadow_dsc->bg_cover = bg_cover;
+            lv_draw_finalize_task_creation(layer, t);
+        }
     }
 
     /*Background*/
@@ -216,17 +230,19 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
         }
 
         t = lv_draw_add_task(layer, &bg_coords, LV_DRAW_TASK_TYPE_FILL);
-        lv_draw_fill_dsc_t * bg_dsc = t->draw_dsc;
+        if(t) {
+            lv_draw_fill_dsc_t * bg_dsc = t->draw_dsc;
 
-        lv_draw_fill_dsc_init(bg_dsc);
-        bg_dsc->base = dsc->base;
-        bg_dsc->base.dsc_size = sizeof(lv_draw_fill_dsc_t);
-        bg_dsc->radius = dsc->radius;
-        bg_dsc->color = dsc->bg_color;
-        bg_dsc->grad = dsc->bg_grad;
-        bg_dsc->opa = dsc->bg_opa;
+            lv_draw_fill_dsc_init(bg_dsc);
+            bg_dsc->base = dsc->base;
+            bg_dsc->base.dsc_size = sizeof(lv_draw_fill_dsc_t);
+            bg_dsc->radius = dsc->radius;
+            bg_dsc->color = dsc->bg_color;
+            bg_dsc->grad = dsc->bg_grad;
+            bg_dsc->opa = dsc->bg_opa;
 
-        lv_draw_finalize_task_creation(layer, t);
+            lv_draw_finalize_task_creation(layer, t);
+        }
     }
 
     /*Background image*/
@@ -257,20 +273,22 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
                     t = lv_draw_add_task(layer, &a, LV_DRAW_TASK_TYPE_IMAGE);
                 }
 
-                lv_draw_image_dsc_t * bg_image_dsc = t->draw_dsc;
+                if(t) {
+                    lv_draw_image_dsc_t * bg_image_dsc = t->draw_dsc;
 
-                lv_draw_image_dsc_init(bg_image_dsc);
-                bg_image_dsc->base = dsc->base;
-                bg_image_dsc->base.dsc_size = sizeof(lv_draw_image_dsc_t);
-                bg_image_dsc->src = dsc->bg_image_src;
-                bg_image_dsc->opa = dsc->bg_image_opa;
-                bg_image_dsc->recolor = dsc->bg_image_recolor;
-                bg_image_dsc->recolor_opa = dsc->bg_image_recolor_opa;
-                bg_image_dsc->tile = dsc->bg_image_tiled;
-                bg_image_dsc->header = header;
-                bg_image_dsc->clip_radius = dsc->radius;
-                bg_image_dsc->image_area = *coords;
-                lv_draw_finalize_task_creation(layer, t);
+                    lv_draw_image_dsc_init(bg_image_dsc);
+                    bg_image_dsc->base = dsc->base;
+                    bg_image_dsc->base.dsc_size = sizeof(lv_draw_image_dsc_t);
+                    bg_image_dsc->src = dsc->bg_image_src;
+                    bg_image_dsc->opa = dsc->bg_image_opa;
+                    bg_image_dsc->recolor = dsc->bg_image_recolor;
+                    bg_image_dsc->recolor_opa = dsc->bg_image_recolor_opa;
+                    bg_image_dsc->tile = dsc->bg_image_tiled;
+                    bg_image_dsc->header = header;
+                    bg_image_dsc->clip_radius = dsc->radius;
+                    bg_image_dsc->image_area = *coords;
+                    lv_draw_finalize_task_creation(layer, t);
+                }
             }
             else {
                 lv_point_t s;
@@ -286,17 +304,18 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
                 lv_area_t a = {0, 0, s.x - 1, s.y - 1};
                 lv_area_align(coords, &a, LV_ALIGN_CENTER, 0, 0);
                 t = lv_draw_add_task(layer, &a, LV_DRAW_TASK_TYPE_LABEL);
+                if(t) {
+                    lv_draw_label_dsc_t * bg_label_dsc = t->draw_dsc;
 
-                lv_draw_label_dsc_t * bg_label_dsc = t->draw_dsc;
-
-                lv_draw_label_dsc_init(bg_label_dsc);
-                bg_label_dsc->base = dsc->base;
-                bg_label_dsc->base.dsc_size = sizeof(lv_draw_label_dsc_t);
-                bg_label_dsc->color = dsc->bg_image_recolor;
-                bg_label_dsc->font = dsc->bg_image_symbol_font;
-                bg_label_dsc->text = dsc->bg_image_src;
-                t->type = LV_DRAW_TASK_TYPE_LABEL;
-                lv_draw_finalize_task_creation(layer, t);
+                    lv_draw_label_dsc_init(bg_label_dsc);
+                    bg_label_dsc->base = dsc->base;
+                    bg_label_dsc->base.dsc_size = sizeof(lv_draw_label_dsc_t);
+                    bg_label_dsc->color = dsc->bg_image_recolor;
+                    bg_label_dsc->font = dsc->bg_image_symbol_font;
+                    bg_label_dsc->text = dsc->bg_image_src;
+                    t->type = LV_DRAW_TASK_TYPE_LABEL;
+                    lv_draw_finalize_task_creation(layer, t);
+                }
             }
         }
     }
@@ -304,16 +323,18 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
     /*Border*/
     if(has_border) {
         t = lv_draw_add_task(layer, coords, LV_DRAW_TASK_TYPE_BORDER);
-        lv_draw_border_dsc_t * border_dsc = t->draw_dsc;
+        if(t) {
+            lv_draw_border_dsc_t * border_dsc = t->draw_dsc;
 
-        border_dsc->base = dsc->base;
-        border_dsc->base.dsc_size = sizeof(lv_draw_border_dsc_t);
-        border_dsc->radius = dsc->radius;
-        border_dsc->color = dsc->border_color;
-        border_dsc->opa = dsc->border_opa;
-        border_dsc->width = dsc->border_width;
-        border_dsc->side = dsc->border_side;
-        lv_draw_finalize_task_creation(layer, t);
+            border_dsc->base = dsc->base;
+            border_dsc->base.dsc_size = sizeof(lv_draw_border_dsc_t);
+            border_dsc->radius = dsc->radius;
+            border_dsc->color = dsc->border_color;
+            border_dsc->opa = dsc->border_opa;
+            border_dsc->width = dsc->border_width;
+            border_dsc->side = dsc->border_side;
+            lv_draw_finalize_task_creation(layer, t);
+        }
     }
 
     /*Outline*/
@@ -321,18 +342,20 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
         lv_area_t outline_coords = *coords;
         lv_area_increase(&outline_coords, dsc->outline_width + dsc->outline_pad, dsc->outline_width + dsc->outline_pad);
         t = lv_draw_add_task(layer, &outline_coords, LV_DRAW_TASK_TYPE_BORDER);
-        lv_draw_border_dsc_t * outline_dsc = t->draw_dsc;
-        lv_area_increase(&t->_real_area, dsc->outline_width, dsc->outline_width);
-        lv_area_increase(&t->_real_area, dsc->outline_pad, dsc->outline_pad);
-        outline_dsc->base = dsc->base;
-        outline_dsc->base.dsc_size = sizeof(lv_draw_border_dsc_t);
-        outline_dsc->radius = dsc->radius == LV_RADIUS_CIRCLE ? LV_RADIUS_CIRCLE : dsc->radius + dsc->outline_width +
-                              dsc->outline_pad;
-        outline_dsc->color = dsc->outline_color;
-        outline_dsc->opa = dsc->outline_opa;
-        outline_dsc->width = dsc->outline_width;
-        outline_dsc->side = LV_BORDER_SIDE_FULL;
-        lv_draw_finalize_task_creation(layer, t);
+        if(t) {
+            lv_draw_border_dsc_t * outline_dsc = t->draw_dsc;
+            lv_area_increase(&t->_real_area, dsc->outline_width, dsc->outline_width);
+            lv_area_increase(&t->_real_area, dsc->outline_pad, dsc->outline_pad);
+            outline_dsc->base = dsc->base;
+            outline_dsc->base.dsc_size = sizeof(lv_draw_border_dsc_t);
+            outline_dsc->radius = dsc->radius == LV_RADIUS_CIRCLE ? LV_RADIUS_CIRCLE : dsc->radius + dsc->outline_width +
+                                  dsc->outline_pad;
+            outline_dsc->color = dsc->outline_color;
+            outline_dsc->opa = dsc->outline_opa;
+            outline_dsc->width = dsc->outline_width;
+            outline_dsc->side = LV_BORDER_SIDE_FULL;
+            lv_draw_finalize_task_creation(layer, t);
+        }
     }
 
     LV_ASSERT_MEM_INTEGRITY();

--- a/src/draw/lv_draw_triangle.c
+++ b/src/draw/lv_draw_triangle.c
@@ -70,6 +70,10 @@ void lv_draw_triangle(lv_layer_t * layer, const lv_draw_triangle_dsc_t * dsc)
     a.y2 = (int32_t)LV_MAX3(dsc->p[0].y, dsc->p[1].y, dsc->p[2].y);
 
     lv_draw_task_t * t = lv_draw_add_task(layer, &a, LV_DRAW_TASK_TYPE_TRIANGLE);
+    if(!t) {
+        LV_PROFILER_DRAW_END;
+        return;
+    }
 
     lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
 

--- a/src/draw/lv_draw_vector.c
+++ b/src/draw/lv_draw_vector.c
@@ -909,16 +909,25 @@ void lv_vector_clear_area(lv_vector_dsc_t * dsc, const lv_area_t * rect)
 
 void lv_draw_vector(lv_vector_dsc_t * dsc)
 {
+    LV_PROFILER_DRAW_BEGIN;
     if(!dsc->tasks.task_list) {
+        LV_PROFILER_DRAW_END;
         return;
     }
 
     lv_layer_t * layer = dsc->layer;
 
     lv_draw_task_t * t = lv_draw_add_task(layer, &(layer->_clip_area), LV_DRAW_TASK_TYPE_VECTOR);
+    if(!t) {
+        LV_PROFILER_DRAW_END;
+        return;
+    }
+
     lv_memcpy(t->draw_dsc, &(dsc->tasks), sizeof(lv_draw_vector_task_dsc_t));
     lv_draw_finalize_task_creation(layer, t);
     dsc->tasks.task_list = NULL;
+
+    LV_PROFILER_DRAW_END;
 }
 
 /* draw dsc transform */


### PR DESCRIPTION
When the rendered content has no intersection with the clipping area, skip drawing.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
