### PR TITLE
fix(draw/ppa): fix build and rendering issues

### DIFF
--- a/env_support/cmake/esp.cmake
+++ b/env_support/cmake/esp.cmake
@@ -3,6 +3,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/version.cmake")
 file(GLOB_RECURSE SOURCES ${LVGL_ROOT_DIR}/src/*.c ${LVGL_ROOT_DIR}/src/*.cpp)
 
 idf_build_get_property(LV_MICROPYTHON LV_MICROPYTHON)
+idf_build_get_property(target IDF_TARGET)
 
 if(LV_MICROPYTHON)
   idf_component_register(
@@ -54,11 +55,11 @@ else()
     set_source_files_properties(${DEMO_MUSIC_SOURCES} COMPILE_FLAGS "-Wno-format")
   endif()
 
-  if(CONFIG_LV_USE_PPA)
-    set(IDF_COMPONENTS esp_driver_ppa esp_mm esp_timer log)
-  else()
-    set(IDF_COMPONENTS esp_timer log)
-  endif()
+if(${target} STREQUAL "esp32p4")
+  set(IDF_COMPONENTS esp_driver_ppa esp_mm esp_timer log)
+else()
+  set(IDF_COMPONENTS esp_timer log)
+endif()
 
   idf_component_register(SRCS ${SOURCES} ${EXAMPLE_SOURCES} ${DEMO_SOURCES}
       INCLUDE_DIRS ${LVGL_ROOT_DIR} ${LVGL_ROOT_DIR}/src ${LVGL_ROOT_DIR}/../

--- a/src/draw/espressif/ppa/lv_draw_ppa.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa.c
@@ -61,7 +61,7 @@ void lv_draw_ppa_init(void)
 
     /* Register Blend client */
     cfg.oper_type = PPA_OPERATION_BLEND;
-    cfg.data_burst_length = PPA_DATA_BURST_LENGTH_32;
+    cfg.data_burst_length = PPA_DATA_BURST_LENGTH_128;
 
     res = ppa_register_client(&cfg, &draw_ppa_unit->blend_client);
     LV_ASSERT(res == ESP_OK);

--- a/src/draw/espressif/ppa/lv_draw_ppa.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa.c
@@ -27,13 +27,6 @@ static int32_t ppa_evaluate(lv_draw_unit_t * draw_unit, lv_draw_task_t * task);
 static int32_t ppa_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer);
 static int32_t ppa_delete(lv_draw_unit_t * draw_unit);
 static void  ppa_execute_drawing(lv_draw_ppa_unit_t * u);
-static bool ppa_isr(ppa_client_handle_t ppa_client, ppa_event_data_t * event_data, void * user_data);
-
-#if LV_PPA_NONBLOCKING_OPS
-    static void ppa_thread(void * arg);
-#endif
-
-static bool g_ppa_complete = true;
 
 /**********************
 *   GLOBAL FUNCTIONS
@@ -43,10 +36,6 @@ void lv_draw_ppa_init(void)
 {
     esp_err_t res;
     ppa_client_config_t cfg = {0};
-    ppa_event_callbacks_t ppa_cbs = {
-        .on_trans_done = ppa_isr,
-
-    };
 
     /* Create draw unit */
     lv_draw_buf_ppa_init_handlers();
@@ -58,7 +47,7 @@ void lv_draw_ppa_init(void)
 
     /* Register SRM client */
     cfg.oper_type = PPA_OPERATION_SRM;
-    cfg.max_pending_trans_num = 8;
+    cfg.max_pending_trans_num = 1;
     cfg.data_burst_length = PPA_DATA_BURST_LENGTH_128;
 
     res = ppa_register_client(&cfg, &draw_ppa_unit->srm_client);
@@ -76,17 +65,6 @@ void lv_draw_ppa_init(void)
 
     res = ppa_register_client(&cfg, &draw_ppa_unit->blend_client);
     LV_ASSERT(res == ESP_OK);
-
-    ppa_client_register_event_callbacks(draw_ppa_unit->srm_client, &ppa_cbs);
-    ppa_client_register_event_callbacks(draw_ppa_unit->fill_client, &ppa_cbs);
-    ppa_client_register_event_callbacks(draw_ppa_unit->blend_client, &ppa_cbs);
-
-#if LV_PPA_NONBLOCKING_OPS
-    lv_result_t lv_res = lv_thread_init(&draw_ppa_unit->thread, "ppa_thread", LV_DRAW_THREAD_PRIO, ppa_thread, 8192,
-                                        draw_ppa_unit);
-    LV_ASSERT(lv_res == LV_RESULT_OK);
-#endif
-
 }
 
 void lv_draw_ppa_deinit(void)
