### PR TITLE
fix(draw/neon): disable function using an invalid intrinsic on arm32

### DIFF
--- a/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb888.c
+++ b/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb888.c
@@ -366,6 +366,7 @@ lv_result_t lv_draw_sw_blend_neon_color_to_rgb888_with_opa_mask(lv_draw_sw_blend
     return LV_RESULT_OK;
 }
 
+#ifdef __aarch64__ /* vqtbl1q_u8 is only available on arm64 */
 lv_result_t lv_draw_sw_blend_neon_l8_to_rgb888(lv_draw_sw_blend_image_dsc_t * dsc, uint32_t dest_px_size)
 {
     LV_ASSERT(dest_px_size == 3 || dest_px_size == 4);
@@ -425,6 +426,7 @@ lv_result_t lv_draw_sw_blend_neon_l8_to_rgb888(lv_draw_sw_blend_image_dsc_t * ds
     }
     return LV_RESULT_OK;
 }
+#endif
 
 lv_result_t lv_draw_sw_blend_neon_rgb565_to_rgb888(lv_draw_sw_blend_image_dsc_t * dsc, uint32_t dest_px_size)
 {

--- a/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb888.h
+++ b/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb888.h
@@ -39,8 +39,10 @@ extern "C" {
 #define LV_DRAW_SW_COLOR_BLEND_TO_RGB888_MIX_MASK_OPA(dsc, dest_px_size) lv_draw_sw_blend_neon_color_to_rgb888_with_opa_mask(dsc, dest_px_size)
 #endif
 
+#ifdef __aarch64__ /* This function uses a special intrinsic only available for arm64 */
 #ifndef LV_DRAW_SW_L8_BLEND_NORMAL_TO_RGB888
 #define LV_DRAW_SW_L8_BLEND_NORMAL_TO_RGB888(dsc, dest_px_size) lv_draw_sw_blend_neon_l8_to_rgb888(dsc, dest_px_size)
+#endif
 #endif
 
 #ifndef LV_DRAW_SW_RGB565_BLEND_NORMAL_TO_RGB888
@@ -111,7 +113,9 @@ lv_result_t lv_draw_sw_blend_neon_color_to_rgb888_with_mask(lv_draw_sw_blend_fil
 lv_result_t lv_draw_sw_blend_neon_color_to_rgb888_with_opa_mask(lv_draw_sw_blend_fill_dsc_t * dsc,
                                                                 uint32_t dest_px_size);
 
+#ifdef __aarch64__
 lv_result_t lv_draw_sw_blend_neon_l8_to_rgb888(lv_draw_sw_blend_image_dsc_t * dsc, uint32_t dest_px_size);
+#endif /*__aarch64__*/
 
 lv_result_t lv_draw_sw_blend_neon_al88_to_rgb888(lv_draw_sw_blend_image_dsc_t * dsc, uint32_t dest_px_size);
 lv_result_t lv_draw_sw_blend_neon_al88_to_rgb888_with_opa(lv_draw_sw_blend_image_dsc_t * dsc);


### PR DESCRIPTION
Fixes #8959 <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

Documentation: https://developer.arm.com/architectures/instruction-sets/intrinsics/vqtbl1q_u8

Thank you @bryghtlabs-richard for the reference 

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
