### PR TITLE
fix(gif): fix negative loop count handling

### DIFF
--- a/src/libs/gif/lv_gif.c
+++ b/src/libs/gif/lv_gif.c
@@ -438,6 +438,9 @@ static void next_frame_task_cb(lv_timer_t * t)
                 gifobj->loop_count--;
             }
         }
+        else if(gifobj->loop_count < 0) {
+            lv_timer_pause(t);
+        }
         if(res != LV_RESULT_OK) return;
     }
     else {


### PR DESCRIPTION
Previously negative values in the loop count (which are set by default by the new library for retrocompatibility) resulted in a single loop of the gif; with the new implementation both positive and negative values must be checked in order to stop the timer if necessary.