### PR TITLE
fix(windows): correctly calculate Windows window-size

### DIFF
--- a/src/drivers/windows/lv_windows_display.c
+++ b/src/drivers/windows/lv_windows_display.c
@@ -122,17 +122,18 @@ static unsigned int __stdcall lv_windows_display_thread_entrypoint(
     LV_ASSERT_NULL(data);
 
     DWORD window_style = WS_OVERLAPPEDWINDOW;
+    DWORD ext_window_style = WS_EX_CLIENTEDGE;
+    RECT rect = { 0, 0, data->hor_res, data->ver_res };
+
     if(data->simulator_mode) {
         window_style &= ~(WS_SIZEBOX | WS_MAXIMIZEBOX | WS_THICKFRAME);
     }
-
-    DWORD ext_window_style = WS_EX_CLIENTEDGE;
-
-    /* Have Windows compute window size so, regardless of window style,
-     * the CLIENT AREA has dimensions [data->hor_res, data->ver_res].
-     * This is the area needed for LVGL to render to. */
-    RECT rect = { 0, 0, data->hor_res, data->ver_res };
-    AdjustWindowRectEx(&rect, window_style, false, ext_window_style);
+    else {
+        /* Have Windows compute window size so, regardless of window style,
+         * the CLIENT AREA has dimensions [data->hor_res, data->ver_res].
+         * This is the area needed for LVGL to render to. */
+        AdjustWindowRectEx(&rect, window_style, false, ext_window_style);
+    }
 
     HWND window_handle = CreateWindowExW(
                              ext_window_style,

--- a/src/drivers/windows/lv_windows_display.c
+++ b/src/drivers/windows/lv_windows_display.c
@@ -126,19 +126,28 @@ static unsigned int __stdcall lv_windows_display_thread_entrypoint(
         window_style &= ~(WS_SIZEBOX | WS_MAXIMIZEBOX | WS_THICKFRAME);
     }
 
+    DWORD ext_window_style = WS_EX_CLIENTEDGE;
+
+    /* Have Windows compute window size so, regardless of window style,
+     * the CLIENT AREA has dimensions [data->hor_res, data->ver_res].
+     * This is the area needed for LVGL to render to. */
+    RECT rect = { 0, 0, data->hor_res, data->ver_res };
+    AdjustWindowRectEx(&rect, window_style, false, ext_window_style);
+
     HWND window_handle = CreateWindowExW(
-                             WS_EX_CLIENTEDGE,
+                             ext_window_style,
                              L"LVGL.Window",
                              data->title,
                              window_style,
                              CW_USEDEFAULT,
                              0,
-                             data->hor_res,
-                             data->ver_res,
+                             rect.right - rect.left,
+                             rect.bottom - rect.top,
                              NULL,
                              NULL,
                              NULL,
                              data);
+
     if(!window_handle) {
         return 0;
     }

--- a/src/drivers/windows/lv_windows_display.h
+++ b/src/drivers/windows/lv_windows_display.h
@@ -47,8 +47,8 @@ extern "C" {
  * @param zoom_level The zoom level value. Base value is 100 a.k.a 100%.
  * @param allow_dpi_override Allow DPI override if true, or follow the
  *                           Windows DPI scaling setting dynamically.
- * @param simulator_mode Create simulator mode display if true, or create
- *                       application mode display.
+ * @param simulator_mode Create simulator mode display if true (not resizable),
+ *                       or create application mode display (resizable).
  * @return The created LVGL display object.
 */
 lv_display_t * lv_windows_create_display(


### PR DESCRIPTION
Various versions of the Windows `CreateWindow()` function do not, in all cases, use the `width` and `height` arguments to govern the "drawing area" (called "Client Area" in Windows vocabulary).  The `AdjustWindowRect()` and `AdjustWindowRectEx()` functions (used when there is ALSO an "extended window style" involved, which there is) are made to make window size adjustments so that the Client Area (drawing area) DOES turn out to have the desired dimensions.  This function is not currently being used prior to calling the `CreateWindow()` function, so when "Simulator Mode" is not used with the `lv_windows_create_display()` function, the client area comes out considerably smaller than it should.

This PR implements `AdjustWindowRectEx()` as it was intended to be used to adjust the `width` and `height` parameters of the `CreateWindow()` function so that the drawing area has the desired dimensions.

It also clarifies the meaning of the 'simulator_mode' argument in the `lv_windows_create_display()` function documentation.

Note that the "adjustment" is being done only in the ELSE block because the documentation for the `AdjustWindowRectEx()` functions (both of them) is inaccurate, and when the adjustment is also done on the TRUE side of the IF/ELSE block, it does something different than what its documentation says, and corrupts the window size, making it quite a bit too large.  This was tested in both modes and works as designed.

Fixes:  #9033

cc:  @AndreCostaaa 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
