### PR TITLE
feat(opengl): add glsl version 330 support

### DIFF
--- a/src/drivers/opengles/assets/lv_opengles_shader.c
+++ b/src/drivers/opengles/assets/lv_opengles_shader.c
@@ -232,6 +232,7 @@ static const size_t src_includes_v300es_count = sizeof src_includes_v300es / siz
 
 char * lv_opengles_shader_get_vertex(lv_opengl_glsl_version_t version) {
     switch (version){
+        case LV_OPENGL_GLSL_VERSION_330:
         case LV_OPENGL_GLSL_VERSION_300ES:
             return lv_opengl_shader_manager_process_includes(src_vertex_shader_v300es, src_includes_v300es, src_includes_v300es_count);
         case LV_OPENGL_GLSL_VERSION_100:
@@ -245,6 +246,7 @@ char * lv_opengles_shader_get_vertex(lv_opengl_glsl_version_t version) {
 
 char * lv_opengles_shader_get_fragment(lv_opengl_glsl_version_t version) {
     switch (version){
+        case LV_OPENGL_GLSL_VERSION_330:
         case LV_OPENGL_GLSL_VERSION_300ES:
             return lv_opengl_shader_manager_process_includes(src_fragment_shader_v300es, src_includes_v300es, src_includes_v300es_count);
         case LV_OPENGL_GLSL_VERSION_100:
@@ -259,6 +261,7 @@ char * lv_opengles_shader_get_fragment(lv_opengl_glsl_version_t version) {
 void lv_opengles_shader_get_source(lv_opengl_shader_portions_t *portions, lv_opengl_glsl_version_t version)
 {
     switch (version){
+        case LV_OPENGL_GLSL_VERSION_330:
         case LV_OPENGL_GLSL_VERSION_300ES:
             portions->all = src_includes_v300es;
             portions->count = src_includes_v300es_count;

--- a/src/drivers/opengles/assets/lv_opengles_shader.c
+++ b/src/drivers/opengles/assets/lv_opengles_shader.c
@@ -230,7 +230,7 @@ static const size_t src_includes_v300es_count = sizeof src_includes_v300es / siz
  *   GLOBAL FUNCTIONS
  **********************/
 
-char * lv_opengles_shader_get_vertex(lv_opengl_glsl_version version) {
+char * lv_opengles_shader_get_vertex(lv_opengl_glsl_version_t version) {
     switch (version){
         case LV_OPENGL_GLSL_VERSION_300ES:
             return lv_opengl_shader_manager_process_includes(src_vertex_shader_v300es, src_includes_v300es, src_includes_v300es_count);
@@ -243,7 +243,7 @@ char * lv_opengles_shader_get_vertex(lv_opengl_glsl_version version) {
     LV_UNREACHABLE();
 }
 
-char * lv_opengles_shader_get_fragment(lv_opengl_glsl_version version) {
+char * lv_opengles_shader_get_fragment(lv_opengl_glsl_version_t version) {
     switch (version){
         case LV_OPENGL_GLSL_VERSION_300ES:
             return lv_opengl_shader_manager_process_includes(src_fragment_shader_v300es, src_includes_v300es, src_includes_v300es_count);
@@ -256,7 +256,7 @@ char * lv_opengles_shader_get_fragment(lv_opengl_glsl_version version) {
     LV_UNREACHABLE();
 }
 
-void lv_opengles_shader_get_source(lv_opengl_shader_portions_t *portions, lv_opengl_glsl_version version)
+void lv_opengles_shader_get_source(lv_opengl_shader_portions_t *portions, lv_opengl_glsl_version_t version)
 {
     switch (version){
         case LV_OPENGL_GLSL_VERSION_300ES:

--- a/src/drivers/opengles/assets/lv_opengles_shader.h
+++ b/src/drivers/opengles/assets/lv_opengles_shader.h
@@ -21,9 +21,9 @@ extern "C" {
  * GLOBAL PROTOTYPES
  **********************/
 
-char * lv_opengles_shader_get_vertex(lv_opengl_glsl_version version);
-char * lv_opengles_shader_get_fragment(lv_opengl_glsl_version version);
-void lv_opengles_shader_get_source(lv_opengl_shader_portions_t * portions, lv_opengl_glsl_version version);
+char * lv_opengles_shader_get_vertex(lv_opengl_glsl_version_t version);
+char * lv_opengles_shader_get_fragment(lv_opengl_glsl_version_t version);
+void lv_opengles_shader_get_source(lv_opengl_shader_portions_t * portions, lv_opengl_glsl_version_t version);
 
 
 /**********************

--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -380,45 +380,31 @@ static void lv_opengles_index_buffer_unbind(void)
 
 static unsigned int lv_opengles_shader_manager_init(void)
 {
-    lv_opengl_shader_program_t * program  = NULL;
     for(lv_opengl_glsl_version_t version = LV_OPENGL_GLSL_VERSION_300ES; version < LV_OPENGL_GLSL_VERSION_LAST; ++version) {
         LV_LOG_INFO("Trying GLSL version %s", lv_opengles_glsl_version_to_string(version));
-        lv_opengl_shader_portions_t portions;
-        lv_opengles_shader_get_source(&portions, version);
-        char * vertex_shader = lv_opengles_shader_get_vertex(version);
-        char * frag_shader = lv_opengles_shader_get_fragment(version);
-        lv_opengl_shader_manager_init(&shader_manager, portions.all, portions.count, vertex_shader, frag_shader);
-        lv_free(vertex_shader);
-        lv_free(frag_shader);
+        {
+            /* Initialize the shader manager*/
+            lv_opengl_shader_portions_t portions;
+            lv_opengles_shader_get_source(&portions, version);
+            char * vertex_shader = lv_opengles_shader_get_vertex(version);
+            char * frag_shader = lv_opengles_shader_get_fragment(version);
+            lv_opengl_shader_manager_init(&shader_manager, portions.all, portions.count, vertex_shader, frag_shader);
+            lv_free(vertex_shader);
+            lv_free(frag_shader);
+        }
 
-        uint32_t frag_shader_hash;
-        uint32_t vert_shader_hash;
-
-        lv_result_t res = lv_opengl_shader_manager_select_shader(&shader_manager, "__MAIN__.frag", NULL, 0, version,
-                                                                 &frag_shader_hash);
-        if(res != LV_RESULT_OK) {
-            lv_opengl_shader_manager_deinit(&shader_manager);
-            continue;
+        lv_opengl_shader_params_t frag_shader = {.name = "__MAIN__.frag"};
+        lv_opengl_shader_params_t vert_shader = {.name = "__MAIN__.vert"};
+        lv_opengl_shader_program_t * program = lv_opengl_shader_manager_compile_program(&shader_manager, &frag_shader,
+                                                                                        &vert_shader, version);
+        if(program) {
+            LV_LOG_INFO("Compiled shaders with version %s", lv_opengles_glsl_version_to_string(version));
+            return lv_opengl_shader_program_get_id(program);
         }
-        res = lv_opengl_shader_manager_select_shader(&shader_manager, "__MAIN__.vert", NULL, 0, version, &vert_shader_hash);
-        if(res != LV_RESULT_OK) {
-            lv_opengl_shader_manager_deinit(&shader_manager);
-            continue;
-        }
-        program = lv_opengl_shader_manager_get_program(&shader_manager, frag_shader_hash, vert_shader_hash);
-        if(!program) {
-            lv_opengl_shader_manager_deinit(&shader_manager);
-            continue;
-        }
-        LV_LOG_INFO("Compiled shaders with version %s", lv_opengles_glsl_version_to_string(version));
-        break;
+        lv_opengl_shader_manager_deinit(&shader_manager);
     }
-
-    if(!program) {
-        LV_LOG_ERROR("Failed to initialize shaders");
-        return 0;
-    }
-    return lv_opengl_shader_program_get_id(program);
+    LV_LOG_ERROR("Failed to initialize shaders");
+    return 0;
 }
 
 static lv_result_t lv_opengles_shader_init(void)

--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -381,7 +381,7 @@ static void lv_opengles_index_buffer_unbind(void)
 static unsigned int lv_opengles_shader_manager_init(void)
 {
     lv_opengl_shader_program_t * program  = NULL;
-    for(lv_opengl_glsl_version version = LV_OPENGL_GLSL_VERSION_300ES; version < LV_OPENGL_GLSL_VERSION_LAST; ++version) {
+    for(lv_opengl_glsl_version_t version = LV_OPENGL_GLSL_VERSION_300ES; version < LV_OPENGL_GLSL_VERSION_LAST; ++version) {
         LV_LOG_INFO("Trying GLSL version %s", lv_opengles_glsl_version_to_string(version));
         lv_opengl_shader_portions_t portions;
         lv_opengles_shader_get_source(&portions, version);

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
@@ -81,6 +81,7 @@ typedef struct _lv_shader_program {
 
 typedef enum {
     LV_OPENGL_GLSL_VERSION_300ES,
+    LV_OPENGL_GLSL_VERSION_330,
     LV_OPENGL_GLSL_VERSION_100,
     LV_OPENGL_GLSL_VERSION_LAST,
 } lv_opengl_glsl_version_t;

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
@@ -79,6 +79,12 @@ typedef struct _lv_shader_program {
     uint32_t id;
 } lv_opengl_shader_program_t;
 
+typedef struct {
+    const char * name;
+    const lv_opengl_shader_define_t * permutations;
+    size_t permutations_len;
+} lv_opengl_shader_params_t;
+
 typedef enum {
     LV_OPENGL_GLSL_VERSION_300ES,
     LV_OPENGL_GLSL_VERSION_330,
@@ -112,6 +118,18 @@ lv_opengl_shader_program_t * lv_opengl_shader_manager_get_program(lv_opengl_shad
                                                                   uint32_t vertex_shader_hash);
 
 const char * lv_opengles_glsl_version_to_string(lv_opengl_glsl_version_t version);
+
+
+lv_opengl_shader_program_t * lv_opengl_shader_manager_compile_program(lv_opengl_shader_manager_t * manager,
+                                                                      const lv_opengl_shader_params_t * frag_shader,
+                                                                      const lv_opengl_shader_params_t * vert_shader,
+                                                                      lv_opengl_glsl_version_t version);
+
+lv_opengl_shader_program_t * lv_opengl_shader_manager_compile_program_best_version(
+    lv_opengl_shader_manager_t * manager,
+    const lv_opengl_shader_params_t * frag_shader,
+    const lv_opengl_shader_params_t * vert_shader,
+    const lv_opengl_glsl_version_t * versions, size_t version_count);
 
 /**********************
  *      MACROS

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
@@ -83,7 +83,7 @@ typedef enum {
     LV_OPENGL_GLSL_VERSION_300ES,
     LV_OPENGL_GLSL_VERSION_100,
     LV_OPENGL_GLSL_VERSION_LAST,
-} lv_opengl_glsl_version;
+} lv_opengl_glsl_version_t;
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -105,12 +105,12 @@ GLuint lv_opengl_shader_manager_get_texture(lv_opengl_shader_manager_t * manager
 void lv_opengl_shader_manager_store_texture(lv_opengl_shader_manager_t * manager, uint32_t hash, GLuint id);
 lv_result_t lv_opengl_shader_manager_select_shader(lv_opengl_shader_manager_t * shader, const char * shader_identifier,
                                                    const lv_opengl_shader_define_t * permutations, size_t permutations_len,
-                                                   lv_opengl_glsl_version glsl_version, uint32_t * out_hash);
+                                                   lv_opengl_glsl_version_t glsl_version, uint32_t * out_hash);
 lv_opengl_shader_program_t * lv_opengl_shader_manager_get_program(lv_opengl_shader_manager_t * manager,
                                                                   uint32_t fragment_shader_hash,
                                                                   uint32_t vertex_shader_hash);
 
-const char * lv_opengles_glsl_version_to_string(lv_opengl_glsl_version version);
+const char * lv_opengles_glsl_version_to_string(lv_opengl_glsl_version_t version);
 
 /**********************
  *      MACROS

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
@@ -119,7 +119,6 @@ lv_opengl_shader_program_t * lv_opengl_shader_manager_get_program(lv_opengl_shad
 
 const char * lv_opengles_glsl_version_to_string(lv_opengl_glsl_version_t version);
 
-
 lv_opengl_shader_program_t * lv_opengl_shader_manager_compile_program(lv_opengl_shader_manager_t * manager,
                                                                       const lv_opengl_shader_params_t * frag_shader,
                                                                       const lv_opengl_shader_params_t * vert_shader,

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
@@ -291,6 +291,58 @@ lv_opengl_shader_manager_get_program(lv_opengl_shader_manager_t * manager,
     return program;
 }
 
+
+lv_opengl_shader_program_t * lv_opengl_shader_manager_compile_program(lv_opengl_shader_manager_t * manager,
+                                                                      const lv_opengl_shader_params_t * frag_shader,
+                                                                      const lv_opengl_shader_params_t * vert_shader,
+                                                                      lv_opengl_glsl_version_t version)
+{
+    uint32_t frag_shader_hash;
+    uint32_t vert_shader_hash;
+
+
+    lv_result_t res = lv_opengl_shader_manager_select_shader(manager, frag_shader->name, frag_shader->permutations,
+                                                             frag_shader->permutations_len,
+                                                             version, &frag_shader_hash);
+    if(res != LV_RESULT_OK) {
+        LV_LOG_WARN("Failed to compile shader for glsl version %s", lv_opengles_glsl_version_to_string(version));
+        return NULL;
+    }
+
+    res = lv_opengl_shader_manager_select_shader(manager, vert_shader->name, vert_shader->permutations,
+                                                 vert_shader->permutations_len,
+                                                 version, &vert_shader_hash);
+    if(res != LV_RESULT_OK) {
+        LV_LOG_WARN("Failed to compile shader for glsl version %s", lv_opengles_glsl_version_to_string(version));
+        return NULL;
+    }
+    lv_opengl_shader_program_t * program =
+        lv_opengl_shader_manager_get_program(manager, frag_shader_hash, vert_shader_hash);
+
+    if(!program) {
+        LV_LOG_WARN("Failed to link program for glsl version %s", lv_opengles_glsl_version_to_string(version));
+    }
+
+    return program;
+
+}
+
+lv_opengl_shader_program_t * lv_opengl_shader_manager_compile_program_best_version(
+    lv_opengl_shader_manager_t * manager,
+    const lv_opengl_shader_params_t * frag_shader,
+    const lv_opengl_shader_params_t * vert_shader,
+    const lv_opengl_glsl_version_t * versions, size_t version_count)
+{
+    for(size_t i = 0; i < version_count; ++i) {
+        lv_opengl_shader_program_t * program = lv_opengl_shader_manager_compile_program(manager, frag_shader, vert_shader,
+                                                                                        versions[i]);
+        if(program) {
+            return program;
+        }
+    }
+    return NULL;
+}
+
 void lv_opengl_shader_manager_deinit(lv_opengl_shader_manager_t * manager)
 {
     LV_LOG_INFO("Destroying shader cache");

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
@@ -294,7 +294,6 @@ lv_opengl_shader_manager_get_program(lv_opengl_shader_manager_t * manager,
     return program;
 }
 
-
 lv_opengl_shader_program_t * lv_opengl_shader_manager_compile_program(lv_opengl_shader_manager_t * manager,
                                                                       const lv_opengl_shader_params_t * frag_shader,
                                                                       const lv_opengl_shader_params_t * vert_shader,
@@ -302,7 +301,6 @@ lv_opengl_shader_program_t * lv_opengl_shader_manager_compile_program(lv_opengl_
 {
     uint32_t frag_shader_hash;
     uint32_t vert_shader_hash;
-
 
     lv_result_t res = lv_opengl_shader_manager_select_shader(manager, frag_shader->name, frag_shader->permutations,
                                                              frag_shader->permutations_len,
@@ -327,7 +325,6 @@ lv_opengl_shader_program_t * lv_opengl_shader_manager_compile_program(lv_opengl_
     }
 
     return program;
-
 }
 
 lv_opengl_shader_program_t * lv_opengl_shader_manager_compile_program_best_version(

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
@@ -186,6 +186,9 @@ lv_result_t lv_opengl_shader_manager_select_shader(lv_opengl_shader_manager_t * 
         }
         hash ^= lv_opengl_shader_hash(define);
     }
+    /* hash the version so that the same shader with different versions produces a different hash*/
+    hash ^= lv_opengl_shader_hash(lv_opengles_glsl_version_to_string(glsl_version));
+
     lv_opengl_compiled_shader_t shader_map_key = { hash, 0 };
     lv_rb_node_t * shader_map_node =
         lv_rb_find(&shader->compiled_shaders_map, &shader_map_key);

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
@@ -62,7 +62,7 @@ static bool string_ends_with(const char * value, const char * suffix);
 
 static char * construct_shader(const char * source,
                                const lv_opengl_shader_define_t * permutations,
-                               size_t permutations_len, lv_opengl_glsl_version glsl_version);
+                               size_t permutations_len, lv_opengl_glsl_version_t glsl_version);
 
 static GLuint compile_shader(const char * shader_source, bool is_vertex_shader);
 static GLuint link_program(GLuint vertex_shader_id, GLuint fragment_shader_id);
@@ -161,7 +161,7 @@ GLuint lv_opengl_shader_manager_get_texture(lv_opengl_shader_manager_t * manager
 
 lv_result_t lv_opengl_shader_manager_select_shader(lv_opengl_shader_manager_t * shader, const char * shader_identifier,
                                                    const lv_opengl_shader_define_t * permutations, size_t permutations_len,
-                                                   lv_opengl_glsl_version glsl_version, uint32_t * out_hash)
+                                                   lv_opengl_glsl_version_t glsl_version, uint32_t * out_hash)
 {
     /* First check that the shader identifier exists */
     lv_opengl_shader_t key = { shader_identifier, NULL };
@@ -324,7 +324,7 @@ void lv_opengl_shader_manager_deinit(lv_opengl_shader_manager_t * manager)
 
 }
 
-const char * lv_opengles_glsl_version_to_string(lv_opengl_glsl_version version)
+const char * lv_opengles_glsl_version_to_string(lv_opengl_glsl_version_t version)
 {
 
     switch(version) {
@@ -485,7 +485,7 @@ static char * append_to_shader(char * dst, const char * src, size_t * curr_index
 
 static char * construct_shader(const char * source,
                                const lv_opengl_shader_define_t * permutations,
-                               size_t permutations_len, lv_opengl_glsl_version glsl_version)
+                               size_t permutations_len, lv_opengl_glsl_version_t glsl_version)
 {
     const char * defines = lv_opengles_glsl_version_to_string(glsl_version);
     const char * prefix = "#define ";

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
@@ -332,6 +332,8 @@ const char * lv_opengles_glsl_version_to_string(lv_opengl_glsl_version_t version
             return "#version 100\n";
         case LV_OPENGL_GLSL_VERSION_300ES:
             return "#version 300 es\n";
+        case LV_OPENGL_GLSL_VERSION_330:
+            return "#version 330\n";
         case LV_OPENGL_GLSL_VERSION_LAST:
             LV_LOG_ERROR("LV_OPENGL_GLSL_VERSION_LAST is not a valid version");
             return NULL;

--- a/src/libs/gltf/gltf_data/lv_gltf_data_internal.h
+++ b/src/libs/gltf/gltf_data/lv_gltf_data_internal.h
@@ -175,15 +175,8 @@ typedef struct {
 lv_gltf_uniform_locations_t lv_gltf_uniform_locations_create(GLuint program);
 
 typedef struct {
-    GLuint program;
-    uint32_t bg_program;
-    uint32_t vert;
-    uint32_t frag;
-} lv_gltf_shaderset_t;
-
-typedef struct {
     lv_gltf_uniform_locations_t uniforms;
-    lv_gltf_shaderset_t shaderset;
+    GLuint program;
 } lv_gltf_compiled_shader_t;
 
 void lv_gltf_store_compiled_shader(lv_gltf_model_t * data, size_t identifier, lv_gltf_compiled_shader_t * shader);

--- a/src/libs/gltf/gltf_environment/lv_gltf_ibl_sampler.c
+++ b/src/libs/gltf/gltf_environment/lv_gltf_ibl_sampler.c
@@ -72,7 +72,6 @@ static const lv_opengl_glsl_version_t GLSL_VERSIONS[] = {
 };
 static const size_t GLSL_VERSION_COUNT = sizeof(GLSL_VERSIONS) / sizeof(GLSL_VERSIONS[0]);
 
-
 /**********************
  *      MACROS
  **********************/

--- a/src/libs/gltf/gltf_environment/lv_gltf_ibl_sampler.c
+++ b/src/libs/gltf/gltf_environment/lv_gltf_ibl_sampler.c
@@ -13,7 +13,6 @@
 
 #include "../../../misc/lv_math.h"
 #include "../../../misc/lv_log.h"
-#include "../../../stdlib/lv_sprintf.h"
 #include "../../../stdlib/lv_string.h"
 #include "../../../drivers/opengles/lv_opengles_private.h"
 #include "../../../drivers/opengles/lv_opengles_debug.h"
@@ -66,6 +65,13 @@ static void draw_fullscreen_quad(lv_gltf_ibl_sampler_t * sampler, GLuint program
 /**********************
  *  STATIC VARIABLES
  **********************/
+
+static const lv_opengl_glsl_version_t GLSL_VERSIONS[] = {
+    LV_OPENGL_GLSL_VERSION_300ES,
+    LV_OPENGL_GLSL_VERSION_330,
+};
+static const size_t GLSL_VERSION_COUNT = sizeof(GLSL_VERSIONS) / sizeof(GLSL_VERSIONS[0]);
+
 
 /**********************
  *      MACROS
@@ -378,19 +384,16 @@ static void ibl_panorama_to_cubemap(lv_gltf_ibl_sampler_t * sampler)
         GL_CALL(glViewport(0, 0, sampler->cube_map_resolution, sampler->cube_map_resolution));
         GL_CALL(glClearColor(1.0, 0.0, 0.0, 0.0));
         GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
-        uint32_t frag_shader_hash;
-        uint32_t vert_shader_hash;
-        lv_result_t res = lv_opengl_shader_manager_select_shader(&sampler->shader_manager, "panorama_to_cubemap.frag", NULL, 0,
-                                                                 LV_OPENGL_GLSL_VERSION_300ES, &frag_shader_hash);
-        LV_ASSERT(res == LV_RESULT_OK);
-        res = lv_opengl_shader_manager_select_shader(&sampler->shader_manager, "fullscreen.vert", NULL, 0,
-                                                     LV_OPENGL_GLSL_VERSION_300ES, &vert_shader_hash);
-        LV_ASSERT(res == LV_RESULT_OK);
-        lv_opengl_shader_program_t * program =
-            lv_opengl_shader_manager_get_program(&sampler->shader_manager, frag_shader_hash, vert_shader_hash);
+
+        lv_opengl_shader_params_t frag_shader = {.name = "panorama_to_cubemap.frag"};
+        lv_opengl_shader_params_t vert_shader = {.name = "fullscreen.vert"};
+        lv_opengl_shader_program_t * program = lv_opengl_shader_manager_compile_program_best_version(&sampler->shader_manager,
+                                                                                                     &frag_shader, &vert_shader,
+                                                                                                     GLSL_VERSIONS,
+                                                                                                     GLSL_VERSION_COUNT);
 
         LV_ASSERT_MSG(program != NULL,
-                      "Failed to link program. This probably means your platform doesn't support GLSL version 300 es");
+                      "Failed to link program. This probably means your platform doesn't support a required GLSL version");
 
         GLuint program_id = lv_opengl_shader_program_get_id(program);
 
@@ -423,21 +426,16 @@ static void ibl_apply_filter(lv_gltf_ibl_sampler_t * sampler, uint32_t distribut
         GL_CALL(glClearColor(0.0, 1.0, 0.0, 0.0));
         GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
 
-        uint32_t frag_shader_hash;
-        uint32_t vert_shader_hash;
-        lv_result_t res = lv_opengl_shader_manager_select_shader(&sampler->shader_manager, "ibl_filtering.frag", NULL, 0,
-                                                                 LV_OPENGL_GLSL_VERSION_300ES, &frag_shader_hash);
-        LV_ASSERT(res == LV_RESULT_OK);
-        res = lv_opengl_shader_manager_select_shader(&sampler->shader_manager, "fullscreen.vert", NULL, 0,
-                                                     LV_OPENGL_GLSL_VERSION_300ES, &vert_shader_hash);
-        LV_ASSERT(res == LV_RESULT_OK);
+        lv_opengl_shader_params_t frag_shader = {.name = "ibl_filtering.frag"};
+        lv_opengl_shader_params_t vert_shader = {.name = "fullscreen.vert"};
         lv_opengl_shader_program_t * program =
-            lv_opengl_shader_manager_get_program(&sampler->shader_manager, frag_shader_hash, vert_shader_hash);
-
+            lv_opengl_shader_manager_compile_program_best_version(&sampler->shader_manager, &frag_shader, &vert_shader,
+                                                                  GLSL_VERSIONS,
+                                                                  GLSL_VERSION_COUNT);
         LV_ASSERT_MSG(program != NULL,
-                      "Failed to link program. This probably means your platform doesn't support GLSL version 300 es");
-        GLuint program_id = lv_opengl_shader_program_get_id(program);
+                      "Failed to link program. This probably means your platform doesn't support a required GLSL version");
 
+        GLuint program_id = lv_opengl_shader_program_get_id(program);
 
         GL_CALL(glUseProgram(program_id));
         GL_CALL(glActiveTexture(GL_TEXTURE0));
@@ -493,18 +491,15 @@ static void ibl_sample_lut(lv_gltf_ibl_sampler_t * sampler, uint32_t distributio
     GL_CALL(glViewport(0, 0, currentTextureSize, currentTextureSize));
     GL_CALL(glClearColor(0.0, 1.0, 1.0, 0.0));
     GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
-    uint32_t frag_shader;
-    uint32_t vert_shader;
-    lv_result_t res    = lv_opengl_shader_manager_select_shader(&sampler->shader_manager, "ibl_filtering.frag", NULL, 0,
-                                                                LV_OPENGL_GLSL_VERSION_300ES, &frag_shader);
-    LV_ASSERT(res == LV_RESULT_OK);
-    res = lv_opengl_shader_manager_select_shader(&sampler->shader_manager, "fullscreen.vert", NULL, 0,
-                                                 LV_OPENGL_GLSL_VERSION_300ES, &vert_shader);
-    LV_ASSERT(res == LV_RESULT_OK);
-    lv_opengl_shader_program_t * program = lv_opengl_shader_manager_get_program(&sampler->shader_manager, frag_shader,
-                                                                                vert_shader);
+
+    lv_opengl_shader_params_t frag_shader = {.name = "ibl_filtering.frag"};
+    lv_opengl_shader_params_t vert_shader = {.name = "fullscreen.vert"};
+    lv_opengl_shader_program_t * program =
+        lv_opengl_shader_manager_compile_program_best_version(&sampler->shader_manager, &frag_shader, &vert_shader,
+                                                              GLSL_VERSIONS,
+                                                              GLSL_VERSION_COUNT);
     LV_ASSERT_MSG(program != NULL,
-                  "Failed to link program. This probably means your platform doesn't support GLSL version 300 es");
+                  "Failed to link program. This probably means your platform doesn't support a required GLSL version");
 
     GLuint program_id = lv_opengl_shader_program_get_id(program);
 
@@ -607,7 +602,7 @@ static void init_fullscreen_quad(lv_gltf_ibl_sampler_t * sampler)
     GL_CALL(glBufferData(GL_ARRAY_BUFFER, sizeof(texCoords), texCoords, GL_STATIC_DRAW));
 }
 
-void draw_fullscreen_quad(lv_gltf_ibl_sampler_t * sampler, GLuint program_id)
+static void draw_fullscreen_quad(lv_gltf_ibl_sampler_t * sampler, GLuint program_id)
 {
     GLuint positionAttrib = glGetAttribLocation(program_id, "aPosition");
     GL_CALL(glEnableVertexAttribArray(positionAttrib));

--- a/src/libs/gltf/gltf_view/lv_gltf_view.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view.cpp
@@ -84,6 +84,12 @@ const lv_obj_class_t lv_gltf_class = {
  *  STATIC VARIABLES
  **********************/
 
+static const lv_opengl_glsl_version_t GLSL_VERSIONS[] = {
+    LV_OPENGL_GLSL_VERSION_300ES,
+    LV_OPENGL_GLSL_VERSION_330,
+};
+static const size_t GLSL_VERSION_COUNT = sizeof(GLSL_VERSIONS) / sizeof(GLSL_VERSIONS[0]);
+
 /**********************
  *      MACROS
  **********************/
@@ -762,10 +768,31 @@ static void lv_gltf_parse_model(lv_gltf_t * viewer, lv_gltf_model_t * model)
                 lv_gltf_view_shader_injest_discover_defines(&defines, model, &node, &model_primitive);
 
             LV_ASSERT_MSG(result == LV_RESULT_OK, "Couldn't injest shader defines");
-            lv_gltf_compiled_shader_t compiled_shader;
-            compiled_shader.shaderset = lv_gltf_view_shader_compile_program(viewer, (lv_opengl_shader_define_t *)defines.data,
-                                                                            lv_array_size(&defines));
-            compiled_shader.uniforms = lv_gltf_uniform_locations_create(compiled_shader.shaderset.program);
+
+            lv_opengl_shader_params_t frag_shader = {.name = "__MAIN__.frag",
+                                                     .permutations = (lv_opengl_shader_define_t *) defines.data,
+                                                     .permutations_len = lv_array_size(&defines)
+                                                    };
+
+            lv_opengl_shader_params_t vert_shader = {.name = "__MAIN__.vert",
+                                                     .permutations = (lv_opengl_shader_define_t *) defines.data,
+                                                     .permutations_len = lv_array_size(&defines)
+                                                    };
+
+            lv_opengl_shader_program_t * program = lv_opengl_shader_manager_compile_program_best_version(&viewer->shader_manager,
+                                                                                                         &frag_shader,
+                                                                                                         &vert_shader, GLSL_VERSIONS, GLSL_VERSION_COUNT);
+            LV_ASSERT_MSG(program != NULL,
+                          "Failed to link program. This probably means your platform doesn't support a required GLSL version");
+            GLuint program_id = lv_opengl_shader_program_get_id(program);
+            GL_CALL(glUseProgram(program_id));
+
+            lv_gltf_compiled_shader_t compiled_shader = {
+                .uniforms = lv_gltf_uniform_locations_create(program_id),
+                .program = program_id,
+            };
+
+
             lv_gltf_store_compiled_shader(model, material_index, &compiled_shader);
             const size_t n = lv_array_size(&defines);
             for(size_t i = 0; i < n; ++i) {

--- a/src/libs/gltf/gltf_view/lv_gltf_view.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view.cpp
@@ -792,7 +792,6 @@ static void lv_gltf_parse_model(lv_gltf_t * viewer, lv_gltf_model_t * model)
                 .program = program_id,
             };
 
-
             lv_gltf_store_compiled_shader(model, material_index, &compiled_shader);
             const size_t n = lv_array_size(&defines);
             for(size_t i = 0; i < n; ++i) {

--- a/src/libs/gltf/gltf_view/lv_gltf_view_internal.h
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_internal.h
@@ -116,9 +116,6 @@ lv_result_t lv_gltf_view_shader_injest_discover_defines(lv_array_t * result, lv_
                                                         fastgltf::Node * node,
                                                         fastgltf::Primitive * prim);
 
-lv_gltf_shaderset_t lv_gltf_view_shader_compile_program(lv_gltf_t * view, const lv_opengl_shader_define_t * defines,
-                                                        size_t n);
-
 /**********************
  *      MACROS
  **********************/

--- a/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
@@ -473,7 +473,7 @@ static bool setup_primitive(int32_t prim_num, lv_gltf_t * viewer, lv_gltf_model_
     model->last_material_index = materialIndex;
     model->last_pass_was_transmission = is_transmission_pass;
 
-    const GLuint program = compiled_shader->shaderset.program;
+    const GLuint program = compiled_shader->program;
 
     GL_CALL(glUseProgram(program));
 

--- a/src/libs/gltf/gltf_view/lv_gltf_view_shader.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_shader.cpp
@@ -302,42 +302,6 @@ lv_result_t lv_gltf_view_shader_injest_discover_defines(lv_array_t * result, lv_
     return LV_RESULT_OK;
 }
 
-/**
- * @brief Compile and load shaders.
- *
- * This function compiles and loads the shaders from the specified shader cache, preparing them
- * for use in rendering operations. It returns a structure containing the shader set information.
- *
- * @param shaders Pointer to the lv_opengl_shader_cache_t structure containing the shader cache.
- * @return A gl_renwin_shaderset_t structure representing the compiled and loaded shaders.
- */
-
-lv_gltf_shaderset_t lv_gltf_view_shader_compile_program(lv_gltf_t * view, const lv_opengl_shader_define_t * defines,
-                                                        size_t n)
-{
-    uint32_t frag_shader_hash;
-    uint32_t vert_shader_hash;
-    lv_result_t res = lv_opengl_shader_manager_select_shader(&view->shader_manager, "__MAIN__.frag",
-                                                             defines, n, LV_OPENGL_GLSL_VERSION_300ES, &frag_shader_hash);
-    LV_ASSERT(res == LV_RESULT_OK);
-    res = lv_opengl_shader_manager_select_shader(&view->shader_manager, "__MAIN__.vert",
-                                                 defines, n, LV_OPENGL_GLSL_VERSION_300ES, &vert_shader_hash);
-    LV_ASSERT(res == LV_RESULT_OK);
-    lv_opengl_shader_program_t * program =
-        lv_opengl_shader_manager_get_program(&view->shader_manager, frag_shader_hash, vert_shader_hash);
-
-    LV_ASSERT_MSG(program != NULL,
-                  "Failed to link program. This probably means your platform doesn't support GLSL version 300 es");
-
-    GLuint program_id = lv_opengl_shader_program_get_id(program);
-
-    GL_CALL(glUseProgram(program_id));
-    lv_gltf_shaderset_t shader_prog;
-    shader_prog.program = program_id;
-
-    return shader_prog;
-}
-
 /**********************
  *   STATIC FUNCTIONS
  **********************/


### PR DESCRIPTION
On some devices, version 300 es is not supported but version 330 (no es) is. The current 3D shader is compliant with both so we just need to use the correct version directive