### PR TITLE
fix(opengl): compilation error when using glfw

### DIFF
--- a/src/drivers/opengles/lv_opengles_private.h
+++ b/src/drivers/opengles/lv_opengles_private.h
@@ -81,6 +81,10 @@ extern "C" {
 #define GL_RGBA8 0x8058
 #endif
 
+#if !defined(glClearDepthf) && defined(glClearDepth)
+#define glClearDepthf glClearDepth
+#endif
+
 #ifndef LV_GL_PREFERRED_DEPTH
 #ifdef GL_DEPTH_COMPONENT24
 #define LV_GL_PREFERRED_DEPTH GL_DEPTH_COMPONENT24


### PR DESCRIPTION
Fixes this compilation error:

```
In file included from /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/opengles/lv_draw_opengles.c:14:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/opengles/lv_draw_opengles.c: In function ‘execute_drawing’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/opengles/lv_draw_opengles.c:580:25: error: implicit declaration of function ‘glClearDepthf’; did you mean ‘glClearDepth’? [-Wimplicit-function-declaration]
  580 |                 GL_CALL(glClearDepthf(1.0f));
      |                         ^~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/opengles/../../drivers/opengles/lv_opengles_debug.h:47:9: note: in definition of macro ‘GL_CALL’
   47 |         x;\
      |         ^
gmake[2]: *** [lvgl/CMakeFiles/lvgl.dir/build.make:1241: lvgl/CMakeFiles/lvgl.dir/src/draw/opengles/lv_draw_opengles.c.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
[ 61%] Building C object lvgl/CMakeFiles/lvgl.dir/src/dr
``` 

An API mismatch between desktop GL and EGL, same function just a different name