### PR TITLE
fix(demo): make the Log out and Invite button not overlap on 480 hor. res.

### DIFF
--- a/demos/widgets/lv_demo_widgets_profile.c
+++ b/demos/widgets/lv_demo_widgets_profile.c
@@ -252,8 +252,8 @@ void lv_demo_widgets_profile_create(lv_obj_t * parent)
         lv_obj_set_grid_dsc_array(parent, grid_main_col_dsc, grid_main_row_dsc);
         lv_obj_set_grid_cell(panel1, LV_GRID_ALIGN_STRETCH, 0, 2, LV_GRID_ALIGN_CENTER, 0, 1);
 
-        lv_obj_set_width(log_out_btn, 120);
-        lv_obj_set_width(invite_btn, 120);
+        lv_obj_set_width(log_out_btn, 110);
+        lv_obj_set_width(invite_btn, 110);
 
         lv_obj_set_grid_dsc_array(panel1, grid_1_col_dsc, grid_1_row_dsc);
         lv_obj_set_grid_cell(avatar, LV_GRID_ALIGN_CENTER, 0, 1, LV_GRID_ALIGN_START, 0, 4);


### PR DESCRIPTION
Widget demo before the fix on 480x800 resolution:

<img width="473" height="791" alt="image" src="https://github.com/user-attachments/assets/a250892e-1d03-4b9e-83c5-f62f85987010" />

After the fix
<img width="477" height="798" alt="image" src="https://github.com/user-attachments/assets/d86b85e4-933d-49b7-b57a-8f05e9930221" />

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
