### PR TITLE
fix(property): fix return type of LV_PROPERTY_OBJ_SCROLL_END

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -78,6 +78,8 @@ static void delete_on_screen_unloaded_event_cb(lv_event_t * e);
 #if LV_USE_OBJ_PROPERTY
     static lv_result_t lv_obj_set_any(lv_obj_t *, lv_prop_id_t, const lv_property_t *);
     static lv_result_t lv_obj_get_any(const lv_obj_t *, lv_prop_id_t, lv_property_t *);
+
+    static lv_point_t lv_obj_get_scroll_end_helper(lv_obj_t * obj);
 #endif
 
 /**********************
@@ -166,7 +168,7 @@ static const lv_property_ops_t properties[] = {
     },
     {
         .id = LV_PROPERTY_OBJ_SCROLL_END,
-        .getter = lv_obj_get_scroll_end,
+        .getter = lv_obj_get_scroll_end_helper,
     },
     {
         .id = LV_PROPERTY_OBJ_EXT_DRAW_SIZE,
@@ -1177,6 +1179,13 @@ static void delete_on_screen_unloaded_event_cb(lv_event_t * e)
 }
 
 #if LV_USE_OBJ_PROPERTY
+static lv_point_t lv_obj_get_scroll_end_helper(lv_obj_t * obj)
+{
+    lv_point_t point;
+    lv_obj_get_scroll_end(obj, &point);
+    return point;
+}
+
 static lv_result_t lv_obj_set_any(lv_obj_t * obj, lv_prop_id_t id, const lv_property_t * prop)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
@@ -1226,4 +1235,4 @@ static lv_result_t lv_obj_get_any(const lv_obj_t * obj, lv_prop_id_t id, lv_prop
         return LV_RESULT_INVALID;
     }
 }
-#endif
+#endif /*LV_USE_OBJ_PROPERTY*/

--- a/src/core/lv_obj.h
+++ b/src/core/lv_obj.h
@@ -160,7 +160,7 @@ enum _lv_signed_prop_id_t {
     LV_PROPERTY_ID(OBJ, SCROLL_BOTTOM,              LV_PROPERTY_TYPE_INT,       64),
     LV_PROPERTY_ID(OBJ, SCROLL_LEFT,                LV_PROPERTY_TYPE_INT,       65),
     LV_PROPERTY_ID(OBJ, SCROLL_RIGHT,               LV_PROPERTY_TYPE_INT,       66),
-    LV_PROPERTY_ID(OBJ, SCROLL_END,                 LV_PROPERTY_TYPE_INT,       67),
+    LV_PROPERTY_ID(OBJ, SCROLL_END,                 LV_PROPERTY_TYPE_POINT,     67),
     LV_PROPERTY_ID(OBJ, EXT_DRAW_SIZE,              LV_PROPERTY_TYPE_INT,       68),
     LV_PROPERTY_ID(OBJ, EVENT_COUNT,                LV_PROPERTY_TYPE_INT,       69),
     LV_PROPERTY_ID(OBJ, SCREEN,                     LV_PROPERTY_TYPE_OBJ,       70),


### PR DESCRIPTION
`lv_obj_get_property(..., LV_PROPERTY_OBJ_SCROLL_END)` crashes due to type mismatch of the getter function. Fixes the expected type and introduces a helper function analogous to [`lv_image_get_pivot_helper()`](https://github.com/lvgl/lvgl/blob/cae6123799f22f74eb2a99c3f01bdf80e0b9cea1/src/widgets/image/lv_image.c#L50).