### PR TITLE
fix(screen): double free when loading screens

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -1149,7 +1149,7 @@ static void screen_create_on_trigger_event_cb(lv_event_t * e)
     LV_ASSERT_NULL(dsc);
 
     lv_obj_t * screen = dsc->target.create_cb();
-    lv_screen_load_anim(screen, dsc->anim_type, dsc->duration, dsc->delay, false);
+    lv_screen_load_anim(screen, dsc->anim_type, dsc->duration, dsc->delay, true);
     lv_obj_add_event_cb(screen, delete_on_screen_unloaded_event_cb, LV_EVENT_SCREEN_UNLOADED, NULL);
 }
 

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -1149,7 +1149,7 @@ static void screen_create_on_trigger_event_cb(lv_event_t * e)
     LV_ASSERT_NULL(dsc);
 
     lv_obj_t * screen = dsc->target.create_cb();
-    lv_screen_load_anim(screen, dsc->anim_type, dsc->duration, dsc->delay, true);
+    lv_screen_load_anim(screen, dsc->anim_type, dsc->duration, dsc->delay, false);
     lv_obj_add_event_cb(screen, delete_on_screen_unloaded_event_cb, LV_EVENT_SCREEN_UNLOADED, NULL);
 }
 

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -1317,12 +1317,10 @@ static bool load_new_screen(lv_obj_t * scr)
     LV_ASSERT_NULL(d);
 
     lv_obj_t * old_scr = d->act_scr;
-    lv_result_t res;
     bool old_screen_deleted = false;
     if(old_scr) {
-        res = lv_obj_send_event(old_scr, LV_EVENT_SCREEN_UNLOAD_START, NULL);
-        old_screen_deleted = res == LV_RESULT_INVALID;
-        if(old_screen_deleted) {
+        if(lv_obj_send_event(old_scr, LV_EVENT_SCREEN_UNLOAD_START, NULL) == LV_RESULT_INVALID) {
+            old_screen_deleted = true;
             old_scr = NULL;
         }
     }
@@ -1333,8 +1331,9 @@ static bool load_new_screen(lv_obj_t * scr)
 
     lv_obj_send_event(scr, LV_EVENT_SCREEN_LOADED, NULL);
     if(old_scr) {
-        res = lv_obj_send_event(old_scr, LV_EVENT_SCREEN_UNLOADED, NULL);
-        old_screen_deleted |= res == LV_RESULT_INVALID;
+        if(lv_obj_send_event(old_scr, LV_EVENT_SCREEN_UNLOADED, NULL) == LV_RESULT_INVALID) {
+            old_screen_deleted = true;
+        }
     }
 
     lv_obj_invalidate(scr);
@@ -1370,8 +1369,7 @@ static void scr_anim_completed(lv_anim_t * a)
 {
     lv_display_t * d = lv_obj_get_display(a->var);
 
-    lv_result_t res = lv_obj_send_event(d->act_scr, LV_EVENT_SCREEN_LOADED, NULL);
-    if(res == LV_RESULT_INVALID) {
+    if(lv_obj_send_event(d->act_scr, LV_EVENT_SCREEN_LOADED, NULL) == LV_RESULT_INVALID) {
         d->act_scr = NULL;
     }
 

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -1322,7 +1322,9 @@ static bool load_new_screen(lv_obj_t * scr)
     if(old_scr) {
         res = lv_obj_send_event(old_scr, LV_EVENT_SCREEN_UNLOAD_START, NULL);
         old_screen_deleted = res == LV_RESULT_INVALID;
-        old_scr = NULL;
+        if(old_screen_deleted) {
+            old_scr = NULL;
+        }
     }
     lv_obj_send_event(scr, LV_EVENT_SCREEN_LOAD_START, NULL);
 

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -1368,15 +1368,23 @@ static void scr_anim_completed(lv_anim_t * a)
 {
     lv_display_t * d = lv_obj_get_display(a->var);
 
-    lv_obj_send_event(d->act_scr, LV_EVENT_SCREEN_LOADED, NULL);
-    lv_obj_send_event(d->prev_scr, LV_EVENT_SCREEN_UNLOADED, NULL);
+    lv_result_t res = lv_obj_send_event(d->act_scr, LV_EVENT_SCREEN_LOADED, NULL);
+    if(res == LV_RESULT_INVALID) {
+        d->act_scr = NULL;
+    }
 
-    if(d->prev_scr && d->del_prev) lv_obj_delete(d->prev_scr);
+    if(d->prev_scr && lv_obj_send_event(d->prev_scr, LV_EVENT_SCREEN_UNLOADED, NULL) != LV_RESULT_INVALID) {
+        if(d->del_prev) {
+            lv_obj_delete(d->prev_scr);
+        }
+    }
     d->prev_scr = NULL;
     d->draw_prev_over_act = false;
     d->scr_to_load = NULL;
     lv_obj_remove_local_style_prop(a->var, LV_STYLE_OPA, 0);
-    lv_obj_invalidate(d->act_scr);
+    if(d->act_scr) {
+        lv_obj_invalidate(d->act_scr);
+    }
 }
 
 static bool is_out_anim(lv_screen_load_anim_t anim_type)

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -1322,6 +1322,7 @@ static bool load_new_screen(lv_obj_t * scr)
     if(old_scr) {
         res = lv_obj_send_event(old_scr, LV_EVENT_SCREEN_UNLOAD_START, NULL);
         old_screen_deleted = res == LV_RESULT_INVALID;
+        old_scr = NULL;
     }
     lv_obj_send_event(scr, LV_EVENT_SCREEN_LOAD_START, NULL);
 

--- a/tests/src/test_cases/test_screen_load.c
+++ b/tests/src/test_cases/test_screen_load.c
@@ -132,13 +132,14 @@ void test_screen_load_with_delete_event(void)
     TEST_ASSERT_EQUAL(lv_obj_is_valid(screen_with_anim_4), true);
 }
 
-static lv_obj_t * screen_create_trigger;
+static void unloaded_event_cb(lv_event_t * e)
+{
+    lv_free(lv_event_get_target_obj(e));
+}
 
 static lv_obj_t * screen_create(void)
 {
     lv_obj_t * screen = lv_obj_create(NULL);
-    screen_create_trigger = lv_obj_create(screen);
-    lv_obj_add_screen_create_event(screen_create_trigger, LV_EVENT_CLICKED, screen_create, LV_SCREEN_LOAD_ANIM_NONE, 0, 0);
     return screen;
 }
 
@@ -147,12 +148,19 @@ void test_screen_mix_event_and_manual_creation(void)
     lv_obj_delete(lv_screen_active());
     size_t free_mem = lv_test_get_free_mem();
 
-    for(size_t i = 0; i < 20; ++i) {
-        lv_screen_load_anim(screen_create(), LV_SCREEN_LOAD_ANIM_NONE, 0, 0, true);
-        lv_obj_send_event(screen_create_trigger, LV_EVENT_CLICKED, NULL);
-    }
+    lv_obj_t * screen = lv_obj_create(NULL);
+    lv_obj_t * screen_create_trigger = lv_obj_create(screen);
+    lv_obj_add_event_cb(screen, unloaded_event_cb, LV_EVENT_SCREEN_UNLOADED, NULL);
+    lv_obj_add_screen_create_event(screen_create_trigger, LV_EVENT_CLICKED, screen_create, LV_SCREEN_LOAD_ANIM_NONE, 0, 0);
+
+    /* Load a new screen by pressing the create button. The current screen is deleted in our unloaded event cb*/
+    lv_obj_send_event(screen_create_trigger, LV_EVENT_CLICKED, NULL);
+
+    /* Manually loading a screen with auto delete set to `true` should not create a double free */
+    lv_screen_load_anim(screen, LV_SCREEN_LOAD_ANIM_NONE, 0, 0, true);
 
     lv_obj_delete(lv_screen_active());
+
     TEST_ASSERT_MEM_LEAK_LESS_THAN(free_mem, 32);
 }
 

--- a/tests/src/test_cases/test_screen_load.c
+++ b/tests/src/test_cases/test_screen_load.c
@@ -132,4 +132,28 @@ void test_screen_load_with_delete_event(void)
     TEST_ASSERT_EQUAL(lv_obj_is_valid(screen_with_anim_4), true);
 }
 
