### PR TITLE
feat(scripts): add automatic gcovr code coverage analysis

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -135,6 +135,9 @@ jobs:
       run: echo "NON_AMD64_BUILD=1" >> $GITHUB_ENV
     - name: Run tests
       run: python tests/main.py --report --update-image test --auto-clean
+    - name: Code coverage analysis
+      # The threshold is temporarily set to 0 to prevent CI from being blocked.
+      run: python scripts/check_gcov_coverage.py --fail-under=0
     - name: Archive screenshot errors
       if: failure()
       uses: actions/upload-artifact@v5

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -136,15 +136,14 @@ jobs:
     - name: Run tests
       run: python tests/main.py --report --update-image test --auto-clean
     - name: Code coverage analysis
-      # The threshold is temporarily set to 0 to prevent CI from being blocked.
       run: |
         if [ "${{ github.event_name }}" = "pull_request" ]; then
           git fetch --no-tags --prune origin ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }}
           MB=$(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
           echo "Merge-base: $MB"
-          python scripts/check_gcov_coverage.py --fail-under=0 --commit="${MB}...${{ github.event.pull_request.head.sha }}"
+          python scripts/check_gcov_coverage.py --commit="${MB}...${{ github.event.pull_request.head.sha }}"
         else
-          python scripts/check_gcov_coverage.py --fail-under=0 --commit=HEAD
+          python scripts/check_gcov_coverage.py --commit=HEAD
         fi
     - name: Archive screenshot errors
       if: failure()

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -135,6 +135,11 @@ jobs:
       run: echo "NON_AMD64_BUILD=1" >> $GITHUB_ENV
     - name: Run tests
       run: python tests/main.py --report --update-image test --auto-clean
+    - name: Fetch PR commits
+      if: github.event_name == 'pull_request'
+      run: |
+        git fetch --no-tags --prune --depth=1 origin +refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
+        git fetch --no-tags --prune --depth=1 origin +refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/origin/pr/${{ github.event.pull_request.number }}
     - name: Code coverage analysis
       # The threshold is temporarily set to 0 to prevent CI from being blocked.
       run: |

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -137,7 +137,12 @@ jobs:
       run: python tests/main.py --report --update-image test --auto-clean
     - name: Code coverage analysis
       # The threshold is temporarily set to 0 to prevent CI from being blocked.
-      run: python scripts/check_gcov_coverage.py --fail-under=0
+      run: |
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          python scripts/check_gcov_coverage.py --fail-under=0 --commit="${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"
+        else
+          python scripts/check_gcov_coverage.py --fail-under=0 --commit=HEAD
+        fi
     - name: Archive screenshot errors
       if: failure()
       uses: actions/upload-artifact@v5

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -135,16 +135,14 @@ jobs:
       run: echo "NON_AMD64_BUILD=1" >> $GITHUB_ENV
     - name: Run tests
       run: python tests/main.py --report --update-image test --auto-clean
-    - name: Fetch PR commits
-      if: github.event_name == 'pull_request'
-      run: |
-        git fetch --no-tags --prune origin +refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
-        git fetch --no-tags --prune origin +refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/origin/pr/${{ github.event.pull_request.number }}
     - name: Code coverage analysis
       # The threshold is temporarily set to 0 to prevent CI from being blocked.
       run: |
         if [ "${{ github.event_name }}" = "pull_request" ]; then
-          python scripts/check_gcov_coverage.py --fail-under=0 --commit="${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"
+          git fetch --no-tags --prune origin ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }}
+          MB=$(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
+          echo "Merge-base: $MB"
+          python scripts/check_gcov_coverage.py --fail-under=0 --commit="${MB}...${{ github.event.pull_request.head.sha }}"
         else
           python scripts/check_gcov_coverage.py --fail-under=0 --commit=HEAD
         fi

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -138,8 +138,8 @@ jobs:
     - name: Fetch PR commits
       if: github.event_name == 'pull_request'
       run: |
-        git fetch --no-tags --prune --depth=1 origin +refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
-        git fetch --no-tags --prune --depth=1 origin +refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/origin/pr/${{ github.event.pull_request.number }}
+        git fetch --no-tags --prune origin +refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
+        git fetch --no-tags --prune origin +refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/origin/pr/${{ github.event.pull_request.number }}
     - name: Code coverage analysis
       # The threshold is temporarily set to 0 to prevent CI from being blocked.
       run: |

--- a/scripts/check_gcov_coverage.py
+++ b/scripts/check_gcov_coverage.py
@@ -195,7 +195,6 @@ def main() -> int:
         print(f"Current working directory: {root}")
 
         covered, total, uncovered = check_commit_coverage(args.commit, root)
-        title = f" Coverage analysis results for {args.commit} "
 
         # Print results with better formatting
         title = f" Coverage analysis results for commit {args.commit} "
@@ -220,10 +219,12 @@ def main() -> int:
             for filename, lineno in sorted(uncovered):
                 print(f"  {filename}:{lineno}")
 
+            # `fail-under=0` means ignoring uncovered code and always returning success.
             if args.fail_under is not None and args.fail_under == 0:
                 print("Ignore uncovered lines due to --fail-under=0 setting, skipped.")
                 return 0
 
+            # Return failure if uncovered lines are found
             return 1
         else:
             print("\n✓ All new code is covered!")
@@ -238,7 +239,7 @@ def main() -> int:
         return e.returncode if e.returncode is not None else 64
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
-        return 1
+        return 2
 
 
 if __name__ == "__main__":

--- a/scripts/check_gcov_coverage.py
+++ b/scripts/check_gcov_coverage.py
@@ -28,6 +28,7 @@ def create_argument_parser() -> argparse.ArgumentParser:
         "--fail-under",
         type=float,
         metavar="PERCENT",
+        default=75,
         help="Fail if coverage is below this percentage (0-100)",
     )
 
