### PR TITLE
feat(gltf): use alternate blending mode for glTF views

### DIFF
--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -658,8 +658,8 @@ static void lv_draw_opengles_3d(lv_draw_task_t * t, const lv_draw_3d_dsc_t * dsc
     lv_area_t clip_area = t->clip_area;
     lv_area_move(&clip_area, -dest_layer->buf_area.x1, -dest_layer->buf_area.y1);
 
-    lv_opengles_render_texture(dsc->tex_id, coords, dsc->opa, targ_tex_w, targ_tex_h, &clip_area, dsc->h_flip,
-                               !dsc->v_flip);
+    lv_opengles_render_texture_alt(dsc->tex_id, coords, dsc->opa, targ_tex_w, targ_tex_h, &clip_area, dsc->h_flip,
+                                   !dsc->v_flip);
 
     if(target_texture) {
         GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -663,8 +663,8 @@ static void lv_draw_opengles_3d(lv_draw_task_t * t, const lv_draw_3d_dsc_t * dsc
     lv_area_t clip_area = t->clip_area;
     lv_area_move(&clip_area, -dest_layer->buf_area.x1, -dest_layer->buf_area.y1);
 
-    lv_opengles_render_texture_alt(dsc->tex_id, coords, dsc->opa, targ_tex_w, targ_tex_h, &clip_area, dsc->h_flip,
-                                   !dsc->v_flip);
+    lv_opengles_render(dsc->tex_id, coords, dsc->opa, targ_tex_w, targ_tex_h, &clip_area, dsc->h_flip, !dsc->v_flip,
+                       lv_color_black(), true);
 
     if(target_texture) {
         GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -626,7 +626,12 @@ static unsigned int create_texture(int32_t w, int32_t h, const void * data)
 #if 0
     GL_CALL(glGenerateMipmap(GL_TEXTURE_2D));
     GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 20));
-    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST));
+    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR));
+    /* GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST));
+     * Alternatively, the above form can be used in some cases for slightly faster performance, but
+     * visual quality when using image scales that are not exactly 1:1 (or 2:1 or some other increment)
+     * will be not as good.
+     */
 #endif
 
     GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST));

