### PR TITLE
fix(examples): fix format specifier warning

### DIFF
--- a/examples/widgets/scale/lv_example_scale_12.c
+++ b/examples/widgets/scale/lv_example_scale_12.c
@@ -26,7 +26,7 @@ static void set_heading_value(void * obj, int32_t v)
 {
     LV_UNUSED(obj);
     lv_scale_set_rotation(scale, 270 - v);
-    lv_label_set_text_fmt(label, "%d°\n%s", v, heading_to_cardinal(v));
+    lv_label_set_text_fmt(label, "%d°\n%s", (int)v, heading_to_cardinal(v));
 }
 
 static void draw_event_cb(lv_event_t * e)


### PR DESCRIPTION
```
   29 |     lv_label_set_text_fmt(label, "%d°\n%s", v, heading_to_cardinal(v));
      |                                   ~^        ~
      |                                    |        |
      |                                    int      int32_t {aka long int}
      |                                   %ld
```

Is it ok to cast to a primitive type rather than use `PRId32` for examples, for beginners?

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
