### PR TITLE
feat(gltf): direct buffer writes (experimental performance optimization)

### DIFF
--- a/demos/gltf/lv_demo_gltf.c
+++ b/demos/gltf/lv_demo_gltf.c
@@ -118,16 +118,14 @@ static lv_subject_t animation_speed_subject;
 lv_obj_t * lv_demo_gltf(const char * path)
 {
     lv_obj_t * viewer = lv_gltf_create(lv_screen_active());
-    //lv_obj_set_size(viewer, LV_PCT(100), LV_PCT(100));
-    lv_obj_set_size(viewer, LV_PCT(50), LV_PCT(50));
-    //lv_obj_set_pos(viewer, LV_PCT(10), LV_PCT(10));
+    lv_obj_set_size(viewer, LV_PCT(100), LV_PCT(100));
     lv_obj_remove_flag(viewer, LV_OBJ_FLAG_SCROLLABLE);
     lv_gltf_set_background_mode(viewer, LV_GLTF_BG_MODE_ENVIRONMENT);
     lv_gltf_model_t * model = lv_gltf_load_model_from_file(viewer, path);
     LV_ASSERT_NULL(model);
 
     init_subjects(viewer);
-    create_control_panel(viewer);
+    //create_control_panel(viewer);
 
     mouse_event_data_t * mouse_state = lv_zalloc(sizeof(*mouse_state));
     LV_ASSERT_MALLOC(mouse_state);

--- a/demos/gltf/lv_demo_gltf.c
+++ b/demos/gltf/lv_demo_gltf.c
@@ -112,13 +112,15 @@ static lv_subject_t animation_speed_subject;
  **********************/
 
 /**********************
- *   GLOBAL FUNCTIONS
+ *   GLOBAL FUNCTIONSc
  **********************/
 
 lv_obj_t * lv_demo_gltf(const char * path)
 {
     lv_obj_t * viewer = lv_gltf_create(lv_screen_active());
-    lv_obj_set_size(viewer, LV_PCT(100), LV_PCT(100));
+    //lv_obj_set_size(viewer, LV_PCT(100), LV_PCT(100));
+    lv_obj_set_size(viewer, LV_PCT(50), LV_PCT(50));
+    //lv_obj_set_pos(viewer, LV_PCT(10), LV_PCT(10));
     lv_obj_remove_flag(viewer, LV_OBJ_FLAG_SCROLLABLE);
     lv_gltf_set_background_mode(viewer, LV_GLTF_BG_MODE_ENVIRONMENT);
     lv_gltf_model_t * model = lv_gltf_load_model_from_file(viewer, path);
@@ -327,7 +329,7 @@ static void create_background_panel(lv_obj_t * panel)
     lv_slider_bind_value(env_brightness_slider, &env_brightness_subject);
     lv_obj_set_width(env_brightness_slider, LV_PCT(100));
 
-    lv_slider_set_min_value(env_brightness_slider, 0);
+    lv_slider_set_min_value(env_brightness_slider, -500); /* MK temp fix for framebuffer issue */
     lv_slider_set_max_value(env_brightness_slider, 1000);
     style_slider(env_brightness_slider, SLIDER_COLOR);
 

--- a/demos/gltf/lv_demo_gltf.c
+++ b/demos/gltf/lv_demo_gltf.c
@@ -223,16 +223,15 @@ static void create_camera_panel(lv_obj_t * panel, lv_obj_t * viewer)
     lv_obj_set_width(pitch_slider, LV_PCT(100));
     lv_slider_set_min_value(pitch_slider, -90);
     lv_slider_set_max_value(pitch_slider, 90);
-
     style_slider(pitch_slider, SLIDER_COLOR);
 
     lv_obj_t * distance_title = add_title_to_row(camera_row, "");
     lv_label_bind_text(distance_title, &distance_subject, "Distance %.2f");
 
     lv_obj_t * distance_slider = lv_slider_create(camera_row);
-    lv_obj_set_width(distance_slider, LV_PCT(100));
     lv_slider_bind_value(distance_slider, &distance_subject);
-    lv_slider_set_min_value(distance_slider, 1);
+    lv_obj_set_width(distance_slider, LV_PCT(100));
+    lv_slider_set_min_value(distance_slider, -10);
     lv_slider_set_max_value(distance_slider, 25);
     style_slider(distance_slider, SLIDER_COLOR);
 

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -37,6 +37,7 @@
  *********************/
 
 #define DRAW_UNIT_ID_OPENGLES 6
+#define LV_TEMP_DEBUG_TEX_SIZE 1
 
 /**********************
  *      TYPEDEFS
@@ -263,12 +264,14 @@ static bool draw_to_texture(lv_draw_opengles_unit_t * u, cache_data_t * cache_da
     int32_t texture_w = lv_area_get_width(&task->_real_area);
     int32_t texture_h = lv_area_get_height(&task->_real_area);
 
-    LV_LOG("DRAW_TO_TEXTURE SIZE (w/h) -> (%d, %d)\n", texture_w, texture_h);
-    if ((texture_w <= 0) || (texture_h <= 0)) {
-        LV_LOG("ERROR BAD TEX SIZE, CANCEL: (w/h) -> (%d, %d)\n", texture_w, texture_h);
+#if LV_TEMP_DEBUG_TEX_SIZE
+    LV_LOG_TRACE("Draw to texture size (w/h) -> (%d, %d)\n", texture_w, texture_h);
+    if((texture_w <= 0) || (texture_h <= 0)) {
+        LV_LOG("Error bad texture size, cancel: (w/h) -> (%d, %d)\n", texture_w, texture_h);
         LV_PROFILER_DRAW_END;
         return false;
     }
+#endif
 
     if(NULL == lv_draw_buf_reshape(&u->render_draw_buf, LV_COLOR_FORMAT_ARGB8888, texture_w, texture_h, LV_STRIDE_AUTO)) {
         uint8_t * data = u->render_draw_buf.unaligned_data;

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -28,6 +28,10 @@
 #include "../../stdlib/lv_string.h"
 #include "../../misc/lv_area_private.h"
 
+#if LV_USE_GLTF
+#include "../../libs/gltf/gltf_view/lv_gltf_view_internal.h"
+#endif
+
 /*********************
  *      DEFINES
  *********************/
@@ -43,6 +47,7 @@ typedef struct {
     lv_draw_task_t * task_act;
     lv_cache_t * texture_cache;
     unsigned int framebuffer;
+    unsigned int depth_texture;
     lv_draw_buf_t render_draw_buf;
 } lv_draw_opengles_unit_t;
 
@@ -588,7 +593,9 @@ static void execute_drawing(lv_draw_opengles_unit_t * u)
 
 #if LV_USE_3DTEXTURE
     if(t->type == LV_DRAW_TASK_TYPE_3D) {
-        lv_draw_opengles_3d(t, t->draw_dsc, &t->area);
+        #if !LV_GLTF_DIRECT_BUFFER_WRITES
+            lv_draw_opengles_3d(t, t->draw_dsc, &t->area);
+        #endif
         return;
     }
 #endif
@@ -605,6 +612,31 @@ static unsigned int get_framebuffer(lv_draw_opengles_unit_t * u)
 {
     if(u->framebuffer == 0) {
         GL_CALL(glGenFramebuffers(1, &u->framebuffer));
+        #if LV_GLTF_DIRECT_BUFFER_WRITES
+            GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, u->framebuffer));
+            lv_draw_task_t * task = u->task_act;
+            int32_t display_w = lv_area_get_width(&task->_real_area);
+            int32_t display_h = lv_area_get_height(&task->_real_area);
+
+            GL_CALL(glGenTextures(1, &u->depth_texture));
+            GL_CALL(glBindTexture(GL_TEXTURE_2D, u->depth_texture));
+            GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
+            GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
+            GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
+            GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
+            GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));
+            #ifdef __EMSCRIPTEN__ // Check if compiling for Emscripten (WebGL)
+                // For WebGL2
+                GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, LV_GL_PREFERRED_DEPTH, display_w, display_h, 0, GL_DEPTH_COMPONENT,
+                                    GL_UNSIGNED_INT, NULL));
+            #else
+                // For Desktop OpenGL
+                GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, LV_GL_PREFERRED_DEPTH, display_w, display_h, 0, GL_DEPTH_COMPONENT,
+                                    GL_UNSIGNED_SHORT, NULL));
+            #endif
+            GL_CALL(glBindTexture(GL_TEXTURE_2D, GL_NONE));
+            GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, u->depth_texture, 0));
+        #endif
     }
     return u->framebuffer;
 }

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -137,6 +137,11 @@ void lv_draw_opengles_deinit(void)
     g_unit = NULL;
 }
 
