### PR TITLE
fix(sdl): do not dereferencing nullptr in lv_sdl_mouse_handler if an invalid windows id (0) has been received

### DIFF
--- a/src/drivers/sdl/lv_sdl_mouse.c
+++ b/src/drivers/sdl/lv_sdl_mouse.c
@@ -128,6 +128,7 @@ void lv_sdl_mouse_handler(SDL_Event * event)
     }
 
     lv_display_t * disp = lv_sdl_get_disp_from_win_id(win_id);
+    if(disp == NULL) return;
 
     /*Find a suitable indev*/
     lv_indev_t * indev = lv_indev_get_next(NULL);


### PR DESCRIPTION
Fixes #8608

Hard to reproduce. We are using multiple SDL displays at the same time and switching between them (using `lv_display_set_default`. Just checking if `disp` is valid solves it.
