### PR TITLE
refactor(opengles): set texture id to layer head on disp creation

### DIFF
--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -193,17 +193,12 @@ static int32_t dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
     unsigned int texture = layer_get_texture(layer);
     if(texture == 0) {
         lv_display_t * disp = lv_refr_get_disp_refreshing();
-        if(layer != disp->layer_head) {
-            int32_t w = lv_area_get_width(&layer->buf_area);
-            int32_t h = lv_area_get_height(&layer->buf_area);
+        LV_ASSERT(layer != disp->layer_head);
+        int32_t w = lv_area_get_width(&layer->buf_area);
+        int32_t h = lv_area_get_height(&layer->buf_area);
 
-            texture = create_texture(w, h, NULL);
-
-            layer->user_data = (void *)(uintptr_t)texture;
-        }
-        else {
-            layer->user_data = (void *)(uintptr_t)lv_opengles_texture_get_texture_id(disp);
-        }
+        texture = create_texture(w, h, NULL);
+        layer->user_data = (void *)(uintptr_t)texture;
     }
 
     t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;

--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -170,7 +170,7 @@ void lv_opengles_render_fill(lv_color_t color, const lv_area_t * area, lv_opa_t 
 void lv_opengles_render_display(lv_display_t * display, const lv_opengles_render_params_t * params)
 {
     LV_PROFILER_DRAW_BEGIN;
-    unsigned int texture = *(unsigned int *)lv_display_get_driver_data(display);
+    unsigned int texture = (lv_uintptr_t)display->layer_head->user_data;
     GL_CALL(glActiveTexture(GL_TEXTURE0));
     GL_CALL(glBindTexture(GL_TEXTURE_2D, texture));
 

--- a/src/drivers/opengles/lv_opengles_texture_private.h
+++ b/src/drivers/opengles/lv_opengles_texture_private.h
@@ -40,8 +40,8 @@ typedef struct {
  * GLOBAL PROTOTYPES
  **********************/
 
-lv_result_t lv_opengles_texture_create_draw_buffers(lv_opengles_texture_t * texture, lv_display_t * display);
-void lv_opengles_texture_reshape(lv_display_t * disp, int32_t width, int32_t height);
+lv_result_t lv_opengles_texture_reshape(lv_opengles_texture_t * texture, lv_display_t * display,
+                                        int32_t width, int32_t height);
 void lv_opengles_texture_deinit(lv_opengles_texture_t * texture);
 
 /**********************


### PR DESCRIPTION
Before, the opengles draw unit would call `lv_opengles_texture_get_texture_id` to get the display head layer's texture ID

This relied on the fact that the driver data contains a `lv_opengles_texture_t` as its first attribute, for DRM this worked fine, but now, while working on wayland + EGL, it would take a lot of work to keep this architecture.

This PR changes it, by immediately setting the display head layer's user data to the texture id on creation, meaning that the draw unit will have access to the texture without having to query the opengles driver and we don't have to respect a specific attribute order on the display driver data

Pre-requisite for the Wayland + EGL PR