### PR TITLE
docs(API pages):  convert to workable source link

### DIFF
--- a/docs/src/_templates/components/view-this-page.html
+++ b/docs/src/_templates/components/view-this-page.html
@@ -1,0 +1,18 @@
+{% extends "furo/components/view-this-page.html" %}
+{% from "basic-ng/components/view-this-page.html" import determine_page_view_link with context %}
+
+{#- Only this block is redefined (overridden) from furo/components/view-this-page.html.
+   All else remains intact. -#}
+{% block link_available -%}
+{#- Ensure `page_source_suffix` exists, else `determine_page_view_link()` fails. -#}
+{%- if page_source_suffix -%}
+  {%- set page_link = determine_page_view_link() -%}
+  {%- if "docs/src/API/" in page_link -%}
+    {#- Adjust page_link from fictional API pages to point to real .h files. -#}
+    {%- set page_link = page_link.replace("docs/src/API/", "src/") -%}
+    {%- set page_link = page_link.replace("_h.rst", ".h") -%}
+    {%- set page_link = page_link.replace("?plain=true", "") -%}
+  {%- endif -%}
+  {{ furo_view_button(page_link) }}
+{%- endif -%}
+{%- endblock %}


### PR DESCRIPTION
Fixes #9393

Previously the GitHub source link icon led to a link that looked like this:
```
https://github.com/lvgl/lvgl/blob/master/docs/src/API/core/lv_obj_h.rst?plain=true
```
which is an `.rst` file which ONLY exists in the intermediate directory while docs are being built, which led to a 404 error since the file  doesn't exist in the set of web-hosting files.  Now the link looks like this:
```
https://github.com/lvgl/lvgl/blob/master/src/core/lv_obj.h
```
which leads to the `.h` file from which it was derived.

This template does what the original template did, except that it examines the resulting URL and adjusts it when it is from an API page.

See pre-rendered examples here:  http://crystal-clear-research.com/lvgl-docs-demo/master/API/core/lv_obj_h.html

cc:  @AndreCostaaa 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