@@ -203,29 +204,28 @@ def main() -> int:
         print(f"New lines of code: {total}")
         print(f"Covered lines: {covered}")
         print(f"Uncovered lines: {len(uncovered)}")
+        retval = 0
 
         if total > 0:
             coverage_percent = (covered / total) * 100
             print(f"Coverage: {coverage_percent:.2f}%")
 
             # Check if coverage meets minimum requirement
-            if args.fail_under is not None and coverage_percent < args.fail_under:
+            if args.fail_under == 0:
+                print("Skipping uncovered failure due to --fail-under=0 setting.")
+                retval = 0
+            elif coverage_percent < args.fail_under:
                 print(
                     f"\n✗ Coverage {coverage_percent:.2f}% is below required {args.fail_under}%"
                 )
+                retval = 1
 
         if uncovered:
             print("\nUncovered lines:")
             for filename, lineno in sorted(uncovered):
                 print(f"  {filename}:{lineno}")
 
-            # `fail-under=0` means ignoring uncovered code and always returning success.
-            if args.fail_under is not None and args.fail_under == 0:
-                print("Ignore uncovered lines due to --fail-under=0 setting, skipped.")
-                return 0
-
-            # Return failure if uncovered lines are found
-            return 1
+            return retval
         else:
             print("\n✓ All new code is covered!")
             return 0

