### PR TITLE
fix(anim): play animations from their current progress

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -1143,15 +1143,23 @@ static void play_timeline_on_trigger_event_cb(lv_event_t * e)
     timeline_play_dsc_t * dsc = lv_event_get_user_data(e);
     LV_ASSERT_NULL(dsc);
 
+    /*Reset the progress only if the animation was finished*/
+    uint16_t progress = lv_anim_timeline_get_progress(dsc->at);
     if(dsc->reverse) {
-        lv_anim_timeline_set_progress(dsc->at, LV_ANIM_TIMELINE_PROGRESS_MAX);
+        if(progress == 0) {
+            lv_anim_timeline_set_progress(dsc->at, LV_ANIM_TIMELINE_PROGRESS_MAX);
+            lv_anim_timeline_set_delay(dsc->at, dsc->delay);
+        }
+
         lv_anim_timeline_set_reverse(dsc->at, true);
     }
     else {
-        lv_anim_timeline_set_progress(dsc->at, 0);
+        if(progress == LV_ANIM_TIMELINE_PROGRESS_MAX) {
+            lv_anim_timeline_set_progress(dsc->at, 0);
+            lv_anim_timeline_set_delay(dsc->at, dsc->delay);
+        }
         lv_anim_timeline_set_reverse(dsc->at, false);
     }
-    lv_anim_timeline_set_delay(dsc->at, dsc->delay);
     lv_anim_timeline_start(dsc->at);
 }
 

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -1148,6 +1148,9 @@ static void play_timeline_on_trigger_event_cb(lv_event_t * e)
     if(dsc->reverse) {
         if(progress == 0) {
             lv_anim_timeline_set_progress(dsc->at, LV_ANIM_TIMELINE_PROGRESS_MAX);
+        }
+
+        if(lv_anim_timeline_get_progress(dsc->at) == LV_ANIM_TIMELINE_PROGRESS_MAX) {
             lv_anim_timeline_set_delay(dsc->at, dsc->delay);
         }
 
@@ -1156,8 +1159,12 @@ static void play_timeline_on_trigger_event_cb(lv_event_t * e)
     else {
         if(progress == LV_ANIM_TIMELINE_PROGRESS_MAX) {
             lv_anim_timeline_set_progress(dsc->at, 0);
+        }
+
+        if(lv_anim_timeline_get_progress(dsc->at) == 0) {
             lv_anim_timeline_set_delay(dsc->at, dsc->delay);
         }
+
         lv_anim_timeline_set_reverse(dsc->at, false);
     }
     lv_anim_timeline_start(dsc->at);

--- a/src/others/xml/parsers/lv_xml_obj_parser.c
+++ b/src/others/xml/parsers/lv_xml_obj_parser.c
@@ -1054,6 +1054,9 @@ static void play_anim_on_trigger_event_cb(lv_event_t * e)
     if(dsc->reverse) {
         if(progress == 0) {
             lv_anim_timeline_set_progress(timeline, LV_ANIM_TIMELINE_PROGRESS_MAX);
+        }
+
+        if(lv_anim_timeline_get_progress(timeline) == LV_ANIM_TIMELINE_PROGRESS_MAX) {
             lv_anim_timeline_set_delay(timeline, dsc->delay);
         }
 
@@ -1062,8 +1065,12 @@ static void play_anim_on_trigger_event_cb(lv_event_t * e)
     else {
         if(progress == LV_ANIM_TIMELINE_PROGRESS_MAX) {
             lv_anim_timeline_set_progress(timeline, 0);
+        }
+
+        if(lv_anim_timeline_get_progress(timeline) == 0) {
             lv_anim_timeline_set_delay(timeline, dsc->delay);
         }
+
         lv_anim_timeline_set_reverse(timeline, false);
     }
 

--- a/src/others/xml/parsers/lv_xml_obj_parser.c
+++ b/src/others/xml/parsers/lv_xml_obj_parser.c
@@ -1049,16 +1049,24 @@ static void play_anim_on_trigger_event_cb(lv_event_t * e)
         return;
     }
 
+    /*Reset the progress only if the animation was finished*/
+    uint16_t progress = lv_anim_timeline_get_progress(timeline);
     if(dsc->reverse) {
+        if(progress == 0) {
+            lv_anim_timeline_set_progress(timeline, LV_ANIM_TIMELINE_PROGRESS_MAX);
+            lv_anim_timeline_set_delay(timeline, dsc->delay);
+        }
+
         lv_anim_timeline_set_reverse(timeline, true);
-        lv_anim_timeline_set_progress(timeline, LV_ANIM_TIMELINE_PROGRESS_MAX);
     }
     else {
+        if(progress == LV_ANIM_TIMELINE_PROGRESS_MAX) {
+            lv_anim_timeline_set_progress(timeline, 0);
+            lv_anim_timeline_set_delay(timeline, dsc->delay);
+        }
         lv_anim_timeline_set_reverse(timeline, false);
-        lv_anim_timeline_set_progress(timeline, 0);
     }
 
-    lv_anim_timeline_set_delay(timeline, dsc->delay);
     lv_anim_timeline_start(timeline);
 
 }


### PR DESCRIPTION


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
