### PR TITLE
feat(vg_lite): add dynamic input parameter printing control

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite.c
@@ -329,6 +329,9 @@ static void draw_event_cb(lv_event_t * e)
         case LV_EVENT_DEFOCUSED:
             lv_vg_lite_set_dump_param_enable(false);
             break;
+        case LV_EVENT_HIT_TEST:
+            lv_vg_lite_dump_info();
+            break;
         default:
             break;
     }

--- a/src/draw/vg_lite/lv_draw_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite.c
@@ -323,6 +323,12 @@ static void draw_event_cb(lv_event_t * e)
 #endif
             }
             break;
+        case LV_EVENT_FOCUSED:
+            lv_vg_lite_set_dump_param_enable(true);
+            break;
+        case LV_EVENT_DEFOCUSED:
+            lv_vg_lite_set_dump_param_enable(false);
+            break;
         default:
             break;
     }

--- a/src/draw/vg_lite/lv_vg_lite_grad.c
+++ b/src/draw/vg_lite/lv_vg_lite_grad.c
@@ -208,14 +208,14 @@ bool lv_vg_lite_draw_grad(
                                            (vg_lite_matrix_t *)matrix,
                                            linear_grad,
                                            blend),
-                                       /*Error handler*/
+                                       /* Dump parameters */
                 {
                     lv_vg_lite_buffer_dump_info(buffer);
                     lv_vg_lite_path_dump_info(path);
-                    LV_LOG_ERROR("fill_rule: 0x%X", (int)fill);
+                    LV_LOG_USER("fill_rule: 0x%X", (int)fill);
                     lv_vg_lite_matrix_dump_info(matrix);
                     lv_vg_lite_linear_gradient_dump_info(linear_grad);
-                    LV_LOG_ERROR("blend_mode: 0x%X", (int)blend);
+                    LV_LOG_USER("blend_mode: 0x%X", (int)blend);
                 });
                 LV_PROFILER_DRAW_END_TAG("vg_lite_draw_grad");
             }
@@ -236,14 +236,14 @@ bool lv_vg_lite_draw_grad(
                                            0,
                                            blend,
                                            VG_LITE_FILTER_LINEAR),
-                                       /*Error handler*/
+                                       /* Dump parameters */
                 {
                     lv_vg_lite_buffer_dump_info(buffer);
                     lv_vg_lite_path_dump_info(path);
-                    LV_LOG_ERROR("fill_rule: 0x%X", (int)fill);
+                    LV_LOG_USER("fill_rule: 0x%X", (int)fill);
                     lv_vg_lite_matrix_dump_info(matrix);
                     lv_vg_lite_ext_linear_gradient_dump_info(linear_grad);
-                    LV_LOG_ERROR("blend_mode: 0x%X", (int)blend);
+                    LV_LOG_USER("blend_mode: 0x%X", (int)blend);
                 });
                 LV_PROFILER_DRAW_END_TAG("vg_lite_draw_linear_grad");
             }
@@ -266,14 +266,14 @@ bool lv_vg_lite_draw_grad(
                         0,
                         blend,
                         VG_LITE_FILTER_LINEAR),
-                    /*Error handler*/
+                    /* Dump parameters */
                 {
                     lv_vg_lite_buffer_dump_info(buffer);
                     lv_vg_lite_path_dump_info(path);
-                    LV_LOG_ERROR("fill_rule: 0x%X", (int)fill);
+                    LV_LOG_USER("fill_rule: 0x%X", (int)fill);
                     lv_vg_lite_matrix_dump_info(matrix);
                     lv_vg_lite_radial_gradient_dump_info(radial_gradient);
-                    LV_LOG_ERROR("blend_mode: 0x%X", (int)blend);
+                    LV_LOG_USER("blend_mode: 0x%X", (int)blend);
                 });
                 LV_PROFILER_DRAW_END_TAG("vg_lite_draw_radial_grad");
             }