--- a/scripts/check_gcov_coverage.py
+++ b/scripts/check_gcov_coverage.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+Check code coverage for new lines in a git commit using gcovr
+"""
+import argparse
+import subprocess
+import json
+import re
+import sys
+from typing import Dict, Set, Tuple, List
+
+
+def create_argument_parser() -> argparse.ArgumentParser:
+    """Create argument parser"""
+    parser = argparse.ArgumentParser(
+        description="Check gcov coverage for new code in a git commit",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""  
+Examples:  
+  %(prog)s HEAD                    # Check latest commit  
+  %(prog)s abc123def               # Check specific commit  
+  %(prog)s HEAD --root /path/to/project  
+  %(prog)s HEAD --gcovr-args "--filter src/"  
+        """,
+    )
+
+    parser.add_argument(
+        "commit", help="Git commit hash or reference (e.g. HEAD, HEAD~1)"
+    )
+
+    parser.add_argument(
+        "--root",
+        "-r",
+        default=".",
+        help="Project root directory (default: current directory)",
+    )
+
+    parser.add_argument(
+        "--gcovr-args",
+        default="",
+        help="Additional arguments to pass to gcovr (e.g. '--filter src/ --exclude test/')",
+    )
+
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Show verbose output"
+    )
+
+    parser.add_argument(
+        "--fail-under",
+        type=float,
+        metavar="PERCENT",
+        help="Fail if coverage is below this percentage (0-100)",
+    )
+
+    return parser
+
+
+def run_git_command(args: List[str], cwd: str = ".") -> str:
+    """Run git command and return output"""
+    result = subprocess.run(
+        ["git"] + args, capture_output=True, text=True, cwd=cwd, check=True
+    )
+    return result.stdout
+
+
+def get_changed_lines(commit: str, root: str) -> Dict[str, Set[int]]:
+    """
+    Get changed lines in specified commit
+    Returns: {file_path: {set of changed line numbers}}
+    """
+    diff_output = run_git_command(
+        ["diff", f"{commit}^", commit, "--unified=0"], cwd=root
+    )
+
+    changed_lines: Dict[str, Set[int]] = {}
+    current_file = None
+
+    for line in diff_output.split("\n"):
+        if line.startswith("+++ b/"):
+            current_file = line[6:]
+            if current_file not in changed_lines:
+                changed_lines[current_file] = set()
+
+        elif line.startswith("@@"):
+            match = re.search(r"\+(\d+)(?:,(\d+))?", line)
+            if match and current_file:
+                start_line = int(match.group(1))
+                count = int(match.group(2)) if match.group(2) else 1
+                for lineno in range(start_line, start_line + count):
+                    changed_lines[current_file].add(lineno)
+
+    return changed_lines
+
+
+def get_coverage_data(root: str, extra_args: str) -> Dict[str, Dict[int, int]]:
+    """
+    Get coverage data using gcovr
+    Returns: {file_path: {line_number: execution_count}}
+    Raises: subprocess.CalledProcessError if gcovr fails
+    """
+    cmd = ["gcovr", "--gcov-ignore-parse-errors", "--json", "-", "--root", root]
+    if extra_args:
+        cmd.extend(extra_args.split())
+
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        cwd=root,
+        check=False,  # Don't raise exception automatically
+    )
+
+    if result.returncode != 0:
+        error_msg = f"gcovr command failed (exit code {result.returncode}):\n"
+        if result.stderr:
+            error_msg += f"Error output:\n{result.stderr}\n"
+        if result.stdout:
+            error_msg += f"Standard output:\n{result.stdout}\n"
+        raise subprocess.CalledProcessError(
+            result.returncode, cmd, result.stdout, result.stderr
+        )
+
+    coverage_json = json.loads(result.stdout)
+    coverage_data: Dict[str, Dict[int, int]] = {}
+
+    for file_info in coverage_json.get("files", []):
+        filename = file_info["file"]
+        coverage_data[filename] = {}
+
+        for line_info in file_info.get("lines", []):
+            line_number = line_info["line_number"]
+            count = line_info["count"]
+            coverage_data[filename][line_number] = count
+
+    return coverage_data
+
+
+def check_commit_coverage(
+    commit: str, root: str, gcovr_args: str, verbose: bool
+) -> Tuple[int, int, List[Tuple[str, int]]]:
+    """
+    Check coverage for a commit
+    Returns: (covered_lines, total_new_lines, uncovered_lines)
+    """
+    if verbose:
+        print(f"Analyzing commit {commit}...")
+
+    changed_lines = get_changed_lines(commit, root)
+    if verbose:
+        print(f"Found changes in {len(changed_lines)} files")
+
+    if verbose:
+        print("Getting coverage data...")
+    coverage_data = get_coverage_data(root, gcovr_args)
+
+    total_new_lines = 0
+    covered_lines = 0
+    uncovered_lines: List[Tuple[str, int]] = []
+
+    for filename, line_numbers in changed_lines.items():
+        file_coverage = coverage_data.get(filename, {})
+
+        for lineno in line_numbers:
+            total_new_lines += 1
+
+            if lineno in file_coverage and file_coverage[lineno] > 0:
+                covered_lines += 1
+            else:
+                uncovered_lines.append((filename, lineno))
+
+    return covered_lines, total_new_lines, uncovered_lines
+
+
+def main() -> int:
+    """Main entry point"""
+    parser = create_argument_parser()
+    args = parser.parse_args()
+
+    try:
+        covered, total, uncovered = check_commit_coverage(
+            args.commit, args.root, args.gcovr_args, args.verbose
+        )
+
+        # Print results
+        print("\n" + "=" * 60)
+        print(f"Coverage analysis results for commit {args.commit}:")
+        print("=" * 60)
+        print(f"New lines of code: {total}")
+        print(f"Covered lines: {covered}")
+        print(f"Uncovered lines: {len(uncovered)}")
+
+        if total > 0:
+            coverage_percent = (covered / total) * 100
+            print(f"Coverage: {coverage_percent:.2f}%")
+
+            # Check if coverage meets minimum requirement
+            if args.fail_under is not None and coverage_percent < args.fail_under:
+                print(
+                    f"\n✗ Coverage {coverage_percent:.2f}% is below required {args.fail_under}%"
+                )
+                return 2
+
+        if uncovered:
+            print("\nUncovered lines:")
+            for filename, lineno in sorted(uncovered):
+                print(f"  {filename}:{lineno}")
+            return 1
+        else:
+            print("\n✓ All new code is covered!")
+            return 0
+
+    except subprocess.CalledProcessError as e:
+        print(f"Error: Command failed - {e}", file=sys.stderr)
+        if e.stderr:
+            print(f"Error details:\n{e.stderr}", file=sys.stderr)
+        if e.stdout:
+            print(f"Command output:\n{e.stdout}", file=sys.stderr)
+        return e.returncode if e.returncode is not None else 64
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_gcov_coverage.py
+++ b/scripts/check_gcov_coverage.py
@@ -14,13 +14,13 @@ from typing import Dict, Set, Tuple, List
 def create_argument_parser() -> argparse.ArgumentParser:
     """Create argument parser"""
     parser = argparse.ArgumentParser(
-        description="Check gcov coverage for new code in a git commit or PR",
+        description="Check gcov coverage for new code in a git commit",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
     parser.add_argument(
         "--commit",
-        help="Git commit hash, reference (e.g. HEAD, HEAD~1) or PR range (base...head)",
+        help="Git commit hash, reference (e.g. HEAD, HEAD~1) or range (base...head)",
         default="HEAD",
     )
 
@@ -127,17 +127,17 @@ def check_commit_coverage(
     commit: str, root: str
 ) -> Tuple[int, int, List[Tuple[str, int]]]:
     """
-    Check coverage for a commit or PR range
+    Check coverage for a commit or range
     Returns: (covered_lines, total_new_lines, uncovered_lines)
     """
     if "..." in commit:
-        # Handle PR range format (base...head)
+        # Handle range format (base...head)
         base, head = commit.split("...")
-        print(f"Analyzing PR commits '{base}...{head}'...")
+        print(f"Analyzing commits '{base}...{head}'...")
         changed_lines = {}
-        # Get changes for each commit in the PR range
+        # Get changes for each commit in the range
         commits = run_git_command(["rev-list", f"{base}...{head}"], cwd=root).split()
-        print(f"Found {len(commits)} commits in PR range:")
+        print(f"Found {len(commits)} commits in range:")
         for c in commits:
             print(f"  {c}")
             cl = get_changed_lines(c, root)
@@ -236,7 +236,7 @@ def main() -> int:
             print(f"Error details:\n{e.stderr}", file=sys.stderr)
         if e.stdout:
             print(f"Command output:\n{e.stdout}", file=sys.stderr)
-        return e.returncode if e.returncode is not None else 64
+        return e.returncode
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         return 2

--- a/scripts/check_gcov_coverage.py
+++ b/scripts/check_gcov_coverage.py
@@ -28,8 +28,8 @@ def create_argument_parser() -> argparse.ArgumentParser:
         "--fail-under",
         type=float,
         metavar="PERCENT",
-        default=75,
-        help="Fail if coverage is below this percentage (0-100)",
+        default=0,
+        help="Fail if coverage is below this percentage (0-100), default: 0 (no failure)",
     )
 
     return parser
