### PR TITLE
docs(misc):  remove last warnings from doc-build with skip_api argument

### DIFF
--- a/docs/src/details/auxiliary-modules/test.rst
+++ b/docs/src/details/auxiliary-modules/test.rst
@@ -22,6 +22,8 @@ assertions can be performed to check if, for example:
 Note that it is assumed the tests are performed on a desktop or server environment,
 where there are no memory constraints.
 
+
+
 Usage
 *****
 
@@ -32,6 +34,7 @@ and it consists of the following components:
 - Display emulation
 - Input device emulation
 - Screenshot comparison
+
 
 Helpers
 -------
@@ -70,6 +73,7 @@ a tolerance of 32 bytes is recommended.
 
     if(LV_ABS((int64_t)mem2 - (int64_t)mem1) > 32) fail();
 
+
 Display Emulation
 -----------------
 
@@ -82,6 +86,7 @@ a framebuffer will be allocated for this size, and ``XRGB8888`` color format wil
 
 The resolution and color format can be changed at any time by calling :cpp:func:`lv_display_set_resolution` and
 :cpp:func:`lv_display_set_color_format`.
+
 
 Input Device Emulation
 ----------------------
@@ -117,8 +122,9 @@ by getting the Y coordinate of a child.
     int32_t y_end = lv_obj_get_y(child);
     if(y_start + 100 != y_end) fail();
 
-Please refer to :ref:`others/test/lv_test_indev.h` for the list of supported input
-device emulation functions.
+Please refer to the ``lv_test_indev.h`` link below (in the :ref:`test_api` section)
+for the list of supported input device emulation functions.
+
 
 Screenshot Comparison
 ---------------------
@@ -160,5 +166,11 @@ The screenshot comparison uses ``lodepng`` which is built-in to LVGL and just ne
 To avoid making the entire Test module dependent on ``lodepng``, screenshot comparison can be individually enabled by
 ``LV_USE_TEST_SCREENSHOT_COMPARE``.
 
+
+
+.. _test_api:
+
 API
 ***
+
+.. API startswith:  lv_test_

--- a/docs/src/details/integration/chip_vendors/arm/arm2d.rst
+++ b/docs/src/details/integration/chip_vendors/arm/arm2d.rst
@@ -65,6 +65,7 @@ Examples
 API
 ***
 
-:ref:`draw/sw/arm2d/lv_draw_sw_arm2d.h`
+.. API equals:  lv_draw_sw_image_recolor_rgb888
 
-:ref:`draw/sw/blend/arm2d/lv_blend_arm2d.h`
+.. API equals:  lv_rgb888_blend_normal_to_rgb565_arm2d
+

--- a/docs/src/details/libs/lfs.rst
+++ b/docs/src/details/libs/lfs.rst
@@ -62,7 +62,7 @@ Example
 API
 ***
 
-.. API equals:  lv_fs_frogfs_register_blob
+.. API equals:  lv_fs_littlefs_init
 
 See also:  `lvgl/src/libs/fsdrv/lv_fs_littlefs.c <https://github.com/lvgl/lvgl/blob/master/src/libs/fsdrv/lv_fs_littlefs.c>`__
 

--- a/docs/src/details/libs/lfs.rst
+++ b/docs/src/details/libs/lfs.rst
@@ -62,7 +62,7 @@ Example
 API
 ***
 
-:ref:`libs/fsdrv/lv_fsdrv.h`
+.. API equals:  lv_fs_frogfs_register_blob
 
 See also:  `lvgl/src/libs/fsdrv/lv_fs_littlefs.c <https://github.com/lvgl/lvgl/blob/master/src/libs/fsdrv/lv_fs_littlefs.c>`__
 

--- a/docs/src/details/libs/libjpeg_turbo.rst
+++ b/docs/src/details/libs/libjpeg_turbo.rst
@@ -76,5 +76,5 @@ Example
 API
 ***
 
-:ref:`libs/libjpeg_turbo/lv_libjpeg_turbo.h`
+.. API equals:  lv_libjpeg_turbo_init
 

--- a/docs/src/details/libs/rle.rst
+++ b/docs/src/details/libs/rle.rst
@@ -101,4 +101,4 @@ the output to ``./output/cogwheel.bin``.
 API
 ***
 
-:ref:`libs/rle/lv_rle.h`
+.. API equals:  lv_rle_decompress

--- a/docs/src/details/main-modules/display/index.rst
+++ b/docs/src/details/main-modules/display/index.rst
@@ -26,4 +26,4 @@ Display (lv_display)
 API
 ***
 
-:ref:`display/lv_display.h`
+.. API equals:  lv_display_create


### PR DESCRIPTION
The only remaining Sphinx warnings were generated when the `skip_api` argument was used on a fresh build of the docs.  This PR removes those last 7 (or so) warnings.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
