### PR TITLE
feat(drm): add lv_linux_drm_cleanup() and free all DRM resources

### DIFF
--- a/src/drivers/display/drm/lv_linux_drm.c
+++ b/src/drivers/display/drm/lv_linux_drm.c
@@ -146,6 +146,7 @@ static int find_plane(drm_dev_t * drm_dev, unsigned int fourcc, uint32_t * plane
 static int drm_find_connector(drm_dev_t * drm_dev, int64_t connector_id);
 static int drm_open(const char * path);
 static int drm_setup(drm_dev_t * drm_dev, const char * device_path, int64_t connector_id, unsigned int fourcc);
+static void drm_cleanup_cb(lv_event_t * e);
 
 static uint32_t tick_get_cb(void);
 
@@ -215,6 +216,8 @@ lv_display_t * lv_linux_drm_create(void)
     drm_dev->kms_out_fence_fd = -1;
 
 #endif
+
+    lv_display_add_event_cb(disp, drm_cleanup_cb, LV_EVENT_DELETE, NULL);
 
     return disp;
 }
@@ -1563,8 +1566,9 @@ static void drm_cleanup(drm_dev_t * drm)
     }
 }
 
-void lv_linux_drm_cleanup(lv_display_t * disp)
+static void drm_cleanup_cb(lv_event_t * e)
 {
+    lv_display_t * disp = lv_event_get_current_target(e);
     if(!disp) return;
 
 #if LV_LINUX_DRM_USE_EGL

--- a/src/drivers/display/drm/lv_linux_drm.h
+++ b/src/drivers/display/drm/lv_linux_drm.h
@@ -33,8 +33,6 @@ lv_display_t * lv_linux_drm_create(void);
 
 void lv_linux_drm_set_file(lv_display_t * disp, const char * file, int64_t connector_id);
 
-void lv_linux_drm_cleanup(lv_display_t * disp);
-
 /**********************
  *      MACROS
  **********************/

--- a/src/drivers/display/drm/lv_linux_drm.h
+++ b/src/drivers/display/drm/lv_linux_drm.h
@@ -33,6 +33,8 @@ lv_display_t * lv_linux_drm_create(void);
 
 void lv_linux_drm_set_file(lv_display_t * disp, const char * file, int64_t connector_id);
 
+void lv_linux_drm_cleanup(lv_display_t * disp);
+
 /**********************
  *      MACROS
  **********************/


### PR DESCRIPTION
### What & Why
- Add public `lv_linux_drm_cleanup(lv_display_t*)` and internal `drm_cleanup(drm_dev_t*)`
- Properly release DRM/GBM resources (blob_id, fb/bo, props, fd, IDs)
- Make repeated init/teardown robust and leak-free

### Implementation notes
- Optional atomic disable (CRTC/ACTIVE/FB_ID=0) before teardown
- Destroy mode property blob if present
- Free drmMode* property descriptors
- Close GBM/FB/FD, reset IDs/counters

### Testing
- Manual: init → render → cleanup → re-init (no leaks, no stale FDs)
- Verified no VT/CRTC stuck state after exit

### Risks / Compatibility
- Adds a new public API (`lv_linux_drm_cleanup`); no behavior change for existing apps unless they call it.
- Naming and visibility open for discussion.

### DCO
- Code builds successfully on Linux DRM target.
- All commits are DCO-signed (`-s`).
