### PR TITLE
perf(draw/opengl): use glScissor for opaque fills

### DIFF
--- a/demos/gltf/lv_demo_gltf.c
+++ b/demos/gltf/lv_demo_gltf.c
@@ -232,7 +232,8 @@ static void create_camera_panel(lv_obj_t * panel, lv_obj_t * viewer)
     lv_obj_t * distance_slider = lv_slider_create(camera_row);
     lv_obj_set_width(distance_slider, LV_PCT(100));
     lv_slider_bind_value(distance_slider, &distance_subject);
-    lv_slider_set_min_value(distance_slider, 1);
+    lv_slider_set_min_value(distance_slider,
+                            -10); /* Temporary work-around for Issue: 9249 (excessive framebuffer texture attachment switching) - raises framerate approx 15-20% */
     lv_slider_set_max_value(distance_slider, 25);
     style_slider(distance_slider, SLIDER_COLOR);
 

--- a/demos/gltf/lv_demo_gltf.c
+++ b/demos/gltf/lv_demo_gltf.c
@@ -232,8 +232,6 @@ static void create_camera_panel(lv_obj_t * panel, lv_obj_t * viewer)
     lv_obj_t * distance_slider = lv_slider_create(camera_row);
     lv_obj_set_width(distance_slider, LV_PCT(100));
     lv_slider_bind_value(distance_slider, &distance_subject);
-    /* This minimum value activates Issue: 9249 (excessive framebuffer texture attachment switching),
-     * which lowers framerate approx 5-10% when the slider knob overlaps the control's edge  */
     lv_slider_set_min_value(distance_slider, 1);
     lv_slider_set_max_value(distance_slider, 25);
     style_slider(distance_slider, SLIDER_COLOR);

--- a/demos/gltf/lv_demo_gltf.c
+++ b/demos/gltf/lv_demo_gltf.c
@@ -232,8 +232,9 @@ static void create_camera_panel(lv_obj_t * panel, lv_obj_t * viewer)
     lv_obj_t * distance_slider = lv_slider_create(camera_row);
     lv_obj_set_width(distance_slider, LV_PCT(100));
     lv_slider_bind_value(distance_slider, &distance_subject);
-    lv_slider_set_min_value(distance_slider,
-                            -10); /* Temporary work-around for Issue: 9249 (excessive framebuffer texture attachment switching) - raises framerate approx 15-20% */
+    /* This minimum value activates Issue: 9249 (excessive framebuffer texture attachment switching),
+     * which lowers framerate approx 5-10% when the slider knob overlaps the control's edge  */
+    lv_slider_set_min_value(distance_slider, 1);
     lv_slider_set_max_value(distance_slider, 25);
     style_slider(distance_slider, SLIDER_COLOR);
 

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -573,13 +573,13 @@ static void execute_drawing(lv_draw_opengles_unit_t * u)
             if(fill_dsc->opa >= LV_OPA_MAX) {
                 float tex_w = (float)lv_area_get_width(&fill_area);
                 float tex_h = (float)lv_area_get_height(&fill_area);
-                glEnable(GL_SCISSOR_TEST);
-                glScissor(fill_area.x1, targ_tex_h - fill_area.y1 - tex_h, tex_w, tex_h);
-                glClearColor((float)fill_dsc->color.red / 255.0f, (float)fill_dsc->color.green / 255.0f,
-                             (float)fill_dsc->color.blue / 255.0f, 1.0f);
-                glClearDepthf(1.0f);
+                GL_CALL(glEnable(GL_SCISSOR_TEST));
+                GL_CALL(glScissor(fill_area.x1, targ_tex_h - fill_area.y1 - tex_h, tex_w, tex_h));
+                GL_CALL(glClearColor((float)fill_dsc->color.red / 255.0f, (float)fill_dsc->color.green / 255.0f,
+                                     (float)fill_dsc->color.blue / 255.0f, 1.0f));
+                GL_CALL(glClearDepthf(1.0f));
                 GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
-                glDisable(GL_SCISSOR_TEST);
+                GL_CALL(glDisable(GL_SCISSOR_TEST));
             }
             else {
                 lv_opengles_viewport(0, 0, targ_tex_w, targ_tex_h);

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -570,7 +570,7 @@ static void execute_drawing(lv_draw_opengles_unit_t * u)
                 GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, target_texture, 0));
             }
 
