### PR TITLE
feat(chart): add cursor removal method

### DIFF
--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -550,12 +550,12 @@ lv_chart_cursor_t  * lv_chart_add_cursor(lv_obj_t * obj, lv_color_t color, lv_di
 
 void lv_chart_remove_cursor(lv_obj_t *obj, lv_chart_cursor_t *cursor)
 {
-	LV_ASSERT_OBJ(obj, MY_CLASS);
-	LV_ASSERT_NULL(cursor);
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    LV_ASSERT_NULL(cursor);
 
-	lv_chart_t *chart = (lv_chart_t *)obj;
-	lv_ll_remove(&chart->cursor_ll, cursor);
-	lv_free(cursor);
+    lv_chart_t *chart = (lv_chart_t *)obj;
+    lv_ll_remove(&chart->cursor_ll, cursor);
+    lv_free(cursor);
 }
 
 void lv_chart_set_cursor_pos(lv_obj_t * chart, lv_chart_cursor_t * cursor, lv_point_t * pos)

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -548,6 +548,16 @@ lv_chart_cursor_t  * lv_chart_add_cursor(lv_obj_t * obj, lv_color_t color, lv_di
     return cursor;
 }
 
+void lv_chart_remove_cursor(lv_obj_t *obj, lv_chart_cursor_t *cursor)
+{
+	LV_ASSERT_OBJ(obj, MY_CLASS);
+	LV_ASSERT_NULL(cursor);
+
+	lv_chart_t *chart = (lv_chart_t *)obj;
+	lv_ll_remove(&chart->cursor_ll, cursor);
+	lv_free(cursor);
+}
+
 void lv_chart_set_cursor_pos(lv_obj_t * chart, lv_chart_cursor_t * cursor, lv_point_t * pos)
 {
     LV_ASSERT_NULL(cursor);

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -548,12 +548,12 @@ lv_chart_cursor_t  * lv_chart_add_cursor(lv_obj_t * obj, lv_color_t color, lv_di
     return cursor;
 }
 
-void lv_chart_remove_cursor(lv_obj_t *obj, lv_chart_cursor_t *cursor)
+void lv_chart_remove_cursor(lv_obj_t * obj, lv_chart_cursor_t * cursor)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
     LV_ASSERT_NULL(cursor);
 
-    lv_chart_t *chart = (lv_chart_t *)obj;
+    lv_chart_t * chart = (lv_chart_t *)obj;
     lv_ll_remove(&chart->cursor_ll, cursor);
     lv_free(cursor);
 }

--- a/src/widgets/chart/lv_chart.h
+++ b/src/widgets/chart/lv_chart.h
@@ -253,9 +253,9 @@ lv_chart_series_t * lv_chart_get_series_next(const lv_obj_t * chart, const lv_ch
 lv_chart_cursor_t  * lv_chart_add_cursor(lv_obj_t * obj, lv_color_t color, lv_dir_t dir);
 
 /**
- * Remove a cursor 
+ * Remove a cursor
  * @param obj       pointer to chart object
- * @param cursor    pointer to the cursor 
+ * @param cursor    pointer to the cursor
  */
 void lv_chart_remove_cursor(lv_obj_t * obj, lv_chart_cursor_t * cursor);
 

--- a/src/widgets/chart/lv_chart.h
+++ b/src/widgets/chart/lv_chart.h
@@ -255,8 +255,9 @@ lv_chart_cursor_t  * lv_chart_add_cursor(lv_obj_t * obj, lv_color_t color, lv_di
 /**
  * Remove a cursor 
  * @param obj       pointer to chart object
- * @param cursor    pointer to the cursor
-void lv_chart_remove_cursor(lv_obj_t *obj, lv_chart_cursor_t *cursor);
+ * @param cursor    pointer to the cursor 
+ */
+void lv_chart_remove_cursor(lv_obj_t * obj, lv_chart_cursor_t * cursor);
 
 /**
  * Set the coordinate of the cursor with respect to the paddings

--- a/src/widgets/chart/lv_chart.h
+++ b/src/widgets/chart/lv_chart.h
@@ -253,6 +253,12 @@ lv_chart_series_t * lv_chart_get_series_next(const lv_obj_t * chart, const lv_ch
 lv_chart_cursor_t  * lv_chart_add_cursor(lv_obj_t * obj, lv_color_t color, lv_dir_t dir);
 
 /**
+ * Remove a cursor 
+ * @param obj       pointer to chart object
+ * @param cursor    pointer to the cursor
+void lv_chart_remove_cursor(lv_obj_t *obj, lv_chart_cursor_t *cursor);
+
+/**
  * Set the coordinate of the cursor with respect to the paddings
  * @param chart     pointer to a chart object
  * @param cursor    pointer to the cursor


### PR DESCRIPTION
Feature ability to remove a cursor from a chart.
In the chart widget you can add multiple cursors, but there is no function to remove it.
lv_chart_remove_cursor() gives the ability to remove a cursor from a chart.


```
/**
 * Remove a cursor
 * @param obj       pointer to chart object
 * @param cursor    pointer to the cursor
 */
void lv_chart_remove_cursor(lv_obj_t * obj, lv_chart_cursor_t * cursor);
```