### PR TITLE
fix(gltf): force depth mask for transparent items used with refractive materials

### DIFF
--- a/src/libs/gltf/gltf_view/lv_gltf_view.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view.cpp
@@ -688,8 +688,8 @@ static void lv_gltf_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
 static void lv_gltf_view_state_init(lv_gltf_t * view)
 {
     lv_memset(&view->state, 0, sizeof(view->state));
-    view->state.opaque_frame_buffer_width = 256;
-    view->state.opaque_frame_buffer_height = 256;
+    view->state.opaque_frame_buffer_width = LV_GLTF_TRANSMISSION_PASS_SIZE;
+    view->state.opaque_frame_buffer_height = LV_GLTF_TRANSMISSION_PASS_SIZE;
     view->state.material_variant = 0;
     view->state.render_state_ready = false;
     view->state.render_opaque_buffer = false;

--- a/src/libs/gltf/gltf_view/lv_gltf_view_internal.h
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_internal.h
@@ -26,6 +26,7 @@
  *********************/
 
 #define LV_GLTF_DISTANCE_SCALE_FACTOR 2.5f
+#define LV_GLTF_TRANSMISSION_PASS_SIZE 256
 
 /**********************
  *      TYPEDEFS

--- a/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
@@ -571,7 +571,9 @@ static bool draw_material(lv_gltf_t * viewer, const lv_gltf_uniform_locations_t 
         GL_CALL(glDisable(GL_CULL_FACE));
     if(gltfMaterial.alphaMode == fastgltf::AlphaMode::Blend) {
         GL_CALL(glEnable(GL_BLEND));
-        GL_CALL(glDepthMask(GL_FALSE));
+        if(!is_transmission_pass) {
+            GL_CALL(glDepthMask(GL_FALSE));
+        }
         GL_CALL(glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
         GL_CALL(glBlendEquation(GL_FUNC_ADD));
         GL_CALL(glEnable(GL_CULL_FACE));
@@ -1040,8 +1042,8 @@ static void setup_view_proj_matrix_from_camera(lv_gltf_t * viewer, uint32_t came
 
     float aspect = (float)width / (float)height;
     if(transmission_pass) {
-        width = 256;
-        height = 256;
+        width = LV_GLTF_TRANSMISSION_PASS_SIZE;
+        height = LV_GLTF_TRANSMISSION_PASS_SIZE;
     }
 
     std::visit(fastgltf::visitor{


### PR DESCRIPTION
Edit: PR title should actually read "force depth mask for ..."

A bug was identified where using semi-transparent alpha-blended materials along with other materials that are refractive and use the transmission pass texture would create severe glitches and image corruption.  This effect seems to only happen if the current camera is within a certain range of the refractive item, but the exact cause is not yet known.

Until it can be resolved more thoroughly, this patch guards the line that disables depth mask feature, effectively forcing depth masking when rendering transparent materials into the transmission pass texture.  This fixes the problem for now while the issue is investigated further.