### PR TITLE
fix(property): fix reading style property returns uninitialized if non-local

### DIFF
--- a/src/core/lv_obj_property.c
+++ b/src/core/lv_obj_property.c
@@ -150,9 +150,9 @@ lv_property_t lv_obj_get_property(lv_obj_t * obj, lv_prop_id_t id)
     }
 
     if(index < LV_PROPERTY_ID_START) {
-        lv_obj_get_local_style_prop(obj, index, &value.style, 0);
+        value.style = lv_obj_get_style_prop(obj, LV_PART_MAIN, index);
         value.id = id;
-        value.selector = 0;
+        value.selector = LV_PART_MAIN | obj->state;
         return value;
     }
 
@@ -163,7 +163,7 @@ lv_property_t lv_obj_get_property(lv_obj_t * obj, lv_prop_id_t id)
     return value;
 }
 
-lv_property_t lv_obj_get_style_property(lv_obj_t * obj, lv_prop_id_t id, uint32_t selector)
+lv_property_t lv_obj_get_style_property(lv_obj_t * obj, lv_prop_id_t id, lv_part_t part)
 {
     lv_property_t value;
     uint32_t index = LV_PROPERTY_ID_INDEX(id);
@@ -175,9 +175,9 @@ lv_property_t lv_obj_get_style_property(lv_obj_t * obj, lv_prop_id_t id, uint32_
         return value;
     }
 
-    lv_obj_get_local_style_prop(obj, id, &value.style, selector);
+    value.style = lv_obj_get_style_prop(obj, part, index);
     value.id = id;
-    value.selector = selector;
+    value.selector = part | obj->state;
     return value;
 }
 

--- a/src/core/lv_obj_property.h
+++ b/src/core/lv_obj_property.h
@@ -15,6 +15,7 @@ extern "C" {
  *********************/
 #include "../misc/lv_types.h"
 #include "../misc/lv_style.h"
+#include "lv_obj_style.h"
 
 #if LV_USE_OBJ_PROPERTY
 
@@ -222,7 +223,7 @@ lv_result_t lv_obj_set_properties(lv_obj_t * obj, const lv_property_t * value, u
 
 /**
  * Read property value from Widget.
- * If id is a style property.  Style selector is 0 by default.
+ * If id is a style property, computes the style of PART_MAIN.
  * @param obj       pointer to Widget
  * @param id        ID of property to read
  * @return          return property value read. The returned property ID is set to `LV_PROPERTY_ID_INVALID` if read failed.
@@ -233,10 +234,10 @@ lv_property_t lv_obj_get_property(lv_obj_t * obj, lv_prop_id_t id);
  * Read style property value from Widget
  * @param obj       pointer to Widget
  * @param id        ID of style property
- * @param selector  selector for style property
+ * @param part      part for which the style property should be computed
  * @return          return property value read. The returned property ID is set to `LV_PROPERTY_ID_INVALID` if read failed.
  */
-lv_property_t lv_obj_get_style_property(lv_obj_t * obj, lv_prop_id_t id, uint32_t selector);
+lv_property_t lv_obj_get_style_property(lv_obj_t * obj, lv_prop_id_t id, lv_part_t part);
 
 /**
  * Get property ID by recursively searching for name in Widget's class hierarchy, and


### PR DESCRIPTION
Currently `lv_obj_get_property()` returns 0 and `lv_obj_get_style_property()` returns an uninitialized value if the style is not set locally. What should happen?

* Should the property be resolved using non-local styles, ultimately returning a default value? This is implemented here. It then no longer supports arbitrary style selectors, only parts.
* Or should the failure be handled and return an invalid value? If so, should we add a new function that allows using the property system to look up non-local styles?