### PR TITLE
refactor(indev): remove the unused last_obj field from lv_indev_t

### DIFF
--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -696,7 +696,7 @@ static void obj_delete_core(lv_obj_t * obj)
     while(indev) {
         lv_indev_type_t indev_type = lv_indev_get_type(indev);
         if(indev_type == LV_INDEV_TYPE_POINTER || indev_type == LV_INDEV_TYPE_BUTTON) {
-            if(indev->pointer.act_obj == obj || indev->pointer.last_obj == obj || indev->pointer.scroll_obj == obj) {
+            if(indev->pointer.act_obj == obj || indev->pointer.scroll_obj == obj) {
                 obj_indev_reset(indev, obj);
             }
             if(indev->pointer.last_pressed == obj) {

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -1262,14 +1262,12 @@ static void indev_proc_press(lv_indev_t * indev)
         /*If a new object found the previous was lost, so send a PRESS_LOST event*/
         if(indev->pointer.act_obj != NULL) {
             /*Save the obj because in special cases `act_obj` can change in the event */
-            lv_obj_t * last_obj = indev->pointer.act_obj;
-
-            lv_obj_send_event(last_obj, LV_EVENT_PRESS_LOST, indev_act);
+            lv_obj_t * prev_act_obj = indev->pointer.act_obj;
+            lv_obj_send_event(prev_act_obj, LV_EVENT_PRESS_LOST, indev_act);
             if(indev_reset_check(indev)) return;
         }
 
         indev->pointer.act_obj  = indev_obj_act; /*Save the pressed object*/
-        indev->pointer.last_obj = indev_obj_act;
 
         if(indev_obj_act != NULL) {
 
@@ -1439,7 +1437,6 @@ static void indev_proc_release(lv_indev_t * indev)
         }
 
         indev->pointer.act_obj  = NULL;
-        indev->pointer.last_obj = NULL;
         indev->pr_timestamp           = 0;
         indev->longpr_rep_timestamp   = 0;
         indev->wait_until_release     = 0;
@@ -1637,7 +1634,6 @@ static void indev_proc_reset_query_handler(lv_indev_t * indev)
 {
     if(indev->reset_query) {
         indev->pointer.act_obj           = NULL;
-        indev->pointer.last_obj          = NULL;
         indev->pointer.scroll_obj        = NULL;
         indev->pointer.last_hovered      = NULL;
         indev->timestamp = lv_tick_get();
@@ -1828,10 +1824,6 @@ static void indev_reset_core(lv_indev_t * indev, lv_obj_t * obj)
             lv_obj_send_event(act_obj, LV_EVENT_INDEV_RESET, indev);
             lv_indev_send_event(indev, LV_EVENT_INDEV_RESET, act_obj);
             act_obj = NULL;
-        }
-
-        if(obj == NULL || indev->pointer.last_obj == obj) {
-            indev->pointer.last_obj = NULL;
         }
 
         if(indev->pointer.scroll_obj) {

--- a/src/indev/lv_indev_private.h
+++ b/src/indev/lv_indev_private.h
@@ -92,7 +92,6 @@ struct _lv_indev_t {
         lv_point_t scroll_throw_vect;
         lv_point_t scroll_throw_vect_ori;
         lv_obj_t * act_obj;      /*The object being pressed*/
-        lv_obj_t * last_obj;     /*The last object which was pressed*/
         lv_obj_t * scroll_obj;   /*The object being scrolled*/
         lv_obj_t * last_pressed; /*The lastly pressed object*/
         lv_obj_t * last_hovered; /*The lastly hovered object*/


### PR DESCRIPTION
I removed the last_obj field from lv_indev_t because it appears to be unused.

