### PR TITLE
feat(EVE): allow disabling write buffering

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -544,7 +544,7 @@ menu "LVGL configuration"
 			depends on LV_USE_DRAW_EVE
 
 		config LV_DRAW_EVE_WRITE_BUFFER_SIZE
-			int "Max bytes to buffer for each SPI transmission"
+			int "Max bytes to buffer for each SPI transmission or 0 to disable buffering"
 			default 2048
 			depends on LV_USE_DRAW_EVE
 

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -395,7 +395,9 @@
     /* EVE_GEN value: 2, 3, or 4 */
     #define LV_DRAW_EVE_EVE_GENERATION 4
 
-    /* the maximum number of bytes to buffer before a single SPI transmission */
+    /* The maximum number of bytes to buffer before a single SPI transmission.
+     * Set it to 0 to disable write buffering.
+     */
     #define LV_DRAW_EVE_WRITE_BUFFER_SIZE 2048
 #endif
 

--- a/src/draw/eve/lv_draw_eve_private.h
+++ b/src/draw/eve/lv_draw_eve_private.h
@@ -34,10 +34,10 @@ extern "C" {
 #include "../lv_draw_arc.h"
 
 #if LV_DRAW_EVE_WRITE_BUFFER_SIZE != 0 && LV_DRAW_EVE_WRITE_BUFFER_SIZE < 4
-    #warning LV_DRAW_EVE_WRITE_BUFFER_SIZE cannot be less than 4. Using 0 (buffering disabled).
-    #define LV_DRAW_EVE_WRITE_BUFFER_SIZE_INTERNAL 0
+#warning LV_DRAW_EVE_WRITE_BUFFER_SIZE cannot be less than 4. Using 0 (buffering disabled).
+#define LV_DRAW_EVE_WRITE_BUFFER_SIZE_INTERNAL 0
 #else
-    #define LV_DRAW_EVE_WRITE_BUFFER_SIZE_INTERNAL LV_DRAW_EVE_WRITE_BUFFER_SIZE
+#define LV_DRAW_EVE_WRITE_BUFFER_SIZE_INTERNAL LV_DRAW_EVE_WRITE_BUFFER_SIZE
 #endif
 
 /*********************

--- a/src/draw/eve/lv_draw_eve_private.h
+++ b/src/draw/eve/lv_draw_eve_private.h
@@ -33,6 +33,13 @@ extern "C" {
 #include "../../font/lv_font_fmt_txt.h"
 #include "../lv_draw_arc.h"
 
+#if LV_DRAW_EVE_WRITE_BUFFER_SIZE != 0 && LV_DRAW_EVE_WRITE_BUFFER_SIZE < 4
+    #warning LV_DRAW_EVE_WRITE_BUFFER_SIZE cannot be less than 4. Using 0 (buffering disabled).
+    #define LV_DRAW_EVE_WRITE_BUFFER_SIZE_INTERNAL 0
+#else
+    #define LV_DRAW_EVE_WRITE_BUFFER_SIZE_INTERNAL LV_DRAW_EVE_WRITE_BUFFER_SIZE
+#endif
+
 /*********************
  *      DEFINES
  *********************/
@@ -60,8 +67,10 @@ struct _lv_draw_eve_unit_t {
     lv_draw_eve_ramg_t ramg;
     lv_draw_eve_parameters_t params;
     lv_draw_eve_operation_cb_t op_cb;
+#if LV_DRAW_EVE_WRITE_BUFFER_SIZE_INTERNAL
     uint32_t lv_eve_write_buf_len;
-    uint8_t lv_eve_write_buf[LV_DRAW_EVE_WRITE_BUFFER_SIZE];
+    uint8_t lv_eve_write_buf[LV_DRAW_EVE_WRITE_BUFFER_SIZE_INTERNAL];
+#endif
 };
 
 /**********************

--- a/src/libs/FT800-FT813/EVE_target.h
+++ b/src/libs/FT800-FT813/EVE_target.h
@@ -9,6 +9,8 @@
 #define lv_eve_write_buf (LV_GLOBAL_DEFAULT()->draw_eve_unit->lv_eve_write_buf)
 #define lv_eve_write_buf_len (LV_GLOBAL_DEFAULT()->draw_eve_unit->lv_eve_write_buf_len)
 
+#define LV_EVE_TARGET_SPI_SEND(data, size) lv_draw_eve_unit_g->op_cb(lv_draw_eve_unit_g->disp, LV_DRAW_EVE_OPERATION_SPI_SEND, (data), (size))
+
 static inline void lv_eve_target_flush_write_buf(void);
 
 static inline void DELAY_MS(uint16_t ms)
@@ -39,10 +41,14 @@ static inline void EVE_pdn_clear(void)
 
 static inline void spi_transmit(uint8_t data)
 {
+#if LV_DRAW_EVE_WRITE_BUFFER_SIZE_INTERNAL
     if(lv_eve_write_buf_len == sizeof(lv_eve_write_buf)) {
         lv_eve_target_flush_write_buf();
     }
     lv_eve_write_buf[lv_eve_write_buf_len++] = data;
+#else
+    LV_EVE_TARGET_SPI_SEND(&data, sizeof(data));
+#endif
 }
 
 static inline void spi_transmit_32(uint32_t data)
@@ -50,6 +56,7 @@ static inline void spi_transmit_32(uint32_t data)
 #if LV_BIG_ENDIAN_SYSTEM
     data = lv_swap_bytes_32(data);
 #endif
+#if LV_DRAW_EVE_WRITE_BUFFER_SIZE_INTERNAL
     if(lv_eve_write_buf_len + 4 > sizeof(lv_eve_write_buf)) {
         lv_eve_target_flush_write_buf();
     }
@@ -58,21 +65,26 @@ static inline void spi_transmit_32(uint32_t data)
     lv_eve_write_buf[lv_eve_write_buf_len++] = buf4[1];
     lv_eve_write_buf[lv_eve_write_buf_len++] = buf4[2];
     lv_eve_write_buf[lv_eve_write_buf_len++] = buf4[3];
+#else
+    LV_EVE_TARGET_SPI_SEND(&data, sizeof(data));
+#endif
 }
 
 static inline void lv_eve_target_spi_transmit_buf(const void * data, uint32_t size)
 {
     lv_eve_target_flush_write_buf();
-    lv_draw_eve_unit_g->op_cb(lv_draw_eve_unit_g->disp, LV_DRAW_EVE_OPERATION_SPI_SEND, (void *) data, size);
+    LV_EVE_TARGET_SPI_SEND((void *) data, size);
 }
 
 static inline void lv_eve_target_flush_write_buf(void)
 {
+#if LV_DRAW_EVE_WRITE_BUFFER_SIZE_INTERNAL
     if(lv_eve_write_buf_len == 0) {
         return;
     }
-    lv_draw_eve_unit_g->op_cb(lv_draw_eve_unit_g->disp, LV_DRAW_EVE_OPERATION_SPI_SEND, lv_eve_write_buf, lv_eve_write_buf_len);
+    LV_EVE_TARGET_SPI_SEND(lv_eve_write_buf, lv_eve_write_buf_len);
     lv_eve_write_buf_len = 0;
+#endif
 }
 
 static inline void spi_transmit_burst(uint32_t data)

--- a/src/libs/FT800-FT813/EVE_target.h
+++ b/src/libs/FT800-FT813/EVE_target.h
@@ -9,8 +9,6 @@
 #define lv_eve_write_buf (LV_GLOBAL_DEFAULT()->draw_eve_unit->lv_eve_write_buf)
 #define lv_eve_write_buf_len (LV_GLOBAL_DEFAULT()->draw_eve_unit->lv_eve_write_buf_len)
 
-#define LV_EVE_TARGET_SPI_SEND(data, size) lv_draw_eve_unit_g->op_cb(lv_draw_eve_unit_g->disp, LV_DRAW_EVE_OPERATION_SPI_SEND, (data), (size))
-
 static inline void lv_eve_target_flush_write_buf(void);
 
 static inline void DELAY_MS(uint16_t ms)
@@ -47,7 +45,7 @@ static inline void spi_transmit(uint8_t data)
     }
     lv_eve_write_buf[lv_eve_write_buf_len++] = data;
 #else
-    LV_EVE_TARGET_SPI_SEND(&data, sizeof(data));
+    lv_draw_eve_unit_g->op_cb(lv_draw_eve_unit_g->disp, LV_DRAW_EVE_OPERATION_SPI_SEND, &data, sizeof(data));
 #endif
 }
 
@@ -66,14 +64,14 @@ static inline void spi_transmit_32(uint32_t data)
     lv_eve_write_buf[lv_eve_write_buf_len++] = buf4[2];
     lv_eve_write_buf[lv_eve_write_buf_len++] = buf4[3];
 #else
-    LV_EVE_TARGET_SPI_SEND(&data, sizeof(data));
+    lv_draw_eve_unit_g->op_cb(lv_draw_eve_unit_g->disp, LV_DRAW_EVE_OPERATION_SPI_SEND, &data, sizeof(data));
 #endif
 }
 
 static inline void lv_eve_target_spi_transmit_buf(const void * data, uint32_t size)
 {
     lv_eve_target_flush_write_buf();
-    LV_EVE_TARGET_SPI_SEND((void *) data, size);
+    lv_draw_eve_unit_g->op_cb(lv_draw_eve_unit_g->disp, LV_DRAW_EVE_OPERATION_SPI_SEND, (void *) data, size);
 }
 
 static inline void lv_eve_target_flush_write_buf(void)
@@ -82,7 +80,7 @@ static inline void lv_eve_target_flush_write_buf(void)
     if(lv_eve_write_buf_len == 0) {
         return;
     }
-    LV_EVE_TARGET_SPI_SEND(lv_eve_write_buf, lv_eve_write_buf_len);
+    lv_draw_eve_unit_g->op_cb(lv_draw_eve_unit_g->disp, LV_DRAW_EVE_OPERATION_SPI_SEND, lv_eve_write_buf, lv_eve_write_buf_len);
     lv_eve_write_buf_len = 0;
 #endif
 }

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -1122,7 +1122,9 @@
         #endif
     #endif
 
-    /* the maximum number of bytes to buffer before a single SPI transmission */
+    /* The maximum number of bytes to buffer before a single SPI transmission.
+     * Set it to 0 to disable write buffering.
+     */
     #ifndef LV_DRAW_EVE_WRITE_BUFFER_SIZE
         #ifdef CONFIG_LV_DRAW_EVE_WRITE_BUFFER_SIZE
             #define LV_DRAW_EVE_WRITE_BUFFER_SIZE CONFIG_LV_DRAW_EVE_WRITE_BUFFER_SIZE


### PR DESCRIPTION
Correctness followup after #9051

Validate input and allow 0 to disable entirely. This is why I sometimes don't like to make something configurable.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
