### PR TITLE
fix(demo): fix compiler warnings regarding the use of LV_UNUSED

### DIFF
--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -658,8 +658,6 @@ static void load_scene(uint32_t scene)
 
 static void next_scene_timer_cb(lv_timer_t * timer)
 {
-    LV_UNUSED(timer);
-
     scene_act++;
 
     load_scene(scene_act);

--- a/examples/others/fragment/lv_example_fragment_2.c
+++ b/examples/others/fragment/lv_example_fragment_2.c
@@ -68,7 +68,6 @@ void lv_example_fragment_2(void)
 
 static void sample_fragment_ctor(lv_fragment_t * self, void * args)
 {
-    LV_UNUSED(args);
     ((sample_fragment_t *) self)->depth = *((int *) args);
     ((sample_fragment_t *) self)->counter = 0;
 }

--- a/examples/others/observer/lv_example_observer_6.c
+++ b/examples/others/observer/lv_example_observer_6.c
@@ -59,7 +59,6 @@ typedef struct {
 static void my_panel_style_observer_cb(lv_observer_t * observer, lv_subject_t * subject)
 {
     LV_UNUSED(subject);
-    LV_UNUSED(observer);
 
     lv_theme_mode_t m = (lv_theme_mode_t) lv_subject_get_int(&theme_subject);
     lv_panel_styles_t * styles = (lv_panel_styles_t *) lv_observer_get_target(observer);
@@ -129,7 +128,6 @@ typedef struct {
 static void my_button_style_observer_cb(lv_observer_t * observer, lv_subject_t * subject)
 {
     LV_UNUSED(subject);
-    LV_UNUSED(observer);
 
     lv_theme_mode_t m = (lv_theme_mode_t) lv_subject_get_int(&theme_subject);
     lv_button_styles_t * styles = (lv_button_styles_t *) lv_observer_get_target(observer);

--- a/examples/widgets/checkbox/lv_example_checkbox_1.c
+++ b/examples/widgets/checkbox/lv_example_checkbox_1.c
@@ -5,8 +5,8 @@ static void event_handler(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
     lv_obj_t * obj = lv_event_get_target_obj(e);
+    LV_UNUSED(obj);
     if(code == LV_EVENT_VALUE_CHANGED) {
-        LV_UNUSED(obj);
         const char * txt = lv_checkbox_get_text(obj);
         const char * state = lv_obj_get_state(obj) & LV_STATE_CHECKED ? "Checked" : "Unchecked";
         LV_UNUSED(txt);

--- a/examples/widgets/list/lv_example_list_1.c
+++ b/examples/widgets/list/lv_example_list_1.c
@@ -6,8 +6,8 @@ static void event_handler(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
     lv_obj_t * obj = lv_event_get_target_obj(e);
+    LV_UNUSED(obj);
     if(code == LV_EVENT_CLICKED) {
-        LV_UNUSED(obj);
         LV_LOG_USER("Clicked: %s", lv_list_get_button_text(list1, obj));
     }
 }

--- a/examples/widgets/switch/lv_example_switch_1.c
+++ b/examples/widgets/switch/lv_example_switch_1.c
@@ -5,8 +5,8 @@ static void event_handler(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
     lv_obj_t * obj = lv_event_get_target_obj(e);
+    LV_UNUSED(obj);
     if(code == LV_EVENT_VALUE_CHANGED) {
-        LV_UNUSED(obj);
         LV_LOG_USER("State: %s\n", lv_obj_has_state(obj, LV_STATE_CHECKED) ? "On" : "Off");
     }
 }

--- a/examples/widgets/switch/lv_example_switch_2.c
+++ b/examples/widgets/switch/lv_example_switch_2.c
@@ -5,8 +5,8 @@ static void event_handler(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
     lv_obj_t * obj = lv_event_get_target_obj(e);
+    LV_UNUSED(obj);
     if(code == LV_EVENT_VALUE_CHANGED) {
-        LV_UNUSED(obj);
         LV_LOG_USER("State: %s\n", lv_obj_has_state(obj, LV_STATE_CHECKED) ? "On" : "Off");
     }
 }

--- a/src/core/lv_obj_id_builtin.c
+++ b/src/core/lv_obj_id_builtin.c
@@ -88,7 +88,6 @@ void lv_obj_set_id(lv_obj_t * obj, void * id)
 
 void lv_obj_free_id(lv_obj_t * obj)
 {
-    LV_UNUSED(obj);
     obj->id = NULL;
 }
 


### PR DESCRIPTION
Fixes compiler warnings regarding the use of LV_UNUSED <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
