### PR TITLE
fix(spinbox): fix stack corruption

### DIFF
--- a/examples/widgets/canvas/lv_example_canvas_1.c
+++ b/examples/widgets/canvas/lv_example_canvas_1.c
@@ -25,7 +25,7 @@ void lv_example_canvas_1(void)
     lv_draw_label_dsc_t label_dsc;
     lv_draw_label_dsc_init(&label_dsc);
     label_dsc.color = lv_palette_main(LV_PALETTE_ORANGE);
-    label_dsc.text = lv_strdup("Some text on text canvas");
+    label_dsc.text = "Some text on text canvas";
     /*Create a buffer for the canvas*/
     LV_DRAW_BUF_DEFINE_STATIC(draw_buf_16bpp, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_RGB565);
     LV_DRAW_BUF_INIT_STATIC(draw_buf_16bpp);

--- a/examples/widgets/canvas/lv_example_canvas_1.c
+++ b/examples/widgets/canvas/lv_example_canvas_1.c
@@ -25,7 +25,7 @@ void lv_example_canvas_1(void)
     lv_draw_label_dsc_t label_dsc;
     lv_draw_label_dsc_init(&label_dsc);
     label_dsc.color = lv_palette_main(LV_PALETTE_ORANGE);
-    label_dsc.text = "Some text on text canvas";
+    label_dsc.text = lv_strdup("Some text on text canvas");
     /*Create a buffer for the canvas*/
     LV_DRAW_BUF_DEFINE_STATIC(draw_buf_16bpp, CANVAS_WIDTH, CANVAS_HEIGHT, LV_COLOR_FORMAT_RGB565);
     LV_DRAW_BUF_INIT_STATIC(draw_buf_16bpp);

--- a/src/widgets/spinbox/lv_spinbox.c
+++ b/src/widgets/spinbox/lv_spinbox.c
@@ -495,7 +495,7 @@ static void lv_spinbox_updatevalue(lv_obj_t * obj)
     const size_t digits_len = lv_strlen(digits);
 
     const int leading_zeros_cnt = spinbox->digit_count - digits_len;
-    if(leading_zeros_cnt) {
+    if(leading_zeros_cnt > 0) {
         for(i = (int32_t) digits_len; i >= 0; i--) {
             digits[i + leading_zeros_cnt] = digits[i];
         }

--- a/tests/src/test_cases/widgets/test_spinbox.c
+++ b/tests/src/test_cases/widgets/test_spinbox.c
@@ -305,7 +305,7 @@ void test_spinbox_zero_crossing(void)
     TEST_ASSERT_EQUAL(13, lv_spinbox_get_value(spinbox_events));
 }
 
-void test_spinbox_few_gigits(void)
+void test_spinbox_few_digits(void)
 {
     lv_spinbox_set_range(spinbox_events, -20000, 20000);
     lv_spinbox_set_value(spinbox_events, 19000);

--- a/tests/src/test_cases/widgets/test_spinbox.c
+++ b/tests/src/test_cases/widgets/test_spinbox.c
@@ -305,4 +305,13 @@ void test_spinbox_zero_crossing(void)
     TEST_ASSERT_EQUAL(13, lv_spinbox_get_value(spinbox_events));
 }
 
+void test_spinbox_few_gigits(void)
+{
+    lv_spinbox_set_range(spinbox_events, -20000, 20000);
+    lv_spinbox_set_value(spinbox_events, 19000);
+    lv_spinbox_set_digit_count(spinbox_events, 3);
+    lv_obj_t * label = lv_obj_get_child(spinbox_events, 0);
+    TEST_ASSERT_EQUAL_STRING("+190", lv_label_get_text(label));
+}
+
 #endif


### PR DESCRIPTION
Only add leading zeros when calculation returns a positive number.

Fixes #9255

When the number of digits is greater than currently configured, it happens that the number of zeros to add turns negative. The if() clause fails due to lack of an appropriate comparator.

_Ready_