### PR TITLE
fix(draw/dma2d): correct cache handling

### DIFF
--- a/src/draw/dma2d/lv_draw_dma2d.c
+++ b/src/draw/dma2d/lv_draw_dma2d.c
@@ -209,14 +209,16 @@ void lv_draw_dma2d_configure_and_start_transfer(const lv_draw_dma2d_configuratio
 void lv_draw_dma2d_invalidate_cache(const lv_draw_dma2d_cache_area_t * mem_area)
 {
     if(SCB->CCR & SCB_CCR_DC_Msk) {
-        SCB_InvalidateDCache();
+        SCB_InvalidateDCache_by_Addr((uint32_t *)mem_area->first_byte,
+                                     mem_area->stride * mem_area->height);
     }
 }
 
 void lv_draw_dma2d_clean_cache(const lv_draw_dma2d_cache_area_t * mem_area)
 {
     if(SCB->CCR & SCB_CCR_DC_Msk) {
-        SCB_CleanDCache();
+        SCB_CleanDCache_by_Addr((uint32_t *)mem_area->first_byte,
+                                mem_area->stride * mem_area->height);
     }
 }
 #endif


### PR DESCRIPTION
Commit a8840a263 ("feat(dma2d): improve DMA2D Compatibility (#8293)") introduced usage of the CMSIS functions SCB_InvalidateDCache and SCB_CleanDCache, leading to a regression in that this invalidate/clean the whole DCache instead of only the relevant part. Performing a SCB_CleanDCache doesn't lead to big issue apart performance impact, however SCB_InvalidateDCache usage leads to performing cache invalidate on potentially valid information which haven't yet been flushed into the memory. Indeed, the whole DCache content is not necessarily related to the frame handled by LVGL, leading to data loss.

The issue is visible while running LVGL on top of Zephyr v4.3.0 and running the samples/subsys/display/lvgl sample on various STM32 boards such as STM32F769I-DISCO / STM32H7S78-DK but also STM32N6.