### PR TITLE
fix(obj_tree): fixes exact object name match 

### DIFF
--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -836,7 +836,15 @@ static lv_obj_t * find_by_name_direct(const lv_obj_t * parent, const char * name
 
         char child_name_resolved[LV_OBJ_NAME_MAX_LEN];
         lv_obj_get_name_resolved(child, child_name_resolved, sizeof(child_name_resolved));
-        if(lv_strncmp(child_name_resolved, name, len) == 0) return child;
+
+        if(len == UINT16_MAX) {
+            if(lv_strcmp(child_name_resolved, name) == 0) return child;
+        } else {
+            if(lv_strncmp(child_name_resolved, name, len) == 0 &&
+               child_name_resolved[len] == '\0') {
+                return child;
+            }
+        }
     }
 
     return NULL;

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -839,7 +839,8 @@ static lv_obj_t * find_by_name_direct(const lv_obj_t * parent, const char * name
 
         if(len == UINT16_MAX) {
             if(lv_strcmp(child_name_resolved, name) == 0) return child;
-        } else {
+        }
+        else {
             if(lv_strncmp(child_name_resolved, name, len) == 0 &&
                child_name_resolved[len] == '\0') {
                 return child;

--- a/tests/src/test_cases/widgets/test_obj_tree.c
+++ b/tests/src/test_cases/widgets/test_obj_tree.c
@@ -238,6 +238,10 @@ void test_obj_get_by_name(void)
     lv_obj_t * label5 = lv_label_create(cont3);
     lv_obj_set_name(label5, "title_#");
 
+    lv_obj_t * cont5 = lv_obj_create(lv_screen_active());
+    lv_obj_set_name(cont5, "my_obj_1a");
+    lv_obj_t * cont6 = lv_obj_create(lv_screen_active());
+    lv_obj_set_name(cont6, "my_obj_1");
 
     lv_obj_t * found_obj;
 
@@ -294,6 +298,9 @@ void test_obj_get_by_name(void)
 
     found_obj = lv_obj_get_child_by_name(lv_screen_active(), "third/title_2");
     TEST_ASSERT_EQUAL(label5, found_obj);
+
+    found_obj = lv_obj_get_child_by_name(lv_screen_active(), "my_obj_1");
+    TEST_ASSERT_EQUAL(found_obj, cont6);
 
     /*-------------
      * Find by name


### PR DESCRIPTION
I was using the `lv_obj_get_child_by_name` function and realized that the object names `btn_R` and `btn_R2` would match in this case and return the same object. 

This fixes comparison for the exact object name match.

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
