### PR TITLE
feat(wayland): add xdg_decoration support

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1885,6 +1885,10 @@ menu "LVGL configuration"
 			bool "Draw client side window decorations, only necessary on Mutter (GNOME)"
 			depends on LV_USE_WAYLAND
 			default n
+		config LV_WAYLAND_WINDOW_SERVER_SIDE_DECORATIONS
+			bool "Use server side window decorations, only necessary on Mutter (GNOME)"
+			depends on LV_USE_WAYLAND && !LV_WAYLAND_WINDOW_DECORATIONS
+			default n
 		config LV_WAYLAND_BUF_COUNT
 			int "Use 1 for single buffer with partial render mode or 2 for double buffer with full render mode"
 			depends on LV_USE_WAYLAND

--- a/docs/src/details/integration/embedded_linux/drivers/wayland.rst
+++ b/docs/src/details/integration/embedded_linux/drivers/wayland.rst
@@ -71,6 +71,10 @@ Some optional settings depend on whether DMA buffer support is enabled (`LV_WAYL
      - `1` or `0`
      - `0`
 
+   * - `LV_WAYLAND_WINDOW_SERVER_SIDE_DECORATIONS`
+     - `1` or `0`
+     - `0`
+
 Additional notes
 
 * DMABUF support (`LV_WAYLAND_USE_DMABUF`) improves performance and enables more render modes but has specific requirements and restrictions.
@@ -170,6 +174,13 @@ When `LV_WAYLAND_USE_DMABUF` is set to `1`, the following protocols must also be
 
    wayland-scanner client-header $SYSROOT/usr/share/wayland-protocols/stable/linux-dmabuf/linux-dmabuf-v1.xml wayland_linux_dmabuf.h
    wayland-scanner private-code $SYSROOT/usr/share/wayland-protocols/stable/linux-dmabuf/linux-dmabuf-v1.xml wayland_linux_dmabuf.c
+
+When `LV_WAYLAND_WINDOW_SERVER_SIDE_DECORATIONS` is set to `1`, the following protocols must also be generated:
+
+.. code-block:: sh
+
+   wayland-scanner client-header $SYSROOT/usr/share/wayland-protocols/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml wayland_xdg_decoration.h
+   wayland-scanner private-code $SYSROOT/usr/share/wayland-protocols/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml wayland_xdg_decoration.c
 
 
 The resulting files can then be integrated into the project, it's better to re-run ``wayland-scanner`` on

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -1252,6 +1252,7 @@
     #define LV_WAYLAND_RENDER_MODE          LV_DISPLAY_RENDER_MODE_PARTIAL   /**< DMABUF supports LV_DISPLAY_RENDER_MODE_FULL and LV_DISPLAY_RENDER_MODE_DIRECT*/
                                                                              /**< When LV_WAYLAND_USE_DMABUF is disabled, only LV_DISPLAY_RENDER_MODE_PARTIAL is supported*/
     #define LV_WAYLAND_WINDOW_DECORATIONS   0    /**< Draw client side window decorations only necessary on Mutter/GNOME. Not supported using DMABUF*/
+    #define LV_WAYLAND_WINDOW_SERVER_SIDE_DECORATIONS   0    /**< Use server side window decorations*/
 #endif
 
 /** Driver for /dev/fb */

--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -210,8 +210,9 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
 #endif  /*LV_USE_LOG*/
 
 #if LV_USE_WAYLAND == 0
-    #define LV_WAYLAND_USE_DMABUF           0
-    #define LV_WAYLAND_WINDOW_DECORATIONS   0
+    #define LV_WAYLAND_USE_DMABUF                       0
+    #define LV_WAYLAND_WINDOW_DECORATIONS               0
+    #define LV_WAYLAND_WINDOW_SERVER_SIDE_DECORATIONS   0
 #endif /* LV_USE_WAYLAND */
 
 #if LV_USE_LINUX_DRM == 0

--- a/src/drivers/wayland/lv_wayland.c
+++ b/src/drivers/wayland/lv_wayland.c
@@ -363,6 +363,11 @@ static void handle_global(void * data, struct wl_registry * registry, uint32_t n
         wl_display_roundtrip(app->display);
     }
 #endif
+#if LV_WAYLAND_WINDOW_SERVER_SIDE_DECORATIONS
+    else if(strcmp(interface, zxdg_decoration_manager_v1_interface.name) == 0) {
+        app->xdg_decoration_manager = wl_registry_bind(app->registry, name, &zxdg_decoration_manager_v1_interface, 1);
+    }
+#endif
 }
 
 static void handle_global_remove(void * data, struct wl_registry * registry, uint32_t name)

--- a/src/drivers/wayland/lv_wayland_private.h
+++ b/src/drivers/wayland/lv_wayland_private.h
@@ -22,6 +22,9 @@ extern "C" {
 #include <sys/poll.h>
 #include <wayland-client-protocol.h>
 #include <wayland_xdg_shell.h>
+#if LV_WAYLAND_WINDOW_SERVER_SIDE_DECORATIONS
+#include <wayland_xdg_decoration.h>
+#endif
 
 #if LV_WAYLAND_USE_DMABUF
 #include <sys/mman.h>
@@ -158,6 +161,9 @@ struct lv_wayland_context {
 #endif
 
     struct xdg_wm_base * xdg_wm;
+#if LV_WAYLAND_WINDOW_SERVER_SIDE_DECORATIONS
+    struct zxdg_decoration_manager_v1 * xdg_decoration_manager;
+#endif
 
 #ifdef LV_WAYLAND_WINDOW_DECORATIONS
     bool opt_disable_decorations;
@@ -191,6 +197,9 @@ struct window {
 
     struct xdg_surface * xdg_surface;
     struct xdg_toplevel * xdg_toplevel;
+#if LV_WAYLAND_WINDOW_SERVER_SIDE_DECORATIONS
+    struct zxdg_toplevel_decoration_v1 * xdg_decoration;
+#endif
     uint32_t wm_capabilities;
 
     struct graphic_object * body;

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -4023,6 +4023,13 @@
             #define LV_WAYLAND_WINDOW_DECORATIONS   0    /**< Draw client side window decorations only necessary on Mutter/GNOME. Not supported using DMABUF*/
         #endif
     #endif
+    #ifndef LV_WAYLAND_WINDOW_SERVER_SIDE_DECORATIONS
+        #ifdef CONFIG_LV_WAYLAND_WINDOW_SERVER_SIDE_DECORATIONS
+            #define LV_WAYLAND_WINDOW_SERVER_SIDE_DECORATIONS CONFIG_LV_WAYLAND_WINDOW_SERVER_SIDE_DECORATIONS
+        #else
+            #define LV_WAYLAND_WINDOW_SERVER_SIDE_DECORATIONS   0    /**< Use server side window decorations*/
+        #endif
+    #endif
 #endif
 
 /** Driver for /dev/fb */
@@ -4760,8 +4767,9 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
 #endif  /*LV_USE_LOG*/
 
 #if LV_USE_WAYLAND == 0
-    #define LV_WAYLAND_USE_DMABUF           0
-    #define LV_WAYLAND_WINDOW_DECORATIONS   0
+    #define LV_WAYLAND_USE_DMABUF                       0
+    #define LV_WAYLAND_WINDOW_DECORATIONS               0
+    #define LV_WAYLAND_WINDOW_SERVER_SIDE_DECORATIONS   0
 #endif /* LV_USE_WAYLAND */
 
 #if LV_USE_LINUX_DRM == 0


### PR DESCRIPTION
This PR extends LVGL’s Wayland backend to support the xdg-decoration protocol.

The Wayland protocol requires clients to negotiate window decoration handling with the compositor.

Without xdg-decoration, many compositors will force client-side decorations, which may result in inconsistent look and feel or unusable window chrome.

Adding this support allows LVGL applications to correctly integrate with compositors that offer server-side decorations, improving compatibility with modern Wayland environments and enhancing user experience.