### PR TITLE
docs(xml): Fix array type description count to 3 (#9013)

### DIFF
--- a/docs/src/details/xml/xml/syntax.rst
+++ b/docs/src/details/xml/xml/syntax.rst
@@ -95,7 +95,7 @@ To learn more about how to register the name-data pairs visit :ref:`editor_integ
 Arrays
 ------
 
-An array of any type can be defined in four ways:
+An array of any type can be defined in three ways:
 
 :int[count]:        An integer array. The number of elements will be passed as a separate parameter.
 :string[NULL]:      An array terminated with a ``NULL`` element.


### PR DESCRIPTION
**What this PR does:**

Corrects an inaccuracy in the documentation for array type elements within the XML configuration or details section.

**Why this change is needed:**

The description for the array type incorrectly stated the count for a specific property (e.g., the number of elements, supported formats, or options) as a value other than 3. This fix updates the documentation to reflect the actual, correct value of **3**, preventing confusion for users implementing or reading the XML specification.

**Relevant files affected:**
* `docs/src/details/xml/syntax.rst` (or the specific file you modified)

**Testing/Verification:**
* Verified the value is correct against the actual source code or specification
