### PR TITLE
fix(dma2d): enable dma2d clock for STM32N6

### DIFF
--- a/src/draw/dma2d/lv_draw_dma2d.c
+++ b/src/draw/dma2d/lv_draw_dma2d.c
@@ -79,7 +79,7 @@ void lv_draw_dma2d_init(void)
     RCC->AHB1ENR |= RCC_AHB1ENR_DMA2DEN;
 #elif defined(STM32H7)
     RCC->AHB3ENR |= RCC_AHB3ENR_DMA2DEN;
-#elif defined(STM32H7RS)
+#elif defined(STM32H7RS) || defined(STM32N6)
     RCC->AHB5ENR |= RCC_AHB5ENR_DMA2DEN;
 #else
 #warning "LVGL can't enable the clock for DMA2D"
@@ -102,7 +102,7 @@ void lv_draw_dma2d_deinit(void)
     RCC->AHB1ENR &= ~RCC_AHB1ENR_DMA2DEN;
 #elif defined(STM32H7)
     RCC->AHB3ENR &= ~RCC_AHB3ENR_DMA2DEN;
-#elif defined(STM32H7RS)
+#elif defined(STM32H7RS) || defined(STM32N6)
     RCC->AHB5ENR &= ~RCC_AHB5ENR_DMA2DEN;
 #endif
 


### PR DESCRIPTION
Currently if you are trying to build for any STM32N6xx MCU you will get the warning
`#warning "LVGL can't enable the clock for DMA2D"`
and no DMA2D clock will be enabled (at least to my understanding). This PR is fixing this issue by enabling the clock as documented in RM0486 on p. 577.

PS: This is my first PR for lvgl, if anything is wrong / missing, feel free to comment.