### PR TITLE
chore(scripts/check_gcov_coverage): add analysis of specified file paths

### DIFF
--- a/scripts/check_gcov_coverage.py
+++ b/scripts/check_gcov_coverage.py
@@ -8,7 +8,7 @@ import json
 import re
 import sys
 import os
-from typing import Dict, Set, Tuple, List
+from typing import Dict, Set, Tuple, List, Optional
 
 
 def create_argument_parser() -> argparse.ArgumentParser:
@@ -22,6 +22,15 @@ def create_argument_parser() -> argparse.ArgumentParser:
         "--commit",
         help="Git commit hash, reference (e.g. HEAD, HEAD~1) or range (base...head)",
         default="HEAD",
+    )
+
+    parser.add_argument(
+        "--path",
+        metavar="PATH",
+        help=(
+            "Analyze coverage for a single file or a directory (relative or absolute path). "
+            "When specified, --commit is ignored."
+        ),
     )
 
     parser.add_argument(
@@ -212,6 +221,115 @@ def check_commit_coverage(
     return covered_lines, total_new_lines, uncovered_lines, skipped_noncoverable
 
 
+def check_path_coverage(path: str, root: str) -> Tuple[int, int, List[Tuple[str, int]]]:
+    """
+    Compute coverage for a specific file or directory.
+    Returns: (covered_lines, total_coverable_lines, uncovered_lines)
+    Notes:
+    - Only lines reported by gcovr as coverable are counted toward totals.
+    - If PATH is a directory, coverage is aggregated over all coverable files within it.
+    - If PATH is a file, coverage is computed only for that file.
+    """
+    # Normalize input path
+    abs_path = os.path.abspath(path)
+    # Ensure we operate from repo root to construct relative POSIX paths
+    root = os.path.abspath(root)
+
+    # Build relative POSIX target(s)
+    rel = os.path.relpath(abs_path, root)
+    rel_posix = rel.replace(os.path.sep, "/")
+
+    print("Getting coverage data...")
+    coverage_data = get_coverage_data(root)
+
+    covered = 0
+    total = 0
+    uncovered: List[Tuple[str, int]] = []
+
+    if os.path.isdir(abs_path):
+        # Directory scope: include all files under this directory
+        prefix = rel_posix.rstrip("/") + "/"
+        scoped_files = {
+            f: lines for f, lines in coverage_data.items() if f.startswith(prefix)
+        }
+        print(f"Found {len(scoped_files)} coverable file(s) under: {rel_posix}")
+        for filename, line_map in sorted(scoped_files.items()):
+            for lineno, count in line_map.items():
+                total += 1
+                if count > 0:
+                    covered += 1
+                else:
+                    uncovered.append((filename, lineno))
+    else:
+        # File scope
+        if rel_posix in coverage_data:
+            line_map = coverage_data[rel_posix]
+            print(f"Found coverable file: {rel_posix}")
+            for lineno, count in line_map.items():
+                total += 1
+                if count > 0:
+                    covered += 1
+                else:
+                    uncovered.append((rel_posix, lineno))
+        else:
+            print(
+                f"Warning: No coverable lines found for '{rel_posix}' in gcovr output."
+            )
+
+    return covered, total, uncovered
+
+
+def report_coverage(
+    header: str,
+    total: int,
+    covered: int,
+    uncovered: List[Tuple[str, int]],
+    fail_under: float,
+    *,
+    total_label: str,
+    skipped_noncoverable: Optional[int] = None,
+) -> int:
+    """
+    Print a standardized coverage report and return exit code (0/1).
+
+    - header: text to show in the report title (e.g., "commit <hash>", "'<path>'")
+    - total_label: label to use for the total line count (e.g.,
+      "New coverable lines (per gcovr)" for commit mode, or
+      "Coverable lines (per gcovr)" for path mode)
+    - skipped_noncoverable: when provided, prints the skipped non-coverable count
+    """
+
+    title = f" Coverage analysis results for {header} "
+    separator = "=" * len(title)
+    print(f"\n{separator}\n{title}\n{separator}")
+    print(f"{total_label}: {total}")
+    print(f"Covered lines: {covered}")
+    print(f"Uncovered lines: {len(uncovered)}")
+    if skipped_noncoverable is not None:
+        print(f"Skipped non-coverable changed lines: {skipped_noncoverable}")
+
+    retval = 0
+    if total > 0:
+        coverage_percent = (covered / total) * 100
+        print(f"Coverage: {coverage_percent:.2f}%")
+        if coverage_percent < fail_under:
+            print(
+                f"\n✗ Coverage {coverage_percent:.2f}% is below required {fail_under}%"
+            )
+            retval = 1
+
+    if uncovered:
+        print(
+            "\nUncovered lines (explicitly reported by gcovr as coverable with 0 hits):"
+        )
+        for filename, lineno in sorted(uncovered):
+            print(f"  {filename}:{lineno}")
+    else:
+        print(f"\n✓ Code coverage check passed!")
+
+    return retval
+
+
 def main() -> int:
     """Main entry point"""
     parser = create_argument_parser()
@@ -223,42 +341,33 @@ def main() -> int:
         os.chdir(root)
         print(f"Current working directory: {root}")
 
-        covered, total, uncovered, skipped_noncoverable = check_commit_coverage(
-            args.commit, root
-        )
+        if args.path:
+            # Path mode: ignore commit, compute coverage for file/dir
+            covered, total, uncovered = check_path_coverage(args.path, root)
 
-        # Print results with better formatting
-        title = f" Coverage analysis results for commit {args.commit} "
-        separator = "=" * len(title)
-        print(f"\n{separator}\n{title}\n{separator}")
-        print(f"New coverable lines (per gcovr): {total}")
-        print(f"Covered lines: {covered}")
-        print(f"Uncovered lines: {len(uncovered)}")
-        print(f"Skipped non-coverable changed lines: {skipped_noncoverable}")
-        retval = 0
-
-        if total > 0:
-            coverage_percent = (covered / total) * 100
-            print(f"Coverage: {coverage_percent:.2f}%")
-
-            # Check if coverage meets minimum requirement
-            if coverage_percent < args.fail_under:
-                print(
-                    f"\n✗ Coverage {coverage_percent:.2f}% is below required {args.fail_under}%"
-                )
-                retval = 1
-
-        if uncovered:
-            print(
-                "\nUncovered lines (explicitly reported by gcovr as coverable with 0 hits):"
+            return report_coverage(
+                header=f"'{args.path}'",
+                total=total,
+                covered=covered,
+                uncovered=uncovered,
+                fail_under=args.fail_under,
+                total_label="Coverable lines (per gcovr)",
             )
-            for filename, lineno in sorted(uncovered):
-                print(f"  {filename}:{lineno}")
+        else:
+            # Commit mode: default behavior
+            covered, total, uncovered, skipped_noncoverable = check_commit_coverage(
+                args.commit, root
+            )
 
-            return retval
-
-        print("\n✓ All new coverable code is covered!")
-        return retval
+            return report_coverage(
+                header=f"commit {args.commit}",
+                total=total,
+                covered=covered,
+                uncovered=uncovered,
+                fail_under=args.fail_under,
+                total_label="New coverable lines (per gcovr)",
+                skipped_noncoverable=skipped_noncoverable,
+            )
 
     except subprocess.CalledProcessError as e:
         print(f"Error: Command failed - {e}", file=sys.stderr)


### PR DESCRIPTION
Add `--path` parameter, it can be used to analyze the coverage of a specified directory or a single file.

E.g.
```bash
> ./scripts/check_gcov_coverage.py --path src/widgets/bar   
Current working directory: lvgl
Getting coverage data...
Found 1 coverable file(s) under: src/widgets/bar

=================================================
 Coverage analysis results for 'src/widgets/bar' 
=================================================
Coverable lines (per gcovr): 327
Covered lines: 307
Uncovered lines: 20
Coverage: 93.88%

Uncovered lines (explicitly reported by gcovr as coverable with 0 hits):
  src/widgets/bar/lv_bar.c:143
  src/widgets/bar/lv_bar.c:144
  src/widgets/bar/lv_bar.c:147
  src/widgets/bar/lv_bar.c:148
  src/widgets/bar/lv_bar.c:280
  src/widgets/bar/lv_bar.c:304
  src/widgets/bar/lv_bar.c:305
  src/widgets/bar/lv_bar.c:395
  src/widgets/bar/lv_bar.c:400
  src/widgets/bar/lv_bar.c:401
  src/widgets/bar/lv_bar.c:409
  src/widgets/bar/lv_bar.c:410
  src/widgets/bar/lv_bar.c:411
  src/widgets/bar/lv_bar.c:412
  src/widgets/bar/lv_bar.c:414
  src/widgets/bar/lv_bar.c:416
  src/widgets/bar/lv_bar.c:417
  src/widgets/bar/lv_bar.c:418
  src/widgets/bar/lv_bar.c:421
  src/widgets/bar/lv_bar.c:422

> ./scripts/check_gcov_coverage.py --path src/widgets/button/lv_button.c
Current working directory: lvgl
Getting coverage data...
Found coverable file: src/widgets/button/lv_button.c

================================================================
 Coverage analysis results for 'src/widgets/button/lv_button.c' 
================================================================
Coverable lines (per gcovr): 11
Covered lines: 11
Uncovered lines: 0
Coverage: 100.00%

✓ Code coverage check passed!
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
