### PR TITLE
fix(gltf): stride mismatch issue

### DIFF
--- a/src/libs/gltf/gltf_view/assets/lv_gltf_view_shader.c
+++ b/src/libs/gltf/gltf_view/assets/lv_gltf_view_shader.c
@@ -1257,7 +1257,7 @@ static const lv_opengl_shader_t src_includes[] = {
         uniform ivec2 u_ScreenSize;
         #endif
 
-        uniform mat4 u_ModelMatrix;
+        uniform highp mat4 u_ModelMatrix;
         uniform mat4 u_ViewMatrix;
         uniform mat4 u_ProjectionMatrix;
 
@@ -3410,7 +3410,7 @@ static const lv_opengl_shader_t env_src_includes[] = {
 
 static const char * src_vertex_shader = R"(
     uniform mat4 u_ViewProjectionMatrix;
-    uniform mat4 u_ModelMatrix;
+    uniform highp mat4 u_ModelMatrix;
     uniform mat4 u_NormalMatrix;
 
     in vec3 a_position;


### PR DESCRIPTION
Fixes this issue encountered on the RZ/G2L


```bash
Failed to link program: L0001 The fragment matrix variable u_ModelMatrix does not match the vertex variable u_ModelMatrix.
	The matrix stride does not match.
```