### PR TITLE
feat(fbdev): add return type to set_file

### DIFF
--- a/src/drivers/display/fb/lv_linux_fbdev.h
+++ b/src/drivers/display/fb/lv_linux_fbdev.h
@@ -31,7 +31,7 @@ extern "C" {
  **********************/
 lv_display_t * lv_linux_fbdev_create(void);
 
-void lv_linux_fbdev_set_file(lv_display_t * disp, const char * file);
+lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file);
 
 /**
  * Force the display to be refreshed on every change.


### PR DESCRIPTION
The function has a multitude of ways it could fail, and the user doesn't have a way to know if it failed

This solves that API problem