### PR TITLE
fix(menu): allow using menu section as parent of menu container

### DIFF
--- a/src/widgets/menu/lv_menu.c
+++ b/src/widgets/menu/lv_menu.c
@@ -142,7 +142,12 @@ lv_obj_t * lv_menu_page_create(lv_obj_t * menu, char const * const title)
 
 lv_obj_t * lv_menu_cont_create(lv_obj_t * parent)
 {
-    LV_ASSERT_OBJ(parent, &lv_menu_page_class);
+    LV_ASSERT_NULL(parent);
+    if(!parent || !(parent->class_p == &lv_menu_page_class ||
+                    parent->class_p == &lv_menu_section_class)) {
+        LV_LOG_WARN("Invalid parent object type for menu container object");
+        return NULL;
+    }
 
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(&lv_menu_cont_class, parent);

--- a/src/widgets/menu/lv_menu.c
+++ b/src/widgets/menu/lv_menu.c
@@ -144,8 +144,8 @@ lv_obj_t * lv_menu_cont_create(lv_obj_t * parent)
 {
     LV_ASSERT_NULL(parent);
     if(!parent || (LV_USE_ASSERT_OBJ &&
-                   !(lv_obj_has_class(parent->class_p, &lv_menu_page_class)
-                     || lv_obj_has_class(parent->class_p, &lv_menu_section_class)))) {
+                   !(lv_obj_has_class(parent, &lv_menu_page_class)
+                     || lv_obj_has_class(parent, &lv_menu_section_class)))) {
         LV_LOG_WARN("Invalid parent object type for menu container object");
         return NULL;
     }

--- a/src/widgets/menu/lv_menu.c
+++ b/src/widgets/menu/lv_menu.c
@@ -143,8 +143,9 @@ lv_obj_t * lv_menu_page_create(lv_obj_t * menu, char const * const title)
 lv_obj_t * lv_menu_cont_create(lv_obj_t * parent)
 {
     LV_ASSERT_NULL(parent);
-    if(!parent || !(parent->class_p == &lv_menu_page_class ||
-                    parent->class_p == &lv_menu_section_class)) {
+    if(!parent || (LV_USE_ASSERT_OBJ &&
+                   !(lv_obj_has_class(parent->class_p, &lv_menu_page_class)
+                     || lv_obj_has_class(parent->class_p, &lv_menu_section_class)))) {
         LV_LOG_WARN("Invalid parent object type for menu container object");
         return NULL;
     }

--- a/src/widgets/menu/lv_menu.h
+++ b/src/widgets/menu/lv_menu.h
@@ -73,7 +73,7 @@ lv_obj_t * lv_menu_page_create(lv_obj_t * menu, char const * const title);
 
 /**
  * Create a menu cont object
- * @param parent    pointer to a menu page object, it will be the parent of the new menu cont object
+ * @param parent    pointer to a menu page or menu section object, it will be the parent of the new menu cont object
  * @return          pointer to the created menu cont
  */
 lv_obj_t * lv_menu_cont_create(lv_obj_t * parent);


### PR DESCRIPTION
Currently, `lv_example_menu_5` doesn't run when `LV_ASSERT_OBJ` is enabled because this example passes a `lv_menu_section` object to `lv_menu_cont_create`:

```
[Error]	(0.270, +270)	lv_menu_cont_create: Asserted at expression: lv_obj_has_class(parent, &lv_menu_page_class) == true (Incompatible object type.) lv_menu.c:145
```

The check that verifies that the parent is of type `lv_menu_page` was introduced in #7605 but is not fully accurate as it's also valid to pass in a `lv_menu_section` object to this specific function

I didn't check the other ASSERTs introduced in #7605 but they may also be too constraining