### PR TITLE
Add Kconfig knobs for scroll animation duration

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -784,6 +784,19 @@ menu "LVGL configuration"
 					Add a name table to every widget class, so the property can be accessed by name.
 					Note, the const table will increase flash usage.
 
+			config LV_SCROLL_ANIM_TIME_MIN
+				int "Minimum scroll animation time (ms)"
+				default 200
+				help
+					Lower bound of the automatically calculated scroll animation duration.
+
+			config LV_SCROLL_ANIM_TIME_MAX
+				int "Maximum scroll animation time (ms)"
+				default 400
+				help
+					Upper bound of the automatically calculated scroll animation duration.
+					Should be greater than or equal to the minimum value.
+
 			config LV_USE_VG_LITE_THORVG
 				bool "VG-Lite Simulator"
 				default n

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -1393,6 +1393,12 @@
     #define LV_QNX_BUF_COUNT        1    /**< 1 or 2 */
 #endif
 
+/** Minimum scroll animation time in milliseconds */
+#define LV_SCROLL_ANIM_TIME_MIN 200
+
+/** Maximum scroll animation time in milliseconds */
+#define LV_SCROLL_ANIM_TIME_MAX 400
+
 /*=====================
 * BUILD OPTIONS
 *======================*/

--- a/src/core/lv_obj_scroll.c
+++ b/src/core/lv_obj_scroll.c
@@ -18,12 +18,6 @@
  *      DEFINES
  *********************/
 #define MY_CLASS (&lv_obj_class)
-#ifndef SCROLL_ANIM_TIME_MIN
-    #define SCROLL_ANIM_TIME_MIN    200    /*ms*/
-#endif
-#ifndef SCROLL_ANIM_TIME_MAX
-    #define SCROLL_ANIM_TIME_MAX    400    /*ms*/
-#endif
 #define SCROLLBAR_MIN_SIZE      (LV_DPX(10))
 
 /**********************
@@ -318,8 +312,8 @@ void lv_obj_scroll_by(lv_obj_t * obj, int32_t dx, int32_t dy, lv_anim_enable_t a
         lv_anim_set_deleted_cb(&a, scroll_end_cb);
 
         if(dx) {
-            uint32_t t = lv_anim_speed_clamped((lv_display_get_horizontal_resolution(d)) >> 1, SCROLL_ANIM_TIME_MIN,
-                                               SCROLL_ANIM_TIME_MAX);
+            uint32_t t = lv_anim_speed_clamped((lv_display_get_horizontal_resolution(d)) >> 1, LV_SCROLL_ANIM_TIME_MIN,
+                                               LV_SCROLL_ANIM_TIME_MAX);
             lv_anim_set_duration(&a, t);
             int32_t sx = lv_obj_get_scroll_x(obj);
             lv_anim_set_values(&a, -sx, -sx + dx);
@@ -333,8 +327,8 @@ void lv_obj_scroll_by(lv_obj_t * obj, int32_t dx, int32_t dy, lv_anim_enable_t a
         }
 
         if(dy) {
-            uint32_t t = lv_anim_speed_clamped((lv_display_get_vertical_resolution(d)) >> 1, SCROLL_ANIM_TIME_MIN,
-                                               SCROLL_ANIM_TIME_MAX);
+            uint32_t t = lv_anim_speed_clamped((lv_display_get_vertical_resolution(d)) >> 1, LV_SCROLL_ANIM_TIME_MIN,
+                                               LV_SCROLL_ANIM_TIME_MAX);
             lv_anim_set_duration(&a, t);
             int32_t sy = lv_obj_get_scroll_y(obj);
             lv_anim_set_values(&a, -sy, -sy + dy);

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -230,26 +230,6 @@
     #endif
 #endif  /*LV_USE_STDLIB_MALLOC == LV_STDLIB_BUILTIN*/
 
