### PR TITLE
fix(spinbox):  fix several issues with Spinbox...

### DIFF
--- a/docs/src/widgets/spinbox.rst
+++ b/docs/src/widgets/spinbox.rst
@@ -28,13 +28,15 @@ Value, range and step
 
 - :cpp:expr:`lv_spinbox_set_value(spinbox, 1234)` sets a new value for the Spinbox.
 - :cpp:expr:`lv_spinbox_increment(spinbox)` and :cpp:expr:`lv_spinbox_decrement(spinbox)`
-  increments/decrements the value of the Spinbox according to the currently-selected digit.
+  increment/decrement the Spinbox's value by the `step` value, effectively incrementing
+  or decrementing the value of the selected digit by 1.
 - :cpp:expr:`lv_spinbox_set_range(spinbox, -1000, 2500)` sets its range. If the
   value is changed by :cpp:expr:`lv_spinbox_set_value(spinbox)`, by *Keys*,
   by :cpp:expr:`lv_spinbox_increment(spinbox)` or :cpp:expr:`lv_spinbox_decrement(spinbox)`
   this range will be respected.
-- :cpp:expr:`lv_spinbox_set_step(spinbox, 100)` sets which digit to change on
-  increment/decrement. Only multiples of ten can be set.
+- :cpp:expr:`lv_spinbox_set_step(spinbox, 100)` sets `step` value to
+  increment/decrement.  It is designed to be a power of 10 (1, 10, 100, etc.) so that
+  setting it simultaneously determines which digit is selected.
 - :cpp:expr:`lv_spinbox_set_cursor_pos(spinbox, 1)` sets the cursor to a specific
   digit to change on increment/decrement. Position '0' sets the cursor to
   the least significant digit.

--- a/docs/src/widgets/spinbox.rst
+++ b/docs/src/widgets/spinbox.rst
@@ -28,13 +28,13 @@ Value, range and step
 
 - :cpp:expr:`lv_spinbox_set_value(spinbox, 1234)` sets a new value for the Spinbox.
 - :cpp:expr:`lv_spinbox_increment(spinbox)` and :cpp:expr:`lv_spinbox_decrement(spinbox)`
-  increment/decrement the Spinbox's value by the `step` value, effectively incrementing
+  increment/decrement the Spinbox's value by the ``step`` value, effectively incrementing
   or decrementing the value of the selected digit by 1.
 - :cpp:expr:`lv_spinbox_set_range(spinbox, -1000, 2500)` sets its range. If the
   value is changed by :cpp:expr:`lv_spinbox_set_value(spinbox)`, by *Keys*,
   by :cpp:expr:`lv_spinbox_increment(spinbox)` or :cpp:expr:`lv_spinbox_decrement(spinbox)`
   this range will be respected.
-- :cpp:expr:`lv_spinbox_set_step(spinbox, 100)` sets `step` value to
+- :cpp:expr:`lv_spinbox_set_step(spinbox, 100)` sets ``step`` value to
   increment/decrement.  It is designed to be a power of 10 (1, 10, 100, etc.) so that
   setting it simultaneously determines which digit is selected.
 - :cpp:expr:`lv_spinbox_set_cursor_pos(spinbox, 1)` sets the cursor to a specific

--- a/src/widgets/spinbox/lv_spinbox.c
+++ b/src/widgets/spinbox/lv_spinbox.c
@@ -92,14 +92,14 @@ void lv_spinbox_set_rollover(lv_obj_t * obj, bool rollover)
     spinbox->rollover = rollover;
 }
 
-void lv_spinbox_set_digit_format(lv_obj_t * obj, uint32_t digit_count, uint32_t sep_pos)
+void lv_spinbox_set_digit_format(lv_obj_t * obj, uint32_t digit_count, uint32_t dec_point_pos)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_spinbox_t * spinbox = (lv_spinbox_t *)obj;
 
     if(digit_count > LV_SPINBOX_MAX_DIGIT_COUNT) digit_count = LV_SPINBOX_MAX_DIGIT_COUNT;
 
