### PR TITLE
feat(ffmpeg_player): add set_decoder

### DIFF
--- a/docs/src/details/libs/ffmpeg.rst
+++ b/docs/src/details/libs/ffmpeg.rst
@@ -70,6 +70,8 @@ This library can load videos and images. The LVGL file system
 will always be used when an image is loaded with :cpp:func:`lv_image_set_src`
 regardless of the value of :c:macro:`LV_FFMPEG_PLAYER_USE_LV_FS`.
 
+The ffmpeg player uses software decoding by default. If you require a hardware decoder, you must manually specify it using ``lv_ffmpeg_player_set_decoder``, such as ``h264_v4l2m2m``.
+
 See the examples below for how to correctly use this library.
 
 

--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -572,10 +572,9 @@ static int ffmpeg_open_codec_context(int * stream_idx,
         if(decoder_name) {
             dec = avcodec_find_decoder_by_name(decoder_name);
         }
-	if (dec == NULL)
-	{
+        if(dec == NULL) {
             dec = avcodec_find_decoder(st->codecpar->codec_id);
-	}
+        }
         if(dec == NULL) {
             LV_LOG_ERROR("Failed to find %s codec",
                          av_get_media_type_string(type));

--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -572,9 +572,10 @@ static int ffmpeg_open_codec_context(int * stream_idx,
         if(decoder_name) {
             dec = avcodec_find_decoder_by_name(decoder_name);
         }
-        else {
+	if (dec == NULL)
+	{
             dec = avcodec_find_decoder(st->codecpar->codec_id);
-        }
+	}
         if(dec == NULL) {
             LV_LOG_ERROR("Failed to find %s codec",
                          av_get_media_type_string(type));

--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -548,6 +548,40 @@ static int ffmpeg_decode_packet(AVCodecContext * dec, const AVPacket * pkt,
     return 0;
 }
 
+static int ffmpeg_init_codec_context(AVCodecContext ** dec_ctx, const AVCodec* dec,
+                                     enum AVMediaType type, AVStream* st)
+{
+    int ret = 0;
+
+    /* Allocate a codec context for the decoder */
+    *dec_ctx = avcodec_alloc_context3(dec);
+    if(*dec_ctx == NULL) {
+        return AVERROR(ENOMEM);
+    }
+
+    /* Copy codec parameters from input stream to output codec context */
+    if((ret = avcodec_parameters_to_context(*dec_ctx, st->codecpar)) < 0) {
+        LV_LOG_ERROR("Failed to allocate the %s codec context",
+                     av_get_media_type_string(type));
+        goto free_dec_ctx;
+    }
+
+    /* Init the decoders */
+    if((ret = avcodec_open2(*dec_ctx, dec, NULL)) < 0) {
+        LV_LOG_ERROR(
+            "Failed to copy %s codec parameters to decoder context",
+            av_get_media_type_string(type));
+        goto free_dec_ctx;
+    }
+
+    return 0;
+
+free_dec_ctx:
+    avcodec_free_context(dec_ctx);
+    *dec_ctx = NULL;
+    return ret;
+}
+
 static int ffmpeg_open_codec_context(int * stream_idx,
                                      AVCodecContext ** dec_ctx, AVFormatContext * fmt_ctx,
                                      enum AVMediaType type, const char * decoder_name)
@@ -556,7 +590,6 @@ static int ffmpeg_open_codec_context(int * stream_idx,
     int stream_index;
     AVStream * st;
     const AVCodec * dec = NULL;
-    AVDictionary * opts = NULL;
 
     ret = av_find_best_stream(fmt_ctx, type, -1, -1, NULL, 0);
     if(ret < 0) {
@@ -571,37 +604,27 @@ static int ffmpeg_open_codec_context(int * stream_idx,
         /* find decoder for the stream */
         if(decoder_name) {
             dec = avcodec_find_decoder_by_name(decoder_name);
+            if(dec) {
+                ret = ffmpeg_init_codec_context(dec_ctx, dec, type, st);
+                if(ret < 0) {
+                    dec = NULL;
+                }
+            }
         }
         if(dec == NULL) {
             dec = avcodec_find_decoder(st->codecpar->codec_id);
-        }
-        if(dec == NULL) {
-            LV_LOG_ERROR("Failed to find %s codec",
-                         av_get_media_type_string(type));
-            return AVERROR(EINVAL);
-        }
+            if(dec == NULL) {
+                LV_LOG_ERROR("Failed to find %s codec",
+                             av_get_media_type_string(type));
+                return AVERROR(EINVAL);
+            }
 
-        /* Allocate a codec context for the decoder */
-        *dec_ctx = avcodec_alloc_context3(dec);
-        if(*dec_ctx == NULL) {
-            LV_LOG_ERROR("Failed to allocate the %s codec context",
-                         av_get_media_type_string(type));
-            return AVERROR(ENOMEM);
-        }
-
-        /* Copy codec parameters from input stream to output codec context */
-        if((ret = avcodec_parameters_to_context(*dec_ctx, st->codecpar)) < 0) {
-            LV_LOG_ERROR(
-                "Failed to copy %s codec parameters to decoder context",
-                av_get_media_type_string(type));
-            return ret;
-        }
-
-        /* Init the decoders */
-        if((ret = avcodec_open2(*dec_ctx, dec, &opts)) < 0) {
-            LV_LOG_ERROR("Failed to open %s codec",
-                         av_get_media_type_string(type));
-            return ret;
+            ret = ffmpeg_init_codec_context(dec_ctx, dec, type, st);
+            if(ret < 0) {
+                LV_LOG_ERROR("Failed to initialize %s codec context",
+                             av_get_media_type_string(type));
+                return ret;
+            }
         }
 
         *stream_idx = stream_index;

--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -84,7 +84,7 @@ static void decoder_close(lv_image_decoder_t * dec, lv_image_decoder_dsc_t * dsc
 static int ffmpeg_lvfs_read(void * ptr, uint8_t * buf, int buf_size);
 static int64_t ffmpeg_lvfs_seek(void * ptr, int64_t pos, int whence);
 static AVIOContext * ffmpeg_open_io_context(lv_fs_file_t * file);
-static struct ffmpeg_context_s * ffmpeg_open_file(const char * path, bool is_lv_fs_path,const char* decoder_name);
+static struct ffmpeg_context_s * ffmpeg_open_file(const char * path, bool is_lv_fs_path, const char * decoder_name);
 static void ffmpeg_close(struct ffmpeg_context_s * ffmpeg_ctx);
 static void ffmpeg_close_src_ctx(struct ffmpeg_context_s * ffmpeg_ctx);
 static void ffmpeg_close_dst_ctx(struct ffmpeg_context_s * ffmpeg_ctx);
@@ -148,7 +148,7 @@ void lv_ffmpeg_deinit(void)
 int lv_ffmpeg_get_frame_num(const char * path)
 {
     int ret = -1;
-    struct ffmpeg_context_s * ffmpeg_ctx = ffmpeg_open_file(path, LV_FFMPEG_PLAYER_USE_LV_FS,NULL);
+    struct ffmpeg_context_s * ffmpeg_ctx = ffmpeg_open_file(path, LV_FFMPEG_PLAYER_USE_LV_FS, NULL);
 
     if(ffmpeg_ctx) {
         ret = ffmpeg_ctx->video_stream->nb_frames;
@@ -179,7 +179,7 @@ lv_result_t lv_ffmpeg_player_set_src(lv_obj_t * obj, const char * path)
 
     lv_timer_pause(player->timer);
 
-    player->ffmpeg_ctx = ffmpeg_open_file(path, LV_FFMPEG_PLAYER_USE_LV_FS,player->decoder_name);
+    player->ffmpeg_ctx = ffmpeg_open_file(path, LV_FFMPEG_PLAYER_USE_LV_FS, player->decoder_name);
 
     if(!player->ffmpeg_ctx) {
         goto failed;
@@ -279,7 +279,7 @@ void lv_ffmpeg_player_set_decoder(lv_obj_t * obj, const char * name)
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_ffmpeg_player_t * player = (lv_ffmpeg_player_t *)obj;
     if(player->decoder_name) {
-	lv_free((void*)player->decoder_name);
+        lv_free((void *)player->decoder_name);
     }
     player->decoder_name = lv_strdup(name);
 }
@@ -321,7 +321,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
     if(dsc->src_type == LV_IMAGE_SRC_FILE) {
         const char * path = dsc->src;
 
-        struct ffmpeg_context_s * ffmpeg_ctx = ffmpeg_open_file(path, true,NULL);
+        struct ffmpeg_context_s * ffmpeg_ctx = ffmpeg_open_file(path, true, NULL);
 
         if(ffmpeg_ctx == NULL) {
             return LV_RESULT_INVALID;
@@ -550,7 +550,7 @@ static int ffmpeg_decode_packet(AVCodecContext * dec, const AVPacket * pkt,
 
 static int ffmpeg_open_codec_context(int * stream_idx,
                                      AVCodecContext ** dec_ctx, AVFormatContext * fmt_ctx,
-                                     enum AVMediaType type,const char* decoder_name)
+                                     enum AVMediaType type, const char * decoder_name)
 {
     int ret;
     int stream_index;
@@ -569,12 +569,12 @@ static int ffmpeg_open_codec_context(int * stream_idx,
         st = fmt_ctx->streams[stream_index];
 
         /* find decoder for the stream */
-	if(decoder_name) {
-		dec = avcodec_find_decoder_by_name(decoder_name);
-	}
-	else{
-        	dec = avcodec_find_decoder(st->codecpar->codec_id);
-	}
+        if(decoder_name) {
+            dec = avcodec_find_decoder_by_name(decoder_name);
+        }
+        else {
+            dec = avcodec_find_decoder(st->codecpar->codec_id);
+        }
         if(dec == NULL) {
             LV_LOG_ERROR("Failed to find %s codec",
                          av_get_media_type_string(type));
@@ -647,7 +647,7 @@ static int ffmpeg_get_image_header(lv_image_decoder_dsc_t * dsc,
     }
 
     if(ffmpeg_open_codec_context(&video_stream_idx, &video_dec_ctx,
-                                 fmt_ctx, AVMEDIA_TYPE_VIDEO,NULL)
+                                 fmt_ctx, AVMEDIA_TYPE_VIDEO, NULL)
        >= 0) {
         bool has_alpha = ffmpeg_pix_fmt_has_alpha(video_dec_ctx->pix_fmt);
 
@@ -763,7 +763,7 @@ static AVIOContext * ffmpeg_open_io_context(lv_fs_file_t * file)
     return pIOCtx;
 }
 
-static struct ffmpeg_context_s * ffmpeg_open_file(const char * path, bool is_lv_fs_path,const char* decoder_name)
+static struct ffmpeg_context_s * ffmpeg_open_file(const char * path, bool is_lv_fs_path, const char * decoder_name)
 {
     if(path == NULL || lv_strlen(path) == 0) {
         LV_LOG_ERROR("file path is empty");
@@ -1003,8 +1003,8 @@ static void lv_ffmpeg_player_destructor(const lv_obj_class_t * class_p,
     player->ffmpeg_ctx = NULL;
 
     if(player->decoder_name) {
-	    lv_free((void*)player->decoder_name);
-	    player->decoder_name = NULL;
+        lv_free((void *)player->decoder_name);
+        player->decoder_name = NULL;
     }
 
     LV_TRACE_OBJ_CREATE("finished");

--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -548,8 +548,8 @@ static int ffmpeg_decode_packet(AVCodecContext * dec, const AVPacket * pkt,
     return 0;
 }
 
-static int ffmpeg_init_codec_context(AVCodecContext ** dec_ctx, const AVCodec* dec,
-                                     enum AVMediaType type, AVStream* st)
+static int ffmpeg_init_codec_context(AVCodecContext ** dec_ctx, const AVCodec * dec,
+                                     enum AVMediaType type, AVStream * st)
 {
     int ret = 0;
 

--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -281,7 +281,7 @@ void lv_ffmpeg_player_set_decoder(lv_obj_t * obj, const char * name)
     if(player->decoder_name) {
         lv_free((void *)player->decoder_name);
     }
-    player->decoder_name = lv_strdup(name);
+    player->decoder_name = name ? lv_strdup(name) : NULL;
 }
 
 /**********************

--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -84,7 +84,7 @@ static void decoder_close(lv_image_decoder_t * dec, lv_image_decoder_dsc_t * dsc
 static int ffmpeg_lvfs_read(void * ptr, uint8_t * buf, int buf_size);
 static int64_t ffmpeg_lvfs_seek(void * ptr, int64_t pos, int whence);
 static AVIOContext * ffmpeg_open_io_context(lv_fs_file_t * file);
-static struct ffmpeg_context_s * ffmpeg_open_file(const char * path, bool is_lv_fs_path);
+static struct ffmpeg_context_s * ffmpeg_open_file(const char * path, bool is_lv_fs_path,const char* decoder_name);
 static void ffmpeg_close(struct ffmpeg_context_s * ffmpeg_ctx);
 static void ffmpeg_close_src_ctx(struct ffmpeg_context_s * ffmpeg_ctx);
 static void ffmpeg_close_dst_ctx(struct ffmpeg_context_s * ffmpeg_ctx);
@@ -148,7 +148,7 @@ void lv_ffmpeg_deinit(void)
 int lv_ffmpeg_get_frame_num(const char * path)
 {
     int ret = -1;
-    struct ffmpeg_context_s * ffmpeg_ctx = ffmpeg_open_file(path, LV_FFMPEG_PLAYER_USE_LV_FS);
+    struct ffmpeg_context_s * ffmpeg_ctx = ffmpeg_open_file(path, LV_FFMPEG_PLAYER_USE_LV_FS,NULL);
 
     if(ffmpeg_ctx) {
         ret = ffmpeg_ctx->video_stream->nb_frames;
@@ -179,7 +179,7 @@ lv_result_t lv_ffmpeg_player_set_src(lv_obj_t * obj, const char * path)
 
     lv_timer_pause(player->timer);
 
-    player->ffmpeg_ctx = ffmpeg_open_file(path, LV_FFMPEG_PLAYER_USE_LV_FS);
+    player->ffmpeg_ctx = ffmpeg_open_file(path, LV_FFMPEG_PLAYER_USE_LV_FS,player->decoder_name);
 
     if(!player->ffmpeg_ctx) {
         goto failed;
@@ -274,6 +274,16 @@ void lv_ffmpeg_player_set_auto_restart(lv_obj_t * obj, bool en)
     player->auto_restart = en;
 }
 
+void lv_ffmpeg_player_set_decoder(lv_obj_t * obj, const char * name)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_ffmpeg_player_t * player = (lv_ffmpeg_player_t *)obj;
+    if(player->decoder_name) {
+	lv_free((void*)player->decoder_name);
+    }
+    player->decoder_name = lv_strdup(name);
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/
@@ -311,7 +321,7 @@ static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_d
     if(dsc->src_type == LV_IMAGE_SRC_FILE) {
         const char * path = dsc->src;
 
-        struct ffmpeg_context_s * ffmpeg_ctx = ffmpeg_open_file(path, true);
+        struct ffmpeg_context_s * ffmpeg_ctx = ffmpeg_open_file(path, true,NULL);
 
         if(ffmpeg_ctx == NULL) {
             return LV_RESULT_INVALID;
@@ -540,7 +550,7 @@ static int ffmpeg_decode_packet(AVCodecContext * dec, const AVPacket * pkt,
 
 static int ffmpeg_open_codec_context(int * stream_idx,
                                      AVCodecContext ** dec_ctx, AVFormatContext * fmt_ctx,
-                                     enum AVMediaType type)
+                                     enum AVMediaType type,const char* decoder_name)
 {
     int ret;
     int stream_index;
@@ -559,7 +569,12 @@ static int ffmpeg_open_codec_context(int * stream_idx,
         st = fmt_ctx->streams[stream_index];
 
         /* find decoder for the stream */
-        dec = avcodec_find_decoder(st->codecpar->codec_id);
+	if(decoder_name) {
+		dec = avcodec_find_decoder_by_name(decoder_name);
+	}
+	else{
+        	dec = avcodec_find_decoder(st->codecpar->codec_id);
+	}
         if(dec == NULL) {
             LV_LOG_ERROR("Failed to find %s codec",
                          av_get_media_type_string(type));
@@ -632,7 +647,7 @@ static int ffmpeg_get_image_header(lv_image_decoder_dsc_t * dsc,
     }
 
     if(ffmpeg_open_codec_context(&video_stream_idx, &video_dec_ctx,
-                                 fmt_ctx, AVMEDIA_TYPE_VIDEO)
+                                 fmt_ctx, AVMEDIA_TYPE_VIDEO,NULL)
        >= 0) {
         bool has_alpha = ffmpeg_pix_fmt_has_alpha(video_dec_ctx->pix_fmt);
 
@@ -748,7 +763,7 @@ static AVIOContext * ffmpeg_open_io_context(lv_fs_file_t * file)
     return pIOCtx;
 }
 
-static struct ffmpeg_context_s * ffmpeg_open_file(const char * path, bool is_lv_fs_path)
+static struct ffmpeg_context_s * ffmpeg_open_file(const char * path, bool is_lv_fs_path,const char* decoder_name)
 {
     if(path == NULL || lv_strlen(path) == 0) {
         LV_LOG_ERROR("file path is empty");
@@ -803,7 +818,7 @@ static struct ffmpeg_context_s * ffmpeg_open_file(const char * path, bool is_lv_
     if(ffmpeg_open_codec_context(
            &(ffmpeg_ctx->video_stream_idx),
            &(ffmpeg_ctx->video_dec_ctx),
-           ffmpeg_ctx->fmt_ctx, AVMEDIA_TYPE_VIDEO)
+           ffmpeg_ctx->fmt_ctx, AVMEDIA_TYPE_VIDEO, decoder_name)
        >= 0) {
         ffmpeg_ctx->video_stream = ffmpeg_ctx->fmt_ctx->streams[ffmpeg_ctx->video_stream_idx];
 
@@ -963,6 +978,8 @@ static void lv_ffmpeg_player_constructor(const lv_obj_class_t * class_p,
                                     FRAME_DEF_REFR_PERIOD, obj);
     lv_timer_pause(player->timer);
 
+    player->decoder_name = NULL;
+
     LV_TRACE_OBJ_CREATE("finished");
 }
 
@@ -984,6 +1001,11 @@ static void lv_ffmpeg_player_destructor(const lv_obj_class_t * class_p,
 
     ffmpeg_close(player->ffmpeg_ctx);
     player->ffmpeg_ctx = NULL;
+
+    if(player->decoder_name) {
+	    lv_free((void*)player->decoder_name);
+	    player->decoder_name = NULL;
+    }
 
     LV_TRACE_OBJ_CREATE("finished");
 }

--- a/src/libs/ffmpeg/lv_ffmpeg.h
+++ b/src/libs/ffmpeg/lv_ffmpeg.h
@@ -85,6 +85,12 @@ void lv_ffmpeg_player_set_cmd(lv_obj_t * obj, lv_ffmpeg_player_cmd_t cmd);
  */
 void lv_ffmpeg_player_set_auto_restart(lv_obj_t * obj, bool en);
 
+/**
+ * Set the video decoder
+ * @param obj pointer to a ffmpeg_player object
+ * @param decoder_name decoder name
+ */
+void lv_ffmpeg_player_set_decoder(lv_obj_t* obj, const char* decoder_name);
 /*=====================
  * Other functions
  *====================*/

--- a/src/libs/ffmpeg/lv_ffmpeg.h
+++ b/src/libs/ffmpeg/lv_ffmpeg.h
@@ -90,7 +90,7 @@ void lv_ffmpeg_player_set_auto_restart(lv_obj_t * obj, bool en);
  * @param obj pointer to a ffmpeg_player object
  * @param decoder_name decoder name
  */
-void lv_ffmpeg_player_set_decoder(lv_obj_t* obj, const char* decoder_name);
+void lv_ffmpeg_player_set_decoder(lv_obj_t * obj, const char * decoder_name);
 /*=====================
  * Other functions
  *====================*/

--- a/src/libs/ffmpeg/lv_ffmpeg_private.h
+++ b/src/libs/ffmpeg/lv_ffmpeg_private.h
@@ -32,7 +32,7 @@ struct _lv_ffmpeg_player_t {
     lv_image_dsc_t imgdsc;
     bool auto_restart;
     struct ffmpeg_context_s * ffmpeg_ctx;
-    const char* decoder_name;
+    const char * decoder_name;
 };
 
 /**********************

--- a/src/libs/ffmpeg/lv_ffmpeg_private.h
+++ b/src/libs/ffmpeg/lv_ffmpeg_private.h
@@ -32,6 +32,7 @@ struct _lv_ffmpeg_player_t {
     lv_image_dsc_t imgdsc;
     bool auto_restart;
     struct ffmpeg_context_s * ffmpeg_ctx;
+    const char* decoder_name;
 };
 
 /**********************


### PR DESCRIPTION
ffmpeg uses software decoding by default. Hardware decoding requires manual specification.
On my machine, specifying the h264_v4l2m2m decoder for hardware decoding resulted in smoother video playback. CPU usage also dropped from around 49-50% to approximately 43%. Since it's a dual-core system, the actual reduction was even greater.
If your hardware decoder outputs nv12 format, you need to check #9131.

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
