### PR TITLE
feat(benchmark): show warnings for typical mistakes

### DIFF
--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -537,20 +537,6 @@ void lv_demo_benchmark_set_end_cb(lv_demo_benchmark_on_end_cb_t cb)
     on_demo_end_cb = cb;
 }
 
-lv_obj_t * add_warning_label(const char * text)
-{
-    LV_LOG("%s\n", text);
-
-    lv_obj_t * label = lv_label_create(lv_screen_active());
-    lv_label_set_recolor(label, true);
-    lv_label_set_text_fmt(label, "#ffc000 " LV_SYMBOL_WARNING "# %s", text);
-    lv_obj_set_style_pad_left(label, 12, 0);
-    lv_obj_set_width(label, lv_pct(100));
-
-    return label;
-}
-
-
 void lv_demo_benchmark_summary_display(const lv_demo_benchmark_summary_t * summary)
 {
     LV_ASSERT_NULL(summary)
@@ -1033,6 +1019,18 @@ static bool is_optimization_enabled(void)
     return t_optimized * 5 < t_unoptimized;
 }
 
+static lv_obj_t * add_warning_label(const char * text)
+{
+    LV_LOG("%s\n", text);
+
+    lv_obj_t * label = lv_label_create(lv_screen_active());
+    lv_label_set_recolor(label, true);
+    lv_label_set_text_fmt(label, "#ffc000 " LV_SYMBOL_WARNING "# %s", text);
+    lv_obj_set_style_pad_left(label, 12, 0);
+    lv_obj_set_width(label, lv_pct(100));
+
+    return label;
+}
 
 static void add_warnings(void)
 {

--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -1054,7 +1054,7 @@ static void add_warnings(void)
         char buf[128];
         lv_snprintf(buf, sizeof(buf),
                     "LV_DRAW_LAYER_SIMPLE_BUF_SIZE is small making opa_layered slow. Consider 1/20 screen size for it (> %dkB)",
-                    ideal_layer_size / 1024);
+                    (ideal_layer_size / 1024) + 1);
         add_warning_label(buf);
     }
 

--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -1054,7 +1054,7 @@ static void add_warnings(void)
         char buf[128];
         lv_snprintf(buf, sizeof(buf),
                     "LV_DRAW_LAYER_SIMPLE_BUF_SIZE is small making opa_layered slow. Consider 1/20 screen size for it (> %"LV_PRIu32"kB)",
-                    (ideal_layer_size / 1024) + 1);
+                    LV_ALIGN_UP(ideal_layer_size, 1024) / 1024;
         add_warning_label(buf);
     }
 

--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -1053,7 +1053,7 @@ static void add_warnings(void)
     if(LV_DRAW_LAYER_SIMPLE_BUF_SIZE < ideal_layer_size) {
         char buf[128];
         lv_snprintf(buf, sizeof(buf),
-                    "LV_DRAW_LAYER_SIMPLE_BUF_SIZE is small making opa_layered slow. Consider 1/20 screen size for it (> %dkB)",
+                    "LV_DRAW_LAYER_SIMPLE_BUF_SIZE is small making opa_layered slow. Consider 1/20 screen size for it (> %"LV_PRIu32"kB)",
                     (ideal_layer_size / 1024) + 1);
         add_warning_label(buf);
     }

--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -1054,7 +1054,7 @@ static void add_warnings(void)
         char buf[128];
         lv_snprintf(buf, sizeof(buf),
                     "LV_DRAW_LAYER_SIMPLE_BUF_SIZE is small making opa_layered slow. Consider 1/20 screen size for it (> %"LV_PRIu32"kB)",
-                    LV_ALIGN_UP(ideal_layer_size, 1024) / 1024;
+                    LV_ALIGN_UP(ideal_layer_size, 1024) / 1024);
         add_warning_label(buf);
     }
 

--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -78,6 +78,7 @@ static void scroll_anim_y_cb(void * var, int32_t v);
 static void color_anim_cb(void * var, int32_t v);
 static void color_anim(lv_obj_t * obj);
 static void arc_anim(lv_obj_t * obj);
+static void add_warnings(void);
 
 static lv_obj_t * card_create(void);
 
@@ -536,11 +537,29 @@ void lv_demo_benchmark_set_end_cb(lv_demo_benchmark_on_end_cb_t cb)
     on_demo_end_cb = cb;
 }
 