--- a/src/drivers/opengles/assets/lv_opengles_shader.c
+++ b/src/drivers/opengles/assets/lv_opengles_shader.c
@@ -100,7 +100,7 @@ static const char *src_fragment_shader_v100 = R"(
         }
         if (abs(u_ColorDepth - 8.0) < 0.1) {
             float gray = texColor.r;
-            gl_FragColor = vec4(gray, gray, gray, u_Opa);
+            gl_FragColor = vec4(vec3(gray * u_Opa), u_Opa);
         } else {
             float combinedAlpha = texColor.a * u_Opa;
             gl_FragColor = vec4(texColor.rgb * combinedAlpha, combinedAlpha);
@@ -212,7 +212,7 @@ static const char *src_fragment_shader_v300es = R"(
         }
         if (abs(u_ColorDepth - 8.0) < 0.1) {
             float gray = texColor.r;
-            color = vec4(gray, gray, gray, u_Opa);
+            color = vec4(vec3(gray * u_Opa), u_Opa);
         } else {
             float combinedAlpha = texColor.a * u_Opa;
             color = vec4(texColor.rgb * combinedAlpha, combinedAlpha);

--- a/src/drivers/opengles/assets/lv_opengles_shader.c
+++ b/src/drivers/opengles/assets/lv_opengles_shader.c
@@ -203,8 +203,12 @@ static const char *src_fragment_shader_v300es = R"(
         if (u_IsFill) {
             texColor = vec4(u_FillColor, 1.0);
         } else {
-            //texColor = texture(u_Texture, v_TexCoord);
-            texColor = textureLod(u_Texture, v_TexCoord, 0.0);  // If the vertices have been transformed, and mipmaps have not been generated, some rotation angles (notably 90 and 270) require using textureLod() to mitigate derivative calculation errors from increments flipping direction
+            texColor = texture(u_Texture, v_TexCoord);
+            /* If the vertices have been transformed, and mipmaps have not been generated, 
+             * some rotation angles (notably 90 and 270) require using textureLod() to mitigate 
+             * derivative calculation errors from interpolator increments flipping direction.
+             * texColor = textureLod(u_Texture, v_TexCoord, u_LodLevel);
+             */
         }
         if (abs(u_ColorDepth - 8.0) < 0.1) {
             float gray = texColor.r;

--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -150,15 +150,6 @@ void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_
     LV_PROFILER_DRAW_END;
 }
 
-void lv_opengles_render_texture_alt(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa, int32_t disp_w,
-                                    int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip)
-{
-    LV_PROFILER_DRAW_BEGIN;
-    lv_opengles_render(texture, texture_area, opa, disp_w, disp_h, texture_clip_area, h_flip, v_flip,
-                       lv_color_black(), true);
-    LV_PROFILER_DRAW_END;
-}
-
 void lv_opengles_render_fill(lv_color_t color, const lv_area_t * area, lv_opa_t opa, int32_t disp_w, int32_t disp_h)
 {
     LV_PROFILER_DRAW_BEGIN;

--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -33,9 +33,7 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static void lv_opengles_render_internal(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
-                                        int32_t disp_w, int32_t disp_h, const lv_area_t * texture_clip_area,
-                                        bool h_flip, bool v_flip, lv_color_t fill_color, bool blend_opt);
+
 static void lv_opengles_enable_blending(bool blend_opt);
 static void lv_opengles_disable_blending(void);
 static void lv_opengles_vertex_buffer_init(const void * data, unsigned int size);
@@ -147,8 +145,8 @@ void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_
                                 int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip)
 {
     LV_PROFILER_DRAW_BEGIN;
-    lv_opengles_render_internal(texture, texture_area, opa, disp_w, disp_h, texture_clip_area, h_flip, v_flip,
-                                lv_color_black(), false);
+    lv_opengles_render(texture, texture_area, opa, disp_w, disp_h, texture_clip_area, h_flip, v_flip,
+                       lv_color_black(), false);
     LV_PROFILER_DRAW_END;
 }
 
@@ -156,15 +154,15 @@ void lv_opengles_render_texture_alt(unsigned int texture, const lv_area_t * text
                                     int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip)
 {
     LV_PROFILER_DRAW_BEGIN;
-    lv_opengles_render_internal(texture, texture_area, opa, disp_w, disp_h, texture_clip_area, h_flip, v_flip,
-                                lv_color_black(), true);
+    lv_opengles_render(texture, texture_area, opa, disp_w, disp_h, texture_clip_area, h_flip, v_flip,
+                       lv_color_black(), true);
     LV_PROFILER_DRAW_END;
 }
 
 void lv_opengles_render_fill(lv_color_t color, const lv_area_t * area, lv_opa_t opa, int32_t disp_w, int32_t disp_h)
 {
     LV_PROFILER_DRAW_BEGIN;
-    lv_opengles_render_internal(0, area, opa, disp_w, disp_h, area, false, false, color, false);
+    lv_opengles_render(0, area, opa, disp_w, disp_h, area, false, false, color, false);
     LV_PROFILER_DRAW_END;
 }
 
@@ -220,13 +218,9 @@ void lv_opengles_viewport(int32_t x, int32_t y, int32_t w, int32_t h)
     LV_PROFILER_DRAW_END;
 }
 
