### PR TITLE
feat(text): reintroduce lv_text_get_size without attributes

### DIFF
--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -228,11 +228,7 @@ static void multiple_labels_cb(void)
 #endif
 
     lv_point_t s;
-    lv_text_attributes_t attributes;
-    lv_text_attributes_init(&attributes);
-    attributes.max_width = LV_COORD_MAX;
-
-    lv_text_get_size(&s, "Hello LVGL!", lv_obj_get_style_text_font(scr, 0), &attributes);
+    lv_text_get_size(&s, "Hello LVGL!", lv_obj_get_style_text_font(scr, 0), 0, 0, LV_COORD_MAX, LV_TEXT_FLAG_NONE);
 
     int32_t hor_cnt = ((int32_t)lv_obj_get_content_width(scr)) / (s.x * 3 / 2);
     int32_t ver_cnt = ((int32_t)lv_obj_get_content_height(scr)) / (s.y  * 3);

--- a/demos/widgets/lv_demo_widgets_analytics.c
+++ b/demos/widgets/lv_demo_widgets_analytics.c
@@ -668,12 +668,8 @@ static void chart_event_cb(lv_event_t * e)
             char buf[8];
             lv_snprintf(buf, sizeof(buf), "%"LV_PRId32, lv_chart_get_series_y_array(obj, (lv_chart_series_t *)ser)[base_dsc->id2]);
 
-            lv_text_attributes_t attributes;
-            lv_text_attributes_init(&attributes);
-            attributes.max_width = LV_COORD_MAX;
-            attributes.text_flags = LV_TEXT_FLAG_NONE;
             lv_point_t text_size;
-            lv_text_get_size(&text_size, buf, font_normal, &attributes);
+            lv_text_get_size(&text_size, buf, font_normal, 0, 0, LV_COORD_MAX, LV_TEXT_FLAG_NONE);
 
             lv_area_t txt_area;
             lv_area_t draw_task_area;

--- a/demos/widgets/lv_demo_widgets_profile.c
+++ b/demos/widgets/lv_demo_widgets_profile.c
@@ -457,12 +457,8 @@ static void slider_event_cb(lv_event_t * e)
             char buf[8];
             lv_snprintf(buf, sizeof(buf), "%"LV_PRId32, lv_slider_get_value(obj));
 
-            lv_text_attributes_t attributes;
-            lv_text_attributes_init(&attributes);
-            attributes.max_width = LV_COORD_MAX;
-            attributes.text_flags = LV_TEXT_FLAG_NONE;
             lv_point_t text_size;
-            lv_text_get_size(&text_size, buf, font_normal, &attributes);
+            lv_text_get_size(&text_size, buf, font_normal, 0, 0, LV_COORD_MAX, LV_TEXT_FLAG_NONE);
 
             lv_area_t txt_area;
             lv_area_t draw_task_area;

--- a/examples/widgets/bar/lv_example_bar_6.c
+++ b/examples/widgets/bar/lv_example_bar_6.c
@@ -20,14 +20,9 @@ static void event_cb(lv_event_t * e)
     char buf[8];
     lv_snprintf(buf, sizeof(buf), "%d", (int)lv_bar_get_value(obj));
 
-    lv_text_attributes_t attributes = {0};
-    attributes.letter_space = label_dsc.letter_space;
-    attributes.line_space = label_dsc.line_space;
-    attributes.max_width = LV_COORD_MAX;
-    attributes.text_flags = label_dsc.flag;
-
     lv_point_t txt_size;
-    lv_text_get_size(&txt_size, buf, label_dsc.font, &attributes);
+    lv_text_get_size(&txt_size, buf, label_dsc.font, label_dsc.letter_space, label_dsc.line_space, LV_COORD_MAX,
+                     label_dsc.flag);
 
     lv_area_t txt_area;
     txt_area.x1 = 0;

--- a/examples/widgets/scale/lv_example_scale_7.c
+++ b/examples/widgets/scale/lv_example_scale_7.c
@@ -33,15 +33,8 @@ static void draw_event_cb(lv_event_t * e)
             label_draw_dsc->text = lv_strdup(tmp_buffer);
             label_draw_dsc->text_local = 1;
 
-            lv_text_attributes_t attributes = {0};
             lv_point_t size;
