### PR TITLE
test(array): improve lv_array test coverage

### DIFF
--- a/src/misc/lv_array.c
+++ b/src/misc/lv_array.c
@@ -128,7 +128,7 @@ lv_result_t lv_array_erase(lv_array_t * array, uint32_t start, uint32_t end)
     uint8_t * start_p = lv_array_at(array, start);
     uint8_t * remaining = start_p + (end - start) * array->element_size;
     uint32_t remaining_size = (array->size - end) * array->element_size;
-    lv_memcpy(start_p, remaining, remaining_size);
+    lv_memmove(start_p, remaining, remaining_size);
     array->size -= (end - start);
     lv_array_shrink(array);
     return LV_RESULT_OK;

--- a/tests/src/test_cases/test_array.c
+++ b/tests/src/test_cases/test_array.c
@@ -100,4 +100,147 @@ void test_array_concat(void)
     lv_array_deinit(&b);
 }
 
+void test_array_init_from_buf(void)
+{
+    int32_t buf[4] = { 0 };
+    lv_array_t a;
+    lv_array_init_from_buf(&a, buf, 4, sizeof(int32_t));
+
+    TEST_ASSERT_FALSE(lv_array_resize(&a, 8));
+
+    lv_array_t b;
+    lv_array_init(&b, 4, sizeof(int32_t));
+    lv_array_push_back(&b, NULL);
+
+    TEST_ASSERT_EQUAL_UINT32(4, lv_array_capacity(&a));
+
+    for(int32_t i = 0; i < 4; i++) {
+        lv_array_push_back(&a, &i);
+    }
+
+    /* Test overflow handling, should fail */
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_array_push_back(&a, NULL));
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_array_concat(&a, &b));
+
+    TEST_ASSERT_EQUAL_UINT32(4, lv_array_size(&a));
+    for(int32_t i = 0; i < 4; i++) {
+        int32_t * v = lv_array_at(&a, i);
+        TEST_ASSERT_EQUAL_INT32(i, *v);
+    }
+
+    TEST_ASSERT_EQUAL_PTR(buf, lv_array_front(&a));
+    TEST_ASSERT_EQUAL_PTR(buf + 3, lv_array_back(&a));
+
+    lv_array_deinit(&a);
+    lv_array_deinit(&b);
+}
+
+void test_array_shrink(void)
+{
+    for(int32_t i = 0; i < 10; i++) {
+        lv_array_push_back(&array, &i);
+    }
+    TEST_ASSERT_EQUAL_UINT32(10, lv_array_size(&array));
+
+    lv_array_resize(&array, 20);
+    TEST_ASSERT_EQUAL_UINT32(20, lv_array_capacity(&array));
+
+    lv_array_shrink(&array);
+    TEST_ASSERT_EQUAL_UINT32(10, lv_array_capacity(&array));
+
+    /* Double shrink should not shrink more */
+    lv_array_shrink(&array);
+    TEST_ASSERT_EQUAL_UINT32(10, lv_array_capacity(&array));
+}
+
+void test_array_remove(void)
+{
+    for(int32_t i = 0; i < 5; i++) {
+        lv_array_push_back(&array, &i);
+    }
+    TEST_ASSERT_EQUAL_UINT32(5, lv_array_size(&array));
+
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_array_remove(&array, 4));
+    TEST_ASSERT_EQUAL_UINT32(4, lv_array_size(&array));
+
+    /* Test remove out of range, should fail */
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_array_remove(&array, 4));
+    TEST_ASSERT_EQUAL_UINT32(4, lv_array_size(&array));
+
+    /* remove the last element */
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_array_remove(&array, 3));
+    TEST_ASSERT_EQUAL_UINT32(3, lv_array_size(&array));
+
+    /* remove the first element */
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_array_remove(&array, 0));
+    TEST_ASSERT_EQUAL_UINT32(2, lv_array_size(&array));
+
+    /* verify the content */
+    for(int32_t i = 0; i < 2; i++) {
+        int32_t * v = lv_array_at(&array, i);
+        TEST_ASSERT_EQUAL_INT32(i + 1, *v);
+    }
+}
+
+void test_array_erase(void)
+{
+    for(int32_t i = 0; i < 10; i++) {
+        lv_array_push_back(&array, &i);
+    }
+
+    TEST_ASSERT_EQUAL_UINT32(10, lv_array_size(&array));
+    lv_array_erase(&array, 3, 7);
+    TEST_ASSERT_EQUAL_UINT32(6, lv_array_size(&array));
+
+    for(int32_t i = 0; i < 6; i++) {
+        int32_t * v = lv_array_at(&array, i);
+        if(i < 3) {
+            TEST_ASSERT_EQUAL_INT32(i, *v);
+        }
+        else {
+            TEST_ASSERT_EQUAL_INT32(i + 4, *v);
+        }
+    }
+
+    /* Test edge cases */
+    lv_array_clear(&array);
+    for(int32_t i = 0; i < 10; i++) {
+        lv_array_push_back(&array, &i);
+    }
+
+    /* end > array->size */
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_array_erase(&array, 3, 15));
+    TEST_ASSERT_EQUAL_UINT32(3, lv_array_size(&array));
+
+    /* Reset array */
+    lv_array_clear(&array);
+    for(int32_t i = 0; i < 10; i++) {
+        lv_array_push_back(&array, &i);
+    }
+
+    /* start >= end */
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_array_erase(&array, 5, 5));
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_array_erase(&array, 7, 6));
+
+    /* end == array->size */
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_array_erase(&array, 5, 10));
+    TEST_ASSERT_EQUAL_UINT32(5, lv_array_size(&array));
+}
+
+void test_array_assign(void)
+{
+    for(int32_t i = 0; i < 5; i++) {
+        lv_array_push_back(&array, &i);
+    }
+
+    int32_t v = 100;
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_array_assign(&array, 2, &v));
+
+    int32_t * r = lv_array_at(&array, 2);
+    TEST_ASSERT_EQUAL_INT32(100, *r);
+
+    /* Test out of range, should fail */
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_array_assign(&array, 5, &v));
+}
+
 #endif

