### PR TITLE
fix(spinbox):  fix stack corruption

### DIFF
--- a/docs/src/details/widgets/spinbox.rst
+++ b/docs/src/details/widgets/spinbox.rst
@@ -27,14 +27,16 @@ Value, range and step
 ---------------------
 
 - :cpp:expr:`lv_spinbox_set_value(spinbox, 1234)` sets a new value for the Spinbox.
-- :cpp:expr:`lv_spinbox_increment(spinbox)` and :cpp:expr:`lv_spinbox_decrement(spinbox)`
-  increments/decrements the value of the Spinbox according to the currently-selected digit.
+- :cpp:expr:`lv_spinbox_increment(spinbox)` and :cpp:expr:`lv_spinbox_decrement
+  (spinbox)` increments/decrements the currently-selected digit by the `step` value,
+  changing the value of the Spinbox accordingly.
 - :cpp:expr:`lv_spinbox_set_range(spinbox, -1000, 2500)` sets its range. If the
   value is changed by :cpp:expr:`lv_spinbox_set_value(spinbox)`, by *Keys*,
   by :cpp:expr:`lv_spinbox_increment(spinbox)` or :cpp:expr:`lv_spinbox_decrement(spinbox)`
   this range will be respected.
-- :cpp:expr:`lv_spinbox_set_step(spinbox, 100)` sets which digit to change on
-  increment/decrement. Only multiples of ten can be set.
+- :cpp:expr:`lv_spinbox_set_step(spinbox, 100)` sets `step` value to
+  increment/decrement.  It is designed to be either 1 (its default) or a multiple of
+  10 so that setting it simultaneously determines which digit is selected.
 - :cpp:expr:`lv_spinbox_set_cursor_pos(spinbox, 1)` sets the cursor to a specific
   digit to change on increment/decrement. Position '0' sets the cursor to
   the least significant digit.

--- a/docs/src/details/widgets/spinbox.rst
+++ b/docs/src/details/widgets/spinbox.rst
@@ -28,8 +28,8 @@ Value, range and step
 
 - :cpp:expr:`lv_spinbox_set_value(spinbox, 1234)` sets a new value for the Spinbox.
 - :cpp:expr:`lv_spinbox_increment(spinbox)` and :cpp:expr:`lv_spinbox_decrement(spinbox)`
-  increments/decrements the currently-selected digit by the `step` value, changing the
-  value of the Spinbox accordingly.
+  increments/decrements the Spinbox's value by the `step` value, effectively incrementing
+  or decrementing the value of the selected digit.
 - :cpp:expr:`lv_spinbox_set_range(spinbox, -1000, 2500)` sets its range. If the
   value is changed by :cpp:expr:`lv_spinbox_set_value(spinbox)`, by *Keys*,
   by :cpp:expr:`lv_spinbox_increment(spinbox)` or :cpp:expr:`lv_spinbox_decrement(spinbox)`

--- a/docs/src/details/widgets/spinbox.rst
+++ b/docs/src/details/widgets/spinbox.rst
@@ -35,8 +35,8 @@ Value, range and step
   by :cpp:expr:`lv_spinbox_increment(spinbox)` or :cpp:expr:`lv_spinbox_decrement(spinbox)`
   this range will be respected.
 - :cpp:expr:`lv_spinbox_set_step(spinbox, 100)` sets `step` value to
-  increment/decrement.  It is designed to be either 1 (its default) or a multiple of
-  10 so that setting it simultaneously determines which digit is selected.
+  increment/decrement.  It is designed to be a power of 10 (1, 10, 100, etc.) so that
+  setting it simultaneously determines which digit is selected.
 - :cpp:expr:`lv_spinbox_set_cursor_pos(spinbox, 1)` sets the cursor to a specific
   digit to change on increment/decrement. Position '0' sets the cursor to
   the least significant digit.