@@ -97,19 +75,6 @@ void lv_draw_ppa_deinit(void)
 /**********************
 *   STATIC FUNCTIONS
 **********************/
-
-static bool ppa_isr(ppa_client_handle_t ppa_client, ppa_event_data_t * event_data, void * user_data)
-{
-    g_ppa_complete = true;
-
-#if LV_PPA_NONBLOCKING_OPS
-    lv_draw_ppa_unit_t * u = (lv_draw_ppa_unit_t *)user_data;
-    lv_thread_sync_signal_isr(&u->interrupt_signal);
-#endif
-
-    return false;
-}
-
 static int32_t ppa_evaluate(lv_draw_unit_t * u, lv_draw_task_t * t)
 {
     LV_UNUSED(u);
@@ -170,18 +135,12 @@ static int32_t ppa_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 {
     lv_draw_ppa_unit_t * u = (lv_draw_ppa_unit_t *)draw_unit;
     if(u->task_act) {
-        if(!g_ppa_complete) {
-            return LV_DRAW_UNIT_IDLE;
-        }
-        else {
-            u->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
-            u->task_act = NULL;
-        }
+        return LV_DRAW_UNIT_IDLE;
     }
 
     lv_draw_task_t * t = lv_draw_get_available_task(layer, NULL, DRAW_UNIT_ID_PPA);
     if(!t || t->preferred_draw_unit_id != DRAW_UNIT_ID_PPA) return LV_DRAW_UNIT_IDLE;
-    if(!lv_draw_layer_alloc_buf(layer)) return LV_DRAW_UNIT_IDLE;
+    if(lv_draw_layer_alloc_buf(layer) == NULL) return LV_DRAW_UNIT_IDLE;
 
     t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
     u->task_act = t;
@@ -189,11 +148,9 @@ static int32_t ppa_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 
     ppa_execute_drawing(u);
 
-#if !LV_PPA_NONBLOCKING_OPS
     u->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
     u->task_act = NULL;
     lv_draw_dispatch_request();
-#endif
 
     return 1;
 }
@@ -213,43 +170,22 @@ static void ppa_execute_drawing(lv_draw_ppa_unit_t * u)
     lv_layer_t * layer         = t->target_layer;
     lv_draw_buf_t * buf        = layer->draw_buf;
     lv_area_t area;
-    lv_area_t draw_area;
 
     if(!lv_area_intersect(&area, &t->area, &t->clip_area)) return;
-
-    lv_area_move(&draw_area, -layer->buf_area.x1, -layer->buf_area.y1);
-    lv_draw_buf_invalidate_cache(buf, &draw_area);
+    lv_draw_buf_invalidate_cache(buf, &area);
 
     switch(t->type) {
         case LV_DRAW_TASK_TYPE_FILL:
-            g_ppa_complete = false;
             lv_draw_ppa_fill(t, (lv_draw_fill_dsc_t *)t->draw_dsc, &area);
+            lv_draw_buf_invalidate_cache(buf, &area);
             break;
         case LV_DRAW_TASK_TYPE_IMAGE:
-            g_ppa_complete = false;
             lv_draw_ppa_img(t, (lv_draw_image_dsc_t *)t->draw_dsc, &area);
+            lv_draw_buf_invalidate_cache(buf, &area);
             break;
         default:
             break;
     }
 }
-
-#if LV_PPA_NONBLOCKING_OPS
-static void ppa_thread(void * arg)
-{
-    lv_draw_ppa_unit_t * u = arg;
-    lv_thread_sync_init(&u->interrupt_signal);
-
-    while(1) {
-        do {
-            lv_thread_sync_wait(&u->interrupt_signal);
-        } while(u->task_act != NULL);
-
-        u->task_act->state = LV_DRAW_TASK_STATE_FINISHED;
-        u->task_act = NULL;
-        lv_draw_dispatch_request();
-    }
-}
-#endif
 
 #endif /*LV_USE_PPA*/

--- a/src/draw/espressif/ppa/lv_draw_ppa_buf.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa_buf.c
@@ -29,14 +29,10 @@ static void invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * a
 /**********************
  *   GLOBAL FUNCTIONS
  *********************/
