### PR TITLE
perf(opengl): remove long delay when destroying shader programs

### DIFF
--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
@@ -213,6 +213,7 @@ lv_result_t lv_opengl_shader_manager_select_shader(lv_opengl_shader_manager_t * 
         GL_CALL(glGetShaderInfoLog(shader_map_key.id, sizeof(info_log), NULL, info_log));
         LV_LOG_WARN("Failed to compile shader for glsl version '%s': %s", lv_opengles_glsl_version_to_string(glsl_version),
                     info_log);
+        GL_CALL(glDeleteShader(shader_map_key.id));
         return LV_RESULT_INVALID;
     }
 
@@ -269,6 +270,7 @@ lv_opengl_shader_manager_get_program(lv_opengl_shader_manager_t * manager,
         GL_CALL(glGetProgramInfoLog(program_id, sizeof(info_log), NULL,
                                     info_log));
         LV_LOG_WARN("Failed to link program: %s", info_log);
+        GL_CALL(glDeleteProgram(program_id));
         return NULL;
     }
     LV_LOG_TRACE("Linking program with shaders V: %d F:%d P: %d", vertex_shader_id, fragment_shader_id, program_id);

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_program.c
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_program.c
@@ -76,7 +76,20 @@ void lv_opengl_shader_program_destroy(lv_opengl_shader_program_t * program)
     }
 #endif
 
-    GL_CALL(glDeleteProgram(program->id));
+    /* We should be able to call the function below without issue at this point
+     * but because of subtle issues regarding lazy updates of shader resources
+     * this induces significant pause on some platforms.  Since the shaders
+     * have already been detached, we can safely skip this function and leave
+     * the empty programs in OpenGL's cache until the app shuts down, it's a
+     * very small amount of memory.
+     *
+     * To-do: Consider setting a flag at this point and if that flag is true
+     * when the app finally shuts down, then perform the glDeleteProgram calls
+     * if necessary.  That is not really necessary, OpenGL will do that anyways
+     * when it shut's down. */
+
+    /* GL_CALL(glDeleteProgram(program->id)); */
+
 }
 
 GLuint lv_opengl_shader_program_get_id(lv_opengl_shader_program_t * program)

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_program.c
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_program.c
@@ -86,7 +86,7 @@ void lv_opengl_shader_program_destroy(lv_opengl_shader_program_t * program)
      * To-do: Consider setting a flag at this point and if that flag is true
      * when the app finally shuts down, then perform the glDeleteProgram calls
      * if necessary.  That is not really necessary, OpenGL will do that anyways
-     * when it shut's down. */
+     * when it shuts down. */
 
     /* GL_CALL(glDeleteProgram(program->id)); */
 


### PR DESCRIPTION
glDeleteProgram creates a long delay on some platforms if there is any ongoing use of the resources being deleted, which can happen unexpectedly from lazy resource management strategies used on some hardware.  By skipping the glDeleteProgram and letting it remain in memory until the app shuts down normally (minus it's shaders, so it's empty), load time is reduced on the AM62-Q from 14552ms for the phoenix sample file with "glDeleteProgram" called down to 4131ms without.