-    if(sep_pos >= digit_count) sep_pos = 0;
+    if(dec_point_pos >= digit_count) dec_point_pos = 0;
 
     if(digit_count < LV_SPINBOX_MAX_DIGIT_COUNT) {
         const int64_t max_val = lv_pow(10, digit_count);
@@ -108,7 +108,7 @@ void lv_spinbox_set_digit_format(lv_obj_t * obj, uint32_t digit_count, uint32_t 
     }
 
     spinbox->digit_count   = digit_count;
-    spinbox->dec_point_pos = sep_pos;
+    spinbox->dec_point_pos = dec_point_pos;
 
     lv_spinbox_updatevalue(obj);
 }

--- a/src/widgets/spinbox/lv_spinbox.c
+++ b/src/widgets/spinbox/lv_spinbox.c
@@ -187,6 +187,7 @@ void lv_spinbox_set_max_value(lv_obj_t * obj, int32_t max_value)
 void lv_spinbox_set_cursor_pos(lv_obj_t * obj, uint32_t pos)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
+    if (pos >= LV_SPINBOX_MAX_DIGIT_COUNT) return;  /* Avoid overflow in `new_step` below. */
     lv_spinbox_t * spinbox = (lv_spinbox_t *)obj;
 
     const int32_t step_limit = LV_MAX(spinbox->range_max, LV_ABS(spinbox->range_min));

--- a/src/widgets/spinbox/lv_spinbox.c
+++ b/src/widgets/spinbox/lv_spinbox.c
@@ -187,7 +187,7 @@ void lv_spinbox_set_max_value(lv_obj_t * obj, int32_t max_value)
 void lv_spinbox_set_cursor_pos(lv_obj_t * obj, uint32_t pos)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
-    if (pos >= LV_SPINBOX_MAX_DIGIT_COUNT) return;  /* Avoid overflow in `new_step` below. */
+    if(pos >= LV_SPINBOX_MAX_DIGIT_COUNT) return;   /* Avoid overflow in `new_step` below. */
     lv_spinbox_t * spinbox = (lv_spinbox_t *)obj;
 
     const int32_t step_limit = LV_MAX(spinbox->range_max, LV_ABS(spinbox->range_min));

