### PR TITLE
fix(drm/egl): red and blue channel swap with RGB565

### DIFF
--- a/src/drivers/display/drm/lv_linux_drm_egl.c
+++ b/src/drivers/display/drm/lv_linux_drm_egl.c
@@ -248,7 +248,12 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_m
 #error("Unsupported color format")
 #endif
 
-        lv_opengles_render_display_texture(disp, false, false);
+        lv_opengles_render_params_t params = {
+            .h_flip = false,
+            .v_flip = false,
+            .rb_swap = LV_COLOR_DEPTH == 32,
+        };
+        lv_opengles_render_display(disp, &params);
         lv_opengles_egl_update(ctx->egl_ctx);
     }
     lv_display_flush_ready(disp);

--- a/src/drivers/opengles/lv_opengles_private.h
+++ b/src/drivers/opengles/lv_opengles_private.h
@@ -101,6 +101,12 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
+typedef struct {
+    bool h_flip;
+    bool v_flip;
+    bool rb_swap;
+} lv_opengles_render_params_t;
+
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
@@ -133,6 +139,7 @@ void lv_opengles_render_texture_rbswap(unsigned int texture, const lv_area_t * t
  */
 void lv_opengles_regular_viewport(int32_t x, int32_t y, int32_t w, int32_t h);
 
+void lv_opengles_render_display(lv_display_t * display, const lv_opengles_render_params_t * params);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
When using SW rendering with RGB565, red and blue channels are swapped:

![IMG_5930](https://github.com/user-attachments/assets/3ffc6592-0c01-4507-be38-d9a565350248)