@@ -484,14 +484,17 @@ static bool linear_grad_create(grad_item_t * item)
 {
     LV_PROFILER_DRAW_BEGIN;
 
+    /* Capture error code from LV_VG_LITE_CHECK_ERROR */
+    vg_lite_error_t err = VG_LITE_SUCCESS;
     LV_VG_LITE_CHECK_ERROR(
-        vg_lite_init_grad(&item->vg.linear),
-        /* Error handler */
-    {
+    err = vg_lite_init_grad(&item->vg.linear), {
         lv_vg_lite_linear_gradient_dump_info(&item->vg.linear);
+    });
+
+    if(err != VG_LITE_SUCCESS) {
         LV_PROFILER_DRAW_END;
         return false;
-    });
+    }
 
     vg_lite_uint32_t colors[VLC_MAX_GRADIENT_STOPS];
     vg_lite_uint32_t stops[VLC_MAX_GRADIENT_STOPS];
@@ -513,17 +516,13 @@ static bool linear_grad_create(grad_item_t * item)
     }
 
     LV_VG_LITE_CHECK_ERROR(
-        vg_lite_set_grad(&item->vg.linear, item->lv.stops_count, colors, stops),
-        /* Error handler */
-    {
+    vg_lite_set_grad(&item->vg.linear, item->lv.stops_count, colors, stops), {
         lv_vg_lite_linear_gradient_dump_info(&item->vg.linear);
     });
 
     LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_update_grad");
     LV_VG_LITE_CHECK_ERROR(
-        vg_lite_update_grad(&item->vg.linear),
-        /* Error handler */
-    {
+    vg_lite_update_grad(&item->vg.linear), {
         lv_vg_lite_linear_gradient_dump_info(&item->vg.linear);
     });
     LV_PROFILER_DRAW_END_TAG("vg_lite_update_grad");
@@ -559,20 +558,18 @@ static bool linear_ext_grad_create(grad_item_t * item, vg_lite_color_ramp_t * co
             grad_param,
             lv_spread_to_vg(item->lv.spread),
             1),
-        /* Error handler */
+        /* Dump parameters */
     {
         lv_vg_lite_ext_linear_gradient_dump_info(&item->vg.linear_ext);
     });
     LV_PROFILER_DRAW_END_TAG("vg_lite_set_linear_grad");
 
     LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_update_linear_grad");
-    vg_lite_error_t err = vg_lite_update_linear_grad(&item->vg.linear_ext);
-    LV_PROFILER_DRAW_END_TAG("vg_lite_update_linear_grad");
-    if(err != VG_LITE_SUCCESS)  {
-        LV_LOG_ERROR("vg_lite_update_linear_grad error: %d", (int)err);
-        lv_vg_lite_error_dump_info(err);
+    vg_lite_error_t err = VG_LITE_SUCCESS;
+    LV_VG_LITE_CHECK_ERROR(err = vg_lite_update_linear_grad(&item->vg.linear_ext), {
         lv_vg_lite_ext_linear_gradient_dump_info(&item->vg.linear_ext);
-    }
+    });
+    LV_PROFILER_DRAW_END_TAG("vg_lite_update_linear_grad");
 
     LV_PROFILER_DRAW_END;
     return err == VG_LITE_SUCCESS;
@@ -606,20 +603,18 @@ static bool radial_grad_create(grad_item_t * item, vg_lite_color_ramp_t * color_
             grad_param,
             lv_spread_to_vg(item->lv.spread),
             1),
-        /* Error handler */
+        /* Dump parameters */
     {
         lv_vg_lite_radial_gradient_dump_info(&item->vg.radial);
     });
     LV_PROFILER_DRAW_END_TAG("vg_lite_set_radial_grad");
 
     LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_update_radial_grad");
-    vg_lite_error_t err = vg_lite_update_radial_grad(&item->vg.radial);
-    LV_PROFILER_DRAW_END_TAG("vg_lite_update_radial_grad");
-    if(err != VG_LITE_SUCCESS) {
-        LV_LOG_ERROR("vg_lite_update_radial_grad error: %d", (int)err);
-        lv_vg_lite_error_dump_info(err);
+    vg_lite_error_t err = VG_LITE_SUCCESS;
+    LV_VG_LITE_CHECK_ERROR(err = vg_lite_update_radial_grad(&item->vg.radial), {
         lv_vg_lite_radial_gradient_dump_info(&item->vg.radial);
-    }
+    });
+    LV_PROFILER_DRAW_END_TAG("vg_lite_update_radial_grad");
 
     LV_PROFILER_DRAW_END;
     return err == VG_LITE_SUCCESS;

