### PR TITLE
fix(EVE): align the dummy buf to 4 bytes

### DIFF
--- a/src/drivers/draw/eve/lv_draw_eve_display.c
+++ b/src/drivers/draw/eve/lv_draw_eve_display.c
@@ -49,7 +49,7 @@ static void touch_read_cb(lv_indev_t * indev, lv_indev_data_t * data);
 lv_display_t * lv_draw_eve_display_create(const lv_draw_eve_parameters_t * params, lv_draw_eve_operation_cb_t op_cb,
                                           void * user_data)
 {
-    static uint8_t dummy_buf; /* It won't be used as it will send commands instead of draw pixels. */
+    static uint32_t dummy_buf; /* It won't be used as it will send commands instead of draw pixels. */
 
     lv_display_t * disp = lv_display_create(params->hor_res, params->ver_res);
     lv_display_set_flush_cb(disp, flush_cb);


### PR DESCRIPTION
Fix common crash due to `LV_DRAW_BUF_ALIGN 4`.

```
[Error] (0.020, +20)     lv_display_set_buffers: Asserted at expression: buf1 == lv_draw_buf_align(buf1, cf) buf1 is not aligned: 0x3fc999b5 lv_display.c:475
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
