### PR TITLE
fix(gstreamer): free GStreamer buffer after setting source

### DIFF
--- a/src/libs/gstreamer/lv_gstreamer.c
+++ b/src/libs/gstreamer/lv_gstreamer.c
@@ -455,6 +455,7 @@ static void gstreamer_update_frame(lv_gstreamer_t * streamer)
             }
         };
         lv_image_set_src((lv_obj_t *)streamer, &streamer->frame);
+        gst_buffer_unmap(buffer, &map);
     }
     /* We send the event AFTER setting the image source so that users can query the
      * resolution on this specific event callback */


### PR DESCRIPTION
Fixes #9359 

Previously, after each call to gstreamer_update_frame(), the GstBuffer was not freed, causing memory to accumulate on the heap over time. In long-running streams, this led to progressive RAM growth and eventual memory exhaustion.

This fix ensures that the GstBuffer is properly unmapped after passing the data to lv_image_set_src. Since lv_image_set_src internally makes its own copy of the image data, it is safe to release the buffer immediately, preventing memory leaks and stabilizing RAM usage.

