### PR TITLE
fix(property): remove setter of LV_PROPERTY_TEXTAREA_ACCEPTED_CHARS

### DIFF
--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -107,7 +107,7 @@ static const lv_property_ops_t properties[] = {
     },
     {
         .id = LV_PROPERTY_TEXTAREA_ACCEPTED_CHARS,
-        .setter = lv_textarea_set_accepted_chars,
+        .setter = NULL,
         .getter = lv_textarea_get_accepted_chars,
     },
     {


### PR DESCRIPTION
The contract for `LV_PROPERTY_TYPE_TEXT` appears to be that the content is owned by the widget, but `LV_PROPERTY_TEXTAREA_ACCEPTED_CHARS` stores just the pointer (as documented in `lv_textarea_set_accepted_chars()`).

So it is not suitable as a generic settable text property.