### PR TITLE
fix(gltf): convert baseColorFactor to sRGB for more accurate mid-range colors

### DIFF
--- a/src/libs/gltf/gltf_view/lv_gltf_view_internal.h
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_internal.h
@@ -25,7 +25,6 @@
  *      DEFINES
  *********************/
 
-#define LV_GLTF_CONVERT_BASE_COLOR_TO_SRGB 1
 
 /**********************
  *      TYPEDEFS

--- a/src/libs/gltf/gltf_view/lv_gltf_view_internal.h
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_internal.h
@@ -25,6 +25,7 @@
  *      DEFINES
  *********************/
 
+#define LV_GLTF_CONVERT_BASE_COLOR_TO_SRGB 1
 
 /**********************
  *      TYPEDEFS

--- a/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
@@ -29,6 +29,10 @@
  *      DEFINES
  *********************/
 
+#ifndef LV_GLTF_CONVERT_BASE_COLOR_TO_SRGB
+    #define LV_GLTF_CONVERT_BASE_COLOR_TO_SRGB 1
+#endif
+
 /**********************
  *      TYPEDEFS
  **********************/


### PR DESCRIPTION
I noticed that in some situations, colors were not rendering accurately and appeared too dark.   After trying some tests I found it was mid-range colors that were especially affected, making them darker and somewhat over saturated.   This is a result of the shader expecting that color to be provided in sRGB colorspace, so I implemented a function to convert the supplied Linear Rec.709 colorspace value into the format the shader expects.

In the image below you can see the effects with and without the conversion enabled.   With conversion is on the right, and without is on the left.   It's notable that this affects colors on a per-channel basis, where channels that are somewhere in the mid-value range are the most darkened, with the effect increasing the darker the color was set to.  So if the artist picked a 50% brightness red, what that might actually get is more like 15% red.  But if they picked 100% red, what they will get is 100% red, because that channel value was 1.0 so it wasn't affected.

Note the truck bed and how it's too dark in the unconverted version, also the interior is too dark too.  The right hand versions are much closer to the preview in Blender.

<img width="894" height="649" alt="Screenshot_20251029_035917" src="https://github.com/user-attachments/assets/6f11f557-889b-46ab-b05a-456b8594910f" />