--- a/docs/src/details/widgets/spinbox.rst
+++ b/docs/src/details/widgets/spinbox.rst
@@ -27,9 +27,9 @@ Value, range and step
 ---------------------
 
 - :cpp:expr:`lv_spinbox_set_value(spinbox, 1234)` sets a new value for the Spinbox.
-- :cpp:expr:`lv_spinbox_increment(spinbox)` and :cpp:expr:`lv_spinbox_decrement
-  (spinbox)` increments/decrements the currently-selected digit by the `step` value,
-  changing the value of the Spinbox accordingly.
+- :cpp:expr:`lv_spinbox_increment(spinbox)` and :cpp:expr:`lv_spinbox_decrement(spinbox)`
+  increments/decrements the currently-selected digit by the `step` value, changing the
+  value of the Spinbox accordingly.
 - :cpp:expr:`lv_spinbox_set_range(spinbox, -1000, 2500)` sets its range. If the
   value is changed by :cpp:expr:`lv_spinbox_set_value(spinbox)`, by *Keys*,
   by :cpp:expr:`lv_spinbox_increment(spinbox)` or :cpp:expr:`lv_spinbox_decrement(spinbox)`

--- a/src/widgets/spinbox/lv_spinbox.c
+++ b/src/widgets/spinbox/lv_spinbox.c
@@ -616,12 +616,23 @@ static void clamp_value_to_range(lv_spinbox_t * spinbox)
 
 static void clamp_range_to_digit_count(lv_spinbox_t * spinbox)
 {
-    int32_t max = (int32_t)lv_pow(10, spinbox->digit_count) - 1;
-    int32_t min = -max;
+    int32_t max;
+    int32_t min;
+
+    if(spinbox->digit_count < 10) {
+        max = (int32_t)lv_pow(10, spinbox->digit_count) - 1;
+        min = -max;
+    }
+    else {
+        max = INT32_MAX;
+        min = INT32_MIN + 1;
+        /* INT32_MIN is illegal for `range_min` because it is used with LV_ABS(). */
+    }
     if(spinbox->range_max > max) spinbox->range_max = max;
     else if(spinbox->range_max < min) spinbox->range_max = min;
     if(spinbox->range_min > max) spinbox->range_min = max;
     else if(spinbox->range_min < min) spinbox->range_min = min;
+
     clamp_value_to_range(spinbox);
 }
 

--- a/src/widgets/spinbox/lv_spinbox.c
+++ b/src/widgets/spinbox/lv_spinbox.c
@@ -33,7 +33,7 @@
 static void lv_spinbox_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj);
 static void lv_spinbox_event(const lv_obj_class_t * class_p, lv_event_t * e);
 static void lv_spinbox_updatevalue(lv_obj_t * obj);
-static void clamp_value_to_range(lv_spinbox_t* spinbox);
+static void clamp_value_to_range(lv_spinbox_t * spinbox);
 static void clamp_range_to_digit_count(lv_spinbox_t * spinbox);
 static void extend_digit_count_when_insufficient(lv_spinbox_t * spinbox);
 static uint32_t  digit_count(int32_t num);
@@ -177,7 +177,7 @@ void lv_spinbox_set_range(lv_obj_t * obj, int32_t min_value, int32_t max_value)
     }
 
     /* Prevent overflow with LV_ABS(spinbox->range_min) used elsewhere. */
-    if (min_value == INT32_MIN) {
+    if(min_value == INT32_MIN) {
         min_value = INT32_MIN + 1;
     }
 
@@ -205,7 +205,7 @@ void lv_spinbox_set_min_value(lv_obj_t * obj, int32_t min_value)
     }
 
     /* Prevent overflow with LV_ABS(spinbox->range_min) used elsewhere. */
-    if (min_value == INT32_MIN) {
+    if(min_value == INT32_MIN) {
         min_value = INT32_MIN + 1;
     }
 
@@ -598,10 +598,10 @@ static void lv_spinbox_updatevalue(lv_obj_t * obj)
     lv_textarea_set_cursor_pos(obj, cur_pos);
 }
 
