### PR TITLE
ci(tests): retain the gcov report for coverage analysis

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -134,7 +134,7 @@ jobs:
       if: matrix.build_config == '32bit build'
       run: echo "NON_AMD64_BUILD=1" >> $GITHUB_ENV
     - name: Run tests
-      run: python tests/main.py --report --update-image test --auto-clean
+      run: python tests/main.py --report --update-image test --auto-clean --keep-report
     - name: Code coverage analysis
       run: |
         if [ "${{ github.event_name }}" = "pull_request" ]; then

--- a/tests/main.py
+++ b/tests/main.py
@@ -251,6 +251,8 @@ if __name__ == "__main__":
                         help='Update test image using LVGLImage.py script')
     parser.add_argument('--auto-clean', action='store_true', default=False,
                         help='Automatically clean build directories')
+    parser.add_argument('--keep-report', action='store_true', default=False,
+                        help='Skip cleaning gcov report files when --auto-clean and --report are enabled')
 
     args = parser.parse_args()
 
@@ -296,8 +298,13 @@ if __name__ == "__main__":
                 # the rest to solve the storage capacity limit of GitHub CI
                 clean_filters = ['CMakeFiles', '.c']
                 clean_build_dirs_with_filter(build_dir, clean_filters)
-                print(f"Append {build_dir} to clean list")
-                clean_build_dirs.append(build_dir)
+
+                if args.keep_report:
+                    # Retain the gcov report files for subsequent automated coverage analysis.
+                    print(f"Keeping {build_dir} for report")
+                else:
+                    print(f"Append {build_dir} to clean list")
+                    clean_build_dirs.append(build_dir)
             else:
                 # Remove all build directories directly
                 print(f"Removing {build_dir}")


### PR DESCRIPTION
Retain the gcov report for subsequent automatic coverage analysis.
Currently, because compilation artifacts (including coverage reports) are automatically cleaned up after testing, the code coverage analysis process may not be able to obtain coverage results.

![img_v3_02s8_794565e8-8bef-4e96-b1b6-76745d274c5g](https://github.com/user-attachments/assets/353863de-cc9e-40e6-afa7-014434538bc2)

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