-            if(fill_dsc->opa == LV_OPA_100) {
+            if(fill_dsc->opa >= LV_OPA_MAX) {
                 float tex_w = (float)lv_area_get_width(&fill_area);
                 float tex_h = (float)lv_area_get_height(&fill_area);
                 glEnable(GL_SCISSOR_TEST);

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -570,8 +570,21 @@ static void execute_drawing(lv_draw_opengles_unit_t * u)
                 GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, target_texture, 0));
             }
 
-            lv_opengles_viewport(0, 0, targ_tex_w, targ_tex_h);
-            lv_opengles_render_fill(fill_dsc->color, &fill_area, fill_dsc->opa, targ_tex_w, targ_tex_h);
+            if(fill_dsc->opa == LV_OPA_100) {
+                float tex_w = (float)lv_area_get_width(&fill_area);
+                float tex_h = (float)lv_area_get_height(&fill_area);
+                glEnable(GL_SCISSOR_TEST);
+                glScissor(fill_area.x1, targ_tex_h - fill_area.y1 - tex_h, tex_w, tex_h);
+                glClearColor((float)fill_dsc->color.red / 255.0f, (float)fill_dsc->color.green / 255.0f,
+                             (float)fill_dsc->color.blue / 255.0f, 1.0f);
+                glClearDepthf(1.0f);
+                GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+                glDisable(GL_SCISSOR_TEST);
+            }
+            else {
+                lv_opengles_viewport(0, 0, targ_tex_w, targ_tex_h);
+                lv_opengles_render_fill(fill_dsc->color, &fill_area, fill_dsc->opa, targ_tex_w, targ_tex_h);
+            }
 
             if(target_texture) {
                 GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));

--- a/src/drivers/opengles/assets/lv_opengles_shader.c
+++ b/src/drivers/opengles/assets/lv_opengles_shader.c
@@ -170,13 +170,35 @@ static const char * src_vertex_shader_v300es = R"(
     in vec2 texCoord;
     
     out vec2 v_TexCoord;
-    
+    flat out lowp vec4 fill_color_alpha;
+    flat out lowp int is_gray;
+
+    uniform lowp float u_Opa;
+    uniform bool u_IsFill;
+    uniform vec3 u_FillColor;
     uniform mat3 u_VertexTransform;
+    uniform float u_ColorDepth;
     
     void main()
     {
         gl_Position = vec4((u_VertexTransform * vec3(position.xy, 1)).xy, position.zw);
         v_TexCoord = texCoord;
+
+        if (u_IsFill) {
+            if (abs(u_ColorDepth - 8.0) < 0.1) {
+                /* is_gray = 1; // not necessary */
+                fill_color_alpha = vec4(u_FillColor.rrr, 1.0) * u_Opa;
+            } else {
+                fill_color_alpha = vec4((u_FillColor.rgb * u_Opa), u_Opa);
+            }
+        } else {
+            fill_color_alpha = vec4(0.0);
+            if (abs(u_ColorDepth - 8.0) < 0.1) {
+                is_gray = 1;
+            } else {
+                is_gray = 0;
+            }
+        }
     }
 )";
 
@@ -186,12 +208,11 @@ static const char *src_fragment_shader_v300es = R"(
     out vec4 color;
     
     in vec2 v_TexCoord;
+    flat in lowp vec4 fill_color_alpha;
+    flat in lowp int is_gray;
     
     uniform sampler2D u_Texture;
-    uniform float u_ColorDepth;
-    uniform float u_Opa;
-    uniform bool u_IsFill;
-    uniform vec3 u_FillColor;
+    uniform lowp float u_Opa;
     
     #ifdef HSV_ADJUST
 #include <hsv_adjust.glsl>
