### PR TITLE
chore(lvconf_gen): generate empty lv_conf.h if it doesn't exist

### DIFF
--- a/.github/workflows/build_examples_with_cxx_compiler.yml
+++ b/.github/workflows/build_examples_with_cxx_compiler.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/checkout@v5
       - name: Generate lv_conf.h
         run: |
-          cp lv_conf_template.h lv_conf.h
           python ./scripts/generate_lv_conf.py \
             --template lv_conf_template.h \
             --config lv_conf.h \

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Generate lv_conf.h
         run: |
-          cp lv_conf_template.h lv_conf.h
           python3 ./scripts/generate_lv_conf.py \
             --template lv_conf_template.h \
             --config lv_conf.h \

--- a/.github/workflows/perf_emulation.yml
+++ b/.github/workflows/perf_emulation.yml
@@ -58,7 +58,6 @@ jobs:
           fetch-depth: 0
       - name: Generate lv_conf.h
         run: |
-          cp lv_conf_template.h configs/ci/perf/lv_conf_perf.h
           python scripts/generate_lv_conf.py \
             --template lv_conf_template.h \
             --config configs/ci/perf/lv_conf_perf.h \

--- a/scripts/build_html_examples.sh
+++ b/scripts/build_html_examples.sh
@@ -30,7 +30,6 @@ cd ..
 # Generate lv_conf
 LV_CONF_PATH=`pwd`/lvgl/configs/ci/docs/lv_conf_docs.h
 
-cp lvgl/lv_conf_template.h $LV_CONF_PATH
 python ./lvgl/scripts/generate_lv_conf.py \
   --template lvgl/lv_conf_template.h \
   --config $LV_CONF_PATH \

--- a/scripts/generate_lv_conf.py
+++ b/scripts/generate_lv_conf.py
@@ -3,6 +3,7 @@
 import os
 import re
 import argparse
+from pathlib import Path
 
 DIR_SCRIPTS = os.path.dirname(__file__)
 REPO_ROOT = os.path.join(DIR_SCRIPTS, "..")
@@ -48,7 +49,8 @@ def get_args():
     if not os.path.exists(args.template):
         fatal(f"Template file not found at {args.template}")
     if not os.path.exists(args.config):
-        fatal(f"User config file not found at {args.config}")
+        print(f"{args.config} not found. Generating it")
+        Path(args.config).touch()
     if not os.path.exists(args.defaults):
         fatal(f"User defaults not found at {args.defaults}")
 

--- a/tests/benchmark_emu.py
+++ b/tests/benchmark_emu.py
@@ -162,7 +162,6 @@ def generate_config(config_name: str) -> None:
 
     output_path = os.path.join(build_dir, "lv_conf.h")
     generate_script = os.path.join(lvgl_root_dir, "scripts", "generate_lv_conf.py")
-    shutil.copy(template_path, output_path)
 
     cmd = [
         sys.executable,


### PR DESCRIPTION
When generating a `lv_conf.h` from `lv_conf.defaults` we first need to create an empty file before being able to call this script. 
This PR addresses that issue by creating a new `lv_conf.h` file

Previously I had to do this in CMake to generate a new `lv_conf.h` from a `.defaults`:

```cmake
execute_process(COMMAND ${CMAKE_COMMAND} -E touch ${LV_BUILD_CONF_PATH}
                RESULT_VARIABLE touch_result)

execute_process(
  COMMAND
    ${Python3_EXECUTABLE} ${GENERATE_SCRIPT_PATH} --template
    ${LVGL_TEMPLATE_PATH} --defaults ${LV_CONF_DEFAULTS_PATH} --config
    ${LV_BUILD_CONF_PATH}
  RESULT_VARIABLE config_result
  OUTPUT_VARIABLE config_output
  ERROR_VARIABLE config_error)
```

With this PR I can remove the first `execute_process` call