### PR TITLE
fix(display): always have a solid background with non-alpha color formats

### DIFF
--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -146,6 +146,13 @@ lv_display_t * lv_display_create(int32_t hor_res, int32_t ver_res)
     lv_obj_remove_flag(disp->top_layer, LV_OBJ_FLAG_CLICKABLE);
     lv_obj_remove_flag(disp->sys_layer, LV_OBJ_FLAG_CLICKABLE);
 
+    if(lv_color_format_has_alpha(disp->color_format)) {
+        lv_obj_remove_local_style_prop(disp->bottom_layer, LV_STYLE_BG_OPA, 0);
+    }
+    else {
+        lv_obj_set_style_bg_opa(disp->bottom_layer, 255, 0);
+    }
+
     lv_obj_set_scrollbar_mode(disp->bottom_layer, LV_SCROLLBAR_MODE_OFF);
     lv_obj_set_scrollbar_mode(disp->top_layer, LV_SCROLLBAR_MODE_OFF);
     lv_obj_set_scrollbar_mode(disp->sys_layer, LV_SCROLLBAR_MODE_OFF);
@@ -561,6 +568,13 @@ void lv_display_set_color_format(lv_display_t * disp, lv_color_format_t color_fo
     if(disp->buf_1) disp->buf_1->header.cf = color_format;
     if(disp->buf_2) disp->buf_2->header.cf = color_format;
     if(disp->buf_3) disp->buf_3->header.cf = color_format;
+
+    if(lv_color_format_has_alpha(disp->color_format)) {
+        lv_obj_remove_local_style_prop(disp->bottom_layer, LV_STYLE_BG_OPA, 0);
+    }
+    else {
+        lv_obj_set_style_bg_opa(disp->bottom_layer, 255, 0);
+    }
 
     lv_display_send_event(disp, LV_EVENT_COLOR_FORMAT_CHANGED, NULL);
 }


### PR DESCRIPTION
It prevents a rendering error when screen bg_opa = 0 but screen color format has no alpha. 


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