@@ -199,23 +220,23 @@ static const char *src_fragment_shader_v300es = R"(
 
     void main()
     {
-        vec4 texColor;
-        if (u_IsFill) {
-            texColor = vec4(u_FillColor, 1.0);
+        if (0.0 != fill_color_alpha.a) {
+            color = fill_color_alpha;
+            return;
         } else {
-            texColor = texture(u_Texture, v_TexCoord);
+            color = texture(u_Texture, v_TexCoord);
             /* If the vertices have been transformed, and mipmaps have not been generated, 
              * some rotation angles (notably 90 and 270) require using textureLod() to mitigate 
              * derivative calculation errors from interpolator increments flipping direction.
-             * texColor = textureLod(u_Texture, v_TexCoord, u_LodLevel);
+             * color = textureLod(u_Texture, v_TexCoord, u_LodLevel);
              */
-        }
-        if (abs(u_ColorDepth - 8.0) < 0.1) {
-            float gray = texColor.r;
-            color = vec4(vec3(gray * u_Opa), u_Opa);
-        } else {
-            float combinedAlpha = texColor.a * u_Opa;
-            color = vec4(texColor.rgb * combinedAlpha, combinedAlpha);
+            if (0 != is_gray) {
+                color.r *= u_Opa;
+                color.gba = vec3(color.rr, u_Opa);
+            } else {
+                color.a *= u_Opa;
+                color.rgb *= color.a;
+            }
         }
         #ifdef HSV_ADJUST
         color.rgb = adjustHSV(color.rgb);

--- a/src/drivers/opengles/assets/lv_opengles_shader.c
+++ b/src/drivers/opengles/assets/lv_opengles_shader.c
@@ -183,22 +183,16 @@ static const char * src_vertex_shader_v300es = R"(
     {
         gl_Position = vec4((u_VertexTransform * vec3(position.xy, 1)).xy, position.zw);
         v_TexCoord = texCoord;
+        is_gray = (abs(u_ColorDepth - 8.0) < 0.1) ? 1 : 0;
 
         if (u_IsFill) {
-            if (abs(u_ColorDepth - 8.0) < 0.1) {
-                is_gray = 1;
+            if (is_gray == 1) {
                 fill_color_alpha = vec4(u_FillColor.rrr, 1.0) * u_Opa;
             } else {
-                is_gray = 0;
                 fill_color_alpha = vec4((u_FillColor.rgb * u_Opa), u_Opa);
             }
         } else {
             fill_color_alpha = vec4(0.0, 0.0, 0.0, -1.0);
-            if (abs(u_ColorDepth - 8.0) < 0.1) {
-                is_gray = 1;
-            } else {
-                is_gray = 0;
-            }
         }
     }
 )";
@@ -221,7 +215,7 @@ static const char *src_fragment_shader_v300es = R"(
 
     void main()
     {
-        if (-1.0 != fill_color_alpha.a) {
+        if (fill_color_alpha.a != -1.0) {
             color = fill_color_alpha;
         } else {
             color = texture(u_Texture, v_TexCoord);
@@ -230,7 +224,7 @@ static const char *src_fragment_shader_v300es = R"(
              * derivative calculation errors from interpolator increments flipping direction.
              * color = textureLod(u_Texture, v_TexCoord, u_LodLevel);
              */
-            if (0 != is_gray) {
+            if (is_gray != 0) {
                 color.r *= u_Opa;
                 color.gba = vec3(color.rr, u_Opa);
             } else {

--- a/src/drivers/opengles/assets/lv_opengles_shader.c
+++ b/src/drivers/opengles/assets/lv_opengles_shader.c
@@ -186,13 +186,14 @@ static const char * src_vertex_shader_v300es = R"(
 
         if (u_IsFill) {
             if (abs(u_ColorDepth - 8.0) < 0.1) {
-                /* is_gray = 1; // not necessary */
+                is_gray = 1;
                 fill_color_alpha = vec4(u_FillColor.rrr, 1.0) * u_Opa;
             } else {
+                is_gray = 0;
                 fill_color_alpha = vec4((u_FillColor.rgb * u_Opa), u_Opa);
             }
         } else {
-            fill_color_alpha = vec4(0.0);
+            fill_color_alpha = vec4(0.0, 0.0, 0.0, -1.0);
             if (abs(u_ColorDepth - 8.0) < 0.1) {
                 is_gray = 1;
             } else {
@@ -220,9 +221,8 @@ static const char *src_fragment_shader_v300es = R"(
 
     void main()
     {
-        if (0.0 != fill_color_alpha.a) {
+        if (-1.0 != fill_color_alpha.a) {
             color = fill_color_alpha;
-            return;
         } else {
             color = texture(u_Texture, v_TexCoord);
             /* If the vertices have been transformed, and mipmaps have not been generated, 

--- a/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
@@ -1224,6 +1224,9 @@ static void setup_draw_solid_background(lv_gltf_t * viewer, lv_color_t bg_color,
 #if LV_GLTF_USE_COLORMASKED_CLEAR_FILL
         GL_CALL(glColorMask(true, true, true, true));
     }
+    else {
+        GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+    }
 #endif
 }
 

--- a/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
@@ -35,6 +35,13 @@
     #define LV_GLTF_CONVERT_BASE_COLOR_TO_SRGB 1
 #endif
 
+/* This attempts a potential optimization that only clears the alpha channel if the output
+ * background is 0% opaque.  Additional testing showed this actually created a slight slowdown
+ * so it's optional and off by default.  Needs further testing. */
+#ifndef LV_GLTF_USE_COLORMASKED_CLEAR_FILL
+    #define LV_GLTF_USE_COLORMASKED_CLEAR_FILL 0
+#endif
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -1206,18 +1213,18 @@ static void setup_draw_environment_background(lv_opengl_shader_manager_t * manag
 
 static void setup_draw_solid_background(lv_gltf_t * viewer, lv_color_t bg_color, lv_opa_t bg_opa)
 {
+    GL_CALL(glClearDepthf(1.0f));
+    GL_CALL(glClearColor((float)bg_color.red / 255.0f, (float)bg_color.green / 255.0f,
+                         (float)bg_color.blue / 255.0f, (float)bg_opa / 255.0f));
+#if LV_GLTF_USE_COLORMASKED_CLEAR_FILL
     if(bg_opa == LV_OPA_0) {
-        glColorMask(false, false, false, true);
-        glClearColor((float)bg_color.red / 255.0f, (float)bg_color.green / 255.0f,
-                     (float)bg_color.blue / 255.0f, (float)bg_opa / 255.0f);
-        glColorMask(true, true, true, true);
+        GL_CALL(glColorMask(false, false, false, true));
+#endif
+        GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+#if LV_GLTF_USE_COLORMASKED_CLEAR_FILL
+        GL_CALL(glColorMask(true, true, true, true));
     }
-    else {
-        glClearColor((float)bg_color.red / 255.0f, (float)bg_color.green / 255.0f,
-                     (float)bg_color.blue / 255.0f, (float)bg_opa / 255.0f);
-    }
-    glClearDepthf(1.0f);
-    GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+#endif
 }
 
 static void lv_gltf_view_recache_all_transforms(lv_gltf_model_t * model)

--- a/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
@@ -1216,18 +1216,16 @@ static void setup_draw_solid_background(lv_gltf_t * viewer, lv_color_t bg_color,
     GL_CALL(glClearDepthf(1.0f));
     GL_CALL(glClearColor((float)bg_color.red / 255.0f, (float)bg_color.green / 255.0f,
                          (float)bg_color.blue / 255.0f, (float)bg_opa / 255.0f));
-#if LV_GLTF_USE_COLORMASKED_CLEAR_FILL
-    if(bg_opa == LV_OPA_0) {
+
+    if(LV_GLTF_USE_COLORMASKED_CLEAR_FILL && (bg_opa == LV_OPA_0)) {
         GL_CALL(glColorMask(false, false, false, true));
-#endif
         GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
-#if LV_GLTF_USE_COLORMASKED_CLEAR_FILL
         GL_CALL(glColorMask(true, true, true, true));
     }
     else {
         GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
     }
-#endif
+
 }
 
 static void lv_gltf_view_recache_all_transforms(lv_gltf_model_t * model)

--- a/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
@@ -35,13 +35,6 @@
     #define LV_GLTF_CONVERT_BASE_COLOR_TO_SRGB 1
 #endif
 
-/* This attempts a potential optimization that only clears the alpha channel if the output
- * background is 0% opaque.  Additional testing showed this actually created a slight slowdown
- * so it's optional and off by default.  Needs further testing. */
-#ifndef LV_GLTF_USE_COLORMASKED_CLEAR_FILL
-    #define LV_GLTF_USE_COLORMASKED_CLEAR_FILL 0
-#endif
-
 /**********************
  *      TYPEDEFS
  **********************/
@@ -1217,14 +1210,7 @@ static void setup_draw_solid_background(lv_gltf_t * viewer, lv_color_t bg_color,
     GL_CALL(glClearColor((float)bg_color.red / 255.0f, (float)bg_color.green / 255.0f,
                          (float)bg_color.blue / 255.0f, (float)bg_opa / 255.0f));
 
-    if(LV_GLTF_USE_COLORMASKED_CLEAR_FILL && (bg_opa == LV_OPA_0)) {
-        GL_CALL(glColorMask(false, false, false, true));
-        GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
-        GL_CALL(glColorMask(true, true, true, true));
-    }
-    else {
-        GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
-    }
+    GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
 
 }
 

--- a/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
@@ -119,6 +119,7 @@ static lv_result_t setup_restore_opaque_output(lv_gltf_t * viewer, const lv_gltf
                                                uint32_t texture_w,
                                                uint32_t texture_h, bool prepare_bg);
 static void setup_draw_environment_background(lv_opengl_shader_manager_t * manager, lv_gltf_t * viewer, float blur);
+static void setup_draw_solid_background(lv_gltf_t * viewer, lv_color_t bg_color, lv_opa_t bg_opa);
 static void setup_environment_rotation_matrix(float env_rotation_angle, uint32_t shader_program);
 
 /**********************
@@ -822,12 +823,8 @@ lv_result_t render_primary_output(lv_gltf_t * viewer, const lv_gltf_renwin_state
     GL_CALL(glViewport(0, 0, texture_w, texture_h));
     if(prepare_bg) {
         /* cast is safe because viewer is a lv_obj_t*/
-        lv_color_t bg_color = lv_obj_get_style_bg_color((lv_obj_t *)viewer, LV_PART_MAIN);
-        uint8_t alpha = lv_obj_get_style_bg_opa((lv_obj_t *)viewer, LV_PART_MAIN);
-        GL_CALL(glClearColor(bg_color.red / 255.0f, bg_color.green / 255.0f, bg_color.blue / 255.0f, alpha / 255.0f));
-
-        GL_CALL(glClearDepthf(1.0f));
-        GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+        setup_draw_solid_background(viewer, lv_obj_get_style_bg_color((lv_obj_t *)viewer, LV_PART_MAIN),
+                                    lv_obj_get_style_bg_opa((lv_obj_t *)viewer, LV_PART_MAIN));
     }
 
     return glGetError() == GL_NO_ERROR ? LV_RESULT_OK : LV_RESULT_INVALID;
@@ -1169,11 +1166,8 @@ static lv_result_t setup_restore_opaque_output(lv_gltf_t * viewer, const lv_gltf
     GL_CALL(glViewport(0, 0, texture_w, texture_h));
     if(prepare_bg) {
         /* cast is safe because viewer is a lv_obj_t*/
-        lv_color_t bg_color = lv_obj_get_style_bg_color((lv_obj_t *)viewer, LV_PART_MAIN);
-        uint8_t alpha = lv_obj_get_style_bg_opa((lv_obj_t *)viewer, LV_PART_MAIN);
-        GL_CALL(glClearColor(bg_color.red / 255.0f, bg_color.green / 255.0f, bg_color.blue / 255.0f, alpha / 255.0f));
-        GL_CALL(glClearDepthf(1.0f));
-        GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+        setup_draw_solid_background(viewer, lv_obj_get_style_bg_color((lv_obj_t *)viewer, LV_PART_MAIN),
+                                    lv_obj_get_style_bg_opa((lv_obj_t *)viewer, LV_PART_MAIN));
     }
     return glGetError() == GL_NO_ERROR ? LV_RESULT_OK : LV_RESULT_INVALID;
 }
@@ -1209,6 +1203,23 @@ static void setup_draw_environment_background(lv_opengl_shader_manager_t * manag
     GL_CALL(glBindVertexArray(0));
     return;
 }
+
+static void setup_draw_solid_background(lv_gltf_t * viewer, lv_color_t bg_color, lv_opa_t bg_opa)
+{
+    if(bg_opa == LV_OPA_0) {
+        glColorMask(false, false, false, true);
+        glClearColor((float)bg_color.red / 255.0f, (float)bg_color.green / 255.0f,
+                     (float)bg_color.blue / 255.0f, (float)bg_opa / 255.0f);
+        glColorMask(true, true, true, true);
+    }
+    else {
+        glClearColor((float)bg_color.red / 255.0f, (float)bg_color.green / 255.0f,
+                     (float)bg_color.blue / 255.0f, (float)bg_opa / 255.0f);
+    }
+    glClearDepthf(1.0f);
+    GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+}
+
 static void lv_gltf_view_recache_all_transforms(lv_gltf_model_t * model)
 {
     int32_t anim_num = model->current_animation;


### PR DESCRIPTION
Optimizes several clearing operations to improve performance by 8%, in my tests here (sample scene peak FPS 38 -> 41).  

In the opengles driver, glScissor / glClear is used for rectangular fill operations that are 100% opaque, instead of using a special case shader.  This reduces per-frame overhead by making the active screen clear between frames faster.

Additionally in the glTF code there is a similar clearing operation, and that one was optimized to identify situations where it's clearing the screen to an alpha of 0, in which case it doesn't matter what the r/g/b channels are cleared to, they don't need to be cleared at all.  So it color masks the clearing operation to only enable clearing the alpha in that case.

The opengles driver was also optimized a bit to offload some of the logic from the fragment shader into the vertex shader, so it runs those operations once per vertex instead of once per pixel.