--- a/src/draw/vg_lite/lv_vg_lite_stroke.c
+++ b/src/draw/vg_lite/lv_vg_lite_stroke.c
@@ -251,8 +251,8 @@ static bool stroke_create_cb(stroke_item_t * item, void * user_data)
         /* Dump parameters */
     {
         lv_vg_lite_path_dump_info(vg_path);
-        LV_LOG_USER("Cap: %d", lv_stroke_cap_to_vg(item->lv.cap));
-        LV_LOG_USER("Join: %d", lv_stroke_join_to_vg(item->lv.join));
+        LV_LOG_USER("Cap: 0x%X", (int)lv_stroke_cap_to_vg(item->lv.cap));
+        LV_LOG_USER("Join: 0x%X", (int)lv_stroke_join_to_vg(item->lv.join));
         LV_LOG_USER("Width: %f", item->lv.width);
         LV_LOG_USER("Miter limit: %d", item->lv.miter_limit);
         if(vg_dash_pattern)

--- a/src/draw/vg_lite/lv_vg_lite_stroke.c
+++ b/src/draw/vg_lite/lv_vg_lite_stroke.c
@@ -236,20 +236,34 @@ static bool stroke_create_cb(stroke_item_t * item, void * user_data)
     vg_lite_path_t * vg_path = lv_vg_lite_path_get_path(item->vg.path);
     LV_VG_LITE_CHECK_ERROR(vg_lite_set_path_type(vg_path, VG_LITE_DRAW_STROKE_PATH), {});
 
-    vg_lite_error_t error = vg_lite_set_stroke(
-                                vg_path,
-                                lv_stroke_cap_to_vg(item->lv.cap),
-                                lv_stroke_join_to_vg(item->lv.join),
-                                item->lv.width,
-                                item->lv.miter_limit,
-                                vg_dash_pattern,
-                                size,
-                                item->lv.width / 2,
-                                0);
+    vg_lite_error_t err = VG_LITE_SUCCESS;
+    LV_VG_LITE_CHECK_ERROR(
+        err = vg_lite_set_stroke(
+                  vg_path,
+                  lv_stroke_cap_to_vg(item->lv.cap),
+                  lv_stroke_join_to_vg(item->lv.join),
+                  item->lv.width,
+                  item->lv.miter_limit,
+                  vg_dash_pattern,
+                  size,
+                  item->lv.width / 2,
+                  0),
+        /* Dump parameters */
+    {
+        lv_vg_lite_path_dump_info(vg_path);
+        LV_LOG_USER("Cap: %d", lv_stroke_cap_to_vg(item->lv.cap));
+        LV_LOG_USER("Join: %d", lv_stroke_join_to_vg(item->lv.join));
+        LV_LOG_USER("Width: %f", item->lv.width);
+        LV_LOG_USER("Miter limit: %d", item->lv.miter_limit);
+        if(vg_dash_pattern)
+        {
+            for(uint32_t i = 0; i < size; i++) {
+                LV_LOG_USER("Dash pattern[%" LV_PRIu32 "]: %f", i, vg_dash_pattern[i]);
+            }
+        }
+    });
 
-    if(error != VG_LITE_SUCCESS) {
-        LV_LOG_ERROR("vg_lite_set_stroke error: %d", (int)error);
-        lv_vg_lite_error_dump_info(error);
+    if(err != VG_LITE_SUCCESS) {
         stroke_free_cb(item, NULL);
         return false;
     }
@@ -258,16 +272,16 @@ static bool stroke_create_cb(stroke_item_t * item, void * user_data)
     const vg_lite_uint32_t ori_path_length = vg_path->path_length;
 
     LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_update_stroke");
-    error = vg_lite_update_stroke(vg_path);
+    LV_VG_LITE_CHECK_ERROR(err = vg_lite_update_stroke(vg_path), {
+        lv_vg_lite_path_dump_info(vg_path);
+    });
     LV_PROFILER_DRAW_END_TAG("vg_lite_update_stroke");
 
     /* check if path is changed */
     LV_ASSERT_MSG(vg_path->path_length == ori_path_length, "vg_path->path_length should not change");
     LV_ASSERT_MSG(vg_path->path == ori_path, "vg_path->path should not change");
 
-    if(error != VG_LITE_SUCCESS) {
-        LV_LOG_ERROR("vg_lite_update_stroke error: %d", (int)error);
-        lv_vg_lite_error_dump_info(error);
+    if(err != VG_LITE_SUCCESS) {
         stroke_free_cb(item, NULL);
         return false;
     }

--- a/src/draw/vg_lite/lv_vg_lite_utils.c
+++ b/src/draw/vg_lite/lv_vg_lite_utils.c
@@ -57,6 +57,8 @@ static void image_dsc_free_cb(void * dsc, void * user_data);
  *  STATIC VARIABLES
  **********************/
 
+static bool g_is_dump_param_enabled = false;
+
 /**********************
  *      MACROS
  **********************/
@@ -897,7 +899,13 @@ bool lv_vg_lite_buffer_open_image(vg_lite_buffer_t * buffer, lv_image_decoder_ds
     if(LV_COLOR_FORMAT_IS_INDEXED(decoded->header.cf)) {
         uint32_t palette_size = LV_COLOR_INDEXED_PALETTE_SIZE(decoded->header.cf);
         LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_set_CLUT");
-        LV_VG_LITE_CHECK_ERROR(vg_lite_set_CLUT(palette_size, (vg_lite_uint32_t *)decoded->data), {});
+        LV_VG_LITE_CHECK_ERROR(
+        vg_lite_set_CLUT(palette_size, (vg_lite_uint32_t *)decoded->data), {
+            for(uint32_t i = 0; i < palette_size; i++)
+            {
+                LV_LOG_USER("CLUT[%" LV_PRIu32 "] = 0x%08X", i, ((vg_lite_uint32_t *)decoded->data)[i]);
+            }
+        });
         LV_PROFILER_DRAW_END_TAG("vg_lite_set_CLUT");
     }
 
@@ -1313,10 +1321,10 @@ void lv_vg_lite_set_scissor_area(struct _lv_draw_vg_lite_unit_t * u, const lv_ar
                                area->y1,
                                area->x2 + 1,
                                area->y2 + 1),
-                           /* Error handler */
+                           /* Dump parameters */
     {
-        LV_LOG_ERROR("area: %d, %d, %d, %d",
-                     (int)area->x1, (int)area->y1, (int)area->x2, (int)area->y2);
+        LV_LOG_USER("area: %d, %d, %d, %d",
+                    (int)area->x1, (int)area->y1, (int)area->x2, (int)area->y2);
     });
 
     u->current_scissor_area = *area;
@@ -1332,9 +1340,9 @@ void lv_vg_lite_disable_scissor(void)
                                0,
                                LV_HOR_RES,
                                LV_VER_RES),
-                           /* Error handler */
+                           /* Dump parameters */
     {
-        LV_LOG_ERROR("hor_res: %d, ver_res: %d", (int)LV_HOR_RES, (int)LV_VER_RES);
+        LV_LOG_USER("hor_res: %d, ver_res: %d", (int)LV_HOR_RES, (int)LV_VER_RES);
     });
     LV_PROFILER_DRAW_END;
 }
