### PR TITLE
feat(drm/egl): swap buffers in a separate thread

### DIFF
--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -1238,6 +1238,30 @@ int32_t lv_display_dpx(const lv_display_t * disp, int32_t n)
     return LV_DPX_CALC(lv_display_get_dpi(disp), n);
 }
 
+void lv_display_wait_for_flushing(lv_display_t * disp)
+{
+    LV_PROFILER_REFR_BEGIN;
+    LV_LOG_TRACE("begin");
+
+    lv_display_send_event(disp, LV_EVENT_FLUSH_WAIT_START, NULL);
+
+    if(disp->flush_wait_cb) {
+        if(disp->flushing) {
+            disp->flush_wait_cb(disp);
+            disp->flushing = 0;
+        }
+    }
+    else {
+        while(disp->flushing);
+    }
+    disp->flushing_last = 0;
+
+    lv_display_send_event(disp, LV_EVENT_FLUSH_WAIT_FINISH, NULL);
+
+    LV_LOG_TRACE("end");
+    LV_PROFILER_REFR_END;
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/display/lv_display_private.h
+++ b/src/display/lv_display_private.h
@@ -177,6 +177,8 @@ struct _lv_display_t {
  * GLOBAL PROTOTYPES
  **********************/
 
+void lv_display_wait_for_flushing(lv_display_t * disp);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/drivers/display/drm/lv_linux_drm_egl.c
+++ b/src/drivers/display/drm/lv_linux_drm_egl.c
@@ -25,11 +25,11 @@
 #include "../../opengles/lv_opengles_debug.h"
 
 #include "../../opengles/lv_opengles_driver.h"
-#include "../../opengles/lv_opengles_texture.h"
 #include "../../opengles/lv_opengles_private.h"
 
 #include "../../../stdlib/lv_string.h"
 #include "../../../display/lv_display.h"
+#include "../../../display/lv_display_private.h"
 
 /**********************
  *      TYPEDEFS
@@ -66,6 +66,10 @@ static void * drm_create_window(void * driver_data, const lv_egl_native_window_p
 static void drm_destroy_window(void * driver_data, void * native_window);
 static size_t drm_egl_select_config_cb(void * driver_data, const lv_egl_config_t * configs, size_t config_count);
 static inline void set_viewport(lv_display_t * display);
+
+static void * egl_update_thread_fn(void * arg);
+static void egl_update_thread_init(lv_drm_ctx_t * ctx);
+static void egl_update_thread_deinit(lv_drm_ctx_t * ctx);
 
 /**********************
  *  STATIC VARIABLES
@@ -137,8 +141,10 @@ void lv_linux_drm_set_file(lv_display_t * display, const char * file, int64_t co
     lv_display_set_flush_cb(display, flush_cb);
     lv_display_set_render_mode(display, LV_DISPLAY_RENDER_MODE_DIRECT);
 
+    lv_display_add_event_cb(ctx->display, event_cb, LV_EVENT_RENDER_START, NULL);
     lv_display_add_event_cb(ctx->display, event_cb, LV_EVENT_RESOLUTION_CHANGED, NULL);
     lv_display_add_event_cb(ctx->display, event_cb, LV_EVENT_DELETE, NULL);
+    egl_update_thread_init(ctx);
 }
 
 void lv_linux_drm_set_mode_cb(lv_display_t * disp, lv_linux_drm_select_mode_cb_t callback)
@@ -160,6 +166,7 @@ static void event_cb(lv_event_t * e)
     lv_event_code_t code = lv_event_get_code(e);
     lv_display_t * display = (lv_display_t *) lv_event_get_target(e);
     lv_drm_ctx_t * ctx = lv_display_get_driver_data(display);
+    lv_result_t res;
     switch(code) {
         case LV_EVENT_DELETE:
             if(ctx) {
@@ -167,12 +174,22 @@ static void event_cb(lv_event_t * e)
                 ctx->egl_ctx = NULL;
                 lv_opengles_texture_deinit(&ctx->texture);
                 drm_device_deinit(ctx);
+                egl_update_thread_deinit(ctx);
                 lv_display_set_driver_data(display, NULL);
             }
             break;
         case LV_EVENT_RESOLUTION_CHANGED:
             lv_opengles_texture_reshape(display, lv_display_get_horizontal_resolution(display),
                                         lv_display_get_vertical_resolution(display));
+            break;
+        case LV_EVENT_RENDER_START:
+            /* We need to wait for the swap thread to finish displaying the previous frame
+            * So that we can bind the context to the current thread.
+            * In case the we need opengl to draw (see opengl draw unit),
+            * it will expect the context to be bound to the current thread*/
+            lv_display_wait_for_flushing(display);
+            res = lv_opengles_egl_bind_current_context(ctx->egl_ctx);
+            LV_ASSERT_MSG(res == LV_RESULT_OK, "Failed to bind current EGL context");
             break;
         default:
             return;
@@ -207,13 +224,20 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_m
 {
     LV_UNUSED(area);
     LV_UNUSED(px_map);
-    if(lv_display_flush_is_last(disp)) {
-        set_viewport(disp);
-        lv_drm_ctx_t * ctx = lv_display_get_driver_data(disp);
-        lv_opengles_render_display_texture(disp, false, true);
-        lv_opengles_egl_update(ctx->egl_ctx);
+    if(!lv_display_flush_is_last(disp)) {
+        lv_display_flush_ready(disp);
+        return;
     }
-    lv_display_flush_ready(disp);
+    lv_drm_ctx_t * ctx = lv_display_get_driver_data(disp);
+
+    /* The current context is set in the RENDER_START event so we don't need to do it here*/
+    set_viewport(disp);
+    lv_opengles_render_display_texture(disp, false, true);
+
+    /* Unbind the current context so that it can be bound in the update thread*/
+    lv_result_t res = lv_opengles_egl_unbind_current_context(ctx->egl_ctx);
+    LV_ASSERT_MSG(res == LV_RESULT_OK, "Failed to unbind current EGL context");
+    sem_post(&ctx->egl_update_thread.update_semaphore);
 }
 
 #else
@@ -222,34 +246,42 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_m
 {
     LV_UNUSED(px_map);
     LV_UNUSED(area);
-    if(lv_display_flush_is_last(disp)) {
-        lv_drm_ctx_t * ctx = lv_display_get_driver_data(disp);
-        int32_t disp_width = lv_display_get_horizontal_resolution(disp);
-        int32_t disp_height = lv_display_get_vertical_resolution(disp);
 
-        set_viewport(disp);
+    if(!lv_display_flush_is_last(disp)) {
+        lv_display_flush_ready(disp);
+        return;
+    }
 
-        lv_color_format_t cf = lv_display_get_color_format(disp);
-        uint32_t stride = lv_draw_buf_width_to_stride(lv_display_get_horizontal_resolution(disp), cf);
-        GL_CALL(glBindTexture(GL_TEXTURE_2D, ctx->texture.texture_id));
+    lv_drm_ctx_t * ctx = lv_display_get_driver_data(disp);
+    int32_t disp_width = lv_display_get_horizontal_resolution(disp);
+    int32_t disp_height = lv_display_get_vertical_resolution(disp);
 
-        GL_CALL(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
-        GL_CALL(glPixelStorei(GL_UNPACK_ROW_LENGTH, stride / lv_color_format_get_size(cf)));
-        /*Color depth: 16 (RGB565), 32 (ARGB8888)*/
+    /* The current context is set in the RENDER_START event so we don't need to do it here*/
+    set_viewport(disp);
+
+    lv_color_format_t cf = lv_display_get_color_format(disp);
+    uint32_t stride = lv_draw_buf_width_to_stride(lv_display_get_horizontal_resolution(disp), cf);
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, ctx->texture.texture_id));
+
+    GL_CALL(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
+    GL_CALL(glPixelStorei(GL_UNPACK_ROW_LENGTH, stride / lv_color_format_get_size(cf)));
+    /*Color depth: 16 (RGB565), 32 (ARGB8888)*/
 #if LV_COLOR_DEPTH == 16
-        GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB565, disp_width, disp_height, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5,
-                             ctx->texture.fb1));
+    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB565, disp_width, disp_height, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5,
+                         ctx->texture.fb1));
 #elif LV_COLOR_DEPTH == 32
-        GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, disp_width, disp_height, 0, GL_BGRA, GL_UNSIGNED_BYTE,
-                             ctx->texture.fb1));
+    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, disp_width, disp_height, 0, GL_BGRA, GL_UNSIGNED_BYTE,
+                         ctx->texture.fb1));
 #else
 #error("Unsupported color format")
 #endif
 
