### PR TITLE
fix(nuttx): fix profiler build break

### DIFF
--- a/src/drivers/nuttx/lv_nuttx_profiler.c
+++ b/src/drivers/nuttx/lv_nuttx_profiler.c
@@ -8,10 +8,12 @@
  *********************/
 
 #include "lv_nuttx_profiler.h"
-#include "../../../lvgl.h"
 
 #if LV_USE_NUTTX && LV_USE_PROFILER && LV_USE_PROFILER_BUILTIN
 
+#include "../../misc/lv_profiler_builtin_private.h"
+#include "../../misc/lv_log.h"
+#include "../../stdlib/lv_sprintf.h"
 #include <nuttx/arch.h>
 #include <fcntl.h>
 #include <stdio.h>

--- a/src/drivers/nuttx/lv_nuttx_profiler.h
+++ b/src/drivers/nuttx/lv_nuttx_profiler.h
@@ -14,6 +14,10 @@ extern "C" {
  *      INCLUDES
  *********************/
 
+#include "../../lv_conf_internal.h"
+
+#if LV_USE_NUTTX && LV_USE_PROFILER && LV_USE_PROFILER_BUILTIN
+
 /*********************
  *      DEFINES
  *********************/
@@ -33,6 +37,8 @@ void lv_nuttx_profiler_deinit(void);
 /**********************
  *      MACROS
  **********************/
+
+#endif /*LV_USE_NUTTX && LV_USE_PROFILER && LV_USE_PROFILER_BUILTIN*/
 
 #ifdef __cplusplus
 } /*extern "C"*/


### PR DESCRIPTION
```bash
lvgl/src/drivers/nuttx/lv_nuttx_profiler.c: In function 'lv_nuttx_profiler_init':
lvgl/src/drivers/nuttx/lv_nuttx_profiler.c:65:34: error: storage size of 'config' isn't known
   65 |     lv_profiler_builtin_config_t config;
      |                                  ^~~~~~
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