-static void clamp_value_to_range(lv_spinbox_t* spinbox)
+static void clamp_value_to_range(lv_spinbox_t * spinbox)
 {
-    if (spinbox->value > spinbox->range_max) spinbox->value = spinbox->range_max;
-    if (spinbox->value < spinbox->range_min) spinbox->value = spinbox->range_min;
+    if(spinbox->value > spinbox->range_max) spinbox->value = spinbox->range_max;
+    if(spinbox->value < spinbox->range_min) spinbox->value = spinbox->range_min;
 }
 
 static void clamp_range_to_digit_count(lv_spinbox_t * spinbox)
@@ -627,7 +627,7 @@ static void extend_digit_count_when_insufficient(lv_spinbox_t * spinbox)
 static uint32_t digit_count(int32_t num)
 {
     uint32_t  digit_count = 0;
-    while (num) {
+    while(num) {
         num /= 10;
         digit_count++;
     }

--- a/src/widgets/spinbox/lv_spinbox.c
+++ b/src/widgets/spinbox/lv_spinbox.c
@@ -559,6 +559,8 @@ static void lv_spinbox_updatevalue(lv_obj_t * obj)
     int32_t i;
     const size_t digits_len = lv_strlen(digits);
 
+    LV_ASSERT(spinbox->digit_count >= (uint32_t)digits_len);
+
     const int leading_zeros_cnt = (int)(spinbox->digit_count - (uint32_t)digits_len);
     if(leading_zeros_cnt) {
         for(i = (int32_t) digits_len; i >= 0; i--) {

--- a/src/widgets/spinbox/lv_spinbox.c
+++ b/src/widgets/spinbox/lv_spinbox.c
@@ -102,6 +102,7 @@ void lv_spinbox_set_digit_format(lv_obj_t * obj, uint32_t digit_count, uint32_t 
     lv_spinbox_t * spinbox = (lv_spinbox_t *)obj;
 
     if(digit_count > LV_SPINBOX_MAX_DIGIT_COUNT) digit_count = LV_SPINBOX_MAX_DIGIT_COUNT;
+    if(digit_count == 0) digit_count = 1;
     if(dec_point_pos >= digit_count) dec_point_pos = 0;
 
     spinbox->digit_count = digit_count;

--- a/src/widgets/spinbox/lv_spinbox.c
+++ b/src/widgets/spinbox/lv_spinbox.c
@@ -563,7 +563,7 @@ static void lv_spinbox_updatevalue(lv_obj_t * obj)
     LV_ASSERT(spinbox->digit_count >= (uint32_t)digits_len);
 
     const int leading_zeros_cnt = (int)(spinbox->digit_count - (uint32_t)digits_len);
-    if(leading_zeros_cnt) {
+    if(leading_zeros_cnt > 0) {
         for(i = (int32_t) digits_len; i >= 0; i--) {
             digits[i + leading_zeros_cnt] = digits[i];
         }

--- a/src/widgets/spinbox/lv_spinbox.c
+++ b/src/widgets/spinbox/lv_spinbox.c
@@ -175,7 +175,7 @@ void lv_spinbox_set_range(lv_obj_t * obj, int32_t min_value, int32_t max_value)
     }
 
     spinbox->range_max = max_value;
-    spinbox->range_min = min_value;
+    spinbox->range_min = min_value > INT32_MIN ? min_value : INT32_MIN + 1;
 
     if(spinbox->value > max_value) spinbox->value = max_value;
     if(spinbox->value < min_value) spinbox->value = min_value;
@@ -199,7 +199,7 @@ void lv_spinbox_set_min_value(lv_obj_t * obj, int32_t min_value)
         if(min_value > max) min_value = max;
     }
 
-    spinbox->range_min = min_value;
+    spinbox->range_min = min_value > INT32_MIN ? min_value : INT32_MIN + 1;
 
     if(spinbox->value < spinbox->range_min) spinbox->value = spinbox->range_min;
 

--- a/src/widgets/spinbox/lv_spinbox.c
+++ b/src/widgets/spinbox/lv_spinbox.c
@@ -649,11 +649,13 @@ static void extend_digit_count_when_insufficient(lv_spinbox_t * spinbox)
 
 static uint32_t digit_count(int32_t num)
 {
-    uint32_t  digit_count = 0;
+    uint32_t  digit_count = num == 0 ? 1 : 0;
+
     while(num) {
         num /= 10;
         digit_count++;
     }
+
     return digit_count;
 }
 

--- a/src/widgets/spinbox/lv_spinbox.c
+++ b/src/widgets/spinbox/lv_spinbox.c
@@ -176,9 +176,12 @@ void lv_spinbox_set_range(lv_obj_t * obj, int32_t min_value, int32_t max_value)
         max_value = temp;
     }
 
-    /* Prevent overflow with LV_ABS(spinbox->range_min) used elsewhere. */
+    /* Prevent overflow with LV_ABS(spinbox->range_min) (or range_max) used elsewhere. */
     if(min_value == INT32_MIN) {
         min_value = INT32_MIN + 1;
+    }
+    if(max_value == INT32_MIN) {
+        max_value = INT32_MIN + 1;
     }
 
     spinbox->range_max = max_value;
@@ -229,6 +232,11 @@ void lv_spinbox_set_max_value(lv_obj_t * obj, int32_t max_value)
         const int32_t max = (int32_t)max64;
         if(max_value < -max) max_value = -max;
         if(max_value > max) max_value = max;
+    }
+
+    /* Prevent overflow with LV_ABS(spinbox->range_max) used elsewhere. */
+    if(max_value == INT32_MIN) {
+        max_value = INT32_MIN + 1;
     }
 
     spinbox->range_max = max_value;
@@ -608,8 +616,10 @@ static void clamp_range_to_digit_count(lv_spinbox_t * spinbox)
 {
     int32_t max = (int32_t)lv_pow(10, spinbox->digit_count) - 1;
     int32_t min = -max;
-    if(spinbox->range_max > max || spinbox->range_max < min) spinbox->range_max = max;
-    if(spinbox->range_min > max || spinbox->range_min < min) spinbox->range_min = min;
+    if(spinbox->range_max > max) spinbox->range_max = max;
+    else if(spinbox->range_max < min) spinbox->range_max = min;
+    if(spinbox->range_min > max) spinbox->range_min = max;
+    else if(spinbox->range_min < min) spinbox->range_min = min;
     clamp_value_to_range(spinbox);
 }
 

--- a/src/widgets/spinbox/lv_spinbox.h
+++ b/src/widgets/spinbox/lv_spinbox.h
@@ -65,11 +65,10 @@ void lv_spinbox_set_rollover(lv_obj_t * obj, bool rollover);
 /**
  * Set spinbox digit format (digit count and decimal format)
  * @param obj           pointer to spinbox
- * @param digit_count   number of digit excluding the decimal separator and the sign
- * @param sep_pos       number of digit before the decimal point. If 0, decimal point is not
- * shown
+ * @param digit_count   number of digits excluding the decimal separator and the sign
+ * @param dec_point_pos number of digits before the decimal point (0 = no decimal point)
  */
-void lv_spinbox_set_digit_format(lv_obj_t * obj, uint32_t digit_count, uint32_t sep_pos);
+void lv_spinbox_set_digit_format(lv_obj_t * obj, uint32_t digit_count, uint32_t dec_point_pos);
 
 /**
  * Set the number of digits
@@ -81,7 +80,7 @@ void lv_spinbox_set_digit_count(lv_obj_t * obj, uint32_t digit_count);
 /**
  * Set the position of the decimal point
  * @param obj           pointer to spinbox
- * @param dec_point_pos 0: there is no separator, 2: two integer digits
+ * @param dec_point_pos number of digits before the decimal point (0 = no decimal point)
  */
 void lv_spinbox_set_dec_point_pos(lv_obj_t * obj, uint32_t dec_point_pos);
 
@@ -157,13 +156,13 @@ int32_t lv_spinbox_get_step(lv_obj_t * obj);
  *====================*/
 
 /**
- * Select next lower digit for edition by dividing the step by 10
+ * Select next lower digit for editing by dividing the step by 10
  * @param obj   pointer to spinbox
  */
 void lv_spinbox_step_next(lv_obj_t * obj);
 
 /**
- * Select next higher digit for edition by multiplying the step by 10
+ * Select next higher digit for editing by multiplying the step by 10
  * @param obj   pointer to spinbox
  */
 void lv_spinbox_step_prev(lv_obj_t * obj);

--- a/src/widgets/spinbox/lv_spinbox.h
+++ b/src/widgets/spinbox/lv_spinbox.h
@@ -87,7 +87,7 @@ void lv_spinbox_set_dec_point_pos(lv_obj_t * obj, uint32_t dec_point_pos);
 /**
  * Set spinbox step
  * @param obj   pointer to spinbox
- * @param step  steps on increment/decrement. Can be 1, 10, 100, 1000, etc the digit that will change.
+ * @param step  steps on increment/decrement. Can be 1, 10, 100, 1000, etc.; the digit that will change.
  */
 void lv_spinbox_set_step(lv_obj_t * obj, uint32_t step);
 


### PR DESCRIPTION
Fixes #9255

This PR fixes:

- A design error that was causing stack corruption.  Fixed using an O-O design principle.  See below.
- Several compiler warnings that were being generated under MSVC.
- Makes the 3rd argument and description of `lv_spinbox_set_digit_format()` consistent with the `dec_point_pos` argument of `lv_spinbox_set_dec_point_pos()` with the same meaning, so that it is clear in the API that they do indeed have the same meaning.
- Makes `dec_point_pos` range-checking logic consistent between
  - `lv_spinbox_set_dec_point_pos()` and
  - `lv_spinbox_set_digit_format()`.
- Makes range-checking of the 2 range values consistent between:
  - lv_spinbox_set_range(),
  - lv_spinbox_set_min_value(), and
  - lv_spinbox_set_max_value().
- Make `LV_SPINBOX_MAX_DIGIT_COUNT` have real meaning.  It is currently 10 as set in `lv_spinbox.h`, but this is an automatic digit-count limit of the `int32_t` which is the type of the Spinbox's `value` as well as both range values.  Assuming this value should have meaning in the code, range-checking logic in the range-setting functions was modified to use it to generate range-clamping code if it is ever < 10.  As long as it == 10, that code will be optimized away by the compiler.
- Improves clarity in `spinbox.rst` regarding some API elements.

## Cause of Stack Corruption

Surface cause:  Calling `lv_spinbox_set_range()` with range values that required more digits than the current `digit_count` caused `lv_spinbox_updatevalue()` calls (made after every setting change) to use a negative index on the `digits[]` array, and thus overwrote that number of bytes before that array on the stack.

Lower-level cause:  `lv_spinbox_updatevalue()` assumes `digit_count` and the 2 range values are in a consistent state.  When they are not in a consistent state (`digit_count` < size required by range), the above array boundary get violated.  This is an acceptable design assumption as long as no public API functions can cause them to be left in an inconsistent state.

### Design Error:

<u>Root cause</u>:  the following functions were allowing `digit_count` and the 2 range values to be left in an inconsistent state.

- lv_spinbox_set_range()
- lv_spinbox_set_min_value()
- lv_spinbox_set_max_value()
- lv_spinbox_set_digit_count()
- lv_spinbox_set_digit_format()

### Solution:

Fix those functions to never leave `digit_count` and the 2 range values in an inconsistent state.  This applies:

1. a "class invariant" (i.e. condition(s) which must be true before and after every public API call) which is:  the `digit_count` value must be at least large enough to accommodate the highest-magnitude range value;
2. an internal policy that the LAST item set (either `digit_count` or either of the range values) takes priority, i.e.:

    - Extend `digit_count` when needed when setting range values.
    - Clamp range values when needed when setting `digit_count`.


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
