### PR TITLE
feat(array): add remove_unordered function

### DIFF
--- a/src/misc/lv_array.c
+++ b/src/misc/lv_array.c
@@ -12,6 +12,7 @@
 #include "../stdlib/lv_string.h"
 
 #include "lv_assert.h"
+#include "lv_types.h"
 /*********************
  *      DEFINES
  *********************/
@@ -88,6 +89,10 @@ void lv_array_shrink(lv_array_t * array)
 
 lv_result_t lv_array_remove(lv_array_t * array, uint32_t index)
 {
+    if(!array) {
+        return LV_RESULT_INVALID;
+    }
+
     if(index >= array->size) {
         return LV_RESULT_INVALID;
     }
@@ -103,6 +108,33 @@ lv_result_t lv_array_remove(lv_array_t * array, uint32_t index)
     uint8_t * remaining = start + array->element_size;
     uint32_t remaining_size = (array->size - index - 1) * array->element_size;
     lv_memmove(start, remaining, remaining_size);
+    array->size--;
+    lv_array_shrink(array);
+    return LV_RESULT_OK;
+}
+
+lv_result_t lv_array_remove_unordered(lv_array_t * array, uint32_t index)
+{
+    if(!array) {
+        return LV_RESULT_INVALID;
+    }
+
+    if(index >= array->size) {
+        return LV_RESULT_INVALID;
+    }
+
+    /*Shortcut*/
+    if(index == array->size - 1) {
+        array->size--;
+        lv_array_shrink(array);
+        return LV_RESULT_OK;
+    }
+
+    /* Copy the last element into the position to remove*/
+    uint8_t * dst = lv_array_at(array, index);
+    uint8_t * src = lv_array_at(array, array->size - 1);
+
+    lv_memcpy(dst, src, array->element_size);
     array->size--;
     lv_array_shrink(array);
     return LV_RESULT_OK;

--- a/src/misc/lv_array.h
+++ b/src/misc/lv_array.h
@@ -143,11 +143,25 @@ void lv_array_shrink(lv_array_t * array);
 
 /**
  * Remove the element at the specified position in the array.
+ *
+ * This function keeps the array order. Complexity is O(n)
+ *
  * @param array pointer to an `lv_array_t` variable
  * @param index the index of the element to remove
  * @return LV_RESULT_OK: success, otherwise: error
  */
 lv_result_t lv_array_remove(lv_array_t * array, uint32_t index);
+
+/**
+ * Remove the element at the specified position in the array.
+ *
+ * This function does not guarantee the array order. Complexity is O(1)
+ *
+ * @param array pointer to an `lv_array_t` variable
+ * @param index the index of the element to remove
+ * @return LV_RESULT_OK: success, otherwise: error
+ */
+lv_result_t lv_array_remove_unordered(lv_array_t * array, uint32_t index);
 
 /**
  * Remove from the array either a single element or a range of elements ([start, end)).

--- a/tests/src/test_cases/test_array.c
+++ b/tests/src/test_cases/test_array.c
@@ -155,6 +155,9 @@ void test_array_shrink(void)
 
 void test_array_remove(void)
 {
+    /* NULL array is handled properly */
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_array_remove(NULL, 0));
+
     for(int32_t i = 0; i < 5; i++) {
         lv_array_push_back(&array, &i);
     }
@@ -180,6 +183,40 @@ void test_array_remove(void)
         int32_t * v = lv_array_at(&array, i);
         TEST_ASSERT_EQUAL_INT32(i + 1, *v);
     }
+}
+
+void test_array_remove_unordered(void)
+{
+    /* NULL array is handled properly */
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_array_remove_unordered(NULL, 0));
+
+    for(int32_t i = 0; i < 5; i++) {
+        lv_array_push_back(&array, &i);
+    }
+    TEST_ASSERT_EQUAL_UINT32(5, lv_array_size(&array));
+
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_array_remove_unordered(&array, 4));
+    TEST_ASSERT_EQUAL_UINT32(4, lv_array_size(&array));
+
+    /* Test remove out of range, should fail */
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_array_remove_unordered(&array, 4));
+    TEST_ASSERT_EQUAL_UINT32(4, lv_array_size(&array));
+
+    /* remove the last element */
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_array_remove_unordered(&array, 3));
+    TEST_ASSERT_EQUAL_UINT32(3, lv_array_size(&array));
+
+    /* remove the first element */
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_array_remove_unordered(&array, 0));
+    TEST_ASSERT_EQUAL_UINT32(2, lv_array_size(&array));
+
+    int32_t * v0 = lv_array_at(&array, 0);
+    int32_t * v1 = lv_array_at(&array, 1);
+
+    /* Removing the first element should have moved the last element
+     * to the first position*/
+    TEST_ASSERT_EQUAL_INT32(2, *v0);
+    TEST_ASSERT_EQUAL_INT32(1, *v1);
 }
 
 void test_array_erase(void)


### PR DESCRIPTION
Allows removing an element from the array with O(1) complexity if we don't care about the order the objects are stored in