### PR TITLE
ci(docs): fix docs CI. use the action's checked-out repo for emscripten

### DIFF
--- a/.github/workflows/compile_docs.yml
+++ b/.github/workflows/compile_docs.yml
@@ -64,7 +64,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1
       - name: Build examples (with cache)
         run: |
-          ./scripts/build_html_examples.sh --symlink "${PWD}/lvgl"
+          ./lvgl/scripts/build_html_examples.sh --symlink "${PWD}/lvgl"
       - name: Build docs
         run: lvgl/docs/build.py html
       - name: Remove .doctrees

--- a/.github/workflows/compile_docs.yml
+++ b/.github/workflows/compile_docs.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          path: lvgl
           persist-credentials: false
           fetch-depth: 0
       - name: Setup Python
@@ -48,7 +49,7 @@ jobs:
           sudo apt-get install doxygen texlive-xetex texlive-binaries texlive-lang-english latexmk fonts-freefont-otf
       - name: Install requirements
         run: |
-          pip install -r docs/requirements.txt
+          pip install -r lvgl/docs/requirements.txt
       - name: Setup Emscripten cache
         id: cache-system-libraries
         uses: actions/cache@v4
@@ -63,16 +64,14 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1
       - name: Build examples (with cache)
         run: |
-          REPO_URL="${{ github.server_url }}/${{ github.repository }}"
-          COMMIT_REF="${{ github.sha }}"
-          ./scripts/build_html_examples.sh "$REPO_URL" "$COMMIT_REF"
+          ./scripts/build_html_examples.sh --symlink "${PWD}/lvgl"
       - name: Build docs
-        run: docs/build.py html
+        run: lvgl/docs/build.py html
       - name: Remove .doctrees
-        run: rm -rf docs/build/html/.doctrees
+        run: rm -rf lvgl/docs/build/html/.doctrees
       - name: Retrieve version
         run: |
-          echo "::set-output name=VERSION_NAME::$(scripts/find_version.sh)"
+          echo "::set-output name=VERSION_NAME::$(lvgl/scripts/find_version.sh)"
         id: version
       - name: Deploy to subfolder
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
@@ -81,7 +80,7 @@ jobs:
           token: ${{ secrets.LVGL_BOT_TOKEN }}
           repository-name: lvgl/docs
           branch: gh-pages # The branch the action should deploy to.
-          folder: docs/build/html  # The folder the action should deploy.
+          folder: lvgl/docs/build/html  # The folder the action should deploy.
           target-folder: ${{ steps.version.outputs.VERSION_NAME }}
           git-config-name: lvgl-bot
           git-config-email: lvgl-bot@users.noreply.github.com
@@ -93,7 +92,7 @@ jobs:
           token: ${{ secrets.LVGL_BOT_TOKEN }}
           repository-name: lvgl/docs
           branch: gh-pages # The branch the action should deploy to.
-          folder: docs/build/html  # The folder the action should deploy.
+          folder: lvgl/docs/build/html  # The folder the action should deploy.
           target-folder: master
           git-config-name: lvgl-bot
           git-config-email: lvgl-bot@users.noreply.github.com

--- a/.github/workflows/compile_docs.yml
+++ b/.github/workflows/compile_docs.yml
@@ -42,7 +42,7 @@ jobs:
             !${{ env.pythonLocation }}/bin/pip*
             !${{ env.pythonLocation }}/lib/python*/site-packages/pip*
             !${{ env.pythonLocation }}/lib/python*/site-packages/setuptools*
-          key: ${{ env.pythonLocation }}-${{ hashFiles('docs/requirements.txt') }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('lvgl/docs/requirements.txt') }}
       - name: Install Doxygen and Latex dependencies
         run: |
           sudo apt-get update

--- a/scripts/build_html_examples.sh
+++ b/scripts/build_html_examples.sh
@@ -12,7 +12,7 @@ export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
 rm -rf emscripten_builder
 git clone https://github.com/lvgl/lv_sim_emscripten.git emscripten_builder
 cd emscripten_builder
-if [ "$ARG_1" != "--symlink" ]
+if [ "$ARG_1" != "--symlink" ]; then
   REPO_URL="$ARG_1"
   COMMIT_REF="$ARG_2"
   git submodule update --init -- lvgl
@@ -28,7 +28,7 @@ else
   SYMLINK_TARGET="$ARG_2"
   echo "Using provided symbolic link to LVGL directory (should be absolute): $SYMLINK_TARGET"
   rmdir lvgl # remove the uninitialized submodule empty dir
-  symlink -s -T "$SYMLINK_TARGET" lvgl
+  ln -s -T "$SYMLINK_TARGET" lvgl
 fi
 
 cd lvgl

