### PR TITLE
feat(drm): add return type to set_file

### DIFF
--- a/src/drivers/display/drm/lv_linux_drm.c
+++ b/src/drivers/display/drm/lv_linux_drm.c
@@ -201,7 +201,7 @@ static void drm_dmabuf_set_active_buf(lv_event_t * event)
 
 }
 
-void lv_linux_drm_set_file(lv_display_t * disp, const char * file, int64_t connector_id)
+lv_result_t lv_linux_drm_set_file(lv_display_t * disp, const char * file, int64_t connector_id)
 {
     int ret;
 
@@ -209,7 +209,7 @@ void lv_linux_drm_set_file(lv_display_t * disp, const char * file, int64_t conne
 
     ret = drm_setup(drm_dev, file, connector_id, DRM_FOURCC);
     if(ret) {
-        return;
+        return LV_RESULT_INVALID;
     }
 
     int32_t hor_res = drm_dev->width;
@@ -220,7 +220,7 @@ void lv_linux_drm_set_file(lv_display_t * disp, const char * file, int64_t conne
         LV_LOG_ERROR("DRM buffer allocation failed");
         close(drm_dev->fd);
         drm_dev->fd = -1;
-        return;
+        return LV_RESULT_INVALID;
     }
 
     LV_LOG_INFO("DRM subsystem and buffer mapped successfully");
@@ -246,6 +246,7 @@ void lv_linux_drm_set_file(lv_display_t * disp, const char * file, int64_t conne
 
     LV_LOG_INFO("Resolution is set to %" LV_PRId32 "x%" LV_PRId32 " at %" LV_PRId32 "dpi",
                 hor_res, ver_res, lv_display_get_dpi(disp));
+    return LV_RESULT_OK;
 }
 
 void lv_linux_drm_set_mode_cb(lv_display_t * disp, lv_linux_drm_select_mode_cb_t callback)

--- a/src/drivers/display/drm/lv_linux_drm.h
+++ b/src/drivers/display/drm/lv_linux_drm.h
@@ -64,8 +64,9 @@ lv_display_t * lv_linux_drm_create(void);
  * @param disp         Pointer to the display object created with lv_linux_drm_create()
  * @param file         Path to the DRM device file (e.g., "/dev/dri/card0")
  * @param connector_id ID of the DRM connector to use, or -1 to auto-select the first available
+ * @return LV_RESULT_OK if the initialization succeeeded or LV_RESULT_INVALID if it failed
  */
-void lv_linux_drm_set_file(lv_display_t * disp, const char * file, int64_t connector_id);
+lv_result_t lv_linux_drm_set_file(lv_display_t * disp, const char * file, int64_t connector_id);
 
 /**
  * @brief Automatically find a suitable DRM device path

--- a/src/drivers/display/drm/lv_linux_drm_egl.c
+++ b/src/drivers/display/drm/lv_linux_drm_egl.c
@@ -102,7 +102,7 @@ lv_display_t * lv_linux_drm_create(void)
     return ctx->display;
 }
 
-void lv_linux_drm_set_file(lv_display_t * display, const char * file, int64_t connector_id)
+lv_result_t lv_linux_drm_set_file(lv_display_t * display, const char * file, int64_t connector_id)
 {
     LV_UNUSED(connector_id);
     lv_drm_ctx_t * ctx = lv_display_get_driver_data(display);
@@ -110,7 +110,7 @@ void lv_linux_drm_set_file(lv_display_t * display, const char * file, int64_t co
     lv_result_t err = drm_device_init(ctx, file);
     if(err != LV_RESULT_OK) {
         LV_LOG_ERROR("Failed to initialize DRM device");
-        return;
+        return LV_RESULT_INVALID;
     }
 
     lv_display_set_resolution(display, ctx->drm_mode->hdisplay, ctx->drm_mode->vdisplay);
@@ -119,7 +119,7 @@ void lv_linux_drm_set_file(lv_display_t * display, const char * file, int64_t co
     ctx->egl_ctx = lv_opengles_egl_context_create(&ctx->egl_interface);
     if(!ctx->egl_ctx) {
         LV_LOG_ERROR("Failed to create egl context");
-        return;
+        return LV_RESULT_INVALID;
     }
 
     /* Let the opengles texture driver handle the texture lifetime */
@@ -129,7 +129,7 @@ void lv_linux_drm_set_file(lv_display_t * display, const char * file, int64_t co
         LV_LOG_ERROR("Failed to create draw buffers");
         lv_opengles_egl_context_destroy(ctx->egl_ctx);
         ctx->egl_ctx = NULL;
-        return;
+        return LV_RESULT_INVALID;
     }
     /* This creates the texture for the first time*/
     lv_opengles_texture_reshape(display, ctx->drm_mode->hdisplay, ctx->drm_mode->vdisplay);
@@ -139,6 +139,8 @@ void lv_linux_drm_set_file(lv_display_t * display, const char * file, int64_t co
 
     lv_display_add_event_cb(ctx->display, event_cb, LV_EVENT_RESOLUTION_CHANGED, NULL);
     lv_display_add_event_cb(ctx->display, event_cb, LV_EVENT_DELETE, NULL);
+
+    return LV_RESULT_OK;
 }
 
 void lv_linux_drm_set_mode_cb(lv_display_t * disp, lv_linux_drm_select_mode_cb_t callback)


### PR DESCRIPTION
The function has a multitude of ways it could fail, and the user doesn't have a way to know if it failed

This solves that API problem