### PR TITLE
fix(obj): don't call objid_builtin_destroy if obj_id is not enabled

### DIFF
--- a/src/lv_init.c
+++ b/src/lv_init.c
@@ -395,7 +395,7 @@ void lv_deinit(void)
     lv_profiler_builtin_uninit();
 #endif
 
-#if LV_USE_OBJ_ID_BUILTIN
+#if LV_USE_OBJ_ID && LV_USE_OBJ_ID_BUILTIN
     lv_objid_builtin_destroy();
 #endif
 


### PR DESCRIPTION
Follow up PR to fix docs CI in v9.0 https://github.com/lvgl/lvgl/actions/runs/19672297638/job/56344045995