-        lv_opengles_render_display_texture(disp, false, false);
-        lv_opengles_egl_update(ctx->egl_ctx);
-    }
-    lv_display_flush_ready(disp);
+    lv_opengles_render_display_texture(disp, false, false);
+
+    /* Unbind the current context so that it can be bound in the update thread*/
+    lv_result_t res = lv_opengles_egl_unbind_current_context(ctx->egl_ctx);
+    LV_ASSERT_MSG(res == LV_RESULT_OK, "Failed to unbind current EGL context");
+    sem_post(&ctx->egl_update_thread.update_semaphore);
 }
 #endif
 
@@ -742,5 +774,39 @@ static void drm_destroy_window(void * driver_data, void * native_window)
     ctx->gbm_surface = NULL;
 }
 
+static void * egl_update_thread_fn(void * arg)
+{
+    lv_drm_ctx_t * ctx = (lv_drm_ctx_t *)arg;
+    while(!ctx->egl_update_thread.should_exit) {
+        sem_wait(&ctx->egl_update_thread.update_semaphore);
+        if(ctx->egl_update_thread.should_exit) {
+            LV_LOG_INFO("EGL update thread exiting");
+            break;
+        }
+        lv_result_t res = lv_opengles_egl_bind_current_context(ctx->egl_ctx);
+        LV_ASSERT_MSG(res == LV_RESULT_OK, "Failed to bind current EGL context");
+        lv_opengles_egl_update(ctx->egl_ctx);
+        res = lv_opengles_egl_unbind_current_context(ctx->egl_ctx);
+        LV_ASSERT_MSG(res == LV_RESULT_OK, "Failed to unbind current EGL context");
+        lv_display_flush_ready(ctx->display);
+    }
+    return NULL;
+}
+
+static void egl_update_thread_init(lv_drm_ctx_t * ctx)
+{
+    ctx->egl_update_thread.should_exit = false;
+    sem_init(&ctx->egl_update_thread.update_semaphore, 0, 0);
+
+    pthread_create(&ctx->egl_update_thread.thread, NULL, egl_update_thread_fn, ctx);
+}
+
+static void egl_update_thread_deinit(lv_drm_ctx_t * ctx)
+{
+    ctx->egl_update_thread.should_exit = true;
+    sem_post(&ctx->egl_update_thread.update_semaphore);
+    pthread_join(ctx->egl_update_thread.thread, NULL);
+    sem_destroy(&ctx->egl_update_thread.update_semaphore);
+}
 
 #endif /*LV_USE_LINUX_DRM && LV_LINUX_DRM_USE_EGL*/

