### PR TITLE
fix(textarea): apply Arabic/Persian shaping to placeholder text

### DIFF
--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -449,6 +449,7 @@ void lv_textarea_set_placeholder_text(lv_obj_t * obj, const char * txt)
         lv_strcpy(ta->placeholder_txt, txt);
         ta->placeholder_txt[txt_len] = '\0';
 #endif
+    }
     lv_obj_invalidate(obj);
 }
 

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -20,6 +20,7 @@
 #include "../../misc/lv_text_private.h"
 #include "../../misc/lv_math.h"
 #include "../../stdlib/lv_string.h"
+#include "../../misc/lv_text_ap.h"
 
 /*********************
  *      DEFINES
@@ -422,6 +423,20 @@ void lv_textarea_set_placeholder_text(lv_obj_t * obj, const char * txt)
         ta->placeholder_txt = NULL;
     }
     else {
+#if LV_USE_ARABIC_PERSIAN_CHARS  
+        /*Get the size of the text and process it*/
+        size_t len = lv_text_ap_calc_bytes_count(txt);  
+        
+        ta->placeholder_txt = lv_realloc(ta->placeholder_txt, len + 1);
+        LV_ASSERT_MALLOC(ta->placeholder_txt);
+        if(ta->placeholder_txt == NULL) {
+            LV_LOG_ERROR("Couldn't allocate memory for placeholder");
+            return;
+        }
+        
+        lv_text_ap_proc(txt, ta->placeholder_txt);
+        ta->placeholder_txt[len] = '\0';
+#else
         /*Allocate memory for the placeholder_txt text*/
         /*NOTE: Using special realloc behavior, malloc-like when data_p is NULL*/
         ta->placeholder_txt = lv_realloc(ta->placeholder_txt, txt_len + 1);
@@ -433,8 +448,7 @@ void lv_textarea_set_placeholder_text(lv_obj_t * obj, const char * txt)
 
         lv_strcpy(ta->placeholder_txt, txt);
         ta->placeholder_txt[txt_len] = '\0';
-    }
-
+#endif
     lv_obj_invalidate(obj);
 }
 


### PR DESCRIPTION
**Fix**: Arabic placeholder text does not undergo shaping (letters remain disconnected).
#9404 

**Root Cause**: The `lv_textarea_set_placeholder_text()` function lacks the `LV_USE_ARABIC_PERSIAN_CHARS` conditional processing and the corresponding text shaping function call that `lv_label_set_text()` correctly implements.

**Solution**: Integrate the same Arabic/Persian text shaping logic into the placeholder text handling. This involves adding the conditional compilation and calling `lv_text_ap_proc` (v9) / `_lv_txt_ap_proc` (v8). The required header is `#include "../../misc/lv_text_ap.h"`.


**修复问题**：`lv_textarea` 的占位符（placeholder）文本不支持阿拉伯语连字，导致字符显示为断裂的独立形式。

**根本原因**：`lv_textarea_set_placeholder_text()` 函数中缺少与 `lv_label_set_text()` 一致的 `LV_USE_ARABIC_PERSIAN_CHARS` 条件编译及相应的连字处理函数调用。

**修复方案**：在占位符文本的处理逻辑中集成相同的阿拉伯语/波斯语连字处理。这需要添加条件编译，并调用 `lv_text_ap_proc` (v9) / `_lv_txt_ap_proc` (v8) 函数，相关头文件为 `#include "../../misc/lv_text_ap.h"`。