### PR TITLE
build(kconfig): make log level selection more readable

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -577,17 +577,17 @@ menu "LVGL configuration"
 					Specify how important log should be added.
 
 				config LV_LOG_LEVEL_TRACE
-					bool "A lot of logs to give detailed information"
+					bool "LOG_LEVEL_TRACE: A lot of logs to give detailed information"
 				config LV_LOG_LEVEL_INFO
-					bool "Log important events"
+					bool "LOG_LEVEL_INFO: Log important events"
 				config LV_LOG_LEVEL_WARN
-					bool "Log if something unwanted happened but didn't cause a problem"
+					bool "LOG_LEVEL_WARN: Log if something unwanted happened but didn't cause a problem"
 				config LV_LOG_LEVEL_ERROR
-					bool "Only critical issues, when the system may fail"
+					bool "LOG_LEVEL_ERROR: Only critical issues, when the system may fail"
 				config LV_LOG_LEVEL_USER
-					bool "Only logs added by the user"
+					bool "LOG_LEVEL_USER: Only logs added by the user"
 				config LV_LOG_LEVEL_NONE
-					bool "Do not log anything"
+					bool "LOG_LEVEL_NONE: Do not log anything"
 			endchoice
 
 			config LV_LOG_LEVEL


### PR DESCRIPTION
Previously this is what selecting the default log verbosity looked like: 

<img width="628" height="138" alt="image" src="https://github.com/user-attachments/assets/36f4e0a6-fd74-4816-b5f7-a192b6c446b0" />

It's a bit hard to guess what is INFO, WARN, ERROR, etc...

After:

<img width="886" height="172" alt="image" src="https://github.com/user-attachments/assets/9e1c68d8-9424-4a35-a74f-244d97d0a58f" />
