### PR TITLE
fix(wayland): bind draw buffers to the window instead of the shm_context

### DIFF
--- a/src/drivers/wayland/lv_wayland_private.h
+++ b/src/drivers/wayland/lv_wayland_private.h
@@ -145,7 +145,6 @@ typedef struct {
 } dmabuf_ctx_t;
 
 typedef struct {
-    lv_draw_buf_t * lv_draw_buf;
     struct wl_shm * handler;
     uint32_t format;
 } shm_ctx_t;
@@ -198,8 +197,9 @@ struct window {
     lv_indev_t * lv_indev_touch;
     lv_indev_t * lv_indev_keyboard;
 
-    lv_wayland_display_close_f_t close_cb;
+    lv_draw_buf_t * lv_draw_buf;
 
+    lv_wayland_display_close_f_t close_cb;
     struct lv_wayland_context * wl_ctx;
 
 #if LV_WAYLAND_WL_SHELL
@@ -349,7 +349,7 @@ void lv_wayland_shm_set_interface(shm_ctx_t * context, struct wl_registry * regi
 
 struct graphic_object * lv_wayland_shm_on_graphical_object_creation(shm_ctx_t * context, struct graphic_object * obj);
 void lv_wayland_shm_on_graphical_object_destruction(shm_ctx_t * context, struct graphic_object * obj);
-lv_result_t lv_wayland_shm_set_draw_buffers(shm_ctx_t * context, lv_display_t * display);
+lv_result_t lv_wayland_shm_set_draw_buffers(shm_ctx_t * context, lv_display_t * display, struct window * window);
 lv_result_t lv_wayland_shm_create_draw_buffers(shm_ctx_t * context, struct window * window);
 lv_result_t lv_wayland_shm_resize_window(shm_ctx_t * context, struct window * window, int32_t width, int32_t height);
 lv_result_t lv_wayland_shm_is_ready(shm_ctx_t * context);

--- a/src/drivers/wayland/lv_wl_shm.c
+++ b/src/drivers/wayland/lv_wl_shm.c
@@ -125,6 +125,7 @@ void lv_wayland_shm_on_graphical_object_destruction(shm_ctx_t * context, struct 
 
 lv_result_t lv_wayland_shm_resize_window(shm_ctx_t * context, struct window * window, int32_t width, int32_t height)
 {
+    LV_UNUSED(context);
     const uint8_t bpp = lv_color_format_get_size(LV_COLOR_FORMAT_NATIVE);
 
     /* Update size for newly allocated buffers */
@@ -156,36 +157,37 @@ lv_result_t lv_wayland_shm_resize_window(shm_ctx_t * context, struct window * wi
     if(window->lv_disp != NULL) {
         /* Resize draw buffer */
         const uint32_t stride = lv_draw_buf_width_to_stride(width, lv_display_get_color_format(window->lv_disp));
-        context->lv_draw_buf  = lv_draw_buf_reshape(context->lv_draw_buf, lv_display_get_color_format(window->lv_disp),
-                                                    width, height / LVGL_DRAW_BUFFER_DIV, stride);
+        window->lv_draw_buf = lv_draw_buf_reshape(window->lv_draw_buf, lv_display_get_color_format(window->lv_disp),
+                                                  width, height / LVGL_DRAW_BUFFER_DIV, stride);
     }
 
     return LV_RESULT_OK;
 }
 lv_result_t lv_wayland_shm_create_draw_buffers(shm_ctx_t * context, struct window * window)
 {
-
+    LV_UNUSED(context);
     const uint32_t stride = lv_draw_buf_width_to_stride(window->width, lv_display_get_color_format(window->lv_disp));
 
-    context->lv_draw_buf = lv_draw_buf_create(window->width, window->height / LVGL_DRAW_BUFFER_DIV,
-                                              lv_display_get_color_format(window->lv_disp), stride);
-    return LV_RESULT_OK;
+    window->lv_draw_buf = lv_draw_buf_create(window->width, window->height / LVGL_DRAW_BUFFER_DIV,
+                                             lv_display_get_color_format(window->lv_disp), stride);
+    return window->lv_draw_buf ? LV_RESULT_OK : LV_RESULT_INVALID;
 }
 
-lv_result_t lv_wayland_shm_set_draw_buffers(shm_ctx_t * context, lv_display_t * display)
+lv_result_t lv_wayland_shm_set_draw_buffers(shm_ctx_t * context, lv_display_t * display, struct window * window)
 {
+    LV_UNUSED(context);
     if(LV_WAYLAND_BUF_COUNT != 1) {
         LV_LOG_ERROR("Wayland without dmabuf only supports 1 drawbuffer for now.");
         return LV_RESULT_INVALID;
     }
-    lv_display_set_draw_buffers(display, context->lv_draw_buf, NULL);
+    lv_display_set_draw_buffers(display, window->lv_draw_buf, NULL);
     return LV_RESULT_OK;
 }
 
 void lv_wayland_shm_delete_draw_buffers(shm_ctx_t * context, struct window * window)
 {
-    LV_UNUSED(window);
-    lv_draw_buf_destroy(context->lv_draw_buf);
+    LV_UNUSED(context);
+    if(window->lv_draw_buf) lv_draw_buf_destroy(window->lv_draw_buf);
 }
 void lv_wayland_shm_flush_partial_mode(lv_display_t * disp, const lv_area_t * area, unsigned char * color_p)
 {

--- a/src/drivers/wayland/lv_wl_window.c
+++ b/src/drivers/wayland/lv_wl_window.c
@@ -133,7 +133,7 @@ lv_display_t * lv_wayland_window_create(uint32_t hor_res, uint32_t ver_res, char
     lv_wayland_dmabuf_set_draw_buffers(&lv_wl_ctx.dmabuf_ctx, window->lv_disp);
     lv_display_set_flush_cb(window->lv_disp, lv_wayland_dmabuf_flush_full_mode);
 #else
-    lv_wayland_shm_set_draw_buffers(&lv_wl_ctx.shm_ctx, window->lv_disp);
+    lv_wayland_shm_set_draw_buffers(&lv_wl_ctx.shm_ctx, window->lv_disp, window);
     lv_display_set_flush_cb(window->lv_disp, lv_wayland_shm_flush_partial_mode);
 #endif
 


### PR DESCRIPTION
Fixes #8872 <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