+unsigned int lv_draw_opengles_get_framebuffer(void)
+{
+    return (g_unit == NULL) ? 0 : g_unit->framebuffer;
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -263,6 +263,13 @@ static bool draw_to_texture(lv_draw_opengles_unit_t * u, cache_data_t * cache_da
     int32_t texture_w = lv_area_get_width(&task->_real_area);
     int32_t texture_h = lv_area_get_height(&task->_real_area);
 
+    LV_LOG("DRAW_TO_TEXTURE SIZE (w/h) -> (%d, %d)\n", texture_w, texture_h);
+    if ((texture_w <= 0) || (texture_h <= 0)) {
+        LV_LOG("ERROR BAD TEX SIZE, CANCEL: (w/h) -> (%d, %d)\n", texture_w, texture_h);
+        LV_PROFILER_DRAW_END;
+        return false;
+    }
+
     if(NULL == lv_draw_buf_reshape(&u->render_draw_buf, LV_COLOR_FORMAT_ARGB8888, texture_w, texture_h, LV_STRIDE_AUTO)) {
         uint8_t * data = u->render_draw_buf.unaligned_data;
         uint32_t data_size = LV_DRAW_BUF_SIZE(texture_w, texture_h, LV_COLOR_FORMAT_ARGB8888);

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -633,11 +633,20 @@ static unsigned int get_framebuffer(lv_draw_opengles_unit_t * u, uint32_t color_
         GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, LV_GL_PREFERRED_DEPTH, width, height, 0, GL_DEPTH_COMPONENT,
                              GL_UNSIGNED_SHORT, NULL));
 #endif
-        GL_CALL(glBindTexture(GL_TEXTURE_2D, GL_NONE));
+        GL_CALL(glBindTexture(GL_TEXTURE_2D, 0));
         GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, u->depth_texture, 0));
 #endif
     }
