### PR TITLE
feat(translation): const-correct arrays of strings

### DIFF
--- a/docs/src/details/auxiliary-modules/translation.rst
+++ b/docs/src/details/auxiliary-modules/translation.rst
@@ -26,9 +26,10 @@ If most translations are known at compile time, they can be defined using string
 
 .. code-block:: c
 
-    static const char * languages[] = {"en", "de", "es", NULL};
-    static const char * tags[] = {"tiger", "lion", "rabbit", "elephant", NULL};
-    static const char * translations[] = {
+    /* Arrays are defined `const` to place them in program space instead of RAM. */
+    static const char * const languages[] = {"en", "de", "es", NULL};
+    static const char * const tags[] = {"tiger", "lion", "rabbit", "elephant", NULL};
+    static const char * const translations[] = {
         "The Tiger", "Der Tiger", "El Tigre",
         "The Lion", "Der Löwe", "El León",
         "The Rabbit", "Das Kaninchen", "El Conejo",

--- a/examples/others/translation/lv_example_translation_1.c
+++ b/examples/others/translation/lv_example_translation_1.c
@@ -3,9 +3,10 @@
 
 static void add_static(void)
 {
-    static const char * languages[] = {"en", "de", "es", NULL};
-    static const char * tags[] = {"tiger", "lion", "rabbit", "elephant", NULL};
-    static const char * translations[] = {
+    /* Arrays are defined `const` to place them in program space instead of RAM. */
+    static const char * const languages[] = {"en", "de", "es", NULL};
+    static const char * const tags[] = {"tiger", "lion", "rabbit", "elephant", NULL};
+    static const char * const translations[] = {
         "The Tiger", "Der Tiger", "El Tigre",
         "The Lion", "Der Löwe", "El León",
         "The Rabbit", "Das Kaninchen", "El Conejo",

--- a/examples/others/translation/lv_example_translation_2.c
+++ b/examples/others/translation/lv_example_translation_2.c
@@ -2,12 +2,13 @@
 
 #if LV_USE_TRANSLATION && LV_USE_DROPDOWN && LV_USE_LABEL && LV_BUILD_EXAMPLES
 
-static const char * tags[] = {"tiger", "lion", "rabbit", "elephant", NULL};
-static const char * languages[] = {"English", "Deutsch", "Español", NULL};
+/* Arrays are defined `const` to place them in program space instead of RAM. */
+static const char * const tags[] = {"tiger", "lion", "rabbit", "elephant", NULL};
+static const char * const languages[] = {"English", "Deutsch", "Español", NULL};
 
 static void add_static_translations(void)
 {
-    static const char * translations[] = {
+    static const char * const translations[] = {
         "The Tiger",    "Der Tiger",     "El Tigre",
         "The Lion",     "Der Löwe",      "El León",
         "The Rabbit",   "Das Kaninchen", "El Conejo",

--- a/examples/widgets/label/lv_example_label_7.c
+++ b/examples/widgets/label/lv_example_label_7.c
@@ -2,12 +2,13 @@
 
 #if LV_USE_TRANSLATION && LV_USE_DROPDOWN && LV_USE_LABEL && LV_BUILD_EXAMPLES
 
-static const char * tags[] = {"tiger", "lion", "rabbit", "elephant", NULL};
-static const char * languages[] = {"English", "Deutsch", "Español", NULL};
+/* Arrays are defined `const` to place them in program space instead of RAM. */
+static const char * const tags[] = {"tiger", "lion", "rabbit", "elephant", NULL};
+static const char * const languages[] = {"English", "Deutsch", "Español", NULL};
 
 static void add_static_translations(void)
 {
-    static const char * translations[] = {
+    static const char * const translations[] = {
         "The Tiger",    "Der Tiger",     "El Tigre",
         "The Lion",     "Der Löwe",      "El León",
         "The Rabbit",   "Das Kaninchen", "El Conejo",

--- a/src/others/translation/lv_translation.c
+++ b/src/others/translation/lv_translation.c
@@ -84,8 +84,8 @@ void lv_translation_deinit(void)
     lv_free((void *)selected_lang);
 }
 
-lv_translation_pack_t * lv_translation_add_static(const char * languages[], const char * tags[],
-                                                  const char * translations[])
+lv_translation_pack_t * lv_translation_add_static(const char * const languages[], const char * const tags[],
+                                                  const char * const translations[])
 {
     LV_ASSERT_NULL(languages);
     LV_ASSERT_NULL(tags);
@@ -102,9 +102,9 @@ lv_translation_pack_t * lv_translation_add_static(const char * languages[], cons
         pack->language_cnt++;
     }
 
-    pack->languages = languages;
-    pack->tag_p = tags;
-    pack->translation_p = translations;
+    pack->languages = (const char **)languages;
+    pack->tag_p = (const char **)tags;
+    pack->translation_p = (const char **)translations;
     return pack;
 }
 

--- a/src/others/translation/lv_translation.h
+++ b/src/others/translation/lv_translation.h
@@ -50,8 +50,8 @@ void lv_translation_deinit(void);
  * @param translations  List of translations. E.g. `{"Dog", "Cat", "Hund", "Katze"}`
  * @return              The created pack
  */
-lv_translation_pack_t * lv_translation_add_static(const char * languages[], const char * tags[],
-                                                  const char * translations[]);
+lv_translation_pack_t * lv_translation_add_static(const char * const languages[], const char * const tags[],
+                                                  const char * const translations[]);
 
 /**
  * Add a pack to which translations can be added dynamically.

--- a/tests/src/test_cases/test_translation.c
+++ b/tests/src/test_cases/test_translation.c
@@ -27,9 +27,9 @@ static void on_language_change(lv_event_t * e)
 void test_set_language_sends_language_changed_event(void)
 {
 
-    static const char * tags[] = {"tiger", NULL};
-    static const char * languages[]    = {"en", "de", "es", NULL};
-    static const char * translations[] = { "The Tiger", "Der Tiger", "El Tigre" };
+    static const char * const tags[] = {"tiger", NULL};
+    static const char * const languages[]    = {"en", "de", "es", NULL};
+    static const char * const translations[] = { "The Tiger", "Der Tiger", "El Tigre" };
     lv_translation_add_static(languages, tags, translations);
 
     lv_obj_t * label = lv_label_create(NULL);

--- a/tests/src/test_cases/widgets/test_label.c
+++ b/tests/src/test_cases/widgets/test_label.c
@@ -791,9 +791,10 @@ void test_label_wrap_mode_clip(void)
 }
 void test_label_translation_tag(void)
 {
-    static const char * tags[] = {"tiger", NULL};
-    static const char * languages[]    = {"en", "de", "es", NULL};
-    static const char * translations[] = { "The Tiger", "Der Tiger", "El Tigre" };
+    /* Arrays are defined `const` to place them in program space instead of RAM. */
+    static const char * const tags[] = {"tiger", NULL};
+    static const char * const languages[]    = {"en", "de", "es", NULL};
+    static const char * const translations[] = { "The Tiger", "Der Tiger", "El Tigre" };
     lv_translation_add_static(languages, tags, translations);
     label = lv_label_create(NULL);
     lv_label_set_translation_tag(label, "tiger");
@@ -814,9 +815,10 @@ void test_label_translation_tag(void)
 
 void test_label_setting_text_disables_translation(void)
 {
-    static const char * tags[] = {"tiger", NULL};
-    static const char * languages[]    = {"en", "de", "es", NULL};
-    static const char * translations[] = { "The Tiger", "Der Tiger", "El Tigre" };
+    /* Arrays are defined `const` to place them in program space instead of RAM. */
+    static const char * const tags[] = {"tiger", NULL};
+    static const char * const languages[]    = {"en", "de", "es", NULL};
+    static const char * const translations[] = { "The Tiger", "Der Tiger", "El Tigre" };
     lv_translation_add_static(languages, tags, translations);
     label = lv_label_create(NULL);
     lv_label_set_translation_tag(label, "tiger");

--- a/tests/src/test_cases/xml/test_xml_label.c
+++ b/tests/src/test_cases/xml/test_xml_label.c
@@ -64,9 +64,10 @@ void test_xml_label_with_attrs(void)
 }
 void test_xml_label_translation_tag(void)
 {
-    static const char * tags[] = {"tiger", NULL};
-    static const char * languages[]    = {"en", "de", "es", NULL};
-    static const char * translations[] = { "The Tiger", "Der Tiger", "El Tigre" };
+    /* Arrays are defined `const` to place them in program space instead of RAM. */
+    static const char * const tags[] = {"tiger", NULL};
+    static const char * const languages[]    = {"en", "de", "es", NULL};
+    static const char * const translations[] = { "The Tiger", "Der Tiger", "El Tigre" };
     lv_translation_add_static(languages, tags, translations);
 
     lv_obj_t * scr = lv_screen_active();
@@ -116,9 +117,10 @@ void test_xml_label_translation_tag(void)
 
 void test_xml_label_both_text_and_translation_tag(void)
 {
-    static const char * tags[] = {"tiger", NULL};
-    static const char * languages[]    = {"en", "de", "es", NULL};
-    static const char * translations[] = { "The Tiger", "Der Tiger", "El Tigre" };
+    /* Arrays are defined `const` to place them in program space instead of RAM. */
+    static const char * const tags[] = {"tiger", NULL};
+    static const char * const languages[]    = {"en", "de", "es", NULL};
+    static const char * const translations[] = { "The Tiger", "Der Tiger", "El Tigre" };
     lv_translation_add_static(languages, tags, translations);
 
     lv_obj_t * scr = lv_screen_active();

--- a/tests/src/test_cases/xml/test_xml_translations.c
+++ b/tests/src/test_cases/xml/test_xml_translations.c
@@ -26,10 +26,10 @@ void test_xml_translation(void)
 
     lv_xml_register_translation_from_data(translations_xml);
 
-
-    static const char * languages[] = {"en", "de", "es", NULL};
-    static const char * tags[] = {"tiger", "lion", "rabbit", "elephant", NULL};
-    static const char * translations[] = {
+    /* Arrays are defined `const` to place them in program space instead of RAM. */
+    static const char * const languages[] = {"en", "de", "es", NULL};
+    static const char * const tags[] = {"tiger", "lion", "rabbit", "elephant", NULL};
+    static const char * const translations[] = {
         "The Tiger", "Der Tiger", "El Tigre",
         "The Lion", "Der Löwe", "El León",
         "The Rabbit", "Das Kaninchen", "El Conejo",


### PR DESCRIPTION
Per conversation in #9008:  fixes the `const` typing of 3 args passed in to the `lv_translation_add_static()` function.

Fixes #9008

cc:  @liamHowatt, @bryghtlabs-richard 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
