### PR TITLE
chore(ppa): update cache alignment error message for 128-byte lines

### DIFF
--- a/src/draw/espressif/ppa/lv_draw_ppa_private.h
+++ b/src/draw/espressif/ppa/lv_draw_ppa_private.h
@@ -38,7 +38,7 @@ extern "C" {
 #include "sdkconfig.h"
 
 #if (CONFIG_LV_DRAW_BUF_ALIGN != CONFIG_CACHE_L2_CACHE_LINE_SIZE)
-#error "For using PPA buffers need to be aligned to 64-byte boundary!"
+#error "CONFIG_LV_DRAW_BUF_ALIGN must be equal to CONFIG_CACHE_L2_CACHE_LINE_SIZE!"
 #endif
 
 


### PR DESCRIPTION
The previous #error message explicitly mentioned a "64-byte boundary". This was misleading when CONFIG_CACHE_L2_CACHE_LINE_SIZE is configured to 128 bytes (e.g., on ESP32-P4).

The message has been updated to clarify that CONFIG_LV_DRAW_BUF_ALIGN must simply match CONFIG_CACHE_L2_CACHE_LINE_SIZE, regardless of the specific value.
