### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,7 +21,7 @@ src/drivers/display/ft81x @liamHowatt
 src/drivers/draw/eve @liamHowatt
 src/drivers/evdev @AndreCostaaa
 src/drivers/libinput @AndreCostaaa
-src/drivers/nuttx @liamHowatt
+src/drivers/nuttx @liamHowatt @FASTSHIFT @XuNeo
 src/drivers/qnx @uLipe
 src/drivers/sdl @kisvegabor
 src/drivers/wayland @AndreCostaaa

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,35 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence
+* @kisvegabor @AndreCostaaa @liamHowatt @uLipe
+
+demos/gltf @AndreCostaaa
+examples/libs/gltf @AndreCostaaa
+examples/libs/gstreamer @AndreCostaaa
+src/draw/dma2d @liamHowatt @uLipe
+src/draw/espressif/ppa @uLipe
+src/draw/eve @liamHowatt
+src/draw/nema_gfx @liamHowatt
+src/draw/nxp/g2d @AndreCostaaa
+src/draw/nxp/pxp @uLipe
+src/draw/opengles @AndreCostaaa @kisvegabor
+src/draw/renesas/dave2d @uLipe
+src/draw/sdl @kisvegabor
+src/draw/vg_lite @uLipe @FASTSHIFT
+src/drivers/display/drm @AndreCostaaa
+src/drivers/display/fb @AndreCostaaa
+src/drivers/display/ft81x @liamHowatt
+src/drivers/draw/eve @liamHowatt
+src/drivers/evdev @AndreCostaaa
+src/drivers/libinput @AndreCostaaa
+src/drivers/nuttx @liamHowatt
+src/drivers/qnx @uLipe
+src/drivers/sdl @kisvegabor
+src/drivers/wayland @AndreCostaaa
+src/libs/frogfs @liamHowatt
+src/libs/FT800-FT813 @liamHowatt
+src/libs/gif @liamHowatt
+src/libs/gltf @AndreCostaaa
+src/libs/gstreamer @AndreCostaaa
+src/libs/tiny_ttf @AndreCostaaa
+src/libs/vg_lite_driver @uLipe
+src/misc/cache @AndreCostaaa


### PR DESCRIPTION
We have discussed internally and feel like our review process is too slow, specially for trivial PRs

We have tried to:

1. Use labels to organize and triage issues
2. Make an effort to do Github every day

This is the next step, we're thinking about simplifying the review process and allow a PR to be merged after a single review IF the codeowner of that module approves it

So this PR introduces this codeowners file so that people know who has to review their PR in order to get it merged. Github will also automatically request a review from the code owner

cc @XuNeo @FASTSHIFT