--- a/tests/src/test_cases/test_array.c
+++ b/tests/src/test_cases/test_array.c
@@ -184,6 +184,24 @@ void test_array_remove(void)
 
 void test_array_erase(void)
 {
+    /* Test overlapping memory regions */
+    for(int32_t i = 0; i < 5; i++) {
+        lv_array_push_back(&array, &i);
+    }
+
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_array_erase(&array, 0, 1));
+    TEST_ASSERT_EQUAL_UINT32(4, lv_array_size(&array));
+    for(int32_t i = 0; i < 4; i++) {
+        int32_t * v = lv_array_at(&array, i);
+        TEST_ASSERT_EQUAL_INT32(i + 1, *v);
+    }
+
+    for(int32_t i = 0; i < 10; i++) {
+        lv_array_push_back(&array, &i);
+    }
+
+    /* Test erase from the middle */
+    lv_array_clear(&array);
     for(int32_t i = 0; i < 10; i++) {
         lv_array_push_back(&array, &i);
     }
@@ -191,7 +209,6 @@ void test_array_erase(void)
     TEST_ASSERT_EQUAL_UINT32(10, lv_array_size(&array));
     lv_array_erase(&array, 3, 7);
     TEST_ASSERT_EQUAL_UINT32(6, lv_array_size(&array));
-
     for(int32_t i = 0; i < 6; i++) {
         int32_t * v = lv_array_at(&array, i);
         if(i < 3) {
@@ -211,6 +228,10 @@ void test_array_erase(void)
     /* end > array->size */
     TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_array_erase(&array, 3, 15));
     TEST_ASSERT_EQUAL_UINT32(3, lv_array_size(&array));
+    for(int32_t i = 0; i < 3; i++) {
+        int32_t * v = lv_array_at(&array, i);
+        TEST_ASSERT_EQUAL_INT32(i, *v);
+    }
 
     /* Reset array */
     lv_array_clear(&array);
@@ -225,6 +246,10 @@ void test_array_erase(void)
     /* end == array->size */
     TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_array_erase(&array, 5, 10));
     TEST_ASSERT_EQUAL_UINT32(5, lv_array_size(&array));
+    for(int32_t i = 0; i < 5; i++) {
+        int32_t * v = lv_array_at(&array, i);
+        TEST_ASSERT_EQUAL_INT32(i, *v);
+    }
 }
 
 void test_array_assign(void)


### PR DESCRIPTION
Before: <60%
![img_v3_02rb_dfd1d91a-3dcc-4275-8e61-edbb6c8b330g](https://github.com/user-attachments/assets/39b328b2-9537-408f-92ea-43b2bd48d932)

After: 100%
![img_v3_02rb_7e6d8cb9-9bff-4843-96dc-86afd8ff38dg](https://github.com/user-attachments/assets/e233b6a6-2d1b-46f3-8c5d-55c58a419cc1)


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
