### PR TITLE
perf(label): LAYOUT_COMPLETED only send to the required widget.

### DIFF
--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -35,7 +35,6 @@ static int32_t calc_content_height(lv_obj_t * obj);
 static void layout_update_core(lv_obj_t * obj);
 static void transform_point_array(const lv_obj_t * obj, lv_point_t * p, size_t p_count, bool inv);
 static bool is_transformed(const lv_obj_t * obj);
-static lv_obj_tree_walk_res_t update_layout_completed_cb(lv_obj_t * obj, void * user_data);
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -304,12 +303,6 @@ void lv_obj_mark_layout_as_dirty(lv_obj_t * obj)
     lv_display_send_event(disp, LV_EVENT_REFR_REQUEST, NULL);
 }
 
-void lv_obj_request_layout_complete_event(lv_obj_t * obj)
-{
-    lv_obj_t * scr = lv_obj_get_screen(obj);
-    scr->scr_layout_complete_pending = 1;
-}
-
 void lv_obj_update_layout(const lv_obj_t * obj)
 {
     if(update_layout_mutex) {
@@ -328,11 +321,8 @@ void lv_obj_update_layout(const lv_obj_t * obj)
         LV_LOG_TRACE("Layout update end");
     }
 
-    if(scr->scr_layout_complete_pending) {
-        scr->scr_layout_complete_pending = 0;
-        lv_obj_tree_walk(scr, update_layout_completed_cb, NULL);
-    }
-
+    lv_display_t * disp = lv_obj_get_display(scr);
+    lv_display_send_event(disp, LV_EVENT_UPDATE_LAYOUT_COMPLETED, NULL);
     update_layout_mutex = false;
     LV_PROFILER_LAYOUT_END;
 }
@@ -1326,11 +1316,4 @@ static void transform_point_array(const lv_obj_t * obj, lv_point_t * p, size_t p
     }
 
     lv_point_array_transform(p, p_count, angle, scale_x, scale_y, &pivot, !inv);
-}
-
-static lv_obj_tree_walk_res_t update_layout_completed_cb(lv_obj_t * obj, void * user_data)
-{
-    LV_UNUSED(user_data);
-    lv_obj_send_event(obj, LV_EVENT_UPDATE_LAYOUT_COMPLETED, NULL);
-    return LV_OBJ_TREE_WALK_NEXT;
 }

--- a/src/core/lv_obj_pos.h
+++ b/src/core/lv_obj_pos.h
@@ -154,12 +154,6 @@ bool lv_obj_is_layout_positioned(const lv_obj_t * obj);
 void lv_obj_mark_layout_as_dirty(lv_obj_t * obj);
 
 /**
- * Mark screen to send layout completed event after update.
- * @param obj   Any object on the target screen
- */
-void lv_obj_request_layout_complete_event(lv_obj_t * obj);
-
-/**
  * Update the layout of an object.
  * @param obj      pointer to an object whose position and size needs to be updated
  */