-    GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, u->framebuffer));
+    else {
+        GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, u->framebuffer));
+        uint32_t current_texture_id;
+        glGetFramebufferAttachmentParameteriv(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME,
+                                              (uint32_t *)&current_texture_id);
+        if(current_texture_id != color_texture) {
+            LV_LOG("framebuffer texture_id from %u to %u\n", current_texture_id, color_texture);
+            GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, color_texture, 0));
+        }
+    }
     return u->framebuffer;
 }
 

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -29,7 +29,7 @@
 #include "../../misc/lv_area_private.h"
 
 #if LV_USE_GLTF
-#include "../../libs/gltf/gltf_view/lv_gltf_view_internal.h"
+    #include "../../libs/gltf/gltf_view/lv_gltf_view_internal.h"
 #endif
 
 /*********************
@@ -593,9 +593,9 @@ static void execute_drawing(lv_draw_opengles_unit_t * u)
 
 #if LV_USE_3DTEXTURE
     if(t->type == LV_DRAW_TASK_TYPE_3D) {
-        #if !LV_GLTF_DIRECT_BUFFER_WRITES
-            lv_draw_opengles_3d(t, t->draw_dsc, &t->area);
-        #endif
+#if !LV_GLTF_DIRECT_BUFFER_WRITES
+        lv_draw_opengles_3d(t, t->draw_dsc, &t->area);
+#endif
         return;
     }
 #endif
@@ -612,31 +612,31 @@ static unsigned int get_framebuffer(lv_draw_opengles_unit_t * u)
 {
     if(u->framebuffer == 0) {
         GL_CALL(glGenFramebuffers(1, &u->framebuffer));
-        #if LV_GLTF_DIRECT_BUFFER_WRITES
-            GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, u->framebuffer));
-            lv_draw_task_t * task = u->task_act;
-            int32_t display_w = lv_area_get_width(&task->_real_area);
-            int32_t display_h = lv_area_get_height(&task->_real_area);
+#if LV_GLTF_DIRECT_BUFFER_WRITES
+        GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, u->framebuffer));
+        lv_draw_task_t * task = u->task_act;
+        int32_t display_w = lv_area_get_width(&task->_real_area);
+        int32_t display_h = lv_area_get_height(&task->_real_area);
 
-            GL_CALL(glGenTextures(1, &u->depth_texture));
-            GL_CALL(glBindTexture(GL_TEXTURE_2D, u->depth_texture));
-            GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
-            GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
-            GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
-            GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
-            GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));
-            #ifdef __EMSCRIPTEN__ // Check if compiling for Emscripten (WebGL)
-                // For WebGL2
-                GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, LV_GL_PREFERRED_DEPTH, display_w, display_h, 0, GL_DEPTH_COMPONENT,
-                                    GL_UNSIGNED_INT, NULL));
-            #else
-                // For Desktop OpenGL
-                GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, LV_GL_PREFERRED_DEPTH, display_w, display_h, 0, GL_DEPTH_COMPONENT,
-                                    GL_UNSIGNED_SHORT, NULL));
-            #endif
-            GL_CALL(glBindTexture(GL_TEXTURE_2D, GL_NONE));
-            GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, u->depth_texture, 0));
-        #endif
+        GL_CALL(glGenTextures(1, &u->depth_texture));
+        GL_CALL(glBindTexture(GL_TEXTURE_2D, u->depth_texture));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));
+#ifdef __EMSCRIPTEN__ // Check if compiling for Emscripten (WebGL)
+        // For WebGL2
+        GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, LV_GL_PREFERRED_DEPTH, display_w, display_h, 0, GL_DEPTH_COMPONENT,
+                             GL_UNSIGNED_INT, NULL));
+#else
+        // For Desktop OpenGL
+        GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, LV_GL_PREFERRED_DEPTH, display_w, display_h, 0, GL_DEPTH_COMPONENT,
+                             GL_UNSIGNED_SHORT, NULL));
+#endif
+        GL_CALL(glBindTexture(GL_TEXTURE_2D, GL_NONE));
+        GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, u->depth_texture, 0));
+#endif
     }
     return u->framebuffer;
 }

--- a/src/draw/opengles/lv_draw_opengles.h
+++ b/src/draw/opengles/lv_draw_opengles.h
@@ -31,6 +31,7 @@ extern "C" {
 
 void lv_draw_opengles_init(void);
 void lv_draw_opengles_deinit(void);
+unsigned int lv_draw_opengles_get_framebuffer(void);
 
 /**********************
  *      MACROS

--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -209,6 +209,30 @@ void lv_opengles_viewport(int32_t x, int32_t y, int32_t w, int32_t h)
     LV_PROFILER_DRAW_END;
 }
 
+void lv_opengles_regular_viewport(int32_t x, int32_t y, int32_t w, int32_t h)
+{
+    LV_PROFILER_DRAW_BEGIN;
+    const lv_display_t * display = lv_display_get_default();
+    const lv_display_rotation_t rotation = lv_display_get_rotation(lv_display_get_default());
+    int32_t disp_height;
+    int32_t rx, ry, rw, rh;
+    if (rotation == LV_DISPLAY_ROTATION_0 || rotation == LV_DISPLAY_ROTATION_180) {
+       disp_height = lv_display_get_vertical_resolution(display);
+       rx = x;
+       ry = y;
+       rw = w;
+       rh = h;
+    } else {
+       disp_height = lv_display_get_horizontal_resolution(display);
+       rx = y;
+       ry = x;
+       rw = h;
+       rh = w;
+    }
+    GL_CALL(glViewport(rx, disp_height-ry-rh, rw, rh));
+    LV_PROFILER_DRAW_END;
+}
+
 void lv_opengles_render(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
                         int32_t disp_w, int32_t disp_h, const lv_area_t * texture_clip_area,
                         bool h_flip, bool v_flip, lv_color_t fill_color, bool blend_opt)

--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -212,24 +212,7 @@ void lv_opengles_viewport(int32_t x, int32_t y, int32_t w, int32_t h)
 void lv_opengles_regular_viewport(int32_t x, int32_t y, int32_t w, int32_t h)
 {
     LV_PROFILER_DRAW_BEGIN;
-    const lv_display_t * display = lv_display_get_default();
-    const lv_display_rotation_t rotation = lv_display_get_rotation(lv_display_get_default());
-    int32_t disp_height;
-    int32_t rx, ry, rw, rh;
-    if (rotation == LV_DISPLAY_ROTATION_0 || rotation == LV_DISPLAY_ROTATION_180) {
-       disp_height = lv_display_get_vertical_resolution(display);
-       rx = x;
-       ry = y;
-       rw = w;
-       rh = h;
-    } else {
-       disp_height = lv_display_get_horizontal_resolution(display);
-       rx = y;
-       ry = x;
-       rw = h;
-       rh = w;
-    }
-    GL_CALL(glViewport(rx, disp_height-ry-rh, rw, rh));
+    GL_CALL(glViewport(x, lv_display_get_vertical_resolution(lv_display_get_default()) - y - h, w, h));
     LV_PROFILER_DRAW_END;
 }
 

--- a/src/drivers/opengles/lv_opengles_driver.h
+++ b/src/drivers/opengles/lv_opengles_driver.h
@@ -81,7 +81,7 @@ void lv_opengles_render_fill(lv_color_t color, const lv_area_t * area, lv_opa_t 
 void lv_opengles_render_clear(void);
 
 /**
- * Set the OpenGL viewport
+ * Set the OpenGL viewport (note: x,y refer to the lower left co-ordinate)
  * @param x        x position of the viewport
  * @param y        y position of the viewport
  * @param w        width of the viewport

--- a/src/drivers/opengles/lv_opengles_private.h
+++ b/src/drivers/opengles/lv_opengles_private.h
@@ -107,6 +107,16 @@ void lv_opengles_render(unsigned int texture, const lv_area_t * texture_area, lv
                         int32_t disp_w, int32_t disp_h, const lv_area_t * texture_clip_area,
                         bool h_flip, bool v_flip, lv_color_t fill_color, bool blend_opt);
 
+
+/**
+ * Set the OpenGL viewport, with vertical co-ordinate conversion
+ * @param x        x position of the viewport
+ * @param y        y position of the viewport
+ * @param w        width of the viewport
+ * @param h        height of the viewport
+ */
+void lv_opengles_regular_viewport(int32_t x, int32_t y, int32_t w, int32_t h);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/libs/gltf/gltf_view/lv_gltf_view.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view.cpp
@@ -615,7 +615,9 @@ static void lv_gltf_event(const lv_obj_class_t * class_p, lv_event_t * e)
         lv_obj_t * obj = (lv_obj_t *)lv_event_get_current_target(e);
         lv_gltf_t * viewer = (lv_gltf_t *)obj;
         GLuint texture_id = lv_gltf_view_render(viewer);