-
-            attributes.text_flags = LV_TEXT_FLAG_NONE;
-            attributes.letter_space = 0;
-            attributes.line_space = 0;
-            attributes.max_width = 1000;
-
-            lv_text_get_size(&size, label_draw_dsc->text, label_draw_dsc->font, &attributes);
+            lv_text_get_size(&size, label_draw_dsc->text, label_draw_dsc->font, 0, 0, 1000, LV_TEXT_FLAG_NONE);
             int32_t new_w = size.x;
             int32_t old_w = lv_area_get_width(&draw_task->area);
 

--- a/examples/widgets/slider/lv_example_slider_3.c
+++ b/examples/widgets/slider/lv_example_slider_3.c
@@ -46,14 +46,8 @@ static void slider_event_cb(lv_event_t * e)
         char buf[16];
         lv_snprintf(buf, sizeof(buf), "%d - %d", (int)lv_slider_get_left_value(obj), (int)lv_slider_get_value(obj));
 
-        lv_text_attributes_t attributes = {0};
-        attributes.text_flags = LV_TEXT_FLAG_NONE;
-        attributes.max_width = LV_COORD_MAX;
-        attributes.letter_space = 0;
-        attributes.line_space = 0;
-
         lv_point_t label_size;
-        lv_text_get_size(&label_size, buf, LV_FONT_DEFAULT, &attributes);
+        lv_text_get_size(&label_size, buf, LV_FONT_DEFAULT, 0, 0, LV_COORD_MAX, LV_TEXT_FLAG_NONE);
         lv_area_t label_area;
         label_area.x1 = 0;
         label_area.x2 = label_size.x - 1;

--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -233,7 +233,7 @@ void lv_draw_label_iterate_characters(lv_draw_task_t * t, const lv_draw_label_ds
             attributes.text_flags = dsc->flag;
 
             lv_point_t p;
-            lv_text_get_size(&p, dsc->text, dsc->font, &attributes);
+            lv_text_get_size_attrs(&p, dsc->text, dsc->font, &attributes);
             w = p.x;
         }
     }

