### PR TITLE
docs(macro api links):  fix links to macros in API pages

### DIFF
--- a/docs/src/_static/js/custom.js
+++ b/docs/src/_static/js/custom.js
@@ -141,6 +141,9 @@ document.addEventListener("DOMContentLoaded", (event) => {
         parentDlNode.classList.remove(unExClass);
         parentDlNode.classList.add(exClass);
       }
+
+      /* Have browser scroll `cppListing` into view if it is not already. */
+      cppListing.scrollIntoView();
     } else {
       cppListing.classList.add(unExClass);
     }


### PR DESCRIPTION
In some cases (e.g. when a list of API-page macros was long), clicking on a :c:macro:\`MACRO_NAME\` in a document resulted in the browser jumping to the bottom of the API page instead of showing the expanded macro name in the page.  Adding `cppListing.scrollIntoView()` to the code block dealing with that expanded documentation remedies this.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
