### PR TITLE
fix(xml): pass raw # if there's no constant name

### DIFF
--- a/src/xml/lv_xml.c
+++ b/src/xml/lv_xml.c
@@ -784,6 +784,10 @@ static void resolve_consts(const char ** item_attrs, lv_xml_component_scope_t * 
         if(lv_streq(name, "styles")) continue; /*Styles will handle it themselves*/
         if(value[0] == '#') {
             const char * value_clean = &value[1];
+            /* if there's no constant value, we keep `#` as is */
+            if(*value_clean == '\0') {
+                continue;
+            }
 
             const char * const_value = lv_xml_get_const(scope, value_clean);
             if(const_value) {

--- a/tests/src/test_cases/xml/test_xml_general.c
+++ b/tests/src/test_cases/xml/test_xml_general.c
@@ -365,4 +365,19 @@ void test_xml_complex(void)
     TEST_ASSERT_EQUAL_SCREENSHOT("xml/complex_1.png");
 }
 
+void test_xml_label_pound_sign_gets_rendered_properly(void)
+{
+    const char * my_screen =
+        "<screen>"
+        "<view>"
+        "<lv_label align=\"center\" text=\"#\"/>"
+        "</view>"
+        "</screen>";
+    lv_xml_register_component_from_data("screen", my_screen);
+    lv_obj_t * scr = lv_xml_create_screen("screen");
+    lv_screen_load(scr);
+    lv_obj_t * label = lv_obj_get_child(scr, 0);
+    TEST_ASSERT(lv_streq("#", lv_label_get_text(label)));
+}
+
 #endif


### PR DESCRIPTION
Fixes #9194 <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