--- a/src/drivers/display/drm/lv_linux_drm_egl_private.h
+++ b/src/drivers/display/drm/lv_linux_drm_egl_private.h
@@ -24,6 +24,8 @@ extern "C" {
 #include "../../opengles/lv_opengles_egl.h"
 #include "../../opengles/lv_opengles_egl_private.h"
 #include "lv_linux_drm.h"
+#include <pthread.h>
+#include <semaphore.h>
 
 /*********************
  *      DEFINES
@@ -32,6 +34,13 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
+
+typedef struct {
+    /* TODO: Once we make sure OS_PTHREAD is stable we need to use lvgl's API for this*/
+    pthread_t thread;
+    sem_t update_semaphore;
+    volatile bool should_exit;
+} lv_drm_egl_update_thread_t;
 
 typedef struct {
     lv_opengles_texture_t texture;
@@ -51,6 +60,7 @@ typedef struct {
     struct gbm_bo * gbm_bo_flipped;
     struct gbm_bo * gbm_bo_presented;
 
+    lv_drm_egl_update_thread_t egl_update_thread;
     lv_linux_drm_select_mode_cb_t mode_select_cb;
     int fd;
     bool crtc_isset;

--- a/src/drivers/display/drm/lv_linux_drm_egl_private.h
+++ b/src/drivers/display/drm/lv_linux_drm_egl_private.h
@@ -39,6 +39,7 @@ typedef struct {
     /* TODO: Once we make sure OS_PTHREAD is stable we need to use lvgl's API for this*/
     pthread_t thread;
     sem_t update_semaphore;
+    sem_t update_complete_semaphore;
     volatile bool should_exit;
 } lv_drm_egl_update_thread_t;
 

--- a/src/drivers/opengles/lv_opengles_egl.c
+++ b/src/drivers/opengles/lv_opengles_egl.c
@@ -131,6 +131,17 @@ void lv_opengles_egl_update(lv_opengles_egl_t * ctx)
     ctx->interface.flip_cb(ctx->interface.driver_data, ctx->vsync);
 }
 
+lv_result_t lv_opengles_egl_bind_current_context(lv_opengles_egl_t * ctx)
+{
+    return eglMakeCurrent(ctx->egl_display, ctx->egl_surface, ctx->egl_surface,
+                          ctx->egl_context) ? LV_RESULT_OK : LV_RESULT_INVALID;
+}
+lv_result_t lv_opengles_egl_unbind_current_context(lv_opengles_egl_t * ctx)
+{
+    return eglMakeCurrent(ctx->egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE,
+                          EGL_NO_CONTEXT) ? LV_RESULT_OK : LV_RESULT_INVALID;
+}
+
 
 /**********************
 *   STATIC FUNCTIONS

--- a/src/drivers/opengles/lv_opengles_egl.h
+++ b/src/drivers/opengles/lv_opengles_egl.h
@@ -44,6 +44,9 @@ void lv_opengles_egl_update(lv_opengles_egl_t * ctx);
 void lv_opengles_egl_clear(lv_opengles_egl_t * ctx);
 void lv_opengles_egl_context_destroy(lv_opengles_egl_t * ctx);
 
+lv_result_t lv_opengles_egl_bind_current_context(lv_opengles_egl_t * ctx);
+lv_result_t lv_opengles_egl_unbind_current_context(lv_opengles_egl_t * ctx);
+
 /**********************
  *      MACROS
  **********************/


### PR DESCRIPTION
While working on https://github.com/lvgl/lvgl/pull/9029, I noticed that the flush cb time was capped at 30ms, after measuring it, I realized it was the `eglSwapBuffers` call that was taking most of the time. This is because the GPU is probably stalling so it syncs with the display

Instead of waiting for it to swap buffers before quitting the flush callback, we can dispatch it to a separate thread instead, if the `LV_DEF_REFR_PERIOD` is big enough, the swap will be done in the background and everything will be ready for the next frame render without having to block

Using `LV_EVENT_REFR_START` we can also make sure that the context is again bound to the main LVGL thread so that draw units can do GPU operations if required

With `LV_DEF_REFR_PERIOD` set to 33, i now have these results on the imx8 1920x1080 RGB565 (with #9029 also factored in):

```
Benchmark Summary (9.4.0 dev)
Name, Avg. CPU, Avg. FPS, Avg. time, render time, flush time
Empty screen, 8%, 26, 11, 1, 10
Moving wallpaper, 19%, 29, 14, 7, 7
Single rectangle, 6%, 29, 6, 0, 6
Multiple rectangles, 7%, 29, 10, 4, 6
Multiple RGB images, 11%, 29, 8, 2, 6
Multiple ARGB images, 14%, 30, 10, 4, 6
Rotated ARGB images, 28%, 30, 16, 10, 6
Multiple labels, 17%, 29, 11, 5, 6
Screen sized text, 33%, 29, 17, 12, 5
Multiple arcs, 19%, 29, 12, 6, 6
Containers, 14%, 29, 14, 8, 6
Containers with overlay, 32%, 29, 18, 12, 6
Containers with opa, 18%, 30, 15, 9, 6
Containers with opa_layer, 21%, 30, 18, 12, 6
Containers with scrolling, 26%, 30, 15, 9, 6
Widgets demo, 16%, 29, 12, 7, 5
All scenes avg.,18%, 29, 12, 6, 6
```