--- a/src/draw/lv_draw_rect.c
+++ b/src/draw/lv_draw_rect.c
@@ -282,7 +282,7 @@ void lv_draw_rect(lv_layer_t * layer, const lv_draw_rect_dsc_t * dsc, const lv_a
                 attributes.line_space = 0;
                 attributes.letter_space = 0;
 
-                lv_text_get_size(&s, dsc->bg_image_src, dsc->bg_image_symbol_font, &attributes);
+                lv_text_get_size_attrs(&s, dsc->bg_image_src, dsc->bg_image_symbol_font, &attributes);
 
                 lv_area_t a = {0, 0, s.x - 1, s.y - 1};
                 lv_area_align(coords, &a, LV_ALIGN_CENTER, 0, 0);

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_label.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_label.c
@@ -436,7 +436,7 @@ static void _draw_label_iterate_characters(lv_draw_task_t * t, const lv_draw_lab
     else {
         /*If EXPAND is enabled then not limit the text's width to the object's width*/
         lv_point_t p;
-        lv_text_get_size(&p, dsc->text, dsc->font, &attributes);
+        lv_text_get_size_attrs(&p, dsc->text, dsc->font, &attributes);
         attributes.max_width = p.x;
     }
 

--- a/src/draw/nxp/pxp/lv_draw_pxp.c
+++ b/src/draw/nxp/pxp/lv_draw_pxp.c
@@ -429,7 +429,7 @@ static void _pxp_execute_drawing(lv_draw_pxp_unit_t * u)
         lv_draw_sw_fill((lv_draw_unit_t *)u, &rect_dsc, &draw_area);
 
         lv_point_t txt_size;
-        lv_text_get_size(&txt_size, "W", LV_FONT_DEFAULT, 0, 0, 100, LV_TEXT_FLAG_NONE);
+        lv_text_get_size_attrs(&txt_size, "W", LV_FONT_DEFAULT, 0, 0, 100, LV_TEXT_FLAG_NONE);
 
         lv_area_t txt_area;
         txt_area.x1 = draw_area.x1;

--- a/src/draw/nxp/pxp/lv_draw_pxp_layer.c
+++ b/src/draw/nxp/pxp/lv_draw_pxp_layer.c
@@ -131,7 +131,7 @@ void lv_draw_pxp_layer(lv_draw_task_t * t)
     lv_draw_sw_border(t, &border_dsc, &area_rot);
 
     lv_point_t txt_size;
-    lv_text_get_size(&txt_size, "W", LV_FONT_DEFAULT, 0, 0, 100, LV_TEXT_FLAG_NONE);
+    lv_text_get_size_attrs(&txt_size, "W", LV_FONT_DEFAULT, 0, 0, 100, LV_TEXT_FLAG_NONE);
 
     lv_area_t txt_area;
     txt_area.x1 = draw_area.x1;

--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -460,7 +460,7 @@ static void parallel_debug_draw(lv_draw_task_t * t, uint32_t idx)
         lv_draw_sw_border(t, &border_dsc, &draw_area);
 
         lv_point_t txt_size;
-        lv_text_get_size(&txt_size, "W", LV_FONT_DEFAULT, &attributes);
+        lv_text_get_size_attrs(&txt_size, "W", LV_FONT_DEFAULT, &attributes);
 
         lv_area_t txt_area;
         txt_area.x1 = draw_area.x1;

--- a/src/draw/sw/lv_draw_sw_img.c
+++ b/src/draw/sw/lv_draw_sw_img.c
@@ -178,7 +178,7 @@ void lv_draw_sw_layer(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc, 
         lv_draw_sw_border(t, &border_dsc, &area_rot);
 
         lv_point_t txt_size;
-        lv_text_get_size(&txt_size, "W", LV_FONT_DEFAULT, 0, 0, 100, LV_TEXT_FLAG_NONE);
+        lv_text_get_size_attrs(&txt_size, "W", LV_FONT_DEFAULT, 0, 0, 100, LV_TEXT_FLAG_NONE);
 
         lv_area_t txt_area;
         txt_area.x1 = draw_area.x1;

--- a/src/misc/lv_text.c
+++ b/src/misc/lv_text.c
@@ -93,8 +93,20 @@ void lv_text_attributes_init(lv_text_attributes_t * attributes)
     lv_memzero(attributes, sizeof(lv_text_attributes_t));
 }
 
-void lv_text_get_size(lv_point_t * size_res, const char * text, const lv_font_t * font,
-                      lv_text_attributes_t * attributes)
+void lv_text_get_size(lv_point_t * size_res, const char * text, const lv_font_t * font, int32_t letter_space,
+                      int32_t line_space, int32_t max_width, lv_text_flag_t flag)
+{
+    lv_text_attributes_t attrs;
+    lv_text_attributes_init(&attrs);
+    attrs.line_space = line_space;
+    attrs.max_width = max_width;
+    attrs.text_flags = flag;
+    attrs.letter_space = letter_space;
+    lv_text_get_size_attrs(size_res, text, font, &attrs);
+}
+
+void lv_text_get_size_attrs(lv_point_t * size_res, const char * text, const lv_font_t * font,
+                            lv_text_attributes_t * attributes)
 {
     uint32_t line_start     = 0;
     uint32_t new_line_start = 0;

--- a/src/misc/lv_text.h
+++ b/src/misc/lv_text.h
@@ -14,31 +14,15 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "../lv_conf_internal.h"
-
 #include "lv_types.h"
-#include "lv_area.h"
-#include "../font/lv_font.h"
-#include "../stdlib/lv_sprintf.h"
 
 /*********************
  *      DEFINES
  *********************/
-#ifndef LV_TXT_COLOR_CMD
-#define LV_TXT_COLOR_CMD "#"
-#endif
-
-#define LV_TXT_ENC_UTF8 1
-#define LV_TXT_ENC_ASCII 2
-
-#define LV_TEXT_LEN_MAX UINT32_MAX
 
 /**********************
  *      TYPEDEFS
  **********************/
-
-/**
- * Options for text rendering.
- */
 
 typedef enum {
     LV_TEXT_FLAG_NONE      = 0x00,
@@ -60,47 +44,22 @@ typedef enum {
 
 } lv_text_flag_t;
 
-/** Label align policy*/
-typedef enum {
-    LV_TEXT_ALIGN_AUTO, /**< Align text auto*/
-    LV_TEXT_ALIGN_LEFT, /**< Align text to left*/
-    LV_TEXT_ALIGN_CENTER, /**< Align text to center*/
-    LV_TEXT_ALIGN_RIGHT, /**< Align text to right*/
-} lv_text_align_t;
-
-/** State machine for text renderer. */
-typedef enum {
-    LV_TEXT_CMD_STATE_WAIT, /**< Waiting for command*/
-    LV_TEXT_CMD_STATE_PAR,  /**< Processing the parameter*/
-    LV_TEXT_CMD_STATE_IN,   /**< Processing the command*/
-} lv_text_cmd_state_t;
-
-typedef struct {
-    int32_t letter_space;   /**< Letter space between letters*/
-    int32_t line_space;     /**< Space between lines of text*/
-    int32_t max_width;      /**< Max width of the text (break the lines to fit this size). Set COORD_MAX to avoid*/
-    lv_text_flag_t text_flags;
-} lv_text_attributes_t;
-
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
-
-/**
- * Initialize the text attributes descriptor
- * @param attributes the text attributes descriptor to initialize
- */
-void lv_text_attributes_init(lv_text_attributes_t * attributes);
 
 /**
  * Get size of a text
  * @param size_res pointer to a 'point_t' variable to store the result
  * @param text pointer to a text
  * @param font pointer to font of the text
- * @param attributes the text attributes, flags for line break behaviour, spacing etc
+ * @param letter_space letter space of the text
+ * @param line_space line space of the text
+ * @param max_width max width of the text (break the lines to fit this size). Set COORD_MAX to avoid
+ * @param flag settings for the text from ::lv_text_flag_t
  */
-void lv_text_get_size(lv_point_t * size_res, const char * text, const lv_font_t * font,
-                      lv_text_attributes_t * attributes);
+void lv_text_get_size(lv_point_t * size_res, const char * text, const lv_font_t * font, int32_t letter_space,
+                      int32_t line_space, int32_t max_width, lv_text_flag_t flag);
 
 /**********************
  *      MACROS

--- a/src/misc/lv_text_private.h
+++ b/src/misc/lv_text_private.h
@@ -20,14 +20,64 @@ extern "C" {
  *      DEFINES
  *********************/
 
+#ifndef LV_TXT_COLOR_CMD
+#define LV_TXT_COLOR_CMD "#"
+#endif
+
+#define LV_TXT_ENC_UTF8 1
+#define LV_TXT_ENC_ASCII 2
+
+#define LV_TEXT_LEN_MAX UINT32_MAX
+
 /**********************
  *      TYPEDEFS
  **********************/
+
+/**
+ * Options for text rendering.
+ */
+/** Label align policy*/
+typedef enum {
+    LV_TEXT_ALIGN_AUTO, /**< Align text auto*/
+    LV_TEXT_ALIGN_LEFT, /**< Align text to left*/
+    LV_TEXT_ALIGN_CENTER, /**< Align text to center*/
+    LV_TEXT_ALIGN_RIGHT, /**< Align text to right*/
+} lv_text_align_t;
+
+/** State machine for text renderer. */
+typedef enum {
+    LV_TEXT_CMD_STATE_WAIT, /**< Waiting for command*/
+    LV_TEXT_CMD_STATE_PAR,  /**< Processing the parameter*/
+    LV_TEXT_CMD_STATE_IN,   /**< Processing the command*/
+} lv_text_cmd_state_t;
+
+typedef struct {
+    int32_t letter_space;   /**< Letter space between letters*/
+    int32_t line_space;     /**< Space between lines of text*/
+    int32_t max_width;      /**< Max width of the text (break the lines to fit this size). Set COORD_MAX to avoid*/
+    lv_text_flag_t text_flags;
+} lv_text_attributes_t;
+
 
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
 
+/**
+ * Initialize the text attributes descriptor
+ * @param attributes the text attributes descriptor to initialize
+ */
+void lv_text_attributes_init(lv_text_attributes_t * attributes);
+
+/**
+ * Get size of a text
+ * @param size_res pointer to a 'point_t' variable to store the result
+ * @param text pointer to a text
+ * @param font pointer to font of the text
+ * @param attributes the text attributes, flags for line break behaviour, spacing etc
+ */
+void lv_text_get_size_attrs(lv_point_t * size_res, const char * text, const lv_font_t * font,
+                            lv_text_attributes_t * attributes);
 /**
  * Give the length of a text with a given font with text flags
  * @param txt a '\0' terminate string

--- a/src/widgets/buttonmatrix/lv_buttonmatrix.c
+++ b/src/widgets/buttonmatrix/lv_buttonmatrix.c
@@ -734,7 +734,7 @@ static void draw_main(lv_event_t * e)
         attributes.max_width = lv_area_get_width(&area_obj);
 
         lv_point_t txt_size;
-        lv_text_get_size(&txt_size, txt, font, &attributes);
+        lv_text_get_size_attrs(&txt_size, txt, font, &attributes);
 
         btn_area.x1 += (lv_area_get_width(&btn_area) - txt_size.x) / 2;
         btn_area.y1 += (lv_area_get_height(&btn_area) - txt_size.y) / 2;

--- a/src/widgets/checkbox/lv_checkbox.c
+++ b/src/widgets/checkbox/lv_checkbox.c
@@ -192,7 +192,7 @@ static void lv_checkbox_event(const lv_obj_class_t * class_p, lv_event_t * e)
 
         lv_point_t txt_size;
 
-        lv_text_get_size(&txt_size, cb->txt, font, &attributes);
+        lv_text_get_size_attrs(&txt_size, cb->txt, font, &attributes);
 
         int32_t bg_colp = lv_obj_get_style_pad_column(obj, LV_PART_MAIN);
         int32_t marker_leftp = lv_obj_get_style_pad_left(obj, LV_PART_INDICATOR);
@@ -270,7 +270,7 @@ static void lv_checkbox_draw(lv_event_t * e)
     attributes.max_width = LV_COORD_MAX;
 
     lv_point_t txt_size;
-    lv_text_get_size(&txt_size, cb->txt, font, &attributes);
+    lv_text_get_size_attrs(&txt_size, cb->txt, font, &attributes);
 
     lv_draw_label_dsc_t txt_dsc;
     lv_draw_label_dsc_init(&txt_dsc);

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -926,7 +926,7 @@ static void draw_main(lv_event_t * e)
             attributes.max_width = LV_COORD_MAX;
             attributes.text_flags = symbol_dsc.flag;
 
-            lv_text_get_size(&size, dropdown->symbol, symbol_dsc.font, &attributes);
+            lv_text_get_size_attrs(&size, dropdown->symbol, symbol_dsc.font, &attributes);
             symbol_w = size.x;
             symbol_h = size.y;
         }
@@ -983,7 +983,7 @@ static void draw_main(lv_event_t * e)
     attributes.text_flags = label_dsc.flag;
 
     lv_point_t size;
-    lv_text_get_size(&size, opt_txt, label_dsc.font, &attributes);
+    lv_text_get_size_attrs(&size, opt_txt, label_dsc.font, &attributes);
 
     lv_area_t txt_area;
     txt_area.x1 = obj->coords.x1 + left;

--- a/src/widgets/image/lv_image.c
+++ b/src/widgets/image/lv_image.c
@@ -248,7 +248,7 @@ void lv_image_set_src(lv_obj_t * obj, const void * src)
         attributes.text_flags = LV_TEXT_FLAG_NONE;
 
         lv_point_t size;
-        lv_text_get_size(&size, src, font, &attributes);
+        lv_text_get_size_attrs(&size, src, font, &attributes);
         header.w = size.x;
         header.h = size.y;
     }
@@ -951,7 +951,7 @@ static void draw_image(lv_event_t * e)
                 attributes.max_width = LV_COORD_MAX;
                 attributes.text_flags = LV_TEXT_FLAG_NONE;
 
-                lv_text_get_size(&text_size, label_dsc.text, label_dsc.font, &attributes);
+                lv_text_get_size_attrs(&text_size, label_dsc.text, label_dsc.font, &attributes);
                 lv_area_set(&aligned_coords, 0, 0, text_size.x, text_size.y);
                 lv_area_align(&obj->coords, &aligned_coords, img->align, img->offset.x, img->offset.y);
                 coords = &aligned_coords;

--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -843,7 +843,7 @@ static void lv_label_event(const lv_obj_class_t * class_p, lv_event_t * e)
             attributes.text_flags = flag;
             attributes.max_width = w;
 
-            lv_text_get_size(&label->size_cache, label->text, font, &attributes);
+            lv_text_get_size_attrs(&label->size_cache, label->text, font, &attributes);
             lv_label_set_dots(obj, dot_begin);
 
             label->size_cache.y = LV_MIN(label->size_cache.y, lv_obj_get_style_max_height(obj, LV_PART_MAIN));
@@ -1088,7 +1088,7 @@ static void lv_label_refr_text(lv_obj_t * obj)
     lv_point_t size;
 
     lv_label_revert_dots(obj);
-    lv_text_get_size(&size, label->text, font, &attributes);
+    lv_text_get_size_attrs(&size, label->text, font, &attributes);
     label->text_size = size;
 
     lv_obj_refresh_self_size(obj);

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -593,7 +593,7 @@ static void draw_main(lv_event_t * e)
 
             /*Get the size of the "selected text"*/
             lv_point_t label_sel_size;
-            lv_text_get_size(&label_sel_size, lv_label_get_text(label), label_dsc.font, &attributes);
+            lv_text_get_size_attrs(&label_sel_size, lv_label_get_text(label), label_dsc.font, &attributes);
 
             /*Move the selected label proportionally with the background label*/
             int32_t roller_h = lv_obj_get_height(obj);
@@ -908,7 +908,7 @@ static int32_t get_selected_label_width(const lv_obj_t * obj)
 
     const char * txt = lv_label_get_text(label);
     lv_point_t size;
-    lv_text_get_size(&size, txt, font, &attributes);
+    lv_text_get_size_attrs(&size, txt, font, &attributes);
     return size.x;
 }
 

--- a/src/widgets/scale/lv_scale.c
+++ b/src/widgets/scale/lv_scale.c
@@ -1326,7 +1326,7 @@ static void scale_get_label_coords(lv_obj_t * obj, lv_draw_label_dsc_t * label_d
     lv_point_t label_size;
 
     if(label_dsc->text != NULL) {
-        lv_text_get_size(&label_size, label_dsc->text, label_dsc->font, &attributes);
+        lv_text_get_size_attrs(&label_size, label_dsc->text, label_dsc->font, &attributes);
     }
     else {
         label_size.x = 0;

--- a/src/widgets/table/lv_table.c
+++ b/src/widgets/table/lv_table.c
@@ -828,7 +828,7 @@ static void draw_main(lv_event_t * e)
                     label_dsc_act.flag |= LV_TEXT_FLAG_EXPAND;
                 }
 
-                lv_text_get_size(&txt_size, table->cell_data[cell]->txt, label_dsc_def.font, &attributes);
+                lv_text_get_size_attrs(&txt_size, table->cell_data[cell]->txt, label_dsc_def.font, &attributes);
 
                 /*Align the content to the middle if not cropped*/
                 if(!crop) {
@@ -973,7 +973,7 @@ static int32_t get_row_height(lv_obj_t * obj, uint32_t row_id, const lv_font_t *
             lv_point_t txt_size;
             attributes.max_width -= cell_left + cell_right;
 
-            lv_text_get_size(&txt_size, table->cell_data[cell]->txt, font, &attributes);
+            lv_text_get_size_attrs(&txt_size, table->cell_data[cell]->txt, font, &attributes);
 
             h_max = LV_MAX(txt_size.y + cell_top + cell_bottom, h_max);
             /*Skip until one element after the last merged column*/

--- a/tests/src/test_cases/widgets/test_chart.c
+++ b/tests/src/test_cases/widgets/test_chart.c
@@ -135,7 +135,7 @@ static void chart_event_cb(lv_event_t * e)
         attributes.max_width = LV_COORD_MAX;
         attributes.text_flags = LV_TEXT_FLAG_NONE;
 
-        lv_text_get_size(&text_size, buf, LV_FONT_DEFAULT, &attributes);
+        lv_text_get_size_attrs(&text_size, buf, LV_FONT_DEFAULT, &attributes);
 
         lv_area_t txt_area;
         txt_area.x1 = draw_task->area.x1 + lv_area_get_width(&draw_task->area) / 2 - text_size.x / 2;

--- a/tests/src/test_cases/widgets/test_scale.c
+++ b/tests/src/test_cases/widgets/test_scale.c
@@ -284,7 +284,7 @@ static void draw_event_cb(lv_event_t * e)
             attributes.max_width = 1000;
             attributes.text_flags = LV_TEXT_FLAG_NONE;
 
-            lv_text_get_size(&size, label_draw_dsc->text, label_draw_dsc->font, &attributes);
+            lv_text_get_size_attrs(&size, label_draw_dsc->text, label_draw_dsc->font, &attributes);
             int32_t new_w = size.x;
             int32_t old_w = lv_area_get_width(&draw_task->area);
 


### PR DESCRIPTION
https://github.com/lvgl/lvgl/pull/8500 introduced a breaking change to `lv_text_get_size`. Since this functions is used in public code without a good alternative, we have decided that it's best to keep it as it was before

The new `_attrs` now stays private since it doesn't offer any extra functionality compared to it
