### PR TITLE
ci(release_updater): some release_updater fixes and conf.defaults deprecated configs are non-fatal

### DIFF
--- a/scripts/generate_lv_conf.py
+++ b/scripts/generate_lv_conf.py
@@ -101,7 +101,7 @@ def generate_config(path_destination: str, path_source: str, defaults: dict):
 
     if len(keys_used) != len(defaults):
         unused_keys = [k for k in defaults.keys() if k not in keys_used]
-        fatal('The following keys are deprecated:\n  ' + '\n  '.join(unused_keys))
+        print('WARNING: The following keys are deprecated:\n  ' + '\n  '.join(unused_keys))
 
     with open(path_destination, 'w', encoding='utf-8') as f_dst:
         for dst_line in dst_lines:


### PR DESCRIPTION
- port release updater
  - Handle leftover .gitmodules paths that aren't real submodules in the index
  - Fix bug where a list got `["master", "master", "master", "master", "master"]`
  - Remove `--quiet`s
- lv_conf.defaults generator
  - reduce the deprecated failure from fatal to a warning

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
