### PR TITLE
docs(color):  fix unexpected API page links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -391,10 +391,12 @@ API
 
 .. API equals: lv_scale_t, lv_scale_create
 
-.. API startswith: lv_scale, lv_obj_set_style
+.. API startswith:
 
+    lv_scale
+    lv_obj_set_style
 ```
 
-The list of symbols (or prefixes) can be separated by commas or spaces, and they can wrap onto subsequent lines of text so long as they are indented.  A blank line after each list ends that list.
+The list of symbols (or prefixes) can be separated by commas or spaces, and they can wrap onto subsequent lines of text so long as they are indented.  Each list is terminated by the next ``.. API `` pseudo-directive or end-of-file, whichever comes first.
 
 The API-page generation logic will add at most 1 link to each API documentation page containing matched symbols.  The links are to the whole API page, not to the symbols.  The purpose is to provide the reader with links to applicable API pages.  Links directly to code (e.g. function documentation) are accomplished by using the In-Line Code Expressions documented above.

--- a/docs/api_doc_builder.py
+++ b/docs/api_doc_builder.py
@@ -342,7 +342,7 @@ def _process_end_of_eligible_doc(b: str, rst_file: str) -> (str, str, int):
     links_added_count = len(genned_link_set)
 
     if links_added_count > 0:
-        c = _auto_gen_sep + '\n\n'
+        c = '\n' + _auto_gen_sep + '\n\n'
         for link_name in sorted(genned_link_set, key=_hyperlink_sort_value):
             c += ':ref:`' + link_name + '`\n\n'
 

--- a/docs/src/main-modules/color.rst
+++ b/docs/src/main-modules/color.rst
@@ -38,6 +38,7 @@ Create colors from Red, Green and Blue channel values:
    /* From 3 digits. Same as lv_color_hex(0x112233) */
    lv_color_t c = lv_color_hex3(0x123);
 
+
 HSV
 ---
 
@@ -54,6 +55,7 @@ Create colors from Hue, Saturation and Value values:
 
    //From lv_color_t variable
    lv_color_hsv_t c_hsv = lv_color_to_hsv(color);
+
 
 .. _color_palette:
 
@@ -95,6 +97,7 @@ For the lighter variants of a palette color use
 :cpp:expr:`lv_color_t` ``c =`` :cpp:expr:`lv_palette_darken(LV_PALETTE_..., v)`. ``v`` can be
 1..4.
 
+
 .. _color_modify_and_mix:
 
 Modify and mix colors
@@ -116,6 +119,7 @@ The following functions can modify a color:
 
    // Mix two colors with a given ratio 0: full c2, 255: full c1, 128: half c1 and half c2
    lv_color_t c = lv_color_mix(c1, c2, ratio);
+
 
 .. _color_builtin:
 
@@ -152,3 +156,9 @@ mixing *ratio*.
 
 API
 ***
+
+.. API equals:
+
+      lv_color_make
+      lv_color_mix
+      lv_palette_main


### PR DESCRIPTION
Fixes:

- inappropriate link to page `lv_draw_ppa_private.h`
- missing link to page `lv_palette.h`

I also discovered a statement in `./docs/README.md` which was inaccurate, and fixed that as well.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
