### PR TITLE
fix(g2d): fix compilation error with G2D version <2.3.0

### DIFF
--- a/src/draw/nxp/g2d/lv_draw_g2d.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d.c
@@ -23,6 +23,15 @@
 
 #define DRAW_UNIT_ID_G2D 8
 
+/**
+ * Enum name differs depending on g2d version (breaking API change, not handled in g2d.h)
+ * Note: enum value is the same in either case
+ * See https://github.com/nxp-imx/imx-g2d-pxp/commit/d7af84b5c8ad161b6898ffabe23918cb59fe2fe9
+ */
+#if (G2D_VERSION_MAJOR >= 2) && (G2D_VERSION_MINOR < 3)
+#    define G2D_HARDWARE_PXP_V1 G2D_HARDWARE_PXP
+#endif
+
 /**********************
  *      TYPEDEFS
  **********************/

--- a/src/draw/nxp/g2d/lv_draw_g2d.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d.c
@@ -29,7 +29,7 @@
  * See https://github.com/nxp-imx/imx-g2d-pxp/commit/d7af84b5c8ad161b6898ffabe23918cb59fe2fe9
  */
 #if (G2D_VERSION_MAJOR >= 2) && (G2D_VERSION_MINOR < 3)
-#    define G2D_HARDWARE_PXP_V1 G2D_HARDWARE_PXP
+    #define G2D_HARDWARE_PXP_V1 G2D_HARDWARE_PXP
 #endif
 
 /**********************


### PR DESCRIPTION
Breaking changes in G2D API make it so lvgl+G2D cannot be used if the version is not the current latest. Considering BSPs tend to lag behind, this prevents using G2D in certain cases. 

See https://github.com/nxp-imx/imx-g2d-pxp/commit/d7af84b5c8ad161b6898ffabe23918cb59fe2fe9