### PR TITLE
docs:  fix enumerator expansion upon API page links

### DIFF
--- a/docs/src/_static/js/custom.js
+++ b/docs/src/_static/js/custom.js
@@ -122,40 +122,59 @@ document.addEventListener("DOMContentLoaded", (event) => {
    *---------------------------------------------------------------------*/
   document.querySelectorAll("dl.cpp").forEach((cppListing) => {
     const dt = cppListing.querySelector("dt");
+    let exClass = "expanded";
+    let unExClass = "unexpanded";
     let shouldBeExpanded = false;
     if (dt.id == document.location.hash.substring(1)) shouldBeExpanded = true;
-    cppListing.classList.add(shouldBeExpanded ? "expanded" : "unexpanded");
+    if (shouldBeExpanded) {
+      cppListing.classList.add(exClass);
+
+      /* If `dt.id` is for an enumerator, also expand its parent
+       * <dl class="cpp enum unexpanded"> element. */
+      let parentDlNode = cppListing.parentNode.parentNode;
+      if (
+           parentDlNode != null
+        && parentDlNode.classList.contains("cpp")
+        && parentDlNode.classList.contains("enum")
+        && parentDlNode.classList.contains(unExClass)
+        ) {
+        parentDlNode.classList.remove(unExClass);
+        parentDlNode.classList.add(exClass);
+      }
+    } else {
+      cppListing.classList.add(unExClass);
+    }
     const button = document.createElement("span");
     button.classList.add("lv-api-expansion-button");
     button.addEventListener("click", () => {
-      cppListing.classList.toggle("unexpanded");
-      cppListing.classList.toggle("expanded");
+      cppListing.classList.toggle(unExClass);
+      cppListing.classList.toggle(exClass);
     });
 
     dt.insertBefore(button, dt.firstChild);
   });
 
   /*---------------------------------------------------------------------
-     * Display any current custom banner in `banner.json` at top of each page.
-     *---------------------------------------------------------------------
-     * Custom banners are inserted between these two elements at top of page.
-    <a class="skip-to-content muted-link" href="#furo-main-content">Skip to content</a>
+   * Display any current custom banner in `banner.json` at top of each page.
+   *---------------------------------------------------------------------
+   * Custom banners are inserted between these two elements at top of page.
+  <a class="skip-to-content muted-link" href="#furo-main-content">Skip to content</a>
 
-    <div class="lv-custom-banner-list">
-      <p class="lv-custom-banner">
-         <em>Important</em> announcement one!
-      </p>
-      <p class="lv-custom-banner">
-         <em>Important</em> announcement two!
-      </p>
-      <p class="lv-custom-banner">
-         <em>Important</em> announcement three!
-      </p>
-    </div>
+  <div class="lv-custom-banner-list">
+    <p class="lv-custom-banner">
+      <em>Important</em> announcement one!
+    </p>
+    <p class="lv-custom-banner">
+      <em>Important</em> announcement two!
+    </p>
+    <p class="lv-custom-banner">
+      <em>Important</em> announcement three!
+    </p>
+  </div>
 
-    <div class="page">
-      ...page content...
-     *---------------------------------------------------------------------*/
+  <div class="page">
+    ...page content...
+   *---------------------------------------------------------------------*/
   let bannerJsonUrl = "https://lvgl.io/data/banner.json";
   let bannerContainerClass = "lv-custom-banner-list";
   let bannerClass = "lv-custom-banner";


### PR DESCRIPTION
Fixes #9043

Issue #9043 correctly observed that enumerator values, when clicked in a doc, wound the reader up at the bottom of the page, with the target enumerator value hidden.  The reason for this was that the parent `enum` <dl class="cpp enum unexpanded"> element was unexpanded, and thus its child <dd> element (containing the target enumerator documentation) remained hidden on the page.

This PR, examines the parent <dl> element, and if it is indeed unexpanded, then it is expanded, allowing the browser to move to and show the expanded enumerator as originally intended.

It also fixes unintended indenting in a comment just below this code.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