-
 void lv_draw_buf_ppa_init_handlers(void)
 {
     lv_draw_buf_handlers_t * handlers = lv_draw_buf_get_handlers();
-    lv_draw_buf_handlers_t * image_handlers = lv_draw_buf_get_image_handlers();
-
-    handlers->invalidate_cache_cb       = invalidate_cache;
-    image_handlers->invalidate_cache_cb = invalidate_cache;
+    handlers->invalidate_cache_cb = invalidate_cache;
 }
 
 /**********************
@@ -45,8 +41,6 @@ void lv_draw_buf_ppa_init_handlers(void)
 
 static void invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area)
 {
-    esp_cache_msync((void *)PPA_PTR_ALIGN_DOWN(draw_buf->data, CONFIG_CACHE_L1_CACHE_LINE_SIZE),
-                    PPA_ALIGN_DOWN(draw_buf->data_size, CONFIG_CACHE_L1_CACHE_LINE_SIZE),
-                    ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
+    esp_cache_msync(draw_buf->data, draw_buf->data_size, ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
 }
 #endif /* LV_USE_PPA */

--- a/src/draw/espressif/ppa/lv_draw_ppa_fill.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa_fill.c
@@ -11,35 +11,37 @@
 void lv_draw_ppa_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc,
                       const lv_area_t * coords)
 {
+    ppa_fill_oper_config_t fill_cfg;
     lv_draw_ppa_unit_t * u = (lv_draw_ppa_unit_t *)t->draw_unit;
     lv_draw_buf_t * draw_buf = t->target_layer->draw_buf;
-    int width  = lv_area_get_width(coords);
-    int height = lv_area_get_height(coords);
 
-    if(width <= 0 || height <= 0) {
-        LV_LOG_WARN("Invalid draw area for filling!");
-        return;
-    }
+    lv_area_t rel_coords;
+    lv_area_copy(&rel_coords, coords);
+    lv_area_move(&rel_coords, -t->target_layer->buf_area.x1, -t->target_layer->buf_area.y1);
 
-    ppa_fill_oper_config_t cfg = {
-        .fill_argb_color.val = lv_color_to_u32(dsc->color),
-        .fill_block_w    = width,
-        .fill_block_h    = height,
-        .out = {
-            .buffer         = draw_buf->data,
-            .buffer_size    = draw_buf->data_size,
-            .pic_w          = width,
-            .pic_h          = height,
-            .block_offset_x = 0,
-            .block_offset_y = 0,
-            .fill_cm        = lv_color_format_to_ppa_fill(draw_buf->header.cf),
-        },
+    lv_area_t rel_clip_area;
+    lv_area_copy(&rel_clip_area, &t->clip_area);
+    lv_area_move(&rel_clip_area, -t->target_layer->buf_area.x1, -t->target_layer->buf_area.y1);
 
-        .mode            = PPA_TRANS_MODE_NON_BLOCKING,
-        .user_data       = u,
-    };
+    lv_area_t blend_area;
+    if(!lv_area_intersect(&blend_area, &rel_coords, &rel_clip_area))
+        return; /*Fully clipped, nothing to do*/
 
-    esp_err_t ret = ppa_do_fill(u->fill_client, &cfg);
+    memset(&fill_cfg, 0, sizeof(fill_cfg));
+
+    fill_cfg.fill_argb_color.val = lv_color_to_u32(dsc->color);
+    fill_cfg.out.block_offset_x = 0;
+    fill_cfg.out.block_offset_y = 0;
+    fill_cfg.out.fill_cm        = lv_color_format_to_ppa_fill(draw_buf->header.cf);
+    fill_cfg.fill_block_w       = lv_area_get_width(&blend_area);
+    fill_cfg.fill_block_h       = lv_area_get_height(&blend_area);
+    fill_cfg.out.buffer         = draw_buf->data;
+    fill_cfg.out.buffer_size    = draw_buf->data_size;
+    fill_cfg.out.pic_w          = lv_area_get_width(coords);
+    fill_cfg.out.pic_h          = lv_area_get_height(coords);
+    fill_cfg.mode            = PPA_TRANS_MODE_BLOCKING;
+
+    esp_err_t ret = ppa_do_fill(u->fill_client, &fill_cfg);
     if(ret != ESP_OK) {
         LV_LOG_ERROR("PPA fill failed: %d", ret);
     }

--- a/src/draw/espressif/ppa/lv_draw_ppa_fill.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa_fill.c
@@ -11,7 +11,7 @@
 void lv_draw_ppa_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc,
                       const lv_area_t * coords)
 {
-    ppa_fill_oper_config_t fill_cfg;
+    ppa_fill_oper_config_t fill_cfg = {0};
     lv_draw_ppa_unit_t * u = (lv_draw_ppa_unit_t *)t->draw_unit;
     lv_draw_buf_t * draw_buf = t->target_layer->draw_buf;
 
@@ -27,18 +27,16 @@ void lv_draw_ppa_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc,
     if(!lv_area_intersect(&blend_area, &rel_coords, &rel_clip_area))
         return; /*Fully clipped, nothing to do*/
 
-    memset(&fill_cfg, 0, sizeof(fill_cfg));
-
     fill_cfg.fill_argb_color.val = lv_color_to_u32(dsc->color);
-    fill_cfg.out.block_offset_x = 0;
-    fill_cfg.out.block_offset_y = 0;
+    fill_cfg.out.block_offset_x = blend_area.x1;
+    fill_cfg.out.block_offset_y = blend_area.y1;
     fill_cfg.out.fill_cm        = lv_color_format_to_ppa_fill(draw_buf->header.cf);
     fill_cfg.fill_block_w       = lv_area_get_width(&blend_area);
     fill_cfg.fill_block_h       = lv_area_get_height(&blend_area);
     fill_cfg.out.buffer         = draw_buf->data;
     fill_cfg.out.buffer_size    = draw_buf->data_size;
-    fill_cfg.out.pic_w          = lv_area_get_width(coords);
-    fill_cfg.out.pic_h          = lv_area_get_height(coords);
+    fill_cfg.out.pic_w          = draw_buf->header.w;
+    fill_cfg.out.pic_h          = draw_buf->header.h;;
     fill_cfg.mode            = PPA_TRANS_MODE_BLOCKING;
 
     esp_err_t ret = ppa_do_fill(u->fill_client, &fill_cfg);

--- a/src/draw/espressif/ppa/lv_draw_ppa_img.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa_img.c
@@ -8,62 +8,99 @@
 
 #if LV_USE_PPA
 
+#include "../../lv_draw_image_private.h"
+#include "../../lv_image_decoder_private.h"
+
+static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
+                                 const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
+                                 const lv_area_t * img_coords, const lv_area_t * clipped_img_area);
+
+
 void lv_draw_ppa_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
                      const lv_area_t * coords)
 {
-    if(dsc->opa <= (lv_opa_t)LV_OPA_MIN) {
+    if(dsc->opa <= (lv_opa_t)LV_OPA_MIN)
         return;
-    }
+    lv_draw_image_normal_helper(t, dsc, coords, lv_draw_img_ppa_core);
+}
 