-        lv_3dtexture_set_src((lv_obj_t *)&viewer->texture, (lv_3dtexture_id_t)texture_id);
+        #if !LV_GLTF_DIRECT_BUFFER_WRITES
+            lv_3dtexture_set_src((lv_obj_t *)&viewer->texture, (lv_3dtexture_id_t)texture_id);
+        #endif
     }
 
     lv_result_t res;

--- a/src/libs/gltf/gltf_view/lv_gltf_view.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view.cpp
@@ -615,9 +615,9 @@ static void lv_gltf_event(const lv_obj_class_t * class_p, lv_event_t * e)
         lv_obj_t * obj = (lv_obj_t *)lv_event_get_current_target(e);
         lv_gltf_t * viewer = (lv_gltf_t *)obj;
         GLuint texture_id = lv_gltf_view_render(viewer);
-        #if !LV_GLTF_DIRECT_BUFFER_WRITES
-            lv_3dtexture_set_src((lv_obj_t *)&viewer->texture, (lv_3dtexture_id_t)texture_id);
-        #endif
+#if !LV_GLTF_DIRECT_BUFFER_WRITES
+        lv_3dtexture_set_src((lv_obj_t *)&viewer->texture, (lv_3dtexture_id_t)texture_id);
+#endif
     }
 
     lv_result_t res;

