### PR TITLE
feat(obj_property): add property helper for widget class

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -86,7 +86,7 @@ static void delete_on_screen_unloaded_event_cb(lv_event_t * e);
  *  STATIC VARIABLES
  **********************/
 #if LV_USE_OBJ_PROPERTY
-static const lv_property_ops_t properties[] = {
+static const lv_property_ops_t lv_obj_properties[] = {
     {
         .id = LV_PROPERTY_OBJ_PARENT,
         .setter = lv_obj_set_parent,
@@ -213,18 +213,7 @@ const lv_obj_class_t lv_obj_class = {
     .instance_size = (sizeof(lv_obj_t)),
     .base_class = NULL,
     .name = "lv_obj",
-#if LV_USE_OBJ_PROPERTY
-    .prop_index_start = LV_PROPERTY_OBJ_START,
-    .prop_index_end = LV_PROPERTY_OBJ_END,
-    .properties = properties,
-    .properties_count = sizeof(properties) / sizeof(properties[0]),
-
-#if LV_USE_OBJ_PROPERTY_NAME
-    .property_names = lv_obj_property_names,
-    .names_count = sizeof(lv_obj_property_names) / sizeof(lv_property_name_t),
-#endif
-
-#endif
+    LV_PROPERTY_CLASS_FIELDS(obj, OBJ)
 };
 
 /**********************

--- a/src/core/lv_obj_property.h
+++ b/src/core/lv_obj_property.h
@@ -60,6 +60,25 @@ extern "C" {
 /*Set properties from an array of lv_property_t*/
 #define LV_OBJ_SET_PROPERTY_ARRAY(obj, array) lv_obj_set_properties(obj, array, sizeof(array)/sizeof(array[0]))
 
+/* Helper to implement class definition of property and property names */
+/* *INDENT-OFF* */
+#if LV_USE_OBJ_PROPERTY_NAME
+#define LV_PROPERTY_CLASS_FIELDS(widget, uppercase) \
+    .prop_index_start = LV_PROPERTY_##uppercase##_START, \
+    .prop_index_end = LV_PROPERTY_##uppercase##_END, \
+    .properties = lv_##widget##_properties, \
+    .properties_count = LV_ARRAYLEN(lv_##widget##_properties), \
+    .property_names = lv_##widget##_property_names, \
+    .names_count = LV_ARRAYLEN(lv_##widget##_property_names)
+#else
+#define LV_PROPERTY_CLASS_FIELDS(widget, uppercase) \
+    .prop_index_start = LV_PROPERTY_##uppercase##_START, \
+    .prop_index_end = LV_PROPERTY_##uppercase##_END, \
+    .properties = lv_##widget##_properties, \
+    .properties_count = LV_ARRAYLEN(lv_##widget##_properties)
+#endif
+/* *INDENT-ON* */
+
 
 /**********************
  *      TYPEDEFS
@@ -237,6 +256,8 @@ lv_prop_id_t lv_style_property_get_id(const char * name);
 #include "../widgets/property/lv_obj_property_names.h"
 #include "../widgets/property/lv_style_properties.h"
 
+#else
+#define LV_PROPERTY_CLASS_FIELDS(widget, uppercase)
 #endif /*LV_USE_OBJ_PROPERTY*/
 
 #ifdef __cplusplus

--- a/src/misc/lv_types.h
+++ b/src/misc/lv_types.h
@@ -456,6 +456,10 @@ typedef struct _lv_draw_eve_unit_t lv_draw_eve_unit_t;
 #endif
 #endif /* LV_UNREACHABLE not defined */
 
+#ifndef LV_ARRAYLEN
+#define LV_ARRAYLEN(a) (sizeof(a)/sizeof((a)[0]))
+#endif /*LV_ARRAYLEN*/
+
 #ifdef __cplusplus
 } /*extern "C"*/
 #endif

--- a/src/widgets/animimage/lv_animimage.c
+++ b/src/widgets/animimage/lv_animimage.c
@@ -50,7 +50,7 @@ static void lv_animimg_set_src_inner(lv_obj_t * obj, const void * dsc[], size_t 
  **********************/
 
 #if LV_USE_OBJ_PROPERTY
-static const lv_property_ops_t properties[] = {
+static const lv_property_ops_t lv_animimage_properties[] = {
     {
         .id = LV_PROPERTY_ANIMIMAGE_SRC,
         .setter = lv_animimg_set_src,
@@ -79,17 +79,7 @@ const lv_obj_class_t lv_animimg_class = {
     .instance_size = sizeof(lv_animimg_t),
     .base_class = &lv_image_class,
     .name = "lv_animimg",
-#if LV_USE_OBJ_PROPERTY
-    .prop_index_start = LV_PROPERTY_ANIMIMAGE_START,
-    .prop_index_end = LV_PROPERTY_ANIMIMAGE_END,
-    .properties = properties,
-    .properties_count = sizeof(properties) / sizeof(properties[0]),
-
-#if LV_USE_OBJ_PROPERTY_NAME
-    .property_names = lv_animimage_property_names,
-    .names_count = sizeof(lv_animimage_property_names) / sizeof(lv_property_name_t),
-#endif
-#endif
+    LV_PROPERTY_CLASS_FIELDS(animimage, ANIMIMAGE)
 };
 
 /**********************

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -69,7 +69,7 @@ static lv_obj_t * get_label(const lv_obj_t * obj);
  *  STATIC VARIABLES
  **********************/
 #if LV_USE_OBJ_PROPERTY
-static const lv_property_ops_t properties[] = {
+static const lv_property_ops_t lv_dropdown_properties[] = {
     {
         .id = LV_PROPERTY_DROPDOWN_TEXT,
         .setter = lv_dropdown_set_text,
@@ -129,17 +129,7 @@ const lv_obj_class_t lv_dropdown_class = {
     .group_def = LV_OBJ_CLASS_GROUP_DEF_TRUE,
     .base_class = &lv_obj_class,
     .name = "lv_dropdown",
-#if LV_USE_OBJ_PROPERTY
-    .prop_index_start = LV_PROPERTY_DROPDOWN_START,
-    .prop_index_end = LV_PROPERTY_DROPDOWN_END,
-    .properties = properties,
-    .properties_count = sizeof(properties) / sizeof(properties[0]),
-
-#if LV_USE_OBJ_PROPERTY_NAME
-    .property_names = lv_dropdown_property_names,
-    .names_count = sizeof(lv_dropdown_property_names) / sizeof(lv_property_name_t),
-#endif
-#endif
+    LV_PROPERTY_CLASS_FIELDS(dropdown, DROPDOWN)
 };
 
 const lv_obj_class_t lv_dropdownlist_class = {

--- a/src/widgets/image/lv_image.c
+++ b/src/widgets/image/lv_image.c
@@ -51,7 +51,7 @@ static void reset_image_attributes(lv_obj_t * obj);
 #endif
 
 #if LV_USE_OBJ_PROPERTY
-static const lv_property_ops_t properties[] = {
+static const lv_property_ops_t lv_image_properties[] = {
     {
         .id = LV_PROPERTY_IMAGE_SRC,
         .setter = lv_image_set_src,
@@ -122,18 +122,7 @@ const lv_obj_class_t lv_image_class = {
     .instance_size = sizeof(lv_image_t),
     .base_class = &lv_obj_class,
     .name = "lv_image",
-#if LV_USE_OBJ_PROPERTY
-    .prop_index_start = LV_PROPERTY_IMAGE_START,
-    .prop_index_end = LV_PROPERTY_IMAGE_END,
-    .properties = properties,
-    .properties_count = sizeof(properties) / sizeof(properties[0]),
-
-#if LV_USE_OBJ_PROPERTY_NAME
-    .property_names = lv_image_property_names,
-    .names_count = sizeof(lv_image_property_names) / sizeof(lv_property_name_t),
-#endif
-
-#endif
+    LV_PROPERTY_CLASS_FIELDS(image, IMAGE)
 };
 
 /**********************

--- a/src/widgets/keyboard/lv_keyboard.c
+++ b/src/widgets/keyboard/lv_keyboard.c
@@ -60,7 +60,7 @@ static void lv_keyboard_update_ctrl_map(lv_obj_t * obj);
  *  STATIC VARIABLES
  **********************/
 #if LV_USE_OBJ_PROPERTY
-static const lv_property_ops_t properties[] = {
+static const lv_property_ops_t lv_keyboard_properties[] = {
     {
         .id = LV_PROPERTY_KEYBOARD_TEXTAREA,
         .setter = lv_keyboard_set_textarea,
@@ -92,18 +92,7 @@ const lv_obj_class_t lv_keyboard_class = {
     .editable = 1,
     .base_class = &lv_buttonmatrix_class,
     .name = "lv_keyboard",
-#if LV_USE_OBJ_PROPERTY
-    .prop_index_start = LV_PROPERTY_KEYBOARD_START,
-    .prop_index_end = LV_PROPERTY_KEYBOARD_END,
-    .properties = properties,
-    .properties_count = sizeof(properties) / sizeof(properties[0]),
-
-#if LV_USE_OBJ_PROPERTY_NAME
-    .property_names = lv_keyboard_property_names,
-    .names_count = sizeof(lv_keyboard_property_names) / sizeof(lv_property_name_t),
-#endif
-
-#endif
+    LV_PROPERTY_CLASS_FIELDS(keyboard, KEYBOARD)
 };
 
 static const char * const default_kb_map_lc[] = {LV_KEYBOARD_CTRL_BUTTON_MODE_SPECIAL, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", LV_SYMBOL_BACKSPACE, "\n",

--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -71,7 +71,7 @@ static void lv_label_mark_need_refr_text(lv_obj_t * obj);
  *  STATIC VARIABLES
  **********************/
 #if LV_USE_OBJ_PROPERTY
-static const lv_property_ops_t properties[] = {
+static const lv_property_ops_t lv_label_properties[] = {
     {
         .id = LV_PROPERTY_LABEL_TEXT,
         .setter = lv_label_set_text,
@@ -104,18 +104,7 @@ const lv_obj_class_t lv_label_class = {
     .instance_size = sizeof(lv_label_t),
     .base_class = &lv_obj_class,
     .name = "lv_label",
-#if LV_USE_OBJ_PROPERTY
-    .prop_index_start = LV_PROPERTY_LABEL_START,
-    .prop_index_end = LV_PROPERTY_LABEL_END,
-    .properties = properties,
-    .properties_count = sizeof(properties) / sizeof(properties[0]),
-
-#if LV_USE_OBJ_PROPERTY_NAME
-    .property_names = lv_label_property_names,
-    .names_count = sizeof(lv_label_property_names) / sizeof(lv_property_name_t),
-#endif
-
-#endif
+    LV_PROPERTY_CLASS_FIELDS(label, LABEL)
 };
 
 /**********************

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -62,7 +62,7 @@ static void transform_vect_recursive(lv_obj_t * roller, lv_point_t * vect);
  *  STATIC VARIABLES
  **********************/
 #if LV_USE_OBJ_PROPERTY
-static const lv_property_ops_t properties[] = {
+static const lv_property_ops_t lv_roller_properties[] = {
     {
         .id = LV_PROPERTY_ROLLER_OPTIONS,
         .setter = lv_roller_set_options,
@@ -91,17 +91,7 @@ const lv_obj_class_t lv_roller_class = {
     .group_def = LV_OBJ_CLASS_GROUP_DEF_TRUE,
     .base_class = &lv_obj_class,
     .name = "lv_roller",
-#if LV_USE_OBJ_PROPERTY
-    .prop_index_start = LV_PROPERTY_ROLLER_START,
-    .prop_index_end = LV_PROPERTY_ROLLER_END,
-    .properties = properties,
-    .properties_count = sizeof(properties) / sizeof(properties[0]),
-
-#if LV_USE_OBJ_PROPERTY_NAME
-    .property_names = lv_roller_property_names,
-    .names_count = sizeof(lv_roller_property_names) / sizeof(lv_property_name_t),
-#endif
-#endif
+    LV_PROPERTY_CLASS_FIELDS(roller, ROLLER)
 };
 
 const lv_obj_class_t lv_roller_label_class  = {

--- a/src/widgets/slider/lv_slider.c
+++ b/src/widgets/slider/lv_slider.c
@@ -57,7 +57,7 @@ static void update_knob_pos(lv_obj_t * obj, bool check_drag);
  **********************/
 
 #if LV_USE_OBJ_PROPERTY
-static const lv_property_ops_t properties[] = {
+static const lv_property_ops_t lv_slider_properties[] = {
     {
         .id = LV_PROPERTY_SLIDER_VALUE,
         .setter = lv_slider_set_value,
@@ -109,17 +109,7 @@ const lv_obj_class_t lv_slider_class = {
     .instance_size = sizeof(lv_slider_t),
     .base_class = &lv_bar_class,
     .name = "lv_slider",
-#if LV_USE_OBJ_PROPERTY
-    .prop_index_start = LV_PROPERTY_SLIDER_START,
-    .prop_index_end = LV_PROPERTY_SLIDER_END,
-    .properties = properties,
-    .properties_count = sizeof(properties) / sizeof(properties[0]),
-
-#if LV_USE_OBJ_PROPERTY_NAME
-    .property_names = lv_slider_property_names,
-    .names_count = sizeof(lv_slider_property_names) / sizeof(lv_property_name_t),
-#endif
-#endif
+    LV_PROPERTY_CLASS_FIELDS(slider, SLIDER)
 };
 
 /**********************

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -69,7 +69,7 @@ static void lv_textarea_scroll_to_cusor_pos(lv_obj_t * obj, int32_t pos);
  *  STATIC VARIABLES
  **********************/
 #if LV_USE_OBJ_PROPERTY
-static const lv_property_ops_t properties[] = {
+static const lv_property_ops_t lv_textarea_properties[] = {
     {
         .id = LV_PROPERTY_TEXTAREA_TEXT,
         .setter = lv_textarea_set_text,
@@ -159,18 +159,7 @@ const lv_obj_class_t lv_textarea_class = {
     .instance_size = sizeof(lv_textarea_t),
     .base_class = &lv_obj_class,
     .name = "lv_textarea",
-#if LV_USE_OBJ_PROPERTY
-    .prop_index_start = LV_PROPERTY_TEXTAREA_START,
-    .prop_index_end = LV_PROPERTY_TEXTAREA_END,
-    .properties = properties,
-    .properties_count = sizeof(properties) / sizeof(properties[0]),
-
-#if LV_USE_OBJ_PROPERTY_NAME
-    .property_names = lv_textarea_property_names,
-    .names_count = sizeof(lv_textarea_property_names) / sizeof(lv_property_name_t),
-#endif
-
-#endif
+    LV_PROPERTY_CLASS_FIELDS(textarea, TEXTAREA)
 };
 
 static const char * ta_insert_replace;


### PR DESCRIPTION
Add helper macro `LV_PROPERTY_CLASS_FIELDS` to make it easier for property related initialization in class struct.

E.g.
```
static const lv_property_ops_t lv_animimage_properties[] = {
 // xxx,
};

const lv_obj_class_t lv_animimg_class = {
    .constructor_cb = lv_animimg_constructor,
    .instance_size = sizeof(lv_animimg_t),
    .base_class = &lv_image_class,
    .name = "lv_animimg",
    LV_PROPERTY_CLASS_FIELDS(animimage, ANIMIMAGE)
};
```


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
