### PR TITLE
feat(display): add screen offsets

### DIFF
--- a/src/core/lv_obj_class.c
+++ b/src/core/lv_obj_class.c
@@ -79,10 +79,10 @@ lv_obj_t * lv_obj_class_create_obj(const lv_obj_class_t * class_p, lv_obj_t * pa
         disp->screens[disp->screen_cnt - 1] = obj;
 
         /*Set coordinates to full screen size*/
-        obj->coords.x1 = 0;
-        obj->coords.y1 = 0;
-        obj->coords.x2 = lv_display_get_horizontal_resolution(NULL) - 1;
-        obj->coords.y2 = lv_display_get_vertical_resolution(NULL) - 1;
+        obj->coords.x1 = lv_display_get_screen_left_offset(disp);
+        obj->coords.y1 = lv_display_get_screen_top_offset(disp);
+        obj->coords.x2 = lv_display_get_horizontal_resolution(disp) - (lv_display_get_screen_right_offset(disp) + 1);
+        obj->coords.y2 = lv_display_get_vertical_resolution(disp) - (lv_display_get_screen_bottom_offset(disp) + 1);;
     }
     /*Create a normal object*/
     else {

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -1253,6 +1253,73 @@ int32_t lv_display_dpx(const lv_display_t * disp, int32_t n)
     return LV_DPX_CALC(lv_display_get_dpi(disp), n);
 }
 
+uint32_t lv_display_get_screen_left_offset(lv_display_t * disp)
+{
+    if(!disp) disp = lv_display_get_default();
+    if(!disp) {
+        return 0;
+    }
+    return disp->screen_left_offset;
+}
+uint32_t lv_display_get_screen_right_offset(lv_display_t * disp)
+{
+    if(!disp) disp = lv_display_get_default();
+    if(!disp) {
+        return 0;
+    }
+    return disp->screen_right_offset;
+}
+uint32_t lv_display_get_screen_top_offset(lv_display_t * disp)
+{
+    if(!disp) disp = lv_display_get_default();
+    if(!disp) {
+        return 0;
+    }
+    return disp->screen_top_offset;
+}
+uint32_t lv_display_get_screen_bottom_offset(lv_display_t * disp)
+{
+    if(!disp) disp = lv_display_get_default();
+    if(!disp) {
+        return 0;
+    }
+
+    return disp->screen_bottom_offset;
+}
+
+void lv_display_set_screen_left_offset(lv_display_t * disp, uint32_t offset)
+{
+    if(!disp) disp = lv_display_get_default();
+    if(!disp) {
+        return;
+    }
+    disp->screen_left_offset = offset;
+}
+void lv_display_set_screen_right_offset(lv_display_t * disp, uint32_t offset)
+{
+    if(!disp) disp = lv_display_get_default();
+    if(!disp) {
+        return;
+    }
+    disp->screen_right_offset = offset;
+}
+void lv_display_set_screen_top_offset(lv_display_t * disp, uint32_t offset)
+{
+    if(!disp) disp = lv_display_get_default();
+    if(!disp) {
+        return;
+    }
+    disp->screen_top_offset = offset;
+}
+void lv_display_set_screen_bottom_offset(lv_display_t * disp, uint32_t offset)
+{
+    if(!disp) disp = lv_display_get_default();
+    if(!disp) {
+        return;
+    }
+    disp->screen_bottom_offset = offset;
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/display/lv_display_private.h
+++ b/src/display/lv_display_private.h
@@ -60,6 +60,11 @@ struct _lv_display_t {
     /** DPI (dot per inch) of the display. Default value is `LV_DPI_DEF`.*/
     uint32_t dpi;
 
+    uint32_t screen_left_offset;
+    uint32_t screen_right_offset;
+    uint32_t screen_top_offset;
+    uint32_t screen_bottom_offset;
+
     /*---------------------
      * Buffering
      *--------------------*/
@@ -176,6 +181,16 @@ struct _lv_display_t {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
+
+uint32_t lv_display_get_screen_left_offset(lv_display_t * disp);
+uint32_t lv_display_get_screen_right_offset(lv_display_t * disp);
+uint32_t lv_display_get_screen_top_offset(lv_display_t * disp);
+uint32_t lv_display_get_screen_bottom_offset(lv_display_t * disp);
+
+void lv_display_set_screen_left_offset(lv_display_t * disp, uint32_t offset);
+void lv_display_set_screen_right_offset(lv_display_t * disp, uint32_t offset);
+void lv_display_set_screen_top_offset(lv_display_t * disp, uint32_t offset);
+void lv_display_set_screen_bottom_offset(lv_display_t * disp, uint32_t offset);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
Context: In order to simplify the wayland driver, I needed a way to create a title bar and window borders using normal LVGL widgets
Goal: Use the top display layer to display the title bar and the borders
How: By being able to set default screen offsets so that the screen will be automatically created within these borders (this PR)

These functions are private for now, we could maybe make these public if there's a need

Missing tests