### PR TITLE
fix(gif): compatibility issue when logging uint32_t variables

### DIFF
--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -758,7 +758,8 @@ lv_observer_t * lv_obj_bind_style_prop(lv_obj_t * obj, lv_style_prop_t prop, lv_
 
     if(subject->type != LV_SUBJECT_TYPE_INT && subject->type != LV_SUBJECT_TYPE_COLOR &&
        subject->type != LV_SUBJECT_TYPE_POINTER) {
-        LV_LOG_WARN("Subject type must be `int`, `color`, or `pointer` (was %"LV_PRIu32")", (uint32_t) subject->type);
+        uint32_t type_val = subject->type;
+        LV_LOG_WARN("Subject type must be `int`, `color`, or `pointer` (was %"LV_PRIu32")", type_val);
         return NULL;
     }
 
@@ -1317,7 +1318,8 @@ static void bind_style_prop_observer_cb(lv_observer_t * observer, lv_subject_t *
     else if(subject->type == LV_SUBJECT_TYPE_COLOR) style_v.color = lv_subject_get_color(subject);
     else if(subject->type == LV_SUBJECT_TYPE_POINTER) style_v.ptr = lv_subject_get_pointer(subject);
     else {
-        LV_LOG_WARN("Not supported subject type (%"LV_PRIu32")", (uint32_t) subject->type);
+        uint32_t type_val = subject->type;
+        LV_LOG_WARN("Not supported subject type (%"LV_PRIu32")", type_val);
         return;
     }
 

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -759,6 +759,7 @@ lv_observer_t * lv_obj_bind_style_prop(lv_obj_t * obj, lv_style_prop_t prop, lv_
     if(subject->type != LV_SUBJECT_TYPE_INT && subject->type != LV_SUBJECT_TYPE_COLOR &&
        subject->type != LV_SUBJECT_TYPE_POINTER) {
         uint32_t type_val = subject->type;
+        (void)type_val;
         LV_LOG_WARN("Subject type must be `int`, `color`, or `pointer` (was %"LV_PRIu32")", type_val);
         return NULL;
     }
@@ -1319,6 +1320,7 @@ static void bind_style_prop_observer_cb(lv_observer_t * observer, lv_subject_t *
     else if(subject->type == LV_SUBJECT_TYPE_POINTER) style_v.ptr = lv_subject_get_pointer(subject);
     else {
         uint32_t type_val = subject->type;
+        (void)type_val;
         LV_LOG_WARN("Not supported subject type (%"LV_PRIu32")", type_val);
         return;
     }

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -758,9 +758,7 @@ lv_observer_t * lv_obj_bind_style_prop(lv_obj_t * obj, lv_style_prop_t prop, lv_
 
     if(subject->type != LV_SUBJECT_TYPE_INT && subject->type != LV_SUBJECT_TYPE_COLOR &&
        subject->type != LV_SUBJECT_TYPE_POINTER) {
-        uint32_t type_val = subject->type;
-        (void)type_val;
-        LV_LOG_WARN("Subject type must be `int`, `color`, or `pointer` (was %"LV_PRIu32")", type_val);
+        LV_LOG_WARN("Subject type must be `int`, `color`, or `pointer` (was %"LV_PRIu32")", (uint32_t) subject->type);
         return NULL;
     }
 
@@ -1319,9 +1317,7 @@ static void bind_style_prop_observer_cb(lv_observer_t * observer, lv_subject_t *
     else if(subject->type == LV_SUBJECT_TYPE_COLOR) style_v.color = lv_subject_get_color(subject);
     else if(subject->type == LV_SUBJECT_TYPE_POINTER) style_v.ptr = lv_subject_get_pointer(subject);
     else {
-        uint32_t type_val = subject->type;
-        (void)type_val;
-        LV_LOG_WARN("Not supported subject type (%"LV_PRIu32")", type_val);
+        LV_LOG_WARN("Not supported subject type (%"LV_PRIu32")", (uint32_t) subject->type);
         return;
     }
 

--- a/src/libs/gif/lv_gif.c
+++ b/src/libs/gif/lv_gif.c
@@ -404,7 +404,7 @@ static void initialize(lv_gif_t * gifobj)
     gifobj->draw_buf = lv_draw_buf_create(width, height, gifobj->color_format, LV_STRIDE_AUTO);
 
     if(gifobj->draw_buf == NULL) {
-        LV_LOG_WARN("Couldn't allocate memory for the gif with width: %d and height: %d", width, height);
+        LV_LOG_WARN("Couldn't allocate memory for the gif with width: %"LV_PRIu32" and height: %"LV_PRIu32, width, height);
         GIF_close(gif);
         gifobj->is_open = 0;
         return;

--- a/src/libs/gif/lv_gif.c
+++ b/src/libs/gif/lv_gif.c
@@ -404,7 +404,7 @@ static void initialize(lv_gif_t * gifobj)
     gifobj->draw_buf = lv_draw_buf_create(width, height, gifobj->color_format, LV_STRIDE_AUTO);
 
     if(gifobj->draw_buf == NULL) {
-        LV_LOG_WARN("Couldn't allocate memory for the gif with width: %"LV_PRIu32" and height: %"LV_PRIu32, width, height);
+        LV_LOG_WARN("Couldn't allocate memory for the gif with width: %"LV_PRIu32" and height: %"LV_PRIu32"", width, height);
         GIF_close(gif);
         gifobj->is_open = 0;
         return;


### PR DESCRIPTION
Summary

This pull request addresses a portability issue related to printing uint32_t and enum types in log messages. On certain architectures, passing integer types smaller than int to variadic functions (like printf-based loggers) can result in incorrect type promotion, leading to corrupted or invalid output.

Changes

src/core/lv_obj_style.c:

When logging the subject->type (an enum), the value is now first stored in a uint32_t local variable before being passed to LV_LOG_WARN. This ensures the argument's type correctly matches the %"LV_PRIu32" format specifier, preventing potential printing errors.
src/libs/gif/lv_gif.c:

The format specifiers for logging GIF width and height have been updated from %d to %"LV_PRIu32". This ensures the log output is correct and portable, matching the uint32_t type of these variables.
These changes enhance the robustness of the logging system across different platforms and compilers.