### PR TITLE
fix(gltf): fix indexation of model binds and and a new uniform scale bind

### DIFF
--- a/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
@@ -1208,19 +1208,19 @@ static void lv_gltf_view_recache_all_transforms(lv_gltf_model_t * gltf_data)
                         current_override->data[2] = local_scale[2];
                     }
                     else {
+                        float base_scale = 1.0f;
                         if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_3) {
-                            local_scale[0] = current_override->data[3];
-                            local_scale[1] = current_override->data[3];
-                            local_scale[2] = current_override->data[3];
+                            base_scale = current_override->data[3];
+                            local_scale[0] = base_scale;
+                            local_scale[1] = base_scale;
+                            local_scale[2] = base_scale;
                         }
-                        else {
-                            if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_0)
-                                local_scale[0] = current_override->data[0];
-                            if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_1)
-                                local_scale[1] = current_override->data[1];
-                            if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_2)
-                                local_scale[2] = current_override->data[2];
-                        }
+                        if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_0)
+                            local_scale[0] = base_scale * current_override->data[0];
+                        if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_1)
+                            local_scale[1] = base_scale * current_override->data[1];
+                        if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_2)
+                            local_scale[2] = base_scale * current_override->data[2];
                         made_changes = true;
                     }
                 }

--- a/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
@@ -1208,11 +1208,12 @@ static void lv_gltf_view_recache_all_transforms(lv_gltf_model_t * gltf_data)
                         current_override->data[2] = local_scale[2];
                     }
                     else {
-                        if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_3){
+                        if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_3) {
                             local_scale[0] = current_override->data[3];
                             local_scale[1] = current_override->data[3];
                             local_scale[2] = current_override->data[3];
-                        } else {
+                        }
+                        else {
                             if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_0)
                                 local_scale[0] = current_override->data[0];
                             if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_1)

--- a/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
@@ -1156,34 +1156,34 @@ static void lv_gltf_view_recache_all_transforms(lv_gltf_model_t * gltf_data)
             // Traverse through all linked overrides
             while(current_override != nullptr) {
                 if(current_override->prop == LV_GLTF_BIND_PROP_ROTATION) {
-                    if(current_override->dir) {
+                    if(current_override->dir == LV_GLTF_BIND_DIR_READ) {
                         current_override->data[0] = local_rot[0];
                         current_override->data[1] = local_rot[1];
                         current_override->data[2] = local_rot[2];
                     }
                     else {
-                        if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_1)
+                        if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_0)
                             local_rot[0] = current_override->data[0];
-                        if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_2)
+                        if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_1)
                             local_rot[1] = current_override->data[1];
-                        if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_3)
+                        if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_2)
                             local_rot[2] = current_override->data[2];
                         made_changes = true;
                         made_rotation_changes = true;
                     }
                 }
                 else if(current_override->prop == LV_GLTF_BIND_PROP_POSITION) {
-                    if(current_override->dir) {
+                    if(current_override->dir == LV_GLTF_BIND_DIR_READ) {
                         current_override->data[0] = local_pos[0];
                         current_override->data[1] = local_pos[1];
                         current_override->data[2] = local_pos[2];
                     }
                     else {
-                        if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_1)
+                        if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_0)
                             local_pos[0] = current_override->data[0];
-                        if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_2)
+                        if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_1)
                             local_pos[1] = current_override->data[1];
-                        if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_3)
+                        if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_2)
                             local_pos[2] = current_override->data[2];
                         made_changes = true;
                     }
@@ -1195,25 +1195,31 @@ static void lv_gltf_view_recache_all_transforms(lv_gltf_model_t * gltf_data)
                     fastgltf::math::decomposeTransformMatrix(parentworldmatrix * localmatrix,
                                                              world_scale, world_quat, world_pos);
 
-                    if(current_override->dir) {
+                    if(current_override->dir == LV_GLTF_BIND_DIR_READ) {
                         current_override->data[0] = world_pos[0];
                         current_override->data[1] = world_pos[1];
                         current_override->data[2] = world_pos[2];
                     }
                 }
                 else if(current_override->prop == LV_GLTF_BIND_PROP_SCALE) {
-                    if(current_override->dir) {
+                    if(current_override->dir == LV_GLTF_BIND_DIR_READ) {
                         current_override->data[0] = local_scale[0];
                         current_override->data[1] = local_scale[1];
                         current_override->data[2] = local_scale[2];
                     }
                     else {
-                        if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_1)
-                            local_scale[0] = current_override->data[0];
-                        if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_2)
-                            local_scale[1] = current_override->data[1];
-                        if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_3)
-                            local_scale[2] = current_override->data[2];
+                        if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_3){
+                            local_scale[0] = current_override->data[3];
+                            local_scale[1] = current_override->data[3];
+                            local_scale[2] = current_override->data[3];
+                        } else {
+                            if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_0)
+                                local_scale[0] = current_override->data[0];
+                            if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_1)
+                                local_scale[1] = current_override->data[1];
+                            if(current_override->data_mask & LV_GLTF_BIND_CHANNEL_2)
+                                local_scale[2] = current_override->data[2];
+                        }
                         made_changes = true;
                     }
                 }


### PR DESCRIPTION
Bind checks in lv_gltf_view_render were mismatched, this fixes that.  LV_GLTF_BIND_CHANNEL_0 should correspond to override->data[0], both base zero.   The direction state was being checked as a boolean, that was not working correctly so I changed those checks to be for specific enum values.  

A fourth channel data bind was added for scale properties, it represents the uniform scale of the object.  This helps reduce redundant code since otherwise a user would need to create three binds, one per axis, but in most cases they will want to change all of them at once to the same value, so for that they can use the fourth channel bind (LV_GLTF_BIND_CHANNEL_3, they are base zero)