### PR TITLE
fix(indev): fix off by one error resulting in elastic scroll when disabled

### DIFF
--- a/src/indev/lv_indev_scroll.c
+++ b/src/indev/lv_indev_scroll.c
@@ -652,7 +652,7 @@ static int32_t elastic_diff(lv_obj_t * scroll_obj, int32_t diff, int32_t scroll_
          * then respect the current position instead of going straight back to 0.
          */
         const int32_t scroll_ended = diff > 0 ? scroll_start : scroll_end;
-        if(scroll_ended < 0) diff = 0;
+        if(scroll_ended <= 0) diff = 0;
         else if(scroll_ended - diff < 0) diff = scroll_ended;
     }
     /*Handle elastic scrolling*/


### PR DESCRIPTION
Fixes #8020 <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

Before:

https://github.com/user-attachments/assets/c3f8f3fd-ee37-4742-badc-57e45fdde548

After:

https://github.com/user-attachments/assets/2538af6e-75c2-43a6-ada7-7736480bb7be

cc @W-Mai 

Using port vscode:
```
    sdl_hal_init(480, 180);
    lv_example_flex_1();
    lv_obj_remove_flag(lv_screen_active(), LV_OBJ_FLAG_SCROLL_ELASTIC);
```