### PR TITLE
fix(gif): add disposal handle to fix gif display error

### DIFF
--- a/src/libs/gif/lv_gif.c
+++ b/src/libs/gif/lv_gif.c
@@ -430,6 +430,11 @@ static void disposal_last_frame(GIFIMAGE * gif, lv_draw_buf_t * drawbuf)
     int disposal_method = (gif->ucGIFBits & 0x1c) >> 2;
     int i, j;
 
+    /* Bounds validation to prevent out-of-bounds access */
+    if(x < 0 || y < 0 || w <= 0 || h <= 0 ||
+       x + w > drawbuf->header.w || y + h > drawbuf->header.h) {
+        return;
+    }
     if(disposal_method == 2) {
         /* Restore to background color */
         unsigned char bg = gif->ucBackground;

--- a/src/libs/gif/lv_gif.c
+++ b/src/libs/gif/lv_gif.c
@@ -440,6 +440,7 @@ static void initialize(lv_gif_t * gifobj)
  *   - The palette type and background color are valid for the current GIF frame.
  */
 static void disposal_last_frame(GIFIMAGE * gif, lv_draw_buf_t * drawbuf)
+{
     int x = gif->iX;
     int y = gif->iY;
     int w = gif->iWidth;

--- a/src/libs/gif/lv_gif.c
+++ b/src/libs/gif/lv_gif.c
@@ -421,8 +421,25 @@ static void initialize(lv_gif_t * gifobj)
 
 }
 
+/**
+ * Dispose the previous frame area before rendering the next frame, according to the GIF disposal method.
+ *
+ * This function handles the disposal of the previous frame's area in the GIF image, as specified by the disposal method.
+ * Disposal method values:
+ *   0: No disposal specified (do nothing)
+ *   1: Do not dispose (leave as is)
+ *   2: Restore to background color (the affected area is filled with the background color)
+ *   3: Restore to previous (not implemented here)
+ * Only disposal method 2 ("restore to background") is handled in this function.
+ *
+ * @param gif      Pointer to the GIFIMAGE structure representing the current GIF frame.
+ * @param drawbuf  Pointer to the draw buffer where the frame is rendered.
+ *
+ * Assumptions:
+ *   - The coordinates and dimensions (iX, iY, iWidth, iHeight) are within the bounds of the draw buffer.
+ *   - The palette type and background color are valid for the current GIF frame.
+ */
 static void disposal_last_frame(GIFIMAGE * gif, lv_draw_buf_t * drawbuf)
-{
     int x = gif->iX;
     int y = gif->iY;
     int w = gif->iWidth;


### PR DESCRIPTION
Fix GIF display error in the new GIF decoder.

In the new GIF decoder, it will not disposal the pre-frame area, which will cause display error if the disposal method is 2 (restore to the background).
![2](https://github.com/user-attachments/assets/0fd7aebd-fb60-4805-828d-d4a8957df428)

for the above GIF, it will display error in the 3th frame as below

<img width="475" height="343" alt="gif_error" src="https://github.com/user-attachments/assets/3d3f7555-be73-44cd-aaed-607da0830561" />


<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
