### PR TITLE
fix(test): fix memory leak on failed screenshot compare

### DIFF
--- a/src/others/test/lv_test_screenshot_compare.c
+++ b/src/others/test/lv_test_screenshot_compare.c
@@ -110,7 +110,7 @@ static bool screenshot_compare(const char * fn_ref, uint8_t tolerance)
     uint8_t * screen_buf_xrgb8888 = lv_malloc(draw_buf->header.w * draw_buf->header.h * 4);
     buf_to_xrgb8888(draw_buf, screen_buf_xrgb8888);
 
-    lv_draw_buf_t * ref_draw_buf;
+    lv_draw_buf_t * ref_draw_buf = NULL;
     unsigned ref_img_width = 0;
     unsigned  ref_img_height = 0;
     unsigned  res = read_png_file(&ref_draw_buf, &ref_img_width, &ref_img_height, fn_ref_full);
@@ -118,14 +118,14 @@ static bool screenshot_compare(const char * fn_ref, uint8_t tolerance)
         LV_LOG_WARN("%s%s", fn_ref_full, " was not found, creating it now from the rendered screen");
         write_png_file(screen_buf_xrgb8888, draw_buf->header.w, draw_buf->header.h, fn_ref_full);
         lv_free(screen_buf_xrgb8888);
-        lv_draw_buf_destroy(ref_draw_buf);
+        if(ref_draw_buf) lv_draw_buf_destroy(ref_draw_buf);
         return true;
     }
 
     if(ref_img_width != draw_buf->header.w || ref_img_height != draw_buf->header.h) {
         LV_LOG_WARN("The dimensions of the rendered and the %s reference image don't match", fn_ref);
         lv_free(screen_buf_xrgb8888);
-        lv_draw_buf_destroy(ref_draw_buf);
+        if(ref_draw_buf) lv_draw_buf_destroy(ref_draw_buf);
         return false;
     }
 
@@ -172,7 +172,7 @@ static bool screenshot_compare(const char * fn_ref, uint8_t tolerance)
 
     fflush(stdout);
     lv_free(screen_buf_xrgb8888);
-    lv_draw_buf_destroy(ref_draw_buf);
+    if(ref_draw_buf) lv_draw_buf_destroy(ref_draw_buf);
     return !err;
 
 }

--- a/src/others/test/lv_test_screenshot_compare.c
+++ b/src/others/test/lv_test_screenshot_compare.c
@@ -118,11 +118,14 @@ static bool screenshot_compare(const char * fn_ref, uint8_t tolerance)
         LV_LOG_WARN("%s%s", fn_ref_full, " was not found, creating it now from the rendered screen");
         write_png_file(screen_buf_xrgb8888, draw_buf->header.w, draw_buf->header.h, fn_ref_full);
         lv_free(screen_buf_xrgb8888);
+        lv_draw_buf_destroy(ref_draw_buf);
         return true;
     }
 
     if(ref_img_width != draw_buf->header.w || ref_img_height != draw_buf->header.h) {
         LV_LOG_WARN("The dimensions of the rendered and the %s reference image don't match", fn_ref);
+        lv_free(screen_buf_xrgb8888);
+        lv_draw_buf_destroy(ref_draw_buf);
         return false;
     }
 


### PR DESCRIPTION

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