-/**********************
- *   STATIC FUNCTIONS
- **********************/
-
-static void lv_opengles_render_internal(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
-                                        int32_t disp_w, int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip, lv_color_t fill_color,
-                                        bool blend_opt)
+void lv_opengles_render(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
+                        int32_t disp_w, int32_t disp_h, const lv_area_t * texture_clip_area,
+                        bool h_flip, bool v_flip, lv_color_t fill_color, bool blend_opt)
 {
     LV_PROFILER_DRAW_BEGIN;
     lv_area_t intersection;
@@ -286,6 +280,10 @@ static void lv_opengles_render_internal(unsigned int texture, const lv_area_t * 
     lv_opengles_disable_blending();
     LV_PROFILER_DRAW_END;
 }
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
 
 static void lv_opengles_enable_blending(bool blend_opt)
 {

--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -35,8 +35,9 @@
  **********************/
 static void lv_opengles_render_internal(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
                                         int32_t disp_w, int32_t disp_h, const lv_area_t * texture_clip_area,
-                                        bool h_flip, bool v_flip, lv_color_t fill_color);
-static void lv_opengles_enable_blending(void);
+                                        bool h_flip, bool v_flip, lv_color_t fill_color, bool blend_opt);
+static void lv_opengles_enable_blending(bool blend_opt);
+static void lv_opengles_disable_blending(void);
 static void lv_opengles_vertex_buffer_init(const void * data, unsigned int size);
 static void lv_opengles_vertex_buffer_deinit(void);
 static void lv_opengles_vertex_buffer_bind(void);
@@ -102,7 +103,7 @@ void lv_opengles_init(void)
 {
     if(is_init) return;
 
-    lv_opengles_enable_blending();
+    lv_opengles_enable_blending(false);
 
     unsigned int indices[] = {
         0, 1, 2,
@@ -147,14 +148,23 @@ void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_
 {
     LV_PROFILER_DRAW_BEGIN;
     lv_opengles_render_internal(texture, texture_area, opa, disp_w, disp_h, texture_clip_area, h_flip, v_flip,
-                                lv_color_black());
+                                lv_color_black(), false);
+    LV_PROFILER_DRAW_END;
+}
+
+void lv_opengles_render_texture_alt(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa, int32_t disp_w,
+                                    int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip)
+{
+    LV_PROFILER_DRAW_BEGIN;
+    lv_opengles_render_internal(texture, texture_area, opa, disp_w, disp_h, texture_clip_area, h_flip, v_flip,
+                                lv_color_black(), true);
     LV_PROFILER_DRAW_END;
 }
 
 void lv_opengles_render_fill(lv_color_t color, const lv_area_t * area, lv_opa_t opa, int32_t disp_w, int32_t disp_h)
 {
     LV_PROFILER_DRAW_BEGIN;
-    lv_opengles_render_internal(0, area, opa, disp_w, disp_h, area, false, false, color);
+    lv_opengles_render_internal(0, area, opa, disp_w, disp_h, area, false, false, color, false);
     LV_PROFILER_DRAW_END;
 }
 
@@ -215,7 +225,8 @@ void lv_opengles_viewport(int32_t x, int32_t y, int32_t w, int32_t h)
  **********************/
 
 static void lv_opengles_render_internal(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
-                                        int32_t disp_w, int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip, lv_color_t fill_color)
+                                        int32_t disp_w, int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip, lv_color_t fill_color,
+                                        bool blend_opt)
 {
     LV_PROFILER_DRAW_BEGIN;
     lv_area_t intersection;
@@ -263,6 +274,7 @@ static void lv_opengles_render_internal(unsigned int texture, const lv_area_t * 
     };
 
     lv_opengles_shader_bind();
+    lv_opengles_enable_blending(blend_opt);
     lv_opengles_shader_set_uniform1f("u_ColorDepth", LV_COLOR_DEPTH);
     lv_opengles_shader_set_uniform1i("u_Texture", 0);
     lv_opengles_shader_set_uniformmatrix3fv("u_VertexTransform", 1, transposed_matrix);
@@ -271,13 +283,19 @@ static void lv_opengles_render_internal(unsigned int texture, const lv_area_t * 
     lv_opengles_shader_set_uniform3f("u_FillColor", (float)fill_color.red / 255.0f, (float)fill_color.green / 255.0f,
                                      (float)fill_color.blue / 255.0f);
     lv_opengles_render_draw();
+    lv_opengles_disable_blending();
     LV_PROFILER_DRAW_END;
 }
 
-static void lv_opengles_enable_blending(void)
+static void lv_opengles_enable_blending(bool blend_opt)
 {
     GL_CALL(glEnable(GL_BLEND));
-    GL_CALL(glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
+    GL_CALL(glBlendFunc(blend_opt ? GL_SRC_ALPHA : GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
+}
+
+static void lv_opengles_disable_blending(void)
+{
+    GL_CALL(glDisable(GL_BLEND));
 }
 
 static void lv_opengles_vertex_buffer_init(const void * data, unsigned int size)

--- a/src/drivers/opengles/lv_opengles_driver.h
+++ b/src/drivers/opengles/lv_opengles_driver.h
@@ -54,8 +54,8 @@ void lv_opengles_deinit(void);
  * @param h_flip         horizontal flip
  * @param v_flip         vertical flip
  */
-void lv_opengles_render_texture_alt(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa, int32_t disp_w,
-                                    int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip);
+void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa, int32_t disp_w,
+                                int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip);
 
 /**
  * Render a display texture - Supports rotation

--- a/src/drivers/opengles/lv_opengles_driver.h
+++ b/src/drivers/opengles/lv_opengles_driver.h
@@ -45,19 +45,6 @@ void lv_opengles_init(void);
 void lv_opengles_deinit(void);
 
 /**
- * Render a texture
- * @param texture        OpenGL texture ID
- * @param texture_area   the area in the window to render the texture in
- * @param opa            opacity to blend the texture with existing contents
- * @param disp_w         width of the window/framebuffer being rendered to
- * @param disp_h         height of the window/framebuffer being rendered to
- * @param h_flip         horizontal flip
- * @param v_flip         vertical flip
- */
-void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa, int32_t disp_w,
-                                int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip);
-
-/**
  * Render a texture using alternate blending mode for smoother translucent materials and correct anti-aliasing of glTF elements when using transparent background
  * @param texture        OpenGL texture ID
  * @param texture_area   the area in the window to render the texture in

--- a/src/drivers/opengles/lv_opengles_driver.h
+++ b/src/drivers/opengles/lv_opengles_driver.h
@@ -58,6 +58,19 @@ void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_
                                 int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip);
 
 /**
+ * Render a texture using alternate blending mode for smoother translucent materials and correct anti-aliasing of glTF elements when using transparent background
+ * @param texture        OpenGL texture ID
+ * @param texture_area   the area in the window to render the texture in
+ * @param opa            opacity to blend the texture with existing contents
+ * @param disp_w         width of the window/framebuffer being rendered to
+ * @param disp_h         height of the window/framebuffer being rendered to
+ * @param h_flip         horizontal flip
+ * @param v_flip         vertical flip
+ */
+void lv_opengles_render_texture_alt(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa, int32_t disp_w,
+                                    int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip);
+
+/**
  * Render a display texture - Supports rotation
  * @param display           LVGL Texture display. Created with the `lv_opengles_texture` module
  * @param h_flip            horizontal flip

--- a/src/drivers/opengles/lv_opengles_private.h
+++ b/src/drivers/opengles/lv_opengles_private.h
@@ -17,6 +17,9 @@ extern "C" {
 #include "../../lv_conf_internal.h"
 #if LV_USE_OPENGLES
 
+#include "../../misc/lv_area.h"
+#include "../../misc/lv_color.h"
+
 #if LV_USE_EGL
 #include "glad/include/glad/gles2.h"
 #include "glad/include/glad/egl.h"
@@ -99,6 +102,10 @@ extern "C" {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
+
+void lv_opengles_render(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
+                        int32_t disp_w, int32_t disp_h, const lv_area_t * texture_clip_area,
+                        bool h_flip, bool v_flip, lv_color_t fill_color, bool blend_opt);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
 This allows for smoother translucent materials and proper antialiasing against transparent backgrounds.  To see the effects, view the tractor sample with and without this PR, with a transparent background and anti-aliasing enabled.  Without this pr, the anti-aliasing won't be visible (although it will still be calculated and impact frame rate), and semi-transparent materials that don't affect the depth buffer, like the driver's compartment glass panels, that won't be visible at all.  But with this PR, the anti-aliasing and transparent materials work as expected.

We may want to consider switching all blending operations over to this mode at some point, but that would require we adjust some areas where colors are pre-multiplied by the opacity, since that's only required for GL_ONE based blending.  We will at least require this blend mode for glTF views, for proper functionality.