### PR TITLE
fix(ffmpeg): for nv12 pix_fmt

### DIFF
--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -824,6 +824,11 @@ static int ffmpeg_image_allocate(struct ffmpeg_context_s * ffmpeg_ctx)
 {
     int ret;
 
+    /* Allocate video_dst_data as a separate buffer for the destination image.
+     * This is necessary because the destination may require a different pixel format
+     * or layout than the source (decoded) frame, so we cannot always use the source
+     * frame's data directly. Unlike video_src_data, which is no longer allocated,
+     * video_dst_data is still needed for format conversion or copying. */
     ret = av_image_alloc(
               ffmpeg_ctx->video_dst_data,
               ffmpeg_ctx->video_dst_linesize,

--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -824,13 +824,6 @@ static int ffmpeg_image_allocate(struct ffmpeg_context_s * ffmpeg_ctx)
 {
     int ret;
 
-    if(ret < 0) {
-        LV_LOG_ERROR("Could not allocate src raw video buffer");
-        return ret;
-    }
-
-    LV_LOG_INFO("alloc video_src_bufsize = %d", ret);
-
     ret = av_image_alloc(
               ffmpeg_ctx->video_dst_data,
               ffmpeg_ctx->video_dst_linesize,


### PR DESCRIPTION
Using `av_image_copy` on images in the NV12 format causes a segmentation fault.
Moreover, decoded frames do not need to be copied and can be used directly.
I have tested this on both my x86 computer and a MIPS board.


The default color format output by the H.264 decoder is YUV420P. NV12 is primarily the format used by hardware decoders; for testing, you may need to manually specify the hardware decoder. See #9122.

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
