### PR TITLE
build(Kconfig): auto select LV_USE_GENERIC_MIPI

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2119,18 +2119,22 @@ menu "LVGL configuration"
 		config LV_USE_ST7735
 			bool "Use ST7735 LCD driver"
 			default n
+			select LV_USE_GENERIC_MIPI
 
 		config LV_USE_ST7789
 			bool "Use ST7789 LCD driver"
 			default n
+			select LV_USE_GENERIC_MIPI
 
 		config LV_USE_ST7796
 			bool "Use ST7796 LCD driver"
 			default n
+			select LV_USE_GENERIC_MIPI
 
 		config LV_USE_ILI9341
 			bool "Use ILI9341 LCD driver"
 			default n
+			select LV_USE_GENERIC_MIPI
 
 		config LV_USE_GENERIC_MIPI
 			bool "Generic MIPI driver"


### PR DESCRIPTION
Fixs the build error in Nuttx environment with lvgl v9.4.0: https://github.com/apache/nuttx-apps/pull/3253

In lvgl v9.4.0 and master branch, the config LV_USE_GENERIC_MIPI is changed to depends on Kconfig, but not lvgl internal config (https://github.com/lvgl/lvgl/blob/e9db313f8ccc07e27f6afd0f34fe3cf6f20596f0/src/lv_conf_internal.h#L4336C1-L4356C7)

In lvgl v9.2.0, LV_USE_GENERIC_MIPI is auto selected by lv internal config as https://github.com/lvgl/lvgl/blob/6757a718a88af58591c90f5ab33ca2770606c314/src/lv_conf_internal.h#L3455-L3461

we need to change the Kconfig to auto select LV_USE_GENERIC_MIPI if ST7789 enabled.

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