@@ -212,10 +212,7 @@ def main() -> int:
             print(f"Coverage: {coverage_percent:.2f}%")
 
             # Check if coverage meets minimum requirement
-            if args.fail_under == 0:
-                print("Skipping uncovered failure due to --fail-under=0 setting.")
-                retval = 0
-            elif coverage_percent < args.fail_under:
+            if coverage_percent < args.fail_under:
                 print(
                     f"\n✗ Coverage {coverage_percent:.2f}% is below required {args.fail_under}%"
                 )
@@ -227,9 +224,9 @@ def main() -> int:
                 print(f"  {filename}:{lineno}")
 
             return retval
-        else:
-            print("\n✓ All new code is covered!")
-            return 0
+
+        print("\n✓ All new code is covered!")
+        return retval
 
     except subprocess.CalledProcessError as e:
         print(f"Error: Command failed - {e}", file=sys.stderr)

--- a/scripts/check_gcov_coverage.py
+++ b/scripts/check_gcov_coverage.py
@@ -77,7 +77,7 @@ def get_coverage_data(root: str) -> Tuple[Dict[str, Dict[int, int]], str]:
     Returns: ({file_path: {line_number: execution_count}}, filter_pattern)
     Raises: subprocess.CalledProcessError if gcovr fails
     """
-    filter_pattern = os.path.join(root, "src/.*/lv_.*\\.c")
+    filter_pattern = os.path.join(root, r"src/(?:.*/)?lv_.*\.c")
     cmd = [
         "gcovr",
         "--gcov-ignore-parse-errors",

--- a/scripts/check_gcov_coverage.py
+++ b/scripts/check_gcov_coverage.py
@@ -130,25 +130,26 @@ def check_commit_coverage(
     Check coverage for a commit or range
     Returns: (covered_lines, total_new_lines, uncovered_lines)
     """
