### PR TITLE
fix(vg_lite): fix incomplete coordinate calculation when converting scissor_area to bounding_box_area

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite_vector.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_vector.c
@@ -314,15 +314,12 @@ static void task_draw_cb(void * user_data, const lv_vector_path_t * path, const 
             return;
         }
 
-        /* Reverse the clip area on the source */
-        lv_point_precise_t p1 = { scissor_area.x1, scissor_area.y1 };
-        lv_point_precise_t p1_res = lv_vg_lite_matrix_transform_point(&result, &p1);
-
-        /* vg-lite bounding_box will crop the pixels on the edge, so +1px is needed here */
-        lv_point_precise_t p2 = { scissor_area.x2 + 1, scissor_area.y2 + 1 };
-        lv_point_precise_t p2_res = lv_vg_lite_matrix_transform_point(&result, &p2);
-
-        lv_vg_lite_path_set_bounding_box(lv_vg_path, p1_res.x, p1_res.y, p2_res.x, p2_res.y);
+        /**
+         * Use lv_matrix to uniformly handle clipping region transformations,
+         * and obtain the transformed bounding rectangle.
+         */
+        const lv_area_t bounding_box_area = lv_matrix_transform_area((lv_matrix_t *)&result, &scissor_area);
+        lv_vg_lite_path_set_bounding_box_area(lv_vg_path, &bounding_box_area);
     }
 
     const lv_opa_t layer_opa = u->task_act->opa;


### PR DESCRIPTION
Use lv_matrix to uniformly handle clipping region transformations, and obtain the transformed bounding rectangle.

Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