--- a/src/core/lv_obj_private.h
+++ b/src/core/lv_obj_private.h
@@ -71,7 +71,6 @@ struct _lv_obj_t {
     uint16_t layout_inv : 1;
     uint16_t readjust_scroll_after_layout : 1;
     uint16_t scr_layout_inv : 1;
-    uint16_t scr_layout_complete_pending : 1;
     uint16_t skip_trans : 1;
     uint16_t style_cnt  : 6;
     uint16_t h_layout   : 1;

--- a/src/misc/lv_event.h
+++ b/src/misc/lv_event.h
@@ -93,7 +93,6 @@ typedef enum {
     LV_EVENT_STYLE_CHANGED,       /**< Object's style has changed */
     LV_EVENT_LAYOUT_CHANGED,      /**< A child's position position has changed due to a layout recalculation */
     LV_EVENT_GET_SELF_SIZE,       /**< Get internal size of a widget */
-    LV_EVENT_UPDATE_LAYOUT_COMPLETED,    /**< Sent after layout update completes*/
 
     /** Events of optional LVGL components */
     LV_EVENT_INVALIDATE_AREA,     /**< An area is invalidated (marked for redraw). `lv_event_get_param(e)`
@@ -112,6 +111,7 @@ typedef enum {
     LV_EVENT_FLUSH_FINISH,        /**< Sent after flush callback call has returned. */
     LV_EVENT_FLUSH_WAIT_START,    /**< Sent before flush wait callback is called. */
     LV_EVENT_FLUSH_WAIT_FINISH,   /**< Sent after flush wait callback call has returned. */
+    LV_EVENT_UPDATE_LAYOUT_COMPLETED,    /**< Sent after layout update completes*/
 
     LV_EVENT_VSYNC,
     LV_EVENT_VSYNC_REQUEST,

--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -52,6 +52,7 @@ static void draw_main(lv_event_t * e);
 static void set_text_internal(lv_obj_t * obj, const char * text);
 static void remove_translation_tag(lv_obj_t * obj);
 static void lv_label_refr_text(lv_obj_t * obj);
+static void update_layout_completed_cb(lv_event_t * e);
 static void lv_label_revert_dots(lv_obj_t * label);
 static void lv_label_set_dots(lv_obj_t * label, uint32_t dot_begin);
 
@@ -787,6 +788,9 @@ static void lv_label_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
     if(label->translation_tag) lv_free(label->translation_tag);
     label->translation_tag = NULL;
 #endif /*LV_USE_TRANSLATION*/
+
+    lv_display_t * disp = lv_obj_get_display(obj);
+    lv_display_remove_event_cb_with_user_data(disp, update_layout_completed_cb, obj);
 }
 
 static void lv_label_event(const lv_obj_class_t * class_p, lv_event_t * e)
@@ -853,9 +857,6 @@ static void lv_label_event(const lv_obj_class_t * class_p, lv_event_t * e)
     else if(code == LV_EVENT_DRAW_MAIN) {
         draw_main(e);
 
-    }
-    else if(code == LV_EVENT_UPDATE_LAYOUT_COMPLETED) {
-        lv_label_refr_text(obj);
     }
 #if LV_USE_TRANSLATION
     else if(code == LV_EVENT_TRANSLATION_LANGUAGE_CHANGED) {
@@ -1065,12 +1066,24 @@ static void lv_label_mark_need_refr_text(lv_obj_t * obj)
     lv_label_t * label = (lv_label_t *)obj;
     if(label->text == NULL) return;
     label->invalid_size_cache = true;
-    label->need_refr_text = true;
 
     lv_obj_invalidate(obj);
     lv_obj_refresh_self_size(obj);
 
-    lv_obj_request_layout_complete_event(obj);
+    if(!label->need_refr_text) {
+        label->need_refr_text = true;
+        lv_display_t * disp = lv_obj_get_display(obj);
+        lv_display_add_event_cb(disp, update_layout_completed_cb, LV_EVENT_UPDATE_LAYOUT_COMPLETED, obj);
+    }
+}
+
+static void update_layout_completed_cb(lv_event_t * e)
+{
+    lv_obj_t * obj = lv_event_get_user_data(e);
+    lv_display_t * disp = lv_obj_get_display(obj);
+    lv_display_remove_event_cb_with_user_data(disp, update_layout_completed_cb, obj);
+
+    lv_label_refr_text(obj);
 }
 
 /**


### PR DESCRIPTION
By subscribing to widgets that need `LV_EVENT_UPDATE_LAYOUT_COMPLETED`, you can avoid iterating through all widgets on the screen.

The lv_label will receive `LV_EVENT_UPDATE_LAYOUT_COMPLETED `events by subscribing to the display event.
```c
lv_display_add_event_cb(disp, update_layout_completed_cb, LV_EVENT_UPDATE_LAYOUT_COMPLETED, obj);
```

This avoids iterating through all obj objects in `lv_obj_tree_walk`. (This may take longer..)


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