+lv_obj_t * add_warning_label(const char * text)
+{
+    LV_LOG("%s\n", text);
+
+    lv_obj_t * label = lv_label_create(lv_screen_active());
+    lv_label_set_recolor(label, true);
+    lv_label_set_text_fmt(label, "#ffc000 " LV_SYMBOL_WARNING "# %s", text);
+    lv_obj_set_style_pad_left(label, 12, 0);
+    lv_obj_set_width(label, lv_pct(100));
+
+    return label;
+}
+
+
 void lv_demo_benchmark_summary_display(const lv_demo_benchmark_summary_t * summary)
 {
     LV_ASSERT_NULL(summary)
     lv_obj_clean(lv_screen_active());
     lv_obj_set_style_pad_hor(lv_screen_active(), 0, 0);
+    lv_obj_set_flex_flow(lv_screen_active(), LV_FLEX_COLUMN);
+
+    add_warnings();
+
     lv_obj_t * table = lv_table_create(lv_screen_active());
     lv_obj_set_width(table, lv_pct(100));
     lv_obj_set_style_max_height(table, lv_pct(100), 0);
@@ -962,6 +981,93 @@ static int32_t rnd_next(int32_t min, int32_t max)
 static lv_color_t rnd_color(void)
 {
     return lv_palette_main(rnd_next(0, LV_PALETTE_LAST - 1));
+}
+
+static uint32_t loop_optimizable(void)
+{
+    /*Easy to optimize as only local variables change*/
+    uint32_t i;
+    uint32_t c = 0;
+    for(i = 0; i < 100000; i++) {
+        c++;
+    }
+    return 0;
+}
+static uint32_t loop_not_optimizable(void)
+{
+    volatile uint32_t i;
+    volatile uint32_t c = lv_rand(0, 1000);
+    for(i = 0; i < 100000; i++) {
+        c++;
+    }
+    return c;
+}
+
+static bool is_optimization_enabled(void)
+{
+    uint32_t i;
+    uint32_t t;
+    uint32_t t_unoptimized;
+    uint32_t t_optimized;
+    uint32_t max_cnt = 1;
+    /*Run the unoptimizable loop as many times as needed
+     *to make the execution time at least 50ms  */
+    do {
+        max_cnt *= 2;
+        t = lv_tick_get();
+        for(i = 0; i < max_cnt; i++) {
+            loop_not_optimizable();
+        }
+        t_unoptimized = lv_tick_elaps(t);
+    } while(t_unoptimized < 50);
+
+    /*Run the optimizable loop the same amount of times*/
+    t = lv_tick_get();
+    for(i = 0; i < max_cnt; i++) {
+        loop_optimizable();
+    }
+    t_optimized = lv_tick_elaps(t);
+
+    /*If the optimized loop was at least 5 times faster
+     *the compiler optimization is probably enabled*/
+    return t_optimized * 5 < t_unoptimized;
+}
+
+
+static void add_warnings(void)
+{
+#if LV_USE_ASSERT_OBJ
+    add_warning_label("LV_USE_ASSERT_OBJ is enabled making rendering slower");
+#endif
+
+#if LV_USE_ASSERT_MEM_INTEGRITY
+    add_warning_label("LV_USE_ASSERT_MEM_INTEGRITY is enabled making rendering slower");
+#endif
+
+    lv_color_format_t cf = lv_display_get_color_format(NULL);
+    uint32_t screen_size_byte = LV_HOR_RES * LV_VER_RES * lv_color_format_get_size(cf);
+    uint32_t draw_buf_size = lv_display_get_draw_buf_size(NULL);
+    if(draw_buf_size < screen_size_byte / 10) {
+        add_warning_label("The draw buffer's size is smaller than 1/10 screen size making rendering slower");
+    }
+
+    uint32_t ideal_layer_size = screen_size_byte / 20;
+    if(LV_DRAW_LAYER_SIMPLE_BUF_SIZE < ideal_layer_size) {
+        char buf[128];
+        lv_snprintf(buf, sizeof(buf),
+                    "LV_DRAW_LAYER_SIMPLE_BUF_SIZE is small making opa_layered slow. Consider 1/20 screen size for it (> %dkB)",
+                    ideal_layer_size / 1024);
+        add_warning_label(buf);
+    }
+
+    if(LV_USE_LOG && LV_LOG_LEVEL < LV_LOG_LEVEL_WARN) {
+        add_warning_label("Set LV_LOG_LEVEL at least to LV_LOG_LEVEL_WARN");
+    }
+
+    if(is_optimization_enabled() == false) {
+        add_warning_label("Compiler optimization is not enabled.");
+    }
+
 }
 
 #endif


### PR DESCRIPTION
Show the typical mistakes at the summary screen of the benchmark. For example:
<img width="903" height="283" alt="image" src="https://github.com/user-attachments/assets/c89f2804-42c4-4abe-b662-2133bc191c49" />

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