@@ -1427,6 +1435,17 @@ void lv_vg_lite_set_color_key(const lv_image_colorkey_t * colorkey)
         vg_colorkey[0] = key0;
     }
     LV_VG_LITE_CHECK_ERROR(vg_lite_set_color_key(vg_colorkey), {});
+}
+
+void lv_vg_lite_set_dump_param_enable(bool enable)
+{
+    g_is_dump_param_enabled = enable;
+    LV_LOG_USER(enable ? "Enabled" : "Disabled");
+}
+
+bool lv_vg_lite_is_dump_param_enabled(void)
+{
+    return g_is_dump_param_enabled;
 }
 
 /**********************

--- a/src/draw/vg_lite/lv_vg_lite_utils.h
+++ b/src/draw/vg_lite/lv_vg_lite_utils.h
@@ -41,13 +41,17 @@ extern "C" {
 #define LV_VG_LITE_ASSERT(expr)
 #endif
 
-#define LV_VG_LITE_CHECK_ERROR(expr, error_handler)           \
+#define LV_VG_LITE_CHECK_ERROR(expr, dump_param)              \
     do {                                                      \
+        if(lv_vg_lite_is_dump_param_enabled()) {              \
+            LV_LOG_USER("Call '" #expr "', Parameter:");      \
+            dump_param;                                       \
+        }                                                     \
         vg_lite_error_t error = expr;                         \
         if (error != VG_LITE_SUCCESS) {                       \
             LV_LOG_ERROR("Execute '" #expr "' error: %d", (int)error);  \
             lv_vg_lite_error_dump_info(error);                \
-            error_handler;                                    \
+            dump_param;                                       \
             LV_VG_LITE_ASSERT(false);                         \
         }                                                     \
     } while (0)
@@ -179,6 +183,10 @@ void lv_vg_lite_flush(struct _lv_draw_vg_lite_unit_t * u);
 
 void lv_vg_lite_finish(struct _lv_draw_vg_lite_unit_t * u);
 
+void lv_vg_lite_set_dump_param_enable(bool enable);
+
+bool lv_vg_lite_is_dump_param_enabled(void);
+
 static inline void lv_vg_lite_draw(vg_lite_buffer_t * target,
                                    vg_lite_path_t * path,
                                    vg_lite_fill_t fill_rule,
@@ -198,13 +206,13 @@ static inline void lv_vg_lite_draw(vg_lite_buffer_t * target,
                                matrix,
                                blend,
                                color),
-                           /*Error handler*/
+                           /* Dump parameters */
     {
         lv_vg_lite_buffer_dump_info(target);
         lv_vg_lite_path_dump_info(path);
-        LV_LOG_ERROR("fill_rule: 0x%X,", (int)fill_rule);
+        LV_LOG_USER("fill_rule: 0x%X,", (int)fill_rule);
         lv_vg_lite_matrix_dump_info(matrix);
-        LV_LOG_ERROR("blend: 0x%X,", (int)blend);
+        LV_LOG_USER("blend: 0x%X,", (int)blend);
         lv_vg_lite_color_dump_info(color);
     });
     LV_PROFILER_DRAW_END_TAG("vg_lite_draw");