--- a/src/libs/gltf/gltf_view/lv_gltf_view_internal.h
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_internal.h
@@ -31,7 +31,7 @@
  * Ultimately we'll probably need this to be run-time selectable, per instance.
  * But for now it's all on/off to test with. Note: This disables caching for gltf
  * views, so only use it for continously updated setups. */
-#define LV_GLTF_DIRECT_BUFFER_WRITES 0
+#define LV_GLTF_DIRECT_BUFFER_WRITES 1
 
 /**********************
  *      TYPEDEFS

--- a/src/libs/gltf/gltf_view/lv_gltf_view_internal.h
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_internal.h
@@ -26,6 +26,12 @@
  *********************/
 
 
+/* This is a temporary flag that should only be enabled for testing purposes.
+ * Ultimately we'll probably need this to be run-time selectable, per instance.
+ * But for now it's all on/off to test with. Note: This disables caching for gltf
+ * views, so only use it for continously updated setups. */
+#define LV_GLTF_DIRECT_BUFFER_WRITES 1
+
 /**********************
  *      TYPEDEFS
  **********************/

--- a/src/libs/gltf/gltf_view/lv_gltf_view_internal.h
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_internal.h
@@ -31,7 +31,7 @@
  * Ultimately we'll probably need this to be run-time selectable, per instance.
  * But for now it's all on/off to test with. Note: This disables caching for gltf
  * views, so only use it for continously updated setups. */
-#define LV_GLTF_DIRECT_BUFFER_WRITES 1
+#define LV_GLTF_DIRECT_BUFFER_WRITES 0
 
 /**********************
  *      TYPEDEFS

--- a/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
@@ -18,6 +18,7 @@
 #include "../../../stdlib/lv_sprintf.h"
 #include "../../../drivers/opengles/lv_opengles_private.h"
 #include "../../../drivers/opengles/lv_opengles_debug.h"
+#include "../../../drivers/opengles/lv_opengles_driver.h"
 #include "../../../draw/opengles/lv_draw_opengles.h"
 #include "../math/lv_gltf_math.hpp"
 

--- a/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
@@ -763,24 +763,24 @@ lv_result_t render_primary_output(lv_gltf_t * viewer, const lv_gltf_renwin_state
     if(glGetError() != GL_NO_ERROR) {
         return LV_RESULT_INVALID;
     }
-    #if !LV_GLTF_DIRECT_BUFFER_WRITES
-        GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, state->texture, 0));
-        GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, state->renderbuffer, 0));
-    #endif
+#if !LV_GLTF_DIRECT_BUFFER_WRITES
+    GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, state->texture, 0));
+    GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, state->renderbuffer, 0));
+#endif
     GL_CALL(glViewport(0, 0, texture_w, texture_h));
     if(prepare_bg) {
-        #if !LV_GLTF_DIRECT_BUFFER_WRITES
-            /* cast is safe because viewer is a lv_obj_t*/
-            lv_color_t bg_color = lv_obj_get_style_bg_color((lv_obj_t *)viewer, LV_PART_MAIN);
-            uint8_t alpha = lv_obj_get_style_bg_opa((lv_obj_t *)viewer, LV_PART_MAIN);
-            GL_CALL(glClearColor(bg_color.red / 255.0f, bg_color.green / 255.0f, bg_color.blue / 255.0f, alpha / 255.0f));
+#if !LV_GLTF_DIRECT_BUFFER_WRITES
+        /* cast is safe because viewer is a lv_obj_t*/
+        lv_color_t bg_color = lv_obj_get_style_bg_color((lv_obj_t *)viewer, LV_PART_MAIN);
+        uint8_t alpha = lv_obj_get_style_bg_opa((lv_obj_t *)viewer, LV_PART_MAIN);
+        GL_CALL(glClearColor(bg_color.red / 255.0f, bg_color.green / 255.0f, bg_color.blue / 255.0f, alpha / 255.0f));
 
