### PR TITLE
perf(EVE): buffered writes

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -533,6 +533,11 @@ menu "LVGL configuration"
 			range 2 4
 			depends on LV_USE_DRAW_EVE
 
+		config LV_DRAW_EVE_WRITE_BUFFER_SIZE
+			int "Max bytes to buffer for each SPI transmission"
+			default 2048
+			depends on LV_USE_DRAW_EVE
+
 	endmenu
 
 	menu "Feature Configuration"

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -388,6 +388,9 @@
 #if LV_USE_DRAW_EVE
     /* EVE_GEN value: 2, 3, or 4 */
     #define LV_DRAW_EVE_EVE_GENERATION 4
+
+    /* the maximum number of bytes to buffer before a single SPI transmission */
+    #define LV_DRAW_EVE_WRITE_BUFFER_SIZE 2048
 #endif
 
 /*=======================

--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -282,8 +282,6 @@ typedef struct _lv_global_t {
 
 #if LV_USE_DRAW_EVE
     lv_draw_eve_unit_t * draw_eve_unit;
-    uint32_t lv_eve_write_buf_len;
-    uint8_t lv_eve_write_buf[2048];
 #endif
 } lv_global_t;
 

--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -282,6 +282,8 @@ typedef struct _lv_global_t {
 
 #if LV_USE_DRAW_EVE
     lv_draw_eve_unit_t * draw_eve_unit;
+    uint32_t lv_eve_write_buf_len;
+    uint8_t lv_eve_write_buf[2048];
 #endif
 } lv_global_t;
 

--- a/src/draw/eve/lv_draw_eve.c
+++ b/src/draw/eve/lv_draw_eve.c
@@ -127,13 +127,6 @@ static void eve_execute_drawing(lv_draw_eve_unit_t * u)
 {
     lv_draw_task_t * t = u->task_act;
 
-    uint8_t coprocessor_status;
-    do {
-        coprocessor_status = EVE_busy();
-    } while(coprocessor_status != E_OK && coprocessor_status != EVE_FIFO_HALF_EMPTY);
-
-    EVE_start_cmd_burst();
-
     switch(t->type) {
         case LV_DRAW_TASK_TYPE_LINE:
             lv_draw_eve_line(t, t->draw_dsc);
@@ -159,8 +152,6 @@ static void eve_execute_drawing(lv_draw_eve_unit_t * u)
         default:
             break;
     }
-
-    EVE_end_cmd_burst();
 }
 
 static void disp_delete_cb(lv_event_t * e)

--- a/src/draw/eve/lv_draw_eve_private.h
+++ b/src/draw/eve/lv_draw_eve_private.h
@@ -60,6 +60,8 @@ struct _lv_draw_eve_unit_t {
     lv_draw_eve_ramg_t ramg;
     lv_draw_eve_parameters_t params;
     lv_draw_eve_operation_cb_t op_cb;
+    uint32_t lv_eve_write_buf_len;
+    uint8_t lv_eve_write_buf[LV_DRAW_EVE_WRITE_BUFFER_SIZE];
 };
 
 /**********************

--- a/src/libs/FT800-FT813/EVE_commands.c
+++ b/src/libs/FT800-FT813/EVE_commands.c
@@ -285,12 +285,7 @@ void EVE_memWrite_flash_buffer(uint32_t const ft_address, const uint8_t *p_data,
         spi_transmit((uint8_t) (ft_address >> 8U));
         spi_transmit((uint8_t) (ft_address & 0x000000ffUL));
 
-    //    uint32_t length = (len + 3U) & (~3U);
-
-        for (uint32_t count = 0U; count < len; count++)
-        {
-            spi_transmit(fetch_flash_byte(&p_data[count]));
-        }
+        lv_eve_target_spi_transmit_buf(p_data, len);
 
         EVE_cs_clear();
     }    
@@ -308,12 +303,7 @@ void EVE_memWrite_sram_buffer(uint32_t const ft_address, const uint8_t *p_data, 
         spi_transmit((uint8_t) (ft_address >> 8U));
         spi_transmit((uint8_t) (ft_address & 0x000000ffUL));
 
-    //    uint32_t length = (len + 3U) & (~3U);
-
-        for (uint32_t count = 0U; count < len; count++)
-        {
-            spi_transmit(p_data[count]);
-        }
+        lv_eve_target_spi_transmit_buf(p_data, len);
 
         EVE_cs_clear();
     }
@@ -454,9 +444,9 @@ static void eve_begin_cmd(uint32_t command)
     spi_transmit_32(command);
 }
 
-void private_block_write(const uint8_t *p_data, uint16_t len); /* prototype to comply with MISRA */
+static void private_block_write(const uint8_t *p_data, uint16_t len); /* prototype to comply with MISRA */
 
