### PR TITLE
chore(gdb): add gdb cmd for nuttx drivers to support multi-instance

### DIFF
--- a/scripts/gdb/lvglgdb/cmds/__init__.py
+++ b/scripts/gdb/lvglgdb/cmds/__init__.py
@@ -5,6 +5,7 @@ from .display import DumpDisplayBuf
 from .draw import InfoDrawUnit
 from .misc import InfoStyle
 from .debugger import Debugger
+from .drivers import Lvglobal
 
 __all__ = []
 
@@ -25,3 +26,6 @@ DumpDisplayBuf()
 # Infos
 InfoStyle()
 InfoDrawUnit()
+
+# Drivers
+Lvglobal()

--- a/scripts/gdb/lvglgdb/cmds/drivers/__init__.py
+++ b/scripts/gdb/lvglgdb/cmds/drivers/__init__.py
@@ -1,0 +1,5 @@
+from .nuttx import Lvglobal
+
+__all__ = [
+    "Lvglobal",
+]

--- a/scripts/gdb/lvglgdb/cmds/drivers/nuttx/__init__.py
+++ b/scripts/gdb/lvglgdb/cmds/drivers/nuttx/__init__.py
@@ -1,0 +1,5 @@
+from .nuttx import Lvglobal
+
+__all__ = [
+    "Lvglobal",
+]

--- a/scripts/gdb/lvglgdb/cmds/drivers/nuttx/nuttx.py
+++ b/scripts/gdb/lvglgdb/cmds/drivers/nuttx/nuttx.py
@@ -2,7 +2,6 @@
 
 import argparse
 import sys
-from os import path
 
 import gdb
 from nxgdb import utils

--- a/scripts/gdb/lvglgdb/cmds/drivers/nuttx/nuttx.py
+++ b/scripts/gdb/lvglgdb/cmds/drivers/nuttx/nuttx.py
@@ -1,0 +1,55 @@
+# GDB script to get lvgl global pointer in NuttX.
+
+import argparse
+import sys
+from os import path
+
+import gdb
+from nxgdb import utils
+
+# Add current script folder so we can import module lvgl
+
+
+class Lvglobal(gdb.Command):
+    """Set which lvgl instance to inspect by finding lv_global pointer in task TLS data."""
+
+    def __init__(self):
+        super(Lvglobal, self).__init__("lvglobal", gdb.COMMAND_USER)
+
+    def set_lvgl_instance(self, inst):
+        from lvglgdb.lvgl import curr_inst
+
+        curr_inst().reset()
+        curr_inst().ensure_init(inst)
+
+    def invoke(self, arg, from_tty):
+        parser = argparse.ArgumentParser(description=self.__doc__)
+        parser.add_argument("-p", "--pid", type=int, help="Optional process ID")
+        try:
+            args = parser.parse_args(gdb.string_to_argv(arg))
+        except SystemExit:
+            return
+
+        lv_global = utils.gdb_eval_or_none("lv_global")
+        if lv_global:
+            gdb.write(f"Found single instance lv_global@{hex(lv_global.address)}\n")
+            self.set_lvgl_instance(lv_global)
+            return
+
+        # find the lvgl global pointer in tls
+        if not args.pid:
+            gdb.write("Lvgl is in multi-process mode, need pid argument.\n")
+            return
+        lv_key = utils.gdb_eval_or_none("lv_nuttx_tlskey") or utils.gdb_eval_or_none(
+            "lv_global_default::index"
+        )
+        if lv_key is None:
+            gdb.write("Can't find lvgl tls key in multi-process mode.\n")
+            return
+        lv_global = utils.get_task_tls(args.pid, lv_key)
+        if lv_global:
+            gdb.write(f"Found lv_global@{hex(lv_global)}\n")
+            self.set_lvgl_instance(lv_global)
+        else:
+            gdb.write(f"\nCan't find lv_global with tlskey@{hex(lv_key)}.\n")
+        gdb.write("\n")

--- a/scripts/gdb/lvglgdb/cmds/drivers/nuttx/nuttx.py
+++ b/scripts/gdb/lvglgdb/cmds/drivers/nuttx/nuttx.py
@@ -39,9 +39,9 @@ class Lvglobal(gdb.Command):
         if not args.pid:
             gdb.write("Lvgl is in multi-process mode, need pid argument.\n")
             return
-        lv_key = utils.gdb_eval_or_none("lv_nuttx_tlskey") or utils.gdb_eval_or_none(
-            "lv_global_default::index"
-        )
+        lv_key = utils.gdb_eval_or_none("lv_nuttx_tlskey")
+        if lv_key is None:
+            lv_key = utils.gdb_eval_or_none("lv_global_default::index")
         if lv_key is None:
             gdb.write("Can't find lvgl tls key in multi-process mode.\n")
             return

--- a/scripts/gdb/lvglgdb/lvgl/core/lv_global.py
+++ b/scripts/gdb/lvglgdb/lvgl/core/lv_global.py
@@ -76,7 +76,7 @@ class _LVGLSingleton:
                 print(f"Failed to get lv_global: {e}")
                 return False
         elif not isinstance(lv_global, Value):
-            lv_global = Value(lv_global)
+            lv_global = Value(lv_global).cast("lv_global_t", ptr=True)
 
         if not lv_global.inited:
             print(


### PR DESCRIPTION
Support multi-instance for NuttX.

In NuttX, there maybe multi instance running in the same time, we need to get the `lv_global` through the `tls key`.

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
