### PR TITLE
fix(wayland/g2d): skip deleting busy buffers

### DIFF
--- a/src/drivers/wayland/lv_wayland_private.h
+++ b/src/drivers/wayland/lv_wayland_private.h
@@ -136,6 +136,7 @@ typedef struct {
     struct zwp_linux_dmabuf_v1 * handler;
     uint32_t format;
     uint8_t last_used;
+    struct buffer * buffers_to_delete;
 } dmabuf_ctx_t;
 
 typedef struct {


### PR DESCRIPTION
It's a hotfix to the v9.4 release branch

Fixes https://github.com/lvgl/lvgl/pull/8563#issuecomment-3479402425

When the window was resized using Wayland + G2D + DMABUF, the window would flicker, I realized the issue happened because we delete the draw buffers while they were still busy, after figuring that out it was an easy fix

@anaGrad @nicusorcitu @cosmindanielradu19 


https://github.com/user-attachments/assets/e823a28e-21e9-4517-a3b4-ff59371a6fac
