### PR TITLE
fix(label): ignore empty translation tags

### DIFF
--- a/src/others/xml/parsers/lv_xml_label_parser.c
+++ b/src/others/xml/parsers/lv_xml_label_parser.c
@@ -51,17 +51,26 @@ void lv_xml_label_apply(lv_xml_parser_state_t * state, const char ** attrs)
 
     lv_xml_obj_apply(state, attrs); /*Apply the common properties, e.g. width, height, styles flags etc*/
 
+    bool has_tag = false;
     for(int i = 0; attrs[i]; i += 2) {
         const char * name = attrs[i];
         const char * value = attrs[i + 1];
+        const bool is_value_empty = !value || lv_strlen(value) == 0;
 
-        /* Allow defining both translation_tag and text attributes
-         * Ignore the empty one*/
-        if(lv_streq("text", name) && value && lv_strlen(value) > 0) lv_label_set_text(item, value);
-        else if(lv_streq("long_mode", name)) lv_label_set_long_mode(item, long_mode_text_to_enum_value(value));
+        /* Allow defining both translation_tag and text attributes. Ignore the empty one*/
+        /* Translation tag has precendence over text*/
+        if(lv_streq("text", name) && !has_tag) {
+            lv_label_set_text(item, value);
+        }
 #if LV_USE_TRANSLATION
-        else if(lv_streq("translation_tag", name) && value && lv_strlen(value) > 0) lv_label_set_translation_tag(item, value);
+        /* We only set the translation tag if the value is non empty
+         * but if we set it, then we must ignore the text attribute*/
+        else if(lv_streq("translation_tag", name) && !is_value_empty) {
+            has_tag = true;
+            lv_label_set_translation_tag(item, value);
+        }
 #endif
+        else if(lv_streq("long_mode", name)) lv_label_set_long_mode(item, long_mode_text_to_enum_value(value));
         else if(lv_streq("bind_text", name)) {
             lv_subject_t * subject = lv_xml_get_subject(&state->scope, value);
             if(subject == NULL) {

--- a/src/others/xml/parsers/lv_xml_label_parser.c
+++ b/src/others/xml/parsers/lv_xml_label_parser.c
@@ -51,26 +51,15 @@ void lv_xml_label_apply(lv_xml_parser_state_t * state, const char ** attrs)
 
     lv_xml_obj_apply(state, attrs); /*Apply the common properties, e.g. width, height, styles flags etc*/
 
-    bool has_tag = false;
     for(int i = 0; attrs[i]; i += 2) {
         const char * name = attrs[i];
         const char * value = attrs[i + 1];
-        const bool is_value_empty = !value || lv_strlen(value) == 0;
 
-        /* Allow defining both translation_tag and text attributes. Ignore the empty one*/
-        /* Translation tag has precendence over text*/
-        if(lv_streq("text", name) && !has_tag) {
-            lv_label_set_text(item, value);
-        }
-#if LV_USE_TRANSLATION
-        /* We only set the translation tag if the value is non empty
-         * but if we set it, then we must ignore the text attribute*/
-        else if(lv_streq("translation_tag", name) && !is_value_empty) {
-            has_tag = true;
-            lv_label_set_translation_tag(item, value);
-        }
-#endif
+        if(lv_streq("text", name)) lv_label_set_text(item, value);
         else if(lv_streq("long_mode", name)) lv_label_set_long_mode(item, long_mode_text_to_enum_value(value));
+#if LV_USE_TRANSLATION
+        else if(lv_streq("translation_tag", name)) lv_label_set_translation_tag(item, value);
+#endif
         else if(lv_streq("bind_text", name)) {
             lv_subject_t * subject = lv_xml_get_subject(&state->scope, value);
             if(subject == NULL) {

--- a/src/others/xml/parsers/lv_xml_label_parser.c
+++ b/src/others/xml/parsers/lv_xml_label_parser.c
@@ -55,10 +55,12 @@ void lv_xml_label_apply(lv_xml_parser_state_t * state, const char ** attrs)
         const char * name = attrs[i];
         const char * value = attrs[i + 1];
 
-        if(lv_streq("text", name)) lv_label_set_text(item, value);
+        /* Allow defining both translation_tag and text attributes
+         * Ignore the empty one*/
+        if(lv_streq("text", name) && value && lv_strlen(value) > 0) lv_label_set_text(item, value);
         else if(lv_streq("long_mode", name)) lv_label_set_long_mode(item, long_mode_text_to_enum_value(value));
 #if LV_USE_TRANSLATION
-        else if(lv_streq("translation_tag", name)) lv_label_set_translation_tag(item, value);
+        else if(lv_streq("translation_tag", name) && value && lv_strlen(value) > 0) lv_label_set_translation_tag(item, value);
 #endif
         else if(lv_streq("bind_text", name)) {
             lv_subject_t * subject = lv_xml_get_subject(&state->scope, value);

--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -205,7 +205,7 @@ void lv_label_set_translation_tag(lv_obj_t * obj, const char * tag)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_label_t * label = (lv_label_t *)obj;
-    if(!tag) {
+    if(!tag || tag[0] == '\0') {
         return;
     }
     char * new_tag = lv_strdup(tag);

--- a/tests/src/test_cases/xml/test_xml_label.c
+++ b/tests/src/test_cases/xml/test_xml_label.c
@@ -97,15 +97,24 @@ void test_xml_label_translation_tag(void)
         NULL, NULL,
     };
 
+    /* If both are empty, we should set label to be an empty string */
+    const char * label5_attrs[] = {
+        "translation_tag", "",
+        "text", "",
+        NULL, NULL,
+    };
+
     lv_obj_t * label = lv_xml_create(scr, "lv_label", label1_attrs);
     lv_obj_t * label2 = lv_xml_create(scr, "lv_label", label2_attrs);
     lv_obj_t * label3 = lv_xml_create(scr, "lv_label", label3_attrs);
     lv_obj_t * label4 = lv_xml_create(scr, "lv_label", label4_attrs);
+    lv_obj_t * label5 = lv_xml_create(scr, "lv_label", label5_attrs);
     lv_translation_set_language("de");
     TEST_ASSERT_EQUAL_STRING(lv_label_get_text(label), "Der Tiger");
     TEST_ASSERT_EQUAL_STRING(lv_label_get_text(label2), "This is text");
     TEST_ASSERT_EQUAL_STRING(lv_label_get_text(label3), "Der Tiger");
     TEST_ASSERT_EQUAL_STRING(lv_label_get_text(label4), "Der Tiger");
+    TEST_ASSERT_EQUAL_STRING(lv_label_get_text(label5), "");
 }
 
 void test_xml_label_both_text_and_translation_tag(void)

--- a/tests/src/test_cases/xml/test_xml_label.c
+++ b/tests/src/test_cases/xml/test_xml_label.c
@@ -83,21 +83,18 @@ void test_xml_label_translation_tag(void)
         NULL, NULL,
     };
 
-    /* Translation tag takes precedence over the text*/
     const char * label3_attrs[] = {
         "text", "This is text",
         "translation_tag", "tiger",
         NULL, NULL,
     };
 
-    /* ... even if the text is set later */
     const char * label4_attrs[] = {
         "translation_tag", "tiger",
         "text", "This is text",
         NULL, NULL,
     };
 
-    /* If both are empty, we should set label to be an empty string */
     const char * label5_attrs[] = {
         "translation_tag", "",
         "text", "",
@@ -113,7 +110,7 @@ void test_xml_label_translation_tag(void)
     TEST_ASSERT_EQUAL_STRING(lv_label_get_text(label), "Der Tiger");
     TEST_ASSERT_EQUAL_STRING(lv_label_get_text(label2), "This is text");
     TEST_ASSERT_EQUAL_STRING(lv_label_get_text(label3), "Der Tiger");
-    TEST_ASSERT_EQUAL_STRING(lv_label_get_text(label4), "Der Tiger");
+    TEST_ASSERT_EQUAL_STRING(lv_label_get_text(label4), "This is text");
     TEST_ASSERT_EQUAL_STRING(lv_label_get_text(label5), "");
 }
 

--- a/tests/src/test_cases/xml/test_xml_label.c
+++ b/tests/src/test_cases/xml/test_xml_label.c
@@ -70,6 +70,34 @@ void test_xml_label_translation_tag(void)
     lv_translation_add_static(languages, tags, translations);
 
     lv_obj_t * scr = lv_screen_active();
+
+    const char * label1_attrs[] = {
+        "text", "",
+        "translation_tag", "tiger",
+        NULL, NULL,
+    };
+
+    const char * label2_attrs[] = {
+        "text", "This is text",
+        "translation_tag", "",
+        NULL, NULL,
+    };
+
+    lv_obj_t * label = lv_xml_create(scr, "lv_label", label1_attrs);
+    lv_obj_t * label2 = lv_xml_create(scr, "lv_label", label2_attrs);
+    lv_translation_set_language("de");
+    TEST_ASSERT_EQUAL_STRING(lv_label_get_text(label), "Der Tiger");
+    TEST_ASSERT_EQUAL_STRING(lv_label_get_text(label2), "This is text");
+}
+
+void test_xml_label_both_text_and_translation_tag(void)
+{
+    static const char * tags[] = {"tiger", NULL};
+    static const char * languages[]    = {"en", "de", "es", NULL};
+    static const char * translations[] = { "The Tiger", "Der Tiger", "El Tigre" };
+    lv_translation_add_static(languages, tags, translations);
+
+    lv_obj_t * scr = lv_screen_active();
     const char * label1_attrs[] = {
         "translation_tag", "tiger",
         NULL, NULL,

--- a/tests/src/test_cases/xml/test_xml_label.c
+++ b/tests/src/test_cases/xml/test_xml_label.c
@@ -83,11 +83,29 @@ void test_xml_label_translation_tag(void)
         NULL, NULL,
     };
 
+    /* Translation tag takes precedence over the text*/
+    const char * label3_attrs[] = {
+        "text", "This is text",
+        "translation_tag", "tiger",
+        NULL, NULL,
+    };
+
+    /* ... even if the text is set later */
+    const char * label4_attrs[] = {
+        "translation_tag", "tiger",
+        "text", "This is text",
+        NULL, NULL,
+    };
+
     lv_obj_t * label = lv_xml_create(scr, "lv_label", label1_attrs);
     lv_obj_t * label2 = lv_xml_create(scr, "lv_label", label2_attrs);
+    lv_obj_t * label3 = lv_xml_create(scr, "lv_label", label3_attrs);
+    lv_obj_t * label4 = lv_xml_create(scr, "lv_label", label4_attrs);
     lv_translation_set_language("de");
     TEST_ASSERT_EQUAL_STRING(lv_label_get_text(label), "Der Tiger");
     TEST_ASSERT_EQUAL_STRING(lv_label_get_text(label2), "This is text");
+    TEST_ASSERT_EQUAL_STRING(lv_label_get_text(label3), "Der Tiger");
+    TEST_ASSERT_EQUAL_STRING(lv_label_get_text(label4), "Der Tiger");
 }
 
 void test_xml_label_both_text_and_translation_tag(void)


### PR DESCRIPTION
See https://forum.lvgl.io/t/introducing-lvgls-ui-editor-preview-of-v0-1/19280/22

cc @kisvegabor 

by ignorning empty translation tags, the user can do

`<lv_label text="$label_text" translation_tag="$label_translation_tag" />` by keeping the translation tag empty, the text will be used, else the translation tag will be used

If they prefer text to take precedence over the tag, they can revert the order of the attributes:
`<lv_label translation_tag="$label_translation_tag"  text="$label_text" />`