--- a/src/widgets/spinbox/lv_spinbox.c
+++ b/src/widgets/spinbox/lv_spinbox.c
@@ -102,7 +102,9 @@ void lv_spinbox_set_digit_format(lv_obj_t * obj, uint32_t digit_count, uint32_t 
     if(dec_point_pos >= digit_count) dec_point_pos = 0;
 
     if(digit_count < LV_SPINBOX_MAX_DIGIT_COUNT) {
-        const int64_t max_val = lv_pow(10, digit_count);
+        /* It is important that `digit_count` never be >= 10 here, or else the
+         * value returned from `lv_pow()` will overflow. */
+        const int32_t max_val = (int32_t)lv_pow(10, digit_count);
         if(spinbox->range_max > max_val - 1) spinbox->range_max = max_val - 1;
         if(spinbox->range_min < -max_val  + 1) spinbox->range_min = -max_val  + 1;
     }
@@ -188,7 +190,7 @@ void lv_spinbox_set_cursor_pos(lv_obj_t * obj, uint32_t pos)
     lv_spinbox_t * spinbox = (lv_spinbox_t *)obj;
 
     const int32_t step_limit = LV_MAX(spinbox->range_max, LV_ABS(spinbox->range_min));
-    const int32_t new_step = lv_pow(10, pos);
+    const int32_t new_step = (int32_t)lv_pow(10, pos);
 
     if(pos <= 0) spinbox->step = 1;
     else if(new_step <= step_limit) spinbox->step = new_step;
@@ -387,12 +389,12 @@ static void lv_spinbox_event(const lv_obj_class_t * class_p, lv_event_t * e)
                     }
                     else {
                         /*Restart from the MSB*/
-                        spinbox->step = lv_pow(10, spinbox->digit_count - 2);
+                        spinbox->step = (int32_t)lv_pow(10, spinbox->digit_count - 2);
                         lv_spinbox_step_prev(obj);
                     }
                 }
                 else {
-                    if(spinbox->step < lv_pow(10, spinbox->digit_count - 1)) {
+                    if(spinbox->step < (int32_t)lv_pow(10, spinbox->digit_count - 1)) {
                         lv_spinbox_step_prev(obj);
                     }
                     else {
@@ -416,7 +418,7 @@ static void lv_spinbox_event(const lv_obj_class_t * class_p, lv_event_t * e)
             }
             /* Cursor is already in the right-most digit */
             else if(spinbox->ta.cursor.pos == (uint32_t)txt_len) {
-                lv_textarea_set_cursor_pos(obj, txt_len - 1);
+                lv_textarea_set_cursor_pos(obj, (int32_t)txt_len - 1);
             }
             /* Cursor is already in the left-most digit AND range_min is negative */
             else if(spinbox->ta.cursor.pos == 0 && spinbox->range_min < 0) {
@@ -427,7 +429,7 @@ static void lv_spinbox_event(const lv_obj_class_t * class_p, lv_event_t * e)
             uint32_t cp = spinbox->ta.cursor.pos;
             if(spinbox->ta.cursor.pos > spinbox->dec_point_pos && spinbox->dec_point_pos != 0) cp--;
 
-            const size_t len = spinbox->digit_count - 1;
+            const uint32_t len = spinbox->digit_count - 1;
             uint32_t pos = len - cp;
 
             if(spinbox->range_min < 0) pos++;
@@ -492,9 +494,9 @@ static void lv_spinbox_updatevalue(lv_obj_t * obj)
 
     /*Add leading zeros*/
     int32_t i;
-    const size_t digits_len = lv_strlen(digits);
+    const uint32_t digits_len = (uint32_t)lv_strlen(digits);
 
-    const int leading_zeros_cnt = spinbox->digit_count - digits_len;
+    const int leading_zeros_cnt = (int)(spinbox->digit_count - digits_len);
     if(leading_zeros_cnt) {
         for(i = (int32_t) digits_len; i >= 0; i--) {
             digits[i + leading_zeros_cnt] = digits[i];
@@ -517,7 +519,7 @@ static void lv_spinbox_updatevalue(lv_obj_t * obj)
         (*buf_p) = '.';
         buf_p++;
 
-        for(/*Leave i*/; i < spinbox->digit_count && digits[i] != '\0'; i++) {
+        for(/*Leave i*/; i < (int32_t)spinbox->digit_count && digits[i] != '\0'; i++) {
             (*buf_p) = digits[i];
             buf_p++;
         }

--- a/src/widgets/spinbox/lv_spinbox.h
+++ b/src/widgets/spinbox/lv_spinbox.h
@@ -64,12 +64,11 @@ void lv_spinbox_set_rollover(lv_obj_t * obj, bool rollover);
 
 /**
  * Set spinbox digit format (digit count and decimal format)
- * @param obj           pointer to spinbox
- * @param digit_count   number of digit excluding the decimal separator and the sign
- * @param sep_pos       number of digit before the decimal point. If 0, decimal point is not
- * shown
+ * @param obj            pointer to spinbox
+ * @param digit_count    number of digit excluding the decimal separator and the sign
+ * @param dec_point_pos  number of digits before the decimal point; 0 = no decimal point
  */
-void lv_spinbox_set_digit_format(lv_obj_t * obj, uint32_t digit_count, uint32_t sep_pos);
+void lv_spinbox_set_digit_format(lv_obj_t * obj, uint32_t digit_count, uint32_t dec_point_pos);
 
 /**
  * Set the number of digits
@@ -80,8 +79,8 @@ void lv_spinbox_set_digit_count(lv_obj_t * obj, uint32_t digit_count);
 
 /**
  * Set the position of the decimal point
- * @param obj           pointer to spinbox
- * @param dec_point_pos 0: there is no separator, 2: two integer digits
+ * @param obj            pointer to spinbox
+ * @param dec_point_pos  number of digits before the decimal point; 0 = no decimal point
  */
 void lv_spinbox_set_dec_point_pos(lv_obj_t * obj, uint32_t dec_point_pos);
 


### PR DESCRIPTION
This PR supplements PR #9256:

1.  standardize API arg names and descriptions for consistency (sep_pos → dec_point_pos);
2.  eliminate MSVC compiler warnings;
3.  avoid numeric overflow in `lv_spinbox_set_cursor_pos()`;
4.  docs(spinbox.rst):  improve description clarity for 3 API functions.

cc:  @kisvegabor

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
