### PR TITLE
test(mem): improve memory test coverage

### DIFF
--- a/tests/src/test_cases/test_mem.c
+++ b/tests/src/test_cases/test_mem.c
@@ -15,12 +15,58 @@ void tearDown(void)
 }
 
 /* #3324 */
-void test_mem_buf_realloc(void)
+void test_mem_realloc(void)
 {
 #ifdef LVGL_CI_USING_DEF_HEAP
+    uint32_t mem = lv_test_get_free_mem();
+
     void * buf1 = lv_malloc(20);
-    void * buf2 = lv_realloc(buf1, LV_MEM_SIZE + 16384);
+
+    void * buf2 = lv_realloc(buf1, LV_MEM_SIZE + 1);
     TEST_ASSERT_NULL(buf2);
+
+    /* Realloc failed, but should free buf1 */
+    void * buf3 = lv_reallocf(buf1, LV_MEM_SIZE + 1);
+    TEST_ASSERT_NULL(buf3);
+
+    void * buf4 = lv_reallocf(NULL, 30);
+    TEST_ASSERT_NOT_NULL(buf4);
+    lv_free(buf4);
+
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem, 0);
+#endif
+}
+
+void test_mem_alloc_failed(void)
+{
+#ifdef LVGL_CI_USING_DEF_HEAP
+    uint32_t mem = lv_test_get_free_mem();
+    TEST_ASSERT_NULL(lv_malloc(LV_MEM_SIZE + 1));
+    TEST_ASSERT_NULL(lv_malloc_zeroed(LV_MEM_SIZE + 1));
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem, 0);
+#endif
+}
+
+void test_mem_test(void)
+{
+#ifdef LVGL_CI_USING_DEF_HEAP
+    uint32_t mem = lv_test_get_free_mem();
+    uint32_t * zero_mem = lv_malloc_zeroed(0);
+    TEST_ASSERT_NOT_NULL(zero_mem);
+
+    /* Test magic value */
+    TEST_ASSERT_EQUAL_UINT32(ZERO_MEM_SENTINEL, *zero_mem);
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_mem_test());
+
+    /* Test wrong memory, test should fail */
+    *zero_mem = 0;
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_mem_test());
+
+    /* Restore magic value */
+    *zero_mem = ZERO_MEM_SENTINEL;
+    lv_free(zero_mem);
+
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem, 0);
 #endif
 }
 

--- a/tests/src/test_cases/test_mem.c
+++ b/tests/src/test_cases/test_mem.c
@@ -66,6 +66,12 @@ void test_mem_test(void)
     *zero_mem = ZERO_MEM_SENTINEL;
     lv_free(zero_mem);
 
+    /* Re-verify zero memory */
+    uint32_t * new_zero_mem = lv_malloc_zeroed(0);
+    TEST_ASSERT_EQUAL_UINT32(ZERO_MEM_SENTINEL, *new_zero_mem);
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_mem_test());
+    lv_free(new_zero_mem);
+
     TEST_ASSERT_MEM_LEAK_LESS_THAN(mem, 0);
 #endif
 }

--- a/tests/src/test_cases/test_mem.c
+++ b/tests/src/test_cases/test_mem.c
@@ -14,8 +14,71 @@ void tearDown(void)
     /* Function run after every test */
 }
 
+void test_malloc(void)
+{
+    uint32_t mem = lv_test_get_free_mem();
+    void * buf = lv_malloc(32);
+    TEST_ASSERT_NOT_NULL(buf);
+    lv_free(buf);
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem, 0);
+}
+
+static void check_zero_mem(const void * data, size_t size)
+{
+    const uint8_t * p = data;
+    for(size_t i = 0; i < size; i++) {
+        TEST_ASSERT_EQUAL_UINT8(0, p[i]);
+    }
+}
+
+void test_calloc(void)
+{
+    uint32_t mem = lv_test_get_free_mem();
+    void * buf = lv_calloc(4, 8);
+    TEST_ASSERT_NOT_NULL(buf);
+
+    check_zero_mem(buf, 32);
+
+    lv_free(buf);
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem, 0);
+}
+
+void test_zalloc(void)
+{
+    uint32_t mem = lv_test_get_free_mem();
+    void * buf = lv_zalloc(32);
+    TEST_ASSERT_NOT_NULL(buf);
+
+    check_zero_mem(buf, 32);
+
+    lv_free(buf);
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem, 0);
+}
+
+void test_realloc(void)
+{
+    uint32_t mem = lv_test_get_free_mem();
+    void * buf = lv_malloc(16);
+    TEST_ASSERT_NOT_NULL(buf);
+
+    buf = lv_realloc(buf, 32);
+    TEST_ASSERT_NOT_NULL(buf);
+
+    buf = lv_realloc(buf, 8);
+    TEST_ASSERT_NOT_NULL(buf);
+
+    lv_free(buf);
+
+    /* Should behave like malloc */
+    buf = lv_realloc(NULL, 16);
+    TEST_ASSERT_NOT_NULL(buf);
+    lv_free(buf);
+
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem, 0);
+}
+
 /* #3324 */
-void test_mem_realloc(void)
+void test_realloc_failed(void)
 {
 #ifdef LVGL_CI_USING_DEF_HEAP
     uint32_t mem = lv_test_get_free_mem();
@@ -37,7 +100,7 @@ void test_mem_realloc(void)
 #endif
 }
 
-void test_mem_alloc_failed(void)
+void test_malloc_failed(void)
 {
 #ifdef LVGL_CI_USING_DEF_HEAP
     uint32_t mem = lv_test_get_free_mem();


### PR DESCRIPTION
Before: ~70%
![img_v3_02rc_cfd51174-a317-4034-b544-797e0b963a1g](https://github.com/user-attachments/assets/7c1c6537-4500-49a7-961a-a11d582136ad)

After: 100%
![img_v3_02rc_c506e4e1-5a34-42fa-baf6-2541111d171g](https://github.com/user-attachments/assets/211ac44f-8ed8-4c02-9902-5db7ca4cdd80)

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