--- a/scripts/build_html_examples.sh
+++ b/scripts/build_html_examples.sh
@@ -11,7 +11,6 @@ ARG_2="${2:-}"
 export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
 rm -rf emscripten_builder
 git clone https://github.com/lvgl/lv_sim_emscripten.git emscripten_builder
-scripts/genexamplelist.sh > emscripten_builder/examplelist.c
 cd emscripten_builder
 if [ "$ARG_1" != "--symlink" ]
   REPO_URL="$ARG_1"
@@ -31,6 +30,10 @@ else
   rmdir lvgl # remove the uninitialized submodule empty dir
   symlink -s -T "$SYMLINK_TARGET" lvgl
 fi
+
+cd lvgl
+scripts/genexamplelist.sh > ../examplelist.c
+cd ..
 
 # Generate lv_conf
 LV_CONF_PATH=`pwd`/lvgl/configs/ci/docs/lv_conf_docs.h

--- a/scripts/build_html_examples.sh
+++ b/scripts/build_html_examples.sh
@@ -48,5 +48,10 @@ cd cmbuild
 emcmake cmake .. -DLV_BUILD_CONF_PATH=$LV_CONF_PATH -DLVGL_CHOSEN_DEMO=lv_example_noop -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 emmake make -j$(nproc)
 rm -rf CMakeFiles
-cd ../..
-cp -a emscripten_builder/cmbuild docs/src/_static/built_lv_examples
+cd ..
+if [ "$ARG_1" != "--symlink" ]; then
+  cp -a cmbuild ../docs/src/_static/built_lv_examples
+else
+  cp -a cmbuild lvgl/docs/src/_static/built_lv_examples
+fi
+cd ..

--- a/scripts/build_html_examples.sh
+++ b/scripts/build_html_examples.sh
@@ -5,28 +5,32 @@ set -e
 # These variables allow us to specify an alternate repository URL and commit reference
 # This is particularly useful when running in CI environments for pull requests
 # where we need to build from the contributor's forked repository
-REPO_URL="${1:-}"
-COMMIT_REF="${2:-}"
+ARG_1="${1:-}"
+ARG_2="${2:-}"
 
 export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
 rm -rf emscripten_builder
 git clone https://github.com/lvgl/lv_sim_emscripten.git emscripten_builder
 scripts/genexamplelist.sh > emscripten_builder/examplelist.c
 cd emscripten_builder
-git submodule update --init -- lvgl
-cd lvgl
-if [ -n "$REPO_URL" ] && [ -n "$COMMIT_REF" ]; then
-  echo "Using provided repo URL: $REPO_URL and commit ref: $COMMIT_REF for lvgl submodule"
-  git remote set-url origin "$REPO_URL"
-  git fetch origin
-  git fetch origin '+refs/pull/*:refs/remotes/origin/pull/*'
-  git checkout "$COMMIT_REF"
+if [ "$ARG_1" != "--symlink" ]
+  REPO_URL="$ARG_1"
+  COMMIT_REF="$ARG_2"
+  git submodule update --init -- lvgl
+  if [ -n "$REPO_URL" ] && [ -n "$COMMIT_REF" ]; then
+    cd lvgl
+    echo "Using provided repo URL: $REPO_URL and commit ref: $COMMIT_REF for lvgl submodule"
+    git remote set-url origin "$REPO_URL"
+    git fetch origin
+    git checkout "$COMMIT_REF"
+    cd ..
+  fi
 else
-  CURRENT_REF="$(git rev-parse HEAD)"
-  echo "Using current commit ref: $CURRENT_REF for lvgl"
-  git checkout "$CURRENT_REF"
+  SYMLINK_TARGET="$ARG_2"
+  echo "Using provided symbolic link to LVGL directory (should be absolute): $SYMLINK_TARGET"
+  rmdir lvgl # remove the uninitialized submodule empty dir
+  symlink -s -T "$SYMLINK_TARGET" lvgl
 fi
-cd ..
 
 # Generate lv_conf
 LV_CONF_PATH=`pwd`/lvgl/configs/ci/docs/lv_conf_docs.h


### PR DESCRIPTION
#8880 still did not fix PR docs CI.

Fails with:

```
 * [new ref]             refs/pull/988/head   -> origin/pull/988/head
 * [new ref]             refs/pull/994/head   -> origin/pull/994/head
 * [new ref]             refs/pull/996/head   -> origin/pull/996/head
 * [new ref]             refs/pull/998/head   -> origin/pull/998/head
fatal: unable to read tree (5b2d6c4c8c819c2d43aa2212f1584a10166e417d)
```

This PR attempts to fix it by using the LVGL that's already checked out by the github action.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