-void private_block_write(const uint8_t *p_data, uint16_t len)
+static void private_block_write(const uint8_t *p_data, uint16_t len)
 {
     uint8_t padding;
 
@@ -476,9 +466,9 @@ void private_block_write(const uint8_t *p_data, uint16_t len)
     }
 }
 
-void block_transfer(const uint8_t *p_data, uint32_t len); /* prototype to comply with MISRA */
+static void block_transfer(const uint8_t *p_data, uint32_t len); /* prototype to comply with MISRA */
 
-void block_transfer(const uint8_t *p_data, uint32_t len)
+static void block_transfer(const uint8_t *p_data, uint32_t len)
 {
     uint32_t bytes_left;
     uint32_t offset = 0U;
@@ -1391,9 +1381,9 @@ uint8_t EVE_init_flash(void)
 #endif
 #endif
 
-void use_gt911(void);
+static void use_gt911(void);
 
-void use_gt911(void)
+static void use_gt911(void)
 {
 #if EVE_GEN > 2
     EVE_memWrite16(REG_TOUCH_CONFIG, 0x05d0U); /* switch to Goodix touch controller */

--- a/src/libs/FT800-FT813/EVE_target.h
+++ b/src/libs/FT800-FT813/EVE_target.h
@@ -4,6 +4,12 @@
 #include "../../draw/eve/lv_draw_eve_private.h"
 #include "../../tick/lv_tick.h"
 #include "../../misc/lv_utils.h"
+#include "../../core/lv_global.h"
+
+#define lv_eve_write_buf (LV_GLOBAL_DEFAULT()->lv_eve_write_buf)
+#define lv_eve_write_buf_len (LV_GLOBAL_DEFAULT()->lv_eve_write_buf_len)
+
+static inline void lv_eve_target_flush_write_buf(void);
 
 static inline void DELAY_MS(uint16_t ms)
 {
@@ -17,6 +23,7 @@ static inline void EVE_cs_set(void)
 
 static inline void EVE_cs_clear(void)
 {
+    lv_eve_target_flush_write_buf();
     lv_draw_eve_unit_g->op_cb(lv_draw_eve_unit_g->disp, LV_DRAW_EVE_OPERATION_CS_DEASSERT, NULL, 0);
 }
 
@@ -32,7 +39,10 @@ static inline void EVE_pdn_clear(void)
 
 static inline void spi_transmit(uint8_t data)
 {
-    lv_draw_eve_unit_g->op_cb(lv_draw_eve_unit_g->disp, LV_DRAW_EVE_OPERATION_SPI_SEND, &data, 1);
+    if(lv_eve_write_buf_len == sizeof(lv_eve_write_buf)) {
+        lv_eve_target_flush_write_buf();
+    }
+    lv_eve_write_buf[lv_eve_write_buf_len++] = data;
 }
 
 static inline void spi_transmit_32(uint32_t data)
@@ -40,7 +50,29 @@ static inline void spi_transmit_32(uint32_t data)
 #if LV_BIG_ENDIAN_SYSTEM
     data = lv_swap_bytes_32(data);
 #endif
-    lv_draw_eve_unit_g->op_cb(lv_draw_eve_unit_g->disp, LV_DRAW_EVE_OPERATION_SPI_SEND, &data, 4);
+    if(lv_eve_write_buf_len + 4 > sizeof(lv_eve_write_buf)) {
+        lv_eve_target_flush_write_buf();
+    }
+    uint8_t * buf4 = (uint8_t *) &data;
+    lv_eve_write_buf[lv_eve_write_buf_len++] = buf4[0];
+    lv_eve_write_buf[lv_eve_write_buf_len++] = buf4[1];
+    lv_eve_write_buf[lv_eve_write_buf_len++] = buf4[2];
+    lv_eve_write_buf[lv_eve_write_buf_len++] = buf4[3];
+}
+
+static inline void lv_eve_target_spi_transmit_buf(const void * data, uint32_t size)
+{
+    lv_eve_target_flush_write_buf();
+    lv_draw_eve_unit_g->op_cb(lv_draw_eve_unit_g->disp, LV_DRAW_EVE_OPERATION_SPI_SEND, (void *) data, size);
+}
+
+static inline void lv_eve_target_flush_write_buf(void)
+{
+    if(lv_eve_write_buf_len == 0) {
+        return;
+    }
+    lv_draw_eve_unit_g->op_cb(lv_draw_eve_unit_g->disp, LV_DRAW_EVE_OPERATION_SPI_SEND, lv_eve_write_buf, lv_eve_write_buf_len);
+    lv_eve_write_buf_len = 0;
 }
 
 static inline void spi_transmit_burst(uint32_t data)
@@ -52,6 +84,8 @@ static inline uint8_t spi_receive(uint8_t data)
 {
     /* `data` is 0 everywhere `spi_receive` is called in the FT800-FT813 library */
     LV_UNUSED(data);
+
+    lv_eve_target_flush_write_buf();
 
     uint8_t byte;
     lv_draw_eve_unit_g->op_cb(lv_draw_eve_unit_g->disp, LV_DRAW_EVE_OPERATION_SPI_RECEIVE, &byte, 1);

--- a/src/libs/FT800-FT813/EVE_target.h
+++ b/src/libs/FT800-FT813/EVE_target.h
@@ -6,8 +6,8 @@
 #include "../../misc/lv_utils.h"
 #include "../../core/lv_global.h"
 
-#define lv_eve_write_buf (LV_GLOBAL_DEFAULT()->lv_eve_write_buf)
-#define lv_eve_write_buf_len (LV_GLOBAL_DEFAULT()->lv_eve_write_buf_len)
+#define lv_eve_write_buf (LV_GLOBAL_DEFAULT()->draw_eve_unit->lv_eve_write_buf)
+#define lv_eve_write_buf_len (LV_GLOBAL_DEFAULT()->draw_eve_unit->lv_eve_write_buf_len)
 
 static inline void lv_eve_target_flush_write_buf(void);
 

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -1099,6 +1099,15 @@
             #define LV_DRAW_EVE_EVE_GENERATION 4
         #endif
     #endif
+
+    /* the maximum number of bytes to buffer before a single SPI transmission */
+    #ifndef LV_DRAW_EVE_WRITE_BUFFER_SIZE
+        #ifdef CONFIG_LV_DRAW_EVE_WRITE_BUFFER_SIZE
+            #define LV_DRAW_EVE_WRITE_BUFFER_SIZE CONFIG_LV_DRAW_EVE_WRITE_BUFFER_SIZE
+        #else
+            #define LV_DRAW_EVE_WRITE_BUFFER_SIZE 2048
+        #endif
+    #endif
 #endif
 
 /*=======================

--- a/src/misc/lv_event.h
+++ b/src/misc/lv_event.h
@@ -106,7 +106,7 @@ typedef enum {
     LV_EVENT_REFR_START,          /**< Sent before a refreshing cycle starts. Sent even if there is nothing to redraw. */
     LV_EVENT_REFR_READY,          /**< Sent when refreshing has been completed (after rendering and calling flush callback). Sent even if no redraw happened. */
     LV_EVENT_RENDER_START,        /**< Sent just before rendering begins. */
-    LV_EVENT_RENDER_READY,        /**< Sent after rendering has been completed (before calling flush callback) */
+    LV_EVENT_RENDER_READY,        /**< Sent after rendering has been completed. */
     LV_EVENT_FLUSH_START,         /**< Sent before flush callback is called. */
     LV_EVENT_FLUSH_FINISH,        /**< Sent after flush callback call has returned. */
     LV_EVENT_FLUSH_WAIT_START,    /**< Sent before flush wait callback is called. */


### PR DESCRIPTION
The overhead of starting an SPI transfer on ESP32-S3 with ESP IDF is very high.

This PR shows a ~2x performance improvement.

- Buffer writes into buffer which will flush automatically when the buffer is full, CS is de-asserted, or data is to be received.
- Enter burst mode (SPI CS low) at the start of rendering instead of at the start of each draw task
- Don't wait for the co-processor to be half empty. Checking is expensive.
- Bypass the write buffer when uploading assets. Upload them from the source pointer.

### Before:

<img width="561" height="380" alt="Screenshot from 2025-10-13 13-29-57" src="https://github.com/user-attachments/assets/2337ddc1-a5de-4675-8231-76fbf08c49cd" />

### After:
<img width="361" height="377" alt="Screenshot from 2025-10-13 13-21-41" src="https://github.com/user-attachments/assets/a95691e5-d8cb-43a9-9fbc-32f78bcd4889" />

(zoomed in, at the end):
<img width="410" height="378" alt="image" src="https://github.com/user-attachments/assets/b62e98f0-8e9d-4677-a2a8-c9ce3cf9610b" />

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