+
     if "..." in commit:
         # Handle range format (base...head)
         base, head = commit.split("...")
-        print(f"Analyzing commits '{base}...{head}'...")
-        changed_lines = {}
         # Get changes for each commit in the range
         commits = run_git_command(["rev-list", f"{base}...{head}"], cwd=root).split()
-        print(f"Found {len(commits)} commits in range:")
-        for c in commits:
-            print(f"  {c}")
-            cl = get_changed_lines(c, root)
-            for f, lines in cl.items():
-                if f not in changed_lines:
-                    changed_lines[f] = set()
-                changed_lines[f].update(lines)
     else:
         # Handle single commit
-        print(f"Analyzing commit '{commit}'...")
-        changed_lines = get_changed_lines(commit, root)
+        commits = [commit]
+
+    print(f"Found {len(commits)} commits in range:")
+    changed_lines = {}
+    for c in commits:
+        print(f"  {c}")
+        cl = get_changed_lines(c, root)
+        for f, lines in cl.items():
+            if f not in changed_lines:
+                changed_lines[f] = set()
+            changed_lines[f].update(lines)
+
     print(f"Found changes in {len(changed_lines)} files (before filtering):")
     for filename, lines in sorted(changed_lines.items()):
         print(f"  {filename}: {len(lines)} lines changed")

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -123,6 +123,13 @@ else
     exit 1
 fi
 
+echo "Checking gcov coverage..."
+./scripts/check_gcov_coverage.py
+if [ $? -ne 0 ]; then
+    echo "Gcov coverage check failed!"
+    exit 1
+fi
+
 new_png_files=$(git status --porcelain | grep "\?\? .*\.png")
 if [ -n "$new_png_files" ]; then
     echo "New untracked PNG files detected:"


### PR DESCRIPTION
Add a coverage analysis script to further automate code quality checks.
Currently, the coverage requirement is set to 0 to avoid blocking current development.
The `--fail-under` option can be used to adjust the code coverage threshold.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
