### PR TITLE
fix(tiny_ttf): correctly handle int to uint8_t conversion

### DIFF
--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -652,11 +652,13 @@ static void tiny_ttf_kerning_cache_free_cb(tiny_ttf_kerning_cache_data_t * node,
 static lv_cache_compare_res_t tiny_ttf_kerning_cache_compare_cb(const tiny_ttf_kerning_cache_data_t * lhs,
                                                                 const tiny_ttf_kerning_cache_data_t * rhs)
 {
-    lv_cache_compare_res_t ret = lhs->glyph1_idx - rhs->glyph1_idx;
-    if(ret == 0) {
-        return lhs->glyph2_idx - rhs->glyph2_idx;
+    if(lhs->glyph1_idx != rhs->glyph1_idx) {
+        return lhs->glyph1_idx > rhs->glyph1_idx ? 1 : -1;
     }
-    return ret;
+    if(lhs->glyph2_idx != rhs->glyph2_idx) {
+        return lhs->glyph2_idx > rhs->glyph2_idx ? 1 : -1;
+    }
+    return 0;
 }
 
 static lv_font_t * tiny_ttf_font_create_cb(const lv_font_info_t * info, const void * src)


### PR DESCRIPTION
lv_cache_compare_res_t is int8_t
However, glyph1_idx and glyph2_idx are of type int
This causes unequal values to return 0 due to truncation.
On my platform, this manifests as double free.