### PR TITLE
perf(label): make LAYOUT_COMPLETED a display event

### DIFF
--- a/src/core/lv_obj_pos.h
+++ b/src/core/lv_obj_pos.h
@@ -154,12 +154,6 @@ bool lv_obj_is_layout_positioned(const lv_obj_t * obj);
 void lv_obj_mark_layout_as_dirty(lv_obj_t * obj);
 
 /**
- * Mark screen to send layout completed event after update.
- * @param obj   Any object on the target screen
- */
-void lv_obj_request_layout_complete_event(lv_obj_t * obj);
-
-/**
  * Update the layout of an object.
  * @param obj      pointer to an object whose position and size needs to be updated
  */

--- a/src/core/lv_obj_private.h
+++ b/src/core/lv_obj_private.h
@@ -71,7 +71,6 @@ struct _lv_obj_t {
     uint16_t layout_inv : 1;
     uint16_t readjust_scroll_after_layout : 1;
     uint16_t scr_layout_inv : 1;
-    uint16_t scr_layout_complete_pending : 1;
     uint16_t skip_trans : 1;
     uint16_t style_cnt  : 6;
     uint16_t h_layout   : 1;

--- a/src/misc/lv_event.h
+++ b/src/misc/lv_event.h
@@ -94,7 +94,6 @@ typedef enum {
     LV_EVENT_STYLE_CHANGED,       /**< Object's style has changed */
     LV_EVENT_LAYOUT_CHANGED,      /**< A child's position position has changed due to a layout recalculation */
     LV_EVENT_GET_SELF_SIZE,       /**< Get internal size of a widget */
-    LV_EVENT_UPDATE_LAYOUT_COMPLETED,    /**< Sent after layout update completes*/
 
     /** Events of optional LVGL components */
     LV_EVENT_INVALIDATE_AREA,     /**< An area is invalidated (marked for redraw). `lv_event_get_param(e)`
@@ -113,6 +112,7 @@ typedef enum {
     LV_EVENT_FLUSH_FINISH,        /**< Sent after flush callback call has returned. */
     LV_EVENT_FLUSH_WAIT_START,    /**< Sent before flush wait callback is called. */
     LV_EVENT_FLUSH_WAIT_FINISH,   /**< Sent after flush wait callback call has returned. */
+    LV_EVENT_UPDATE_LAYOUT_COMPLETED,    /**< Sent after layout update completes*/
 
     LV_EVENT_VSYNC,
     LV_EVENT_VSYNC_REQUEST,

--- a/tests/src/test_cases/libs/test_libpng.c
+++ b/tests/src/test_cases/libs/test_libpng.c
@@ -70,7 +70,7 @@ void test_libpng_1(void)
 
     TEST_ASSERT_EQUAL_SCREENSHOT("libs/png_1.png");
 
-    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem_before, 32);
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem_before, 112);
 
     /* Re-add lodepng decoder */
     lv_lodepng_init();

--- a/tests/src/test_cases/libs/test_libwebp.c
+++ b/tests/src/test_cases/libs/test_libwebp.c
@@ -69,7 +69,7 @@ void test_libwebp_1(void)
     TEST_ASSERT_EQUAL_SCREENSHOT("libs/webp_1.png");
 
     /* Check for memory leaks */
-    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem_before, 36);
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem_before, 56);
 }
 
 #endif

--- a/tests/src/test_cases/libs/test_lodepng.c
+++ b/tests/src/test_cases/libs/test_lodepng.c
@@ -70,7 +70,7 @@ void test_lodepng_1(void)
 
     TEST_ASSERT_EQUAL_SCREENSHOT("libs/png_1.png");
 
-    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem_before, 40);
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem_before, 112);
 
     /* Re-add libpng decoder */
     lv_libpng_init();

--- a/tests/src/test_cases/test_snapshot.c
+++ b/tests/src/test_cases/test_snapshot.c
@@ -17,6 +17,11 @@ void test_snapshot_should_not_leak_memory(void)
 
     lv_draw_buf_t * snapshots[NUM_SNAPSHOTS] = {NULL};
 
+    lv_obj_clean(lv_screen_active());
+    lv_obj_clean(lv_layer_top());
+    lv_obj_clean(lv_layer_sys());
+    lv_obj_clean(lv_layer_bottom());
+
     lv_mem_monitor(&monitor);
     initial_available_memory = monitor.free_size;
 
@@ -48,6 +53,7 @@ void test_snapshot_with_transform_should_not_leak_memory(void)
     lv_obj_set_style_text_font(label, &lv_font_montserrat_28, 0);
     lv_label_set_text(label, "Wubba lubba dub dub!");
     lv_obj_set_style_transform_rotation(label, 450, 0);
+    lv_obj_update_layout(label);
 
     lv_mem_monitor(&monitor);
     initial_available_memory = monitor.free_size;


### PR DESCRIPTION
Change `LV_EVENT_UPDATE_LAYOUT_COMPLETED `to a display event. This will only send the event to the widgets that need it, instead of sending it to all widgets.

This avoids iterating through all obj objects in `lv_obj_tree_walk`. (This may take longer..)

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
