### PR TITLE
fix(ime): restrict to lowercase input to avoid overflow

### DIFF
--- a/src/widgets/ime/lv_ime_pinyin.c
+++ b/src/widgets/ime/lv_ime_pinyin.c
@@ -705,8 +705,7 @@ static void lv_ime_pinyin_kb_event(lv_event_t * e)
             }
             pinyin_ime_clear_data(obj);
         }
-        else if((pinyin_ime->mode == LV_IME_PINYIN_MODE_K26) && ((txt[0] >= 'a' && txt[0] <= 'z') || (txt[0] >= 'A' &&
-                                                                                                      txt[0] <= 'Z'))) {
+        else if((pinyin_ime->mode == LV_IME_PINYIN_MODE_K26) && (txt[0] >= 'a' && txt[0] <= 'z')) {
             uint16_t len = lv_strlen(pinyin_ime->input_char);
             lv_snprintf(pinyin_ime->input_char + len, sizeof(pinyin_ime->input_char) - len, "%s", txt);
             pinyin_input_proc(obj);


### PR DESCRIPTION
  ## Summary
  - when the K26 mode processes a keypress it now only accepts `'a'..'z'`
  - uppercase letters are ignored instead of feeding into `pinyin_search_matching`
  - this prevents `offset = txt[0] - 'a'` from becoming negative and reading past `py_pos`, so the segmentation fault disappears
