### PR TITLE
fix(label): skip label draw if width is negative

### DIFF
--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -106,7 +106,10 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_label(lv_layer_t * layer, const lv_draw_label
         LV_LOG_WARN("dsc->font == NULL");
         return;
     }
-
+    if(coords->x1 > coords->x2) {
+        /* Attempting to draw a label too small (negative width), cancel to avoid error */
+        return;
+    }
     LV_PROFILER_DRAW_BEGIN;
     lv_draw_task_t * t = lv_draw_add_task(layer, coords, LV_DRAW_TASK_TYPE_LABEL);
 


### PR DESCRIPTION
While testing the gltf demo, I noticed that if I apply display rotation of 90 degrees, and set the demo_gltf to 50% height/width instead of 100% like normal, while running at a resolution of 1280x720, the app would experience a memory error and would fail.  After further investigation it was found that attempting to call lv_draw_label() with a negative width was the cause.   In my test case, this was caused by a dropdown being so thin that when it tried to remove the symbol width from the text width, there was not enough text width to start with and this resulted in a negative x dimension passed to lv_draw_label.

This PR provides an immediate fix for that so we can investigate further, if needed.