-/************************
- * SCROLL CONFIGURATION
- ************************/
-
-#ifndef LV_SCROLL_ANIM_TIME_MIN
-    #ifdef CONFIG_LV_SCROLL_ANIM_TIME_MIN
-        #define LV_SCROLL_ANIM_TIME_MIN CONFIG_LV_SCROLL_ANIM_TIME_MIN
-    #else
-        #define LV_SCROLL_ANIM_TIME_MIN 200
-    #endif
-#endif
-
-#ifndef LV_SCROLL_ANIM_TIME_MAX
-    #ifdef CONFIG_LV_SCROLL_ANIM_TIME_MAX
-        #define LV_SCROLL_ANIM_TIME_MAX CONFIG_LV_SCROLL_ANIM_TIME_MAX
-    #else
-        #define LV_SCROLL_ANIM_TIME_MAX 400
-    #endif
-#endif
-
 /*====================
    HAL SETTINGS
  *====================*/
@@ -4515,6 +4495,21 @@
         #else
             #define LV_QNX_BUF_COUNT        1    /**< 1 or 2 */
         #endif
+    #endif
+#endif
+
+#ifndef LV_SCROLL_ANIM_TIME_MIN
+    #ifdef CONFIG_LV_SCROLL_ANIM_TIME_MIN
+        #define LV_SCROLL_ANIM_TIME_MIN CONFIG_LV_SCROLL_ANIM_TIME_MIN
+    #else
+        #define LV_SCROLL_ANIM_TIME_MIN 200
+    #endif
+#endif
+#ifndef LV_SCROLL_ANIM_TIME_MAX
+    #ifdef CONFIG_LV_SCROLL_ANIM_TIME_MAX
+        #define LV_SCROLL_ANIM_TIME_MAX CONFIG_LV_SCROLL_ANIM_TIME_MAX
+    #else
+        #define LV_SCROLL_ANIM_TIME_MAX 400
     #endif
 #endif
 

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -230,6 +230,26 @@
     #endif
 #endif  /*LV_USE_STDLIB_MALLOC == LV_STDLIB_BUILTIN*/
 
+/************************
+ * SCROLL CONFIGURATION
+ ************************/
+
+#ifndef LV_SCROLL_ANIM_TIME_MIN
+    #ifdef CONFIG_LV_SCROLL_ANIM_TIME_MIN
+        #define LV_SCROLL_ANIM_TIME_MIN CONFIG_LV_SCROLL_ANIM_TIME_MIN
+    #else
+        #define LV_SCROLL_ANIM_TIME_MIN 200
+    #endif
+#endif
+
+#ifndef LV_SCROLL_ANIM_TIME_MAX
+    #ifdef CONFIG_LV_SCROLL_ANIM_TIME_MAX
+        #define LV_SCROLL_ANIM_TIME_MAX CONFIG_LV_SCROLL_ANIM_TIME_MAX
+    #else
+        #define LV_SCROLL_ANIM_TIME_MAX 400
+    #endif
+#endif
+
 /*====================
    HAL SETTINGS
  *====================*/

--- a/src/lv_conf_kconfig.h
+++ b/src/lv_conf_kconfig.h
@@ -167,6 +167,17 @@ extern "C" {
 #  define CONFIG_LV_USE_MEM_MONITOR_POS LV_ALIGN_CENTER
 #endif
 
+/*******************
+ * SCROLL ANIMATION
+ *******************/
+#ifdef CONFIG_LV_SCROLL_ANIM_TIME_MIN
+#  define LV_SCROLL_ANIM_TIME_MIN CONFIG_LV_SCROLL_ANIM_TIME_MIN
+#endif
+
+#ifdef CONFIG_LV_SCROLL_ANIM_TIME_MAX
+#  define LV_SCROLL_ANIM_TIME_MAX CONFIG_LV_SCROLL_ANIM_TIME_MAX
+#endif
+
 /********************
  * FONT SELECTION
  *******************/


### PR DESCRIPTION
  - add two new Kconfig options `LV_SCROLL_ANIM_TIME_MIN` and `LV_SCROLL_ANIM_TIME_MAX` so the scroll animation duration bounds can be tuned from menuconfig instead of being hard-coded
  - propagate the selected values through `lv_conf_kconfig.h` and `lv_conf_internal.h`, falling back to 200/400
  ms if neither Kconfig nor lv_conf.h overrides them
  - update `lv_obj_scroll.c` to read the new `LV_SCROLL_ANIM_TIME_*` macros, ensuring every build (including
  non-Kconfig users) honors the configuration