### PR TITLE
docs(examples):  fix erroneous example headings

### DIFF
--- a/docs/src/auxiliary-modules/file_explorer.rst
+++ b/docs/src/auxiliary-modules/file_explorer.rst
@@ -212,8 +212,8 @@ through functions such as :cpp:func:`strcpy` and :cpp:func:`strcat` for later us
 
 .. _file_explorer_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/others/file_explorer/index.rst
 

--- a/docs/src/auxiliary-modules/fragment.rst
+++ b/docs/src/auxiliary-modules/fragment.rst
@@ -79,8 +79,8 @@ Fragment Based Navigation
 
 .. _fragment_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/others/fragment/index.rst
 

--- a/docs/src/common-widget-features/layouts/grid.rst
+++ b/docs/src/common-widget-features/layouts/grid.rst
@@ -207,8 +207,8 @@ The columns will be placed from right to left.
 
 .. _grid_examples:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/layouts/grid/index.rst
 

--- a/docs/src/debugging/monkey.rst
+++ b/docs/src/debugging/monkey.rst
@@ -48,8 +48,8 @@ Note that ``input_range`` has different meanings depending on the ``type`` input
 
 .. _monkey_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/others/monkey/index.rst
 

--- a/docs/src/libs/font_support/tiny_ttf.rst
+++ b/docs/src/libs/font_support/tiny_ttf.rst
@@ -44,8 +44,8 @@ allow kerning, if supported, or disable.
 
 .. _tiny_ttf_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/libs/tiny_ttf/index.rst
 

--- a/docs/src/libs/image_support/rlottie.rst
+++ b/docs/src/libs/image_support/rlottie.rst
@@ -295,8 +295,8 @@ IDF) with the appropriate :cpp:expr:`MALLOC_CAP` call --- for SPIRAM usage this 
 
 .. _rlottie_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/libs/rlottie/index.rst
 

--- a/docs/src/libs/image_support/svg.rst
+++ b/docs/src/libs/image_support/svg.rst
@@ -55,8 +55,8 @@ It is also possible to draw SVG vector graphics in draw events:
 
 .. _svg_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/libs/svg/index.rst
 

--- a/docs/src/libs/video_support/gstreamer.rst
+++ b/docs/src/libs/video_support/gstreamer.rst
@@ -298,8 +298,8 @@ Once media is loaded (LV_EVENT_READY), you can access:
 
 .. _gstreamer_example:
 
-Examples
-********
+Example
+*******
 
 .. include:: /examples/libs/gstreamer/index.rst
 

--- a/docs/src/widgets/arc.rst
+++ b/docs/src/widgets/arc.rst
@@ -191,8 +191,8 @@ Keys
 
 .. _lv_arc_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/arc/index.rst
 

--- a/docs/src/widgets/bar.rst
+++ b/docs/src/widgets/bar.rst
@@ -119,8 +119,8 @@ No *Keys* are processed by Bar Widgets.
 
 .. _lv_bar_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/bar/index.rst
 

--- a/docs/src/widgets/button.rst
+++ b/docs/src/widgets/button.rst
@@ -67,8 +67,8 @@ and :cpp:enumerator:`LV_EVENT_RELEASED` etc.
 
 .. _lv_button_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/button/index.rst
 

--- a/docs/src/widgets/buttonmatrix.rst
+++ b/docs/src/widgets/buttonmatrix.rst
@@ -168,8 +168,8 @@ the button will not be activated upon leaving edit mode.
 
 .. _lv_buttonmatrix_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/buttonmatrix/index.rst
 

--- a/docs/src/widgets/calendar.rst
+++ b/docs/src/widgets/calendar.rst
@@ -168,8 +168,8 @@ contains 2 Drop-Drown List Widgets for the year and month.
 
 
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/calendar/index.rst
 

--- a/docs/src/widgets/canvas.rst
+++ b/docs/src/widgets/canvas.rst
@@ -112,8 +112,8 @@ No *Keys* are processed by Canvas Widgets.
 
 .. _lv_canvas_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/canvas/index.rst
 

--- a/docs/src/widgets/chart.rst
+++ b/docs/src/widgets/chart.rst
@@ -390,8 +390,8 @@ No *Keys* are processed by Chart Widgets.
 
 .. _lv_chart_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/chart/index.rst
 