@@ -241,19 +249,19 @@ static inline void lv_vg_lite_draw_pattern(vg_lite_buffer_t * target,
                                pattern_color,
                                color,
                                filter),
-                           /*Error handler*/
+                           /* Dump parameters */
     {
         lv_vg_lite_buffer_dump_info(target);
         lv_vg_lite_path_dump_info(path);
-        LV_LOG_ERROR("fill_rule: 0x%X,", (int)fill_rule);
+        LV_LOG_USER("fill_rule: 0x%X,", (int)fill_rule);
         lv_vg_lite_matrix_dump_info(path_matrix);
         lv_vg_lite_buffer_dump_info(pattern_image);
         lv_vg_lite_matrix_dump_info(pattern_matrix);
-        LV_LOG_ERROR("blend: 0x%X,", (int)blend);
-        LV_LOG_ERROR("pattern_mode: 0x%X,", (int)pattern_mode);
+        LV_LOG_USER("blend: 0x%X,", (int)blend);
+        LV_LOG_USER("pattern_mode: 0x%X,", (int)pattern_mode);
         lv_vg_lite_color_dump_info(pattern_color);
         lv_vg_lite_color_dump_info(color);
-        LV_LOG_ERROR("filter: 0x%X,", (int)filter);
+        LV_LOG_USER("filter: 0x%X,", (int)filter);
     });
     LV_PROFILER_DRAW_END_TAG("vg_lite_draw_pattern");
 }
