### PR TITLE
fix(workflows): revert and skip coverage anaysis if not a pull request

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -143,9 +143,6 @@ jobs:
           echo "Merge-base: $MB"
           python scripts/check_gcov_coverage.py --commit="${MB}...${{ github.event.pull_request.head.sha }}"
         else
-          # For push events, fetch enough history to resolve HEAD^
-          git fetch --no-tags --prune --depth=2 origin
-          echo "Using HEAD commit for push event"
           python scripts/check_gcov_coverage.py --commit=HEAD
         fi
     - name: Archive screenshot errors

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -143,7 +143,7 @@ jobs:
           echo "Merge-base: $MB"
           python scripts/check_gcov_coverage.py --commit="${MB}...${{ github.event.pull_request.head.sha }}"
         else
-          python scripts/check_gcov_coverage.py --commit=HEAD
+          echo "Not a pull request, skipping code coverage analysis."
         fi
     - name: Archive screenshot errors
       if: failure()


### PR DESCRIPTION
Fixes coverage anaysis error as below:

```Using HEAD commit for push event
Error: Command failed - Command '['git', 'diff', 'HEAD^', 'HEAD', '--unified=0']' returned non-zero exit status 128.
Error details:
fatal: ambiguous argument 'HEAD^': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'

Current working directory: /home/runner/work/lvgl/lvgl
Found 1 commits in range:
  HEAD
Error: Process completed with exit code 128.
```

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