-            GL_CALL(glClearDepthf(1.0f));
-            GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
-        #else
-            GL_CALL(glClearDepthf(1.0f));
-            GL_CALL(glClear(GL_DEPTH_BUFFER_BIT));                                    
-        #endif
+        GL_CALL(glClearDepthf(1.0f));
+        GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+#else
+        GL_CALL(glClearDepthf(1.0f));
+        GL_CALL(glClear(GL_DEPTH_BUFFER_BIT));
+#endif
     }
 
     return glGetError() == GL_NO_ERROR ? LV_RESULT_OK : LV_RESULT_INVALID;
@@ -916,49 +916,49 @@ static lv_gltf_renwin_state_t setup_primary_output(int32_t texture_width, int32_
 {
     lv_gltf_renwin_state_t result;
 
-    #if !LV_GLTF_DIRECT_BUFFER_WRITES
-        GLuint rtex;
-        GL_CALL(glGenTextures(1, &rtex));
-        result.texture = rtex;
-        GL_CALL(glBindTexture(GL_TEXTURE_2D, result.texture));
-        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
-                                mipmaps_enabled ? GL_NEAREST_MIPMAP_NEAREST : GL_NEAREST));
-        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
-        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
-        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
-        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 1));
-        GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, texture_width, texture_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL));
-        GL_CALL(glBindTexture(GL_TEXTURE_2D, GL_NONE));
-        GL_CALL(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
+#if !LV_GLTF_DIRECT_BUFFER_WRITES
+    GLuint rtex;
+    GL_CALL(glGenTextures(1, &rtex));
+    result.texture = rtex;
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, result.texture));
+    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
+                            mipmaps_enabled ? GL_NEAREST_MIPMAP_NEAREST : GL_NEAREST));
+    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
+    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
+    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
+    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 1));
+    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, texture_width, texture_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL));
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, GL_NONE));
+    GL_CALL(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
 
-        GLuint rdepth;
-        GL_CALL(glGenTextures(1, &rdepth));
-        result.renderbuffer = rdepth;
-        GL_CALL(glBindTexture(GL_TEXTURE_2D, result.renderbuffer));
-        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
-        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
-        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
-        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
-        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 1));
-    #ifdef __EMSCRIPTEN__ // Check if compiling for Emscripten (WebGL)
-        // For WebGL2
-        GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, LV_GL_PREFERRED_DEPTH, texture_width, texture_height, 0, GL_DEPTH_COMPONENT,
-                            GL_UNSIGNED_INT, NULL));
-    #else
-        // For Desktop OpenGL
-        GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, LV_GL_PREFERRED_DEPTH, texture_width, texture_height, 0, GL_DEPTH_COMPONENT,
-                            GL_UNSIGNED_SHORT, NULL));
-    #endif
-        GL_CALL(glBindTexture(GL_TEXTURE_2D, GL_NONE));
+    GLuint rdepth;
+    GL_CALL(glGenTextures(1, &rdepth));
+    result.renderbuffer = rdepth;
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, result.renderbuffer));
+    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
+    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
+    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
+    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
+    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 1));
+#ifdef __EMSCRIPTEN__ // Check if compiling for Emscripten (WebGL)
+    // For WebGL2
+    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, LV_GL_PREFERRED_DEPTH, texture_width, texture_height, 0, GL_DEPTH_COMPONENT,
+                         GL_UNSIGNED_INT, NULL));
+#else
+    // For Desktop OpenGL
+    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, LV_GL_PREFERRED_DEPTH, texture_width, texture_height, 0, GL_DEPTH_COMPONENT,
+                         GL_UNSIGNED_SHORT, NULL));
+#endif
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, GL_NONE));
 
-        GL_CALL(glGenFramebuffers(1, &result.framebuffer));
-        GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, result.framebuffer));
-        GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, result.texture, 0));
-        GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, result.renderbuffer, 0));
-    #else
-        result.framebuffer = 2;
-        GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, result.framebuffer));
-    #endif
+    GL_CALL(glGenFramebuffers(1, &result.framebuffer));
+    GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, result.framebuffer));
+    GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, result.texture, 0));
+    GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, result.renderbuffer, 0));
+#else
+    result.framebuffer = 2;
+    GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, result.framebuffer));
+#endif
     return result;
 }
 

--- a/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
@@ -770,8 +770,7 @@ lv_result_t render_primary_output(lv_gltf_t * viewer, const lv_gltf_renwin_state
 #else
     GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, state->texture, 0));
     GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, state->renderbuffer, 0));