@@ -279,16 +287,16 @@ static inline void lv_vg_lite_blit_rect(vg_lite_buffer_t * target,
                                blend,
                                color,
                                filter),
-                           /*Error handler*/
+                           /* Dump parameters */
     {
         lv_vg_lite_buffer_dump_info(target);
         lv_vg_lite_buffer_dump_info(source);
-        LV_LOG_ERROR("rect: X%d Y%d W%d H%d",
-                     (int)rect->x, (int)rect->y, (int)rect->width, (int)rect->height);
+        LV_LOG_USER("rect: X%d Y%d W%d H%d",
+                    (int)rect->x, (int)rect->y, (int)rect->width, (int)rect->height);
         lv_vg_lite_matrix_dump_info(matrix);
-        LV_LOG_ERROR("blend: 0x%X", (int)blend);
+        LV_LOG_USER("blend: 0x%X", (int)blend);
         lv_vg_lite_color_dump_info(color);
-        LV_LOG_ERROR("filter: 0x%X", (int)filter);
+        LV_LOG_USER("filter: 0x%X", (int)filter);
     });
     LV_PROFILER_DRAW_END_TAG("vg_lite_blit_rect");
 }
@@ -301,7 +309,7 @@ static inline void lv_vg_lite_clear(vg_lite_buffer_t * target, const lv_area_t *
     LV_PROFILER_DRAW_BEGIN_TAG("vg_lite_clear");
     LV_VG_LITE_CHECK_ERROR(vg_lite_clear(target, &rect, color), {
         lv_vg_lite_buffer_dump_info(target);
-        LV_LOG_ERROR("rect: X%d Y%d W%d H%d", rect.x, rect.y, rect.width, rect.height);
+        LV_LOG_USER("rect: X%d Y%d W%d H%d", rect.x, rect.y, rect.width, rect.height);
         lv_vg_lite_color_dump_info(color);
     });
     LV_PROFILER_DRAW_END_TAG("vg_lite_clear");

--- a/tests/src/test_cases/draw/test_draw_vector.c
+++ b/tests/src/test_cases/draw/test_draw_vector.c
@@ -390,8 +390,15 @@ static void draw_during_rendering(const char * name, draw_cb_t draw_cb, lv_opa_t
 
 void test_draw_during_rendering(void)
 {
+    /* Enable the Draw Unit dump parameters */
+    lv_draw_unit_send_event(NULL, LV_EVENT_FOCUSED, NULL);
+
     draw_during_rendering("shapes", draw_shapes, LV_OPA_COVER);
     draw_during_rendering("lines", draw_lines, LV_OPA_COVER);
+
+    /* Disable the Draw Unit dump parameters */
+    lv_draw_unit_send_event(NULL, LV_EVENT_DEFOCUSED, NULL);
+
     draw_during_rendering("shapes_opa_50", draw_shapes, LV_OPA_50);
     draw_during_rendering("lines_opa_50", draw_lines, LV_OPA_50);
 }

--- a/tests/src/test_cases/draw/test_draw_vector.c
+++ b/tests/src/test_cases/draw/test_draw_vector.c
@@ -29,6 +29,9 @@ void tearDown(void)
     /* Test all cleanup */
     lv_draw_unit_send_event(NULL, LV_EVENT_CANCEL, NULL);
 
+    /* Test draw unit dump info */
+    lv_draw_unit_send_event(NULL, LV_EVENT_HIT_TEST, NULL);
+
     lv_obj_clean(lv_screen_active());
 }
 


### PR DESCRIPTION
Add dynamic printing support for input parameters to facilitate immediate analysis of input parameters when problems occur, reducing the time wasted on manual log addition and analysis.

```c
/* Enable the Draw Unit dump parameters */
lv_draw_unit_send_event(NULL, LV_EVENT_FOCUSED, NULL);

/* Disable the Draw Unit dump parameters */
lv_draw_unit_send_event(NULL, LV_EVENT_DEFOCUSED, NULL);
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
