### PR TITLE
fix(binfont_loader): add include to include missing function from API page

### DIFF
--- a/src/font/binfont_loader/lv_binfont_loader.h
+++ b/src/font/binfont_loader/lv_binfont_loader.h
@@ -13,6 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
+#include "../../lv_conf_internal.h"
 
 /*********************
  *      DEFINES


### PR DESCRIPTION
Function `lv_binfont_create_from_buffer()` and its API documentation were missing from the [lv_binfont_loader API page](https://docs.lvgl.io/master/API/font/binfont_loader/lv_binfont_loader_h.html).  

The root cause was that Doxygen could not see that macro `LV_USE_FS_MEMFS` was set to `1` because in parsing `lv_binfont_loader.h`, nothing was causing `lv_conf.h` to be included.  This is designed to be done by including `lv_conf_internal.h`.  Adding that line for this `.h` file remedies the problem, while also not disturbing the various builds.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