-    //lv_opengles_viewport(0, 0, texture_w, texture_h);
-    GL_CALL(glViewport(0, 0, texture_w, texture_h));
+    lv_opengles_viewport(0, 0, texture_w, texture_h);
 #endif
 
     if(prepare_bg) {

--- a/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
@@ -754,17 +754,24 @@ lv_result_t render_primary_output(lv_gltf_t * viewer, const lv_gltf_renwin_state
     if(glGetError() != GL_NO_ERROR) {
         return LV_RESULT_INVALID;
     }
-    GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, state->texture, 0));
-    GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, state->renderbuffer, 0));
+    #if !LV_GLTF_DIRECT_BUFFER_WRITES
+        GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, state->texture, 0));
+        GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, state->renderbuffer, 0));
+    #endif
     GL_CALL(glViewport(0, 0, texture_w, texture_h));
     if(prepare_bg) {
-        /* cast is safe because viewer is a lv_obj_t*/
-        lv_color_t bg_color = lv_obj_get_style_bg_color((lv_obj_t *)viewer, LV_PART_MAIN);
-        uint8_t alpha = lv_obj_get_style_bg_opa((lv_obj_t *)viewer, LV_PART_MAIN);
-        GL_CALL(glClearColor(bg_color.red / 255.0f, bg_color.green / 255.0f, bg_color.blue / 255.0f, alpha / 255.0f));
+        #if !LV_GLTF_DIRECT_BUFFER_WRITES
+            /* cast is safe because viewer is a lv_obj_t*/
+            lv_color_t bg_color = lv_obj_get_style_bg_color((lv_obj_t *)viewer, LV_PART_MAIN);
+            uint8_t alpha = lv_obj_get_style_bg_opa((lv_obj_t *)viewer, LV_PART_MAIN);
+            GL_CALL(glClearColor(bg_color.red / 255.0f, bg_color.green / 255.0f, bg_color.blue / 255.0f, alpha / 255.0f));
 
-        GL_CALL(glClearDepthf(1.0f));
-        GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+            GL_CALL(glClearDepthf(1.0f));
+            GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+        #else
+            GL_CALL(glClearDepthf(1.0f));
+            GL_CALL(glClear(GL_DEPTH_BUFFER_BIT));                                    
+        #endif
     }
 
     return glGetError() == GL_NO_ERROR ? LV_RESULT_OK : LV_RESULT_INVALID;
@@ -877,45 +884,49 @@ static lv_gltf_renwin_state_t setup_primary_output(int32_t texture_width, int32_
 {
     lv_gltf_renwin_state_t result;
 
-    GLuint rtex;
-    GL_CALL(glGenTextures(1, &rtex));
-    result.texture = rtex;
-    GL_CALL(glBindTexture(GL_TEXTURE_2D, result.texture));
-    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
-                            mipmaps_enabled ? GL_NEAREST_MIPMAP_NEAREST : GL_NEAREST));
-    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
-    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
-    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
-    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 1));
-    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, texture_width, texture_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL));
-    GL_CALL(glBindTexture(GL_TEXTURE_2D, GL_NONE));
-    GL_CALL(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
+    #if !LV_GLTF_DIRECT_BUFFER_WRITES
+        GLuint rtex;
+        GL_CALL(glGenTextures(1, &rtex));
+        result.texture = rtex;
+        GL_CALL(glBindTexture(GL_TEXTURE_2D, result.texture));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
+                                mipmaps_enabled ? GL_NEAREST_MIPMAP_NEAREST : GL_NEAREST));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 1));
+        GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, texture_width, texture_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL));
+        GL_CALL(glBindTexture(GL_TEXTURE_2D, GL_NONE));
+        GL_CALL(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
 
-    GLuint rdepth;
-    GL_CALL(glGenTextures(1, &rdepth));
-    result.renderbuffer = rdepth;
-    GL_CALL(glBindTexture(GL_TEXTURE_2D, result.renderbuffer));
-    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
-    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
-    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
-    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
-    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 1));
-#ifdef __EMSCRIPTEN__ // Check if compiling for Emscripten (WebGL)
-    // For WebGL2
-    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, LV_GL_PREFERRED_DEPTH, texture_width, texture_height, 0, GL_DEPTH_COMPONENT,
-                         GL_UNSIGNED_INT, NULL));
-#else
-    // For Desktop OpenGL
-    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, LV_GL_PREFERRED_DEPTH, texture_width, texture_height, 0, GL_DEPTH_COMPONENT,
-                         GL_UNSIGNED_SHORT, NULL));
-#endif
-    GL_CALL(glBindTexture(GL_TEXTURE_2D, GL_NONE));
+        GLuint rdepth;
+        GL_CALL(glGenTextures(1, &rdepth));
+        result.renderbuffer = rdepth;
+        GL_CALL(glBindTexture(GL_TEXTURE_2D, result.renderbuffer));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 1));
+    #ifdef __EMSCRIPTEN__ // Check if compiling for Emscripten (WebGL)
+        // For WebGL2
+        GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, LV_GL_PREFERRED_DEPTH, texture_width, texture_height, 0, GL_DEPTH_COMPONENT,
+                            GL_UNSIGNED_INT, NULL));
+    #else
+        // For Desktop OpenGL
+        GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, LV_GL_PREFERRED_DEPTH, texture_width, texture_height, 0, GL_DEPTH_COMPONENT,
+                            GL_UNSIGNED_SHORT, NULL));
+    #endif
+        GL_CALL(glBindTexture(GL_TEXTURE_2D, GL_NONE));
 
