### PR TITLE
build(esp): add missing lv_demos.c source file to esp build process

### DIFF
--- a/env_support/cmake/esp.cmake
+++ b/env_support/cmake/esp.cmake
@@ -21,6 +21,10 @@ else()
     set_source_files_properties(${EXAMPLE_SOURCES} COMPILE_FLAGS "-Wno-unused-variable -Wno-format")
   endif()
 
+  if(CONFIG_LV_BUILD_DEMOS)
+    list(APPEND DEMO_SOURCES ${LVGL_ROOT_DIR}/demos/lv_demos.c)
+  endif()
+
   if(CONFIG_LV_USE_DEMO_WIDGETS)
     file(GLOB_RECURSE DEMO_WIDGETS_SOURCES ${LVGL_ROOT_DIR}/demos/widgets/*.c)
     list(APPEND DEMO_SOURCES ${DEMO_WIDGETS_SOURCES})


### PR DESCRIPTION
ESP cmake doesn't add `lv_demos.c` to the build source files which is making the CI fail:

```bash
/home/lvgl/.espressif/tools/xtensa-esp-elf/esp-13.2.0_20230928/xtensa-esp-elf/bin/../lib/gcc/xtensa-esp-elf/13.2.0/../../../../xtensa-esp-elf/bin/ld: esp-idf/lvgl/liblvgl.a(lv_demo_widgets.c.obj): in function `lv_demo_widgets':
/home/lvgl/lv_ej_workspace/esp32s3/components/lvgl/demos/widgets/lv_demo_widgets.c:178:(.text.lv_demo_widgets+0x5): undefined reference to `lv_demo_args_init'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

PS: The CI will not pass in this PR because EJ uses the CMakeLists.txt files from master