--- a/docs/src/widgets/checkbox.rst
+++ b/docs/src/widgets/checkbox.rst
@@ -98,8 +98,8 @@ Note that, as usual, the state of :cpp:enumerator:`LV_KEY_ENTER` is translated t
 
 .. _lv_checkbox_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/checkbox/index.rst
 

--- a/docs/src/widgets/dropdown.rst
+++ b/docs/src/widgets/dropdown.rst
@@ -183,8 +183,8 @@ Keys
 
 .. _lv_dropdown_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/dropdown/index.rst
 

--- a/docs/src/widgets/image.rst
+++ b/docs/src/widgets/image.rst
@@ -240,8 +240,8 @@ No *Keys* are processed by Image Widgets.
 
 .. _lv_image_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/image/index.rst
 

--- a/docs/src/widgets/ime_pinyin.rst
+++ b/docs/src/widgets/ime_pinyin.rst
@@ -118,8 +118,8 @@ The default mode is :cpp:enumerator:`LV_IME_PINYIN_MODE_K26`.
 
 .. _ime_pinyin_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/others/ime/index.rst
 

--- a/docs/src/widgets/keyboard.rst
+++ b/docs/src/widgets/keyboard.rst
@@ -149,8 +149,8 @@ Keys
 
 .. _lv_keyboard_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/keyboard/index.rst
 

--- a/docs/src/widgets/label.rst
+++ b/docs/src/widgets/label.rst
@@ -292,8 +292,8 @@ No *Keys* are processed by Label Widgets.
 
 .. _lv_label_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/label/index.rst
 

--- a/docs/src/widgets/list.rst
+++ b/docs/src/widgets/list.rst
@@ -82,8 +82,8 @@ No *Keys* are processed by List Widgets.
 
 .. _lv_list_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/list/index.rst
 

--- a/docs/src/widgets/lottie.rst
+++ b/docs/src/widgets/lottie.rst
@@ -122,8 +122,8 @@ No keys are processed by Lottie Widgets.
 
 .. _lv_lottie_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/lottie/index.rst
 

--- a/docs/src/widgets/menu.rst
+++ b/docs/src/widgets/menu.rst
@@ -163,8 +163,8 @@ No *Keys* are processed by Menu Widgets.
 
 .. _lv_menu_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/menu/index.rst
 

--- a/docs/src/widgets/msgbox.rst
+++ b/docs/src/widgets/msgbox.rst
@@ -132,8 +132,8 @@ No *Keys* are processed by Message Box Widgets.
 
 .. _lv_msgbox_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/msgbox/index.rst
 

--- a/docs/src/widgets/roller.rst
+++ b/docs/src/widgets/roller.rst
@@ -125,8 +125,8 @@ Keys
 
 .. _lv_roller_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/roller/index.rst
 

--- a/docs/src/widgets/scale.rst
+++ b/docs/src/widgets/scale.rst
@@ -320,8 +320,8 @@ No *Keys* are processed by Scale Widgets.
 
 .. _lv_scale_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/scale/index.rst
 

--- a/docs/src/widgets/slider.rst
+++ b/docs/src/widgets/slider.rst
@@ -145,8 +145,8 @@ Keys
 
 .. _lv_slider_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/slider/index.rst
 

--- a/docs/src/widgets/switch.rst
+++ b/docs/src/widgets/switch.rst
@@ -99,8 +99,8 @@ Keys
 
 .. _lv_switch_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/switch/index.rst
 

--- a/docs/src/widgets/table.rst
+++ b/docs/src/widgets/table.rst
@@ -150,8 +150,8 @@ currently selected cell. Row and column will be set to
 
 .. _lv_table_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/table/index.rst
 

--- a/docs/src/widgets/tabview.rst
+++ b/docs/src/widgets/tabview.rst
@@ -124,8 +124,8 @@ Programmatically add these buttons to a group if required.
 
 .. _lv_tabview_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/tabview/index.rst
 

--- a/docs/src/widgets/textarea.rst
+++ b/docs/src/widgets/textarea.rst
@@ -257,8 +257,8 @@ Keys
 
 .. _lv_textarea_example:
 
-Example
-*******
+Examples
+********
 
 .. include:: /examples/widgets/textarea/index.rst
 


### PR DESCRIPTION
I noticed during inspecting examples earlier today that there were some places where the heading was Example (singular), but there was more than one example.  And there was one case where the heading was plural, but there was only 1 example.   I just fixed all of these and have made the heading plural now.

cc:  @kisvegabor 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
