### PR TITLE
fix(vg_lite): workaround vg_lite_blit_rect offset x/y hardware bug

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -502,6 +502,11 @@ menu "LVGL configuration"
 			default n
 			depends on LV_USE_DRAW_VG_LITE
 
+		config LV_VG_LITE_DISABLE_BLIT_RECT_OFFSET
+			bool "Disable blit rectangular offset to resolve certain hardware errors."
+			default n
+			depends on LV_USE_DRAW_VG_LITE
+
 		config LV_VG_LITE_PATH_DUMP_MAX_LEN
 			int "Maximum path dump print length (in points)"
 			default 1000

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -328,6 +328,9 @@
     /** Remove VLC_OP_CLOSE path instruction (Workaround for NXP) **/
     #define LV_VG_LITE_DISABLE_VLC_OP_CLOSE 0
 
+    /** Disable blit rectangular offset to resolve certain hardware errors. */
+    #define LV_VG_LITE_DISABLE_BLIT_RECT_OFFSET 0
+
     /** Disable linear gradient extension for some older versions of drivers. */
     #define LV_VG_LITE_DISABLE_LINEAR_GRADIENT_EXT 0
 

--- a/src/draw/vg_lite/lv_draw_vg_lite_label.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_label.c
@@ -321,11 +321,22 @@ static void draw_letter_bitmap(lv_draw_task_t * t, const lv_draw_glyph_dsc_t * d
 
     const vg_lite_color_t color = lv_vg_lite_color(dsc->color, dsc->opa, true);
 
+    const int32_t clip_offset_x = clip_area.x1 - image_area.x1;
+    const int32_t clip_offset_y = clip_area.y1 - image_area.y1;
+
     /* If rotation is not required, blit directly */
-    if(!dsc->rotation) {
+    if(!dsc->rotation
+#if LV_VG_LITE_DISABLE_BLIT_RECT_OFFSET
+       /**
+        * For some hardware, the rect.x/y parameters of vg_lite_blit_rect do not work correctly,
+        * so the fallback is to vg_lite_draw_pattern for processing.
+        */
+       && (clip_offset_x == 0 && clip_offset_y == 0)
+#endif
+      ) {
         vg_lite_rectangle_t rect = {
-            .x = clip_area.x1 - image_area.x1,
-            .y = clip_area.y1 - image_area.y1,
+            .x = clip_offset_x,
+            .y = clip_offset_y,
             .width = lv_area_get_width(&clip_area),
             .height = lv_area_get_height(&clip_area)
         };

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -931,6 +931,15 @@
         #endif
     #endif
 
+    /** Disable blit rectangular offset to resolve certain hardware errors. */
+    #ifndef LV_VG_LITE_DISABLE_BLIT_RECT_OFFSET
+        #ifdef CONFIG_LV_VG_LITE_DISABLE_BLIT_RECT_OFFSET
+            #define LV_VG_LITE_DISABLE_BLIT_RECT_OFFSET CONFIG_LV_VG_LITE_DISABLE_BLIT_RECT_OFFSET
+        #else
+            #define LV_VG_LITE_DISABLE_BLIT_RECT_OFFSET 0
+        #endif
+    #endif
+
     /** Disable linear gradient extension for some older versions of drivers. */
     #ifndef LV_VG_LITE_DISABLE_LINEAR_GRADIENT_EXT
         #ifdef CONFIG_LV_VG_LITE_DISABLE_LINEAR_GRADIENT_EXT

--- a/tests/src/lv_test_conf_vg_lite.h
+++ b/tests/src/lv_test_conf_vg_lite.h
@@ -41,4 +41,11 @@
     The rendering engine needs to support 3x3 matrix transformations.*/
 #define LV_DRAW_TRANSFORM_USE_MATRIX            1
 
+/* Used to test coverage of different configuration combinations */
+#ifdef NON_AMD64_BUILD
+    #define LV_VG_LITE_DISABLE_BLIT_RECT_OFFSET  1
+#else
+    #define LV_VG_LITE_DISABLE_BLIT_RECT_OFFSET  0
+#endif
+
 #endif /* LV_TEST_CONF_VG_LITE_H */


### PR DESCRIPTION
For some hardware, the `rect.x/y` parameters of `vg_lite_blit_rect` do not work correctly, so the fallback is to `vg_lite_draw_pattern` for processing.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