+static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
+                                 const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
+                                 const lv_area_t * img_coords, const lv_area_t * clipped_img_area)
+{
+    lv_layer_t * layer = t->target_layer;
+    lv_draw_buf_t * draw_buf = layer->draw_buf;
+    const lv_draw_buf_t * decoded = decoder_dsc->decoded;
     lv_draw_ppa_unit_t * u = (lv_draw_ppa_unit_t *)t->draw_unit;
-    lv_draw_buf_t * draw_buf = t->target_layer->draw_buf;
-    const lv_image_dsc_t * img_dsc = dsc->src;
-    int width  = lv_area_get_width(coords);
-    int height = lv_area_get_height(coords);
+
+    lv_area_t rel_clip_area;
+    lv_area_copy(&rel_clip_area, clipped_img_area);
+    lv_area_move(&rel_clip_area, -img_coords->x1, -img_coords->y1);
+
+    lv_area_t rel_img_coords;
+    lv_area_copy(&rel_img_coords, img_coords);
+    lv_area_move(&rel_img_coords, -img_coords->x1, -img_coords->y1);
+
+    lv_area_t src_area;
+    if(!lv_area_intersect(&src_area, &rel_clip_area, &rel_img_coords))
+        return;
+
+    lv_area_t dest_area;
+    lv_area_copy(&dest_area, clipped_img_area);
+    lv_area_move(&dest_area, -t->target_layer->buf_area.x1, -t->target_layer->buf_area.y1);
+
+    const uint8_t * src_buf = decoded->data;
+    lv_color_format_t src_cf = draw_dsc->header.cf;
+    lv_color_format_t dest_cf = draw_buf->header.cf;
+    uint8_t * dest_buf = draw_buf->data;
+
+    extern const lv_image_dsc_t img_benchmark_lvgl_logo_rgb;
 
     ppa_blend_oper_config_t cfg = {
         .in_bg = {
-            .buffer          = (void *)draw_buf->data,
-            .pic_w           = draw_buf->header.w,
-            .pic_h           = draw_buf->header.h,
-            .block_w         = width,
-            .block_h         = height,
-            .block_offset_x  = 0,
-            .block_offset_y  = 0,
-            .blend_cm        = lv_color_format_to_ppa_blend(draw_buf->header.cf),
+            .buffer          = (void *)src_buf,
+            .pic_w           = draw_dsc->header.w,
+            .pic_h           = draw_dsc->header.h,
+            .block_w         = lv_area_get_width(clipped_img_area),
+            .block_h         = lv_area_get_height(clipped_img_area),
+            .block_offset_x  = src_area.x1,
+            .block_offset_y  = src_area.y1,
+            .blend_cm        = lv_color_format_to_ppa_blend(src_cf),
         },
         .bg_rgb_swap           = false,
         .bg_byte_swap          = false,
-        .bg_alpha_update_mode  = PPA_ALPHA_NO_CHANGE,
-        .bg_alpha_fix_val      = 0,
+        .bg_alpha_update_mode  = PPA_ALPHA_FIX_VALUE,
+        .bg_alpha_fix_val      = 0xFF,
         .bg_ck_en              = false,
-
         .in_fg = {
-            .buffer          = (void *)img_dsc->data,
-            .pic_w           = width,
-            .pic_h           = height,
-            .block_w         = width,
-            .block_h         = height,
-            .block_offset_x  = 0,
-            .block_offset_y  = 0,
-            .blend_cm        = lv_color_format_to_ppa_blend(dsc->header.cf),
+            .buffer          = (void *)dest_buf,
+            .pic_w           = draw_dsc->header.w,
+            .pic_h           = draw_dsc->header.h,
+            .block_w         = lv_area_get_width(clipped_img_area),
+            .block_h         = lv_area_get_height(clipped_img_area),
+            .block_offset_x  = src_area.x1,
+            .block_offset_y  = src_area.y1,
+            .blend_cm        = PPA_BLEND_COLOR_MODE_A8,
+        },
+        .fg_fix_rgb_val = {
+            .r = 0,
+            .g = 0,
+            .b = 0,
         },
         .fg_rgb_swap           = false,
         .fg_byte_swap          = false,
-        .fg_alpha_update_mode = PPA_ALPHA_NO_CHANGE,
-        .fg_alpha_fix_val      = 0xFF,
+        .fg_alpha_update_mode  = PPA_ALPHA_FIX_VALUE,
+        .fg_alpha_fix_val      = 0,
         .fg_ck_en              = false,
-
         .out = {
-            .buffer          = draw_buf->data,
+            .buffer          = dest_buf,
             .buffer_size     = draw_buf->data_size,
             .pic_w           = draw_buf->header.w,
             .pic_h           = draw_buf->header.h,
-            .block_offset_x  = 0,
-            .block_offset_y  = 0,
-            .blend_cm        = lv_color_format_to_ppa_blend(draw_buf->header.cf),
+            .block_offset_x  = dest_area.x1,
+            .block_offset_y  = dest_area.y1,
+            .blend_cm        = lv_color_format_to_ppa_blend(dest_cf),
         },
-
         .mode            = PPA_TRANS_MODE_BLOCKING,
         .user_data       = u,
     };

--- a/src/draw/espressif/ppa/lv_draw_ppa_img.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa_img.c
@@ -56,7 +56,7 @@ void lv_draw_ppa_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
 
         .out = {
             .buffer          = draw_buf->data,
-            .buffer_size     = PPA_ALIGN_UP(draw_buf->data_size, CONFIG_CACHE_L1_CACHE_LINE_SIZE),
+            .buffer_size     = draw_buf->data_size,
             .pic_w           = draw_buf->header.w,
             .pic_h           = draw_buf->header.h,
             .block_offset_x  = 0,
@@ -64,7 +64,7 @@ void lv_draw_ppa_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
             .blend_cm        = lv_color_format_to_ppa_blend(draw_buf->header.cf),
         },
 
-        .mode            = PPA_TRANS_MODE_NON_BLOCKING,
+        .mode            = PPA_TRANS_MODE_BLOCKING,
         .user_data       = u,
     };
 

