### PR TITLE
fix(rb): make compare result type a 32bit integer

### DIFF
--- a/src/misc/cache/lv_cache_private.h
+++ b/src/misc/cache/lv_cache_private.h
@@ -42,7 +42,7 @@ struct _lv_cache_entry_t;
 typedef struct _lv_cache_ops_t lv_cache_ops_t;
 typedef struct _lv_cache_class_t lv_cache_class_t;
 
-typedef int8_t lv_cache_compare_res_t;
+typedef int32_t lv_cache_compare_res_t;
 typedef bool (*lv_cache_create_cb_t)(void * node, void * user_data);
 typedef void (*lv_cache_free_cb_t)(void * node, void * user_data);
 typedef lv_cache_compare_res_t (*lv_cache_compare_cb_t)(const void * a, const void * b);

--- a/src/misc/lv_rb.h
+++ b/src/misc/lv_rb.h
@@ -30,7 +30,7 @@ typedef enum {
     LV_RB_COLOR_BLACK
 } lv_rb_color_t;
 
-typedef int8_t lv_rb_compare_res_t;
+typedef int32_t lv_rb_compare_res_t;
 
 typedef lv_rb_compare_res_t (*lv_rb_compare_t)(const void * a, const void * b);
 


### PR DESCRIPTION
Internally, we just had an issue where this function

```c
static lv_rb_compare_res_t
compiled_shader_compare_cb(const lv_opengl_compiled_shader_t * lhs,
                           const lv_opengl_compiled_shader_t * rhs)
{
    return lhs->hash - rhs->hash;
}
```

Would not behave as expected as the hashes are very big integers, and `lv_rb_compare_res_t` is a `int8_t` meaning that the values are truncated

At the same time I saw this issue: https://github.com/lvgl/lvgl/pull/9430, where the user also encountered the same issue, mainly because he had fonts with more than 255 glyphs.

Anyway, I rather have the current version instead of:

```c
static lv_rb_compare_res_t
compiled_shader_compare_cb(const lv_opengl_compiled_shader_t * lhs,
                           const lv_opengl_compiled_shader_t * rhs)
{
    if(lhs->hash == rhs->hash) {
        return 0;
    }
    return lhs->hash > rhs->hash ? 1 : -1;
}
```

Because these compare functions should be super fast and 1 operation is better than adding if conditions just to not overflow a int8_t. The flash size taken by functions that return int32_t and int8_t will be the same so I rather have it as the result type

