### PR TITLE
fix(xml): correclty use integer format specifier

### DIFF
--- a/src/others/xml/lv_xml_component.c
+++ b/src/others/xml/lv_xml_component.c
@@ -216,7 +216,7 @@ lv_result_t lv_xml_register_component_from_file(const char * path)
     /* Create the buffer */
     char * xml_buf = lv_malloc(file_size + 1);
     if(xml_buf == NULL) {
-        LV_LOG_WARN("Memory allocation failed for file %s (%d bytes)", path, file_size + 1);
+        LV_LOG_WARN("Memory allocation failed for file %s (%" LV_PRIu32 " bytes)", path, file_size + 1);
         lv_free(filename);
         lv_fs_close(&f);
         return LV_RESULT_INVALID;

--- a/src/others/xml/lv_xml_load.c
+++ b/src/others/xml/lv_xml_load.c
@@ -261,7 +261,7 @@ static void load_from_path(const char * path)
         /* Create the buffer */
         char * xml_buf = lv_malloc(file_size + 1);
         if(xml_buf == NULL) {
-            LV_LOG_WARN("Memory allocation failed for file %s (%d bytes)", path, file_size + 1);
+            LV_LOG_WARN("Memory allocation failed for file %s (%" LV_PRIu32 " bytes)", path, file_size + 1);
             lv_fs_close(&f);
             return;
         }

--- a/src/others/xml/lv_xml_test.c
+++ b/src/others/xml/lv_xml_test.c
@@ -153,7 +153,7 @@ lv_result_t lv_xml_test_register_from_file(const char * path, const char * ref_i
     /* Create the buffer */
     char * xml_buf = lv_zalloc(file_size + 1);
     if(xml_buf == NULL) {
-        LV_LOG_WARN("Memory allocation failed for file %s (%d bytes)", path, file_size + 1);
+        LV_LOG_WARN("Memory allocation failed for file %s (%" LV_PRIu32 "bytes)", path, file_size + 1);
         lv_fs_close(&f);
         return LV_RESULT_INVALID;
     }
@@ -242,7 +242,7 @@ bool lv_xml_test_run_next(uint32_t slowdown)
     bool passed = execute_step(&test.steps[test.step_act], slowdown);
     test.steps[test.step_act].passed = passed;
     if(!test.steps[test.step_act].passed) {
-        LV_LOG_WARN("Step %d failed", test.step_act);
+        LV_LOG_WARN("Step %" LV_PRIu32 "failed", test.step_act);
     }
 
     test.step_act++;
@@ -396,7 +396,7 @@ static bool execute_step(lv_xml_test_step_t * step, uint32_t slowdown)
         if(type == LV_SUBJECT_TYPE_INT) {
             int32_t v =  lv_subject_get_int(step->param.subject_compare.subject);
             if(v != lv_xml_atoi(step->param.subject_compare.value)) {
-                LV_LOG_WARN("Subject compare failed. Expected: %s, Actual: %d", step->param.subject_compare.value, v);
+                LV_LOG_WARN("Subject compare failed. Expected: %s, Actual: %" LV_PRId32, step->param.subject_compare.value, v);
                 res = false;
             }
         }

--- a/src/others/xml/lv_xml_translation.c
+++ b/src/others/xml/lv_xml_translation.c
@@ -61,7 +61,7 @@ lv_result_t lv_xml_register_translation_from_file(const char * path)
     char * xml_buf = lv_malloc(file_size + 1);
     LV_ASSERT_MALLOC(xml_buf);
     if(xml_buf == NULL) {
-        LV_LOG_WARN("Memory allocation failed for file %s (%d bytes)", path, file_size + 1);
+        LV_LOG_WARN("Memory allocation failed for file %s (%" LV_PRIu32 " bytes)", path, file_size + 1);
         lv_fs_close(&f);
         return LV_RESULT_INVALID;
     }


### PR DESCRIPTION
Fixes #9120 <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