-    GL_CALL(glGenFramebuffers(1, &result.framebuffer));
-    GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, result.framebuffer));
-    GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, result.texture, 0));
-    GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, result.renderbuffer, 0));
-
+        GL_CALL(glGenFramebuffers(1, &result.framebuffer));
+        GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, result.framebuffer));
+        GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, result.texture, 0));
+        GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, result.renderbuffer, 0));
+    #else
+        result.framebuffer = 2;
+        GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, result.framebuffer));
+    #endif
     return result;
 }
 

--- a/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
@@ -764,47 +764,10 @@ lv_result_t render_primary_output(lv_gltf_t * viewer, const lv_gltf_renwin_state
     if(glGetError() != GL_NO_ERROR) {
         return LV_RESULT_INVALID;
     }
-    //int32_t width = (rotation == LV_DISPLAY_ROTATION_0 || rotation == LV_DISPLAY_ROTATION_180) ? texture_w : texture_h;
-    //int32_t height = (rotation == LV_DISPLAY_ROTATION_0 || rotation == LV_DISPLAY_ROTATION_180) ? texture_h : texture_w;
-    const lv_display_t * display = lv_display_get_default();
-    const lv_display_rotation_t rotation = lv_display_get_rotation((lv_display_t *)display);
-    int32_t width = texture_w;
-    int32_t height = texture_h;
-    int32_t ulx = 0;
-    int32_t uly = 0;
 
 #if LV_GLTF_DIRECT_BUFFER_WRITES
-    const int32_t display_w = lv_display_get_horizontal_resolution(display);
-    const int32_t display_h = lv_display_get_vertical_resolution(display);
-    int32_t screen_w = display_w;
-    int32_t screen_h = display_h;
-    const lv_obj_t * obj = (lv_obj_t *)viewer;
-    if ((rotation == LV_DISPLAY_ROTATION_0) || (rotation == LV_DISPLAY_ROTATION_180)) {
-        ulx = lv_obj_get_x(obj);
-        uly = (screen_h -lv_obj_get_y(obj)) - texture_h;
-    } else {
-        screen_w = display_h;
-        screen_h = display_w;
-        ulx = lv_obj_get_y(obj);
-        uly = lv_obj_get_x(obj);
-        width = texture_h;
-        height = texture_w;
-        if (rotation == LV_DISPLAY_ROTATION_90) {
-            //ulx = ulx;
-            uly = (screen_h - uly) - texture_h;
-        } else {
-            //ulx = (display_w - ulx);
-            uly = (screen_h - uly) - texture_h;
-        }
-    }
-    //int32_t ulx = lv_obj_get_x(obj);
-    //int32_t uly = lv_obj_get_y(obj);
-    //lv_opengles_regular_viewport(ulx, uly, width, height);
-    LV_LOG("DISPLAY WIDTH/HEIGHT / TEXTURE WIDTH/HEIGHT -> ULX/ULY = (%d,%d)/(%d,%d) -> (%d,%d)\n", screen_w, screen_h, width, height, ulx, uly);
-    GL_CALL(glViewport(ulx, uly, width, height));
-    //lv_opengles_viewport(ulx, uly, width, height);
+    lv_opengles_regular_viewport(lv_obj_get_x((lv_obj_t *)viewer), lv_obj_get_y((lv_obj_t *)viewer), texture_w, texture_h);
 #else
-    LV_LOG("TEXTURE WIDTH/HEIGHT = (%d,%d)\n", width, height);
     GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, state->texture, 0));
     GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, state->renderbuffer, 0));
     //lv_opengles_viewport(0, 0, texture_w, texture_h);

--- a/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
@@ -18,6 +18,7 @@
 #include "../../../stdlib/lv_sprintf.h"
 #include "../../../drivers/opengles/lv_opengles_private.h"
 #include "../../../drivers/opengles/lv_opengles_debug.h"
+#include "../../../draw/opengles/lv_draw_opengles.h"
 #include "../math/lv_gltf_math.hpp"
 
 #include <algorithm>
@@ -961,7 +962,7 @@ static lv_gltf_renwin_state_t setup_primary_output(int32_t texture_width, int32_
     GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, result.texture, 0));
     GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, result.renderbuffer, 0));
 #else
-    result.framebuffer = 2;
+    result.framebuffer = lv_draw_opengles_get_framebuffer();
     GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, result.framebuffer));
 #endif
     return result;


### PR DESCRIPTION
This PR has an alternate method of applying the rendered image to the current display that eliminates a step in the process, directly putting the new rendered pixels into their final destination, instead of into a staging texture to later be blitted into the final output surface.   This improves performance by about 10% for me here at lower resolutions and probably improves performance more at higher resolutions.

There are a couple important notes to consider before using this, certain things won't work the same:  there is no caching possible with this, since the rendered pixels are never placed in their own texture.  So this should only be used in situations where the 3D was going to be updated every single frame anyways, continuously.   In that case there can be no benefit of the caching overhead anyways.  Also this code may experience issues with rotated display, and other untested edge cases.

This branch is to help us conduct that testing, identify any other problems, and resolve them.