### PR TITLE
docs(CHANGELOG): fix omission of lv meter -> lv_scale in v9.0 CHANGELOG

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -139,6 +139,8 @@ Others
    used instead
 - ``lv_msgbox`` is update to be more flexible. It uses normal button instead of button matrix
 - ``lv_tabview`` was updated to user real button instead of a button matrix
+- ``lv_meter`` is removed and replaced by
+  `lv_scale <https://docs.lvgl.io/master/widgets/scale.html>`__
 
 
 v8.3


### PR DESCRIPTION
Fixes #9244 

This PR fixes the omission of mention that `lv_meter` Widget was replaced by `lv_scale` in LVGL v9.0.

Note that it is targeted for the docs in the `release/v9.0` branch.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