--- a/src/draw/espressif/ppa/lv_draw_ppa_private.h
+++ b/src/draw/espressif/ppa/lv_draw_ppa_private.h
@@ -124,7 +124,7 @@ static inline ppa_fill_color_mode_t lv_color_format_to_ppa_fill(lv_color_format_
         case LV_COLOR_FORMAT_RGB565:
             return PPA_FILL_COLOR_MODE_RGB565;
         case LV_COLOR_FORMAT_RGB888:
-            return PPA_FILL_COLOR_MODE_ARGB8888;
+            return PPA_FILL_COLOR_MODE_RGB888;
         case LV_COLOR_FORMAT_ARGB8888:
             return PPA_FILL_COLOR_MODE_ARGB8888;
         default:

--- a/src/draw/espressif/ppa/lv_draw_ppa_private.h
+++ b/src/draw/espressif/ppa/lv_draw_ppa_private.h
@@ -37,7 +37,7 @@ extern "C" {
 /* The ppa driver depends heavily on the esp-idf headers*/
 #include "sdkconfig.h"
 
-#if CONFIG_LV_ATTRIBUTE_MEM_ALIGN_SIZE != CONFIG_CACHE_L1_CACHE_LINE_SIZE || CONFIG_LV_DRAW_BUF_ALIGN != CONFIG_CACHE_L1_CACHE_LINE_SIZE
+#if (CONFIG_LV_DRAW_BUF_ALIGN != CONFIG_CACHE_L2_CACHE_LINE_SIZE)
 #error "For using PPA buffers need to be aligned to 64-byte boundary!"
 #endif
 
@@ -66,10 +66,6 @@ typedef struct lv_draw_ppa_unit {
     ppa_client_handle_t fill_client;
     ppa_client_handle_t blend_client;
     uint8_t * buf;
-#if LV_PPA_NONBLOCKING_OPS
-    lv_thread_t thread;
-    lv_thread_sync_t interrupt_signal;
-#endif
 } lv_draw_ppa_unit_t;
 
 /**********************
@@ -113,7 +109,6 @@ static inline bool ppa_dest_cf_supported(lv_color_format_t cf)
         case LV_COLOR_FORMAT_RGB565:
         case LV_COLOR_FORMAT_RGB888:
         case LV_COLOR_FORMAT_ARGB8888:
-        case LV_COLOR_FORMAT_XRGB8888:
             is_cf_supported = true;
             break;
         default:
@@ -129,9 +124,8 @@ static inline ppa_fill_color_mode_t lv_color_format_to_ppa_fill(lv_color_format_
         case LV_COLOR_FORMAT_RGB565:
             return PPA_FILL_COLOR_MODE_RGB565;
         case LV_COLOR_FORMAT_RGB888:
-            return PPA_FILL_COLOR_MODE_RGB888;
+            return PPA_FILL_COLOR_MODE_ARGB8888;
         case LV_COLOR_FORMAT_ARGB8888:
-        case LV_COLOR_FORMAT_XRGB8888:
             return PPA_FILL_COLOR_MODE_ARGB8888;
         default:
             return PPA_FILL_COLOR_MODE_RGB565;
@@ -146,7 +140,6 @@ static inline ppa_blend_color_mode_t lv_color_format_to_ppa_blend(lv_color_forma
         case LV_COLOR_FORMAT_RGB888:
             return PPA_BLEND_COLOR_MODE_RGB888;
         case LV_COLOR_FORMAT_ARGB8888:
-        case LV_COLOR_FORMAT_XRGB8888:
             return PPA_BLEND_COLOR_MODE_ARGB8888;
         default:
             return PPA_BLEND_COLOR_MODE_RGB565;
@@ -161,7 +154,6 @@ static inline ppa_srm_color_mode_t lv_color_format_to_ppa_srm(lv_color_format_t 
         case LV_COLOR_FORMAT_RGB888:
             return PPA_SRM_COLOR_MODE_RGB888;
         case LV_COLOR_FORMAT_XRGB8888:
-        case LV_COLOR_FORMAT_ARGB8888:
             return PPA_SRM_COLOR_MODE_ARGB8888;
         default:
             return PPA_SRM_COLOR_MODE_RGB565;


### PR DESCRIPTION
* Use target string instead of the kconfig symbol to decide if build PPA driver.
* Force draw buffers to be aligned in the cache boundary
* make PPA draw unit run to completion to avoid sync issues.
* flush the cache before and after doing the PPA draw operation.
* Reduce the burst lengths back to 64 bytes.
* Update the documentation with ESP-BSP coniguration snippet for using PPA

Fixes #9046 
Fixes #9136 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