+static lv_obj_t * screen_create_trigger;
+
+static lv_obj_t * screen_create(void)
+{
+    lv_obj_t * screen = lv_obj_create(NULL);
+    screen_create_trigger = lv_obj_create(screen);
+    lv_obj_add_screen_create_event(screen_create_trigger, LV_EVENT_CLICKED, screen_create, LV_SCREEN_LOAD_ANIM_NONE, 0, 0);
+    return screen;
+}
+
+void test_screen_mix_event_and_manual_creation(void)
+{
+    lv_obj_delete(lv_screen_active());
+    size_t free_mem = lv_test_get_free_mem();
+
+    for(size_t i = 0; i < 20; ++i) {
+        lv_screen_load_anim(screen_create(), LV_SCREEN_LOAD_ANIM_NONE, 0, 0, true);
+        lv_obj_send_event(screen_create_trigger, LV_EVENT_CLICKED, NULL);
+    }
+
+    lv_obj_delete(lv_screen_active());
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(free_mem, 32);
+}
+
 #endif

--- a/tests/src/test_cases/test_screen_load.c
+++ b/tests/src/test_cases/test_screen_load.c
@@ -156,7 +156,7 @@ void test_screen_mix_event_and_manual_creation(void)
     /* Load a new screen by pressing the create button. The current screen is deleted in our unloaded event cb*/
     lv_obj_send_event(screen_create_trigger, LV_EVENT_CLICKED, NULL);
 
-    /* Manually loading a screen with auto delete set to `true` should not create a double free */
+    /* Manually loading a screen with auto delete set to `true` should not lead to a double free */
     lv_screen_load_anim(screen, LV_SCREEN_LOAD_ANIM_NONE, 0, 0, true);
 
     lv_obj_delete(lv_screen_active());


### PR DESCRIPTION
Test showcases the issue

Without the changes to `lv_display.c`:

```bash
/lvgl/tests/src/test_cases/test_screen_load.c:56:test_screen_mix_event_and_manual_creation:INFO: [Error]\x09(1.500, +0)\x09 lv_obj_delete: Asserted at expression: lv_obj_has_class(obj, (&lv_obj_class)) == true (Incompatible object type.) lv_obj_tree.c:62

test_screen_load: /home/andre/dev/lvgl/lv_port_pc_vscode/lvgl/tests/src/lv_test_init.c:65: lv_test_assert_fail: Assertion `false' failed.
```

This is because the screen is deleted twice, once in the `UNLOADED` event and a second time in `lv_screen_load_anim`

cc @giobauermeister 