### PR TITLE
fix(DMA2D): fix non-async mode build failure

### DIFF
--- a/src/draw/dma2d/lv_draw_dma2d.c
+++ b/src/draw/dma2d/lv_draw_dma2d.c
@@ -361,6 +361,7 @@ static int32_t delete_cb(lv_draw_unit_t * draw_unit)
     return 0;
 }
 
+#if LV_DRAW_DMA2D_ASYNC
 static int32_t wait_finish_cb(lv_draw_unit_t * draw_unit)
 {
     lv_draw_dma2d_unit_t * u = (lv_draw_dma2d_unit_t *) draw_unit;
@@ -372,6 +373,7 @@ static int32_t wait_finish_cb(lv_draw_unit_t * draw_unit)
     post_transfer_tasks(u);
     return 0;
 }
+#endif /*LV_DRAW_DMA2D_ASYNC*/
 
 #if !LV_DRAW_DMA2D_ASYNC
 static bool check_transfer_completion(void)


### PR DESCRIPTION
After #8765

cc @uLipe

```
../lvgl/src/draw/dma2d/lv_draw_dma2d.c: In function 'wait_finish_cb':
../lvgl/src/draw/dma2d/lv_draw_dma2d.c:369:27: error: 'lv_draw_dma2d_unit_t' has no member named 'interrupt_signal'
  369 |     lv_thread_sync_wait(&u->interrupt_signal);
      |                           ^~
../lvgl/src/draw/dma2d/lv_draw_dma2d.c: At top level:
../lvgl/src/draw/dma2d/lv_draw_dma2d.c:364:16: warning: 'wait_finish_cb' defined but not used [-Wunused-function]
  364 | static int32_t wait_finish_cb(lv_draw_unit_t * draw_unit)
      |                ^~~~~~~~~~~~~~
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
