### PR TITLE
chore(doc_builder):  fix doc-build after xml parser changes

### DIFF
--- a/docs/build.py
+++ b/docs/build.py
@@ -78,7 +78,7 @@ def cmd(s):
 # Get the current branch name
 status, br = subprocess.getstatusoutput("git branch")
 _, gitcommit = subprocess.getstatusoutput("git rev-parse HEAD")
-br = re.sub('\* ', '', br)
+br = re.sub(r'\* ', '', br)
 
 
 urlpath = re.sub('release/', '', br)

--- a/docs/doc_builder.py
+++ b/docs/doc_builder.py
@@ -296,15 +296,19 @@ class FILE(object):
 
             cls = globals()[member.attrib['kind'].upper()]
             if cls == ENUM:
-                member.attrib['name'] = member[0].text.strip()
-                enums_.append(cls(self, **member.attrib))
+                if member[0].text is not None:
+                    member.attrib['name'] = member[0].text.strip()
+                    enums_.append(cls(self, **member.attrib))
             elif cls == ENUMVALUE:
-                if enums_[-1].is_member(member):
-                    enums_[-1].add_member(member)
+                if enums_:
+                    if enums_[-1] is not None:
+                        if enums_[-1].is_member(member):
+                            enums_[-1].add_member(member)
 
             else:
-                member.attrib['name'] = member[0].text.strip()
-                cls(self, **member.attrib)
+                if member[0].text is not None:
+                    member.attrib['name'] = member[0].text.strip()
+                    cls(self, **member.attrib)
 
 
 class ENUM(object):


### PR DESCRIPTION
...apparent change in behavior of `xml.etree` XML parser.

Note:  the change in `build.py` removes a warning that the current Python emits.

cc:  @AndreCostaaa @liamHowatt 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
