### PR TITLE
docs(macros): fix macro links to API docs

### DIFF
--- a/docs/api_doc_builder.py
+++ b/docs/api_doc_builder.py
@@ -818,7 +818,7 @@ def _recursively_create_api_rst_files(depth: int,
         elig_sub_dirs.sort()
         elig_h_files.sort()
 
-        # Create index.rst plus .RST files for any .H* file directly in in dir.
+        # Create index.rst plus .RST files for any .H* file directly in dir.
         _create_rst_files_for_dir(src_root_len,
                                   src_dir_bep,
                                   elig_h_files,

--- a/docs/api_doc_builder.py
+++ b/docs/api_doc_builder.py
@@ -68,6 +68,10 @@ doxy_src_file_ext_list = [
     '.h++'
 ]
 
+# Excluded from doxygen via EXCLUDE config item.  (This config
+# item is set in `doxygen_xml.py`.)
+_cfg_exclude_list = ['lv_conf_internal.h']
+
 # Multi-line match ``API + newline + \*\*\* + whitespace``.
 # NB:  the ``\s*`` at the end forces the regex to match the whitespace
 # at the end including all \r\n's.  This will match UP TO:
@@ -794,7 +798,9 @@ def _recursively_create_api_rst_files(depth: int,
             # `ext` is converted to lower case so that any incidental case change
             # in the extension on Windows will not break this algorithm.
             if ext.lower() in doxy_src_file_ext_list:
-                eligible = (dir_item in doxygen_xml.files)
+                eligible = (dir_item in doxygen_xml.files
+                        and dir_item not in _cfg_exclude_list)
+
                 if eligible:
                     elig_h_files.append(path_bep)  # Add file to list.
                     elig_h_file_count += 1

--- a/docs/build.py
+++ b/docs/build.py
@@ -1,19 +1,6 @@
 #!/usr/bin/env python3
 """ build.py -- Generate LVGL documentation using Doxygen and Sphinx + Breathe.
 
-Synopsis
---------
-    - $ python build.py html  [ skip_api ] [ fresh_env ]
-    - $ python build.py latex [ skip_api ] [ fresh_env ]
-    - $ python build.py intermediate  [ skip_api ]
-    - $ python build.py clean
-    - $ python build.py clean_intermediate
-    - $ python build.py clean_html
-    - $ python build.py clean_latex
-
-    Build Arguments and Clean Arguments can be used one at a time
-    or be freely mixed and combined.
-
 Data Flow
 ---------
 
@@ -34,17 +21,18 @@ Data Flow
     - make htmlhelp
     - etc.
 
+
 Description
 -----------
     Copy source files to an intermediate directory and modify them there before
     doc generation occurs.  If a full rebuild is being done (e.g. after a `clean`)
-    run Doxygen LVGL's source files to generate intermediate API information
+    run Doxygen on LVGL's source files to generate intermediate API information
     in XML format.  Generate API documents for Breathe's consumption.  Add API
     links to end of some documents.  Generate example documents.  From there,
     Sphinx with Breathe extension uses the resulting set of intermediate files
     to generate the desired output.
 
-    It is only during this first build that the `skip_api` option has meaning.
+    It is only during this first build that the `--skip-api` option has meaning.
     After the first build, no further actions is taken regarding API pages since
     they are not regenerated after the first build.
 
@@ -59,7 +47,7 @@ Description
     Caution:
 
     The document build meant for end-user consumption should ONLY be done after a
-    `clean` unless you know that no API documentation and no code examples have changed.
+    `--clean` unless you know that no API documentation and no code examples have changed.
 
     A `sphinx-build` will do a full doc rebuild any time:
 
@@ -68,59 +56,84 @@ Description
       HTML or Latex files, even if nothing changed),
     - the targeted output directory doesn't exist or is empty, or
     - Sphinx determines that a full rebuild is necessary.  This happens when:
-        - intermediate directory (Sphinx's source-file path) has changed,
+        - intermediate directory path (Sphinx's source-file path) has changed,
         - any options on the `sphinx-build` command line have changed,
         - `conf.py` modification date has changed, or
-        - `fresh_env` argument is included (runs `sphinx-build` with -E option).
+        - `--fresh-env` argument is included (runs `sphinx-build` with -E option).
 
     Typical run time:
 
     Full build:  22.5 min
-    skip_api  :   1.9 min  (applies to first build only)
+    --skip-api:   1.9 min  (applies to first build only)
+
+
+Usage
+-----
+    usage: build.py [-h] [-s] [-E]
+                    {html,latex,intermediate,clean,clean-intermediate,clean-html,clean-latex}
+                    [{html,latex,intermediate,clean,clean-intermediate,clean-html,clean-latex} ...]
+
+    Build LVGL documents
+
+    positional arguments:
+      {html,latex,intermediate,clean,clean-intermediate,clean-html,clean-latex}
+                            output targets to generate; one or more of these;
+                              `clean...` targets are completed first
+
+    options:
+      -h, --help            show this help message and exit
+      -s, --skip-api        skip API-page generation
+      -E, --fresh-env       rebuild Sphinx environment
+
 
 Options
 -------
-    help
+    --help
         Print usage note and exit with status 0.
 
-    html [ skip_api ] [ fresh_env ]
+  Targets:
+
+    html [ --skip-api ] [ --fresh-env ]
         Build HTML output.
-        `skip_api` only has effect on first build after a `clean` or `clean_intermediate`.
+        `--skip-api` only has effect on first build after a `clean` or `clean_intermediate`.
 
-    latex [ skip_api ] [ fresh_env ]
+    latex [ --skip-api ] [ --fresh-env ]
         Build Latex/PDF output (on hold pending removal of non-ASCII characters from input files).
-        `skip_api` only has effect on first build after a `clean` or `clean_intermediate`.
+        `--skip-api` only has effect on first build after a `clean` or `clean_intermediate`.
 
-    intermediate [ skip_api ]
+    intermediate [ --skip-api ]
         Generate intermediate directory contents (ready to build output formats).
         If they already exist, they are removed and re-generated.
         Note:  "intermediate" can be abbreviated down to "int".
 
-    skip_api (with `html` and/or `latex` and/or `intermediate` options)
+    clean
+        Remove all generated files.
+
+    clean-intermediate
+        Remove intermediate directory.
+        Note:  "clean_intermediate" can be abbreviated down to "clean_int".
+
+    clean-html
+        Remove HTML output directory.
+
+    clean-latex
+        Remove Latex output directory.
+
+  Options with Output Targets:
+
+    --skip-api (-s) (with `html` and/or `latex` and/or `intermediate` options)
         Skip API pages and links when intermediate directory contents are being generated
         (saving about 91% of build time).  Note: they are not thereafter regenerated unless
         requested by `intermediate` argument or the intermediate directory does not
         exist.  This is intended to be used only during doc development to speed up
         turn-around time between doc modifications and seeing final results.
 
-    fresh_env (with `html` and/or `latex` options)
+    --fresh-env (-E) (with `html` and/or `latex` options)
         Run `sphinx-build` with -E command-line argument, which makes it regenerate its
         "environment" (memory of what was built previously, forcing a full rebuild).
 
-    clean
-        Remove all generated files.
-
-    clean_intermediate
-        Remove intermediate directory.
-        Note:  "clean_intermediate" can be abbreviated down to "clean_int".
-
-    clean_html
-        Remove HTML output directory.
-
-    clean_latex
-        Remove Latex output directory.
-
     Unrecognized arguments print error message, usage note, and exit with status 1.
+
 
 Python Package Requirements
 ---------------------------
@@ -129,6 +142,7 @@ Python Package Requirements
     Install them by:
 
     $ pip install -r requirements.txt
+
 
 History
 -------
@@ -142,7 +156,7 @@ History
 
     to generate the LVGL document tree.  Internally, Sphinx uses `breathe`
     (a Sphinx extension) to provide a bridge between Doxygen XML output and
-    Sphinx documentation.  It also supported a command-line option `clean`
+    Sphinx documentation.  It also supported a command-line option `--clean`
     to remove generated files before starting (eliminates orphan files,
     for docs that have moved or changed).
 
@@ -150,8 +164,8 @@ History
 
     - Using environment variables to convey branch names to several more
       places where they are used in the docs-generating process (instead
-      of re-writing writing `conf.py` and a `header.rst` each time docs
-      were generated).  These are documented where they generated below.
+      of re-writing `conf.py` and a `header.rst` each time docs were
+      generated).  These are documented where they generated below.
 
     - Supporting additional command-line options.
 
@@ -163,13 +177,14 @@ History
 
     - Adding translation and API links (requiring generating docs in an
       intermediate directory so that the links could be programmatically
-      added to each document before Sphinx was run).  Note:  translation link
+      added to each document before Sphinx was run).  Note:  translation links
       are now done manually since they are only on the main landing page.
 
-    - Generating EXAMPLES page + sub-examples where applicable to individual
-      documents, e.g. to widget-, style-, layout-pages, etc.
+    - Generating EXAMPLES page.  Specific example groups are added to individual
+      documents by each document having an ``.. include:: /examples/.../index.rst``
+      directive where the example(s) should go.
 
-    - Building PDF via latex (when working).
+    - Building PDF via latex.
 
     - Shifting doc-generation paradigm to behave more like `make`.
 
@@ -188,6 +203,7 @@ import os
 import subprocess
 import shutil
 import dirsync
+import argparse
 from datetime import datetime
 
 # LVGL Custom
@@ -218,25 +234,16 @@ cfg_lv_version_filename = 'lv_version.h'
 cfg_doxyfile_filename = 'Doxyfile'
 cfg_top_index_filename = 'index.rst'
 cfg_default_branch = 'master'
+cfg_target_html = 'html'
+cfg_target_latex = 'latex'
+cfg_target_intermediate = 'intermediate'
+cfg_target_clean_all = 'clean'
+cfg_target_clean_intermediate = 'clean-intermediate'
+cfg_target_clean_html = 'clean-html'
+cfg_target_clean_latex = 'clean-latex'
 
 # Filename generated in `latex_output_dir` and copied to `pdf_output_dir`.
 cfg_pdf_filename = 'LVGL.pdf'
-
-
-def print_usage_note():
-    """Print usage note."""
-    print('Usage:')
-    print('  $ python build.py [optional_arg ...]')
-    print()
-    print('  where `optional_arg` can be any of these:')
-    print('    html  [ skip_api ] [ fresh_env ]')
-    print('    latex [ skip_api ] [ fresh_env ]')
-    print('    intermediate  [ skip_api ]')
-    print('    clean')
-    print('    clean_intermediate')
-    print('    clean_html')
-    print('    clean_latex')
-    print('    help')
 
 
 def remove_dir(tgt_dir):
@@ -294,92 +301,61 @@ def intermediate_dir_contents_exists(dir):
     return result
 
 
-def run(args):
+def run():
     """Perform doc-build function(s) requested."""
-
-    # ---------------------------------------------------------------------
-    # Set default settings.
-    # ---------------------------------------------------------------------
-    build_html = False
-    build_latex = False
-    build_intermediate = False
-    skip_api = False
-    fresh_sphinx_env = False
-    clean_all = False
-    clean_intermediate = False
-    clean_html = False
-    clean_latex = False
 
     def print_setting(setting_name, val):
         """Print one setting; used for debugging."""
         announce(__file__, f'{setting_name:18} = [{val}]')
 
-    def print_settings(and_exit):
+    def print_settings(args, and_exit: bool):
         """Print all settings and optionally exit; used for debugging."""
-        print_setting("build_html", build_html)
-        print_setting("build_latex", build_latex)
-        print_setting("build_intermediate", build_intermediate)
-        print_setting("skip_api", skip_api)
-        print_setting("fresh_sphinx_env", fresh_sphinx_env)
-        print_setting("clean_all", clean_all)
-        print_setting("clean_intermediate", clean_intermediate)
-        print_setting("clean_html", clean_html)
-        print_setting("clean_latex", clean_latex)
+        print_setting("build_html", cfg_target_html in args.targets)
+        print_setting("build_latex", cfg_target_latex in args.targets)
+        print_setting("build_intermediate", cfg_target_intermediate in args.targets)
+        print_setting("skip_api", args.skip_api)
+        print_setting("fresh_sphinx_env", args.fresh_sphinx_env)
+        print_setting("clean_all", args.clean_all)
+        print_setting("clean_intermediate", args.clean_intermediate)
+        print_setting("clean_html", args.clean_html)
+        print_setting("clean_latex", args.clean_latex)
 
         if and_exit:
             exit(0)
 
     # ---------------------------------------------------------------------
-    # Process args.
+    # Process command-line args.
     # ---------------------------------------------------------------------
+    ap = argparse.ArgumentParser(description='Build LVGL documents')
+    ap.add_argument('targets', nargs='+', choices=[
+            cfg_target_html,
+            cfg_target_latex,
+            cfg_target_intermediate,
+            cfg_target_clean_all,
+            cfg_target_clean_intermediate,
+            cfg_target_clean_html,
+            cfg_target_clean_latex,
+            ],
+            help='output targets to generate; one or more of these;\n`clean...` targets are completed first')
 
-    # No args means print usage note and exit with status 0.
-    if len(args) == 0:
-        print_usage_note()
-        exit(0)
+    ap.add_argument('-s', '--skip-api' , action='store_true', dest='skip_api',
+                help='skip API-page generation'     )
+    ap.add_argument('-E', '--fresh-env', action='store_true', dest='fresh_sphinx_env',
+                help='rebuild Sphinx environment'   )
+    args = ap.parse_args()
 
-    # Some args are present.  Interpret them in loop here.
-    # Unrecognized arg means print error, print usage note, exit with status 1.
-    for arg in args:
-        # We use chained `if-elif-else` instead of `match` for those on Linux
-        # systems that will not have the required version 3.10 of Python yet.
-        if arg == 'help':
-            print_usage_note()
-            exit(0)
-        elif arg == "html":
-            build_html = True
-        elif arg == "latex":
-            build_latex = True
-        elif "intermediate".startswith(arg) and len(arg) >= 3:
-            # Accept abbreviations.
-            build_intermediate = True
-        elif arg == 'skip_api':
-            skip_api = True
-        elif arg == 'fresh_env':
-            fresh_sphinx_env = True
-        elif arg == "clean":
-            clean_all = True
-            clean_intermediate = True
-            clean_html = True
-            clean_latex = True
-        elif arg == "clean_html":
-            clean_html = True
-        elif arg == "clean_latex":
-            clean_latex = True
-        elif "clean_intermediate".startswith(arg) and len(arg) >= 9:
-            # Accept abbreviations.
-            # Needs to be after others so "cl" will not
-            clean_intermediate = True
-        else:
-            print(f'Argument [{arg}] not recognized.')
-            print()
-            print_usage_note()
-            exit(2)  # 2 = customary Unix command-line syntax error.
+    if cfg_target_clean_all in args.targets:
+        if cfg_target_clean_intermediate not in args.targets:
+            args.targets.append(cfg_target_clean_intermediate)
+        if cfg_target_clean_html not in args.targets:
+            args.targets.append(cfg_target_clean_html)
+        if cfg_target_clean_latex not in args.targets:
+            args.targets.append(cfg_target_clean_latex)
 
     # '-E' option forces Sphinx to rebuild its environment so all docs are
     # fully regenerated, even if not changed.
     # Note:  Sphinx runs in ./docs/, but uses `intermediate_dir` for input.
-    if fresh_sphinx_env:
+    if args.fresh_sphinx_env:
         announce(__file__, "Force-regenerating all files...")
         env_opt = '-E'
     else:
@@ -466,25 +442,31 @@ def run(args):
     # ---------------------------------------------------------------------
     # Clean?  If so, clean (like `make clean`), but do not exit.
     # ---------------------------------------------------------------------
-    some_cleaning_to_be_done = clean_intermediate or clean_html or clean_latex \
-        or clean_all or (os.path.isdir(intermediate_dir) and build_intermediate)
+    some_cleaning_to_be_done = cfg_target_clean_intermediate in args.targets \
+            or cfg_target_clean_html in args.targets \
+            or cfg_target_clean_latex in args.targets \
+            or cfg_target_clean_all in args.targets \
+            or ( \
+                os.path.isdir(intermediate_dir) \
+                and cfg_target_intermediate in args.targets \
+            )
 
     if some_cleaning_to_be_done:
         announce(__file__, "Cleaning...", box=True)
 
-        if clean_intermediate:
+        if cfg_target_clean_intermediate in args.targets:
             remove_dir(intermediate_dir)
 
-        if clean_html:
+        if cfg_target_clean_html in args.targets:
             remove_dir(html_output_dir)
 
-        if clean_latex:
+        if cfg_target_clean_latex in args.targets:
             remove_dir(latex_output_dir)
 
-        if clean_all:
+        if cfg_target_clean_all in args.targets:
             remove_dir(output_dir)
 
-        if os.path.isdir(intermediate_dir) and build_intermediate:
+        if os.path.isdir(intermediate_dir) and cfg_target_intermediate in args.targets:
             remove_dir(intermediate_dir)
 
     # ---------------------------------------------------------------------
@@ -567,7 +549,7 @@ def run(args):
         # action == 'update' means DO NOT copy files when they do not already exist in tgt dir.
         dirsync.sync(cfg_doc_src_dir, intermediate_dir, 'sync', **options)
         dirsync.sync(examples_dir, os.path.join(intermediate_dir, cfg_examples_dir), 'sync', **options)
-    elif build_intermediate or build_html or build_latex:
+    elif cfg_target_intermediate in args.targets or cfg_target_html in args.targets or cfg_target_latex in args.targets:
         # We are having to create the intermediate_dir contents by copying.
         announce(__file__, "Building intermediate directory...", box=True)
 
@@ -625,7 +607,7 @@ def run(args):
         #     announce(__file__, "Adding translation links...")
         #     add_translation.exec(intermediate_dir)
 
-        if skip_api:
+        if args.skip_api:
             announce(__file__, "Skipping API generation as requested.")
         else:
             # -------------------------------------------------------------
@@ -663,7 +645,7 @@ def run(args):
     # ---------------------------------------------------------------------
     # Build PDF
     # ---------------------------------------------------------------------
-    if not build_latex:
+    if cfg_target_latex not in args.targets:
         announce(__file__, "Skipping Latex build.")
     else:
         t1 = datetime.now()
@@ -710,7 +692,7 @@ def run(args):
     # ---------------------------------------------------------------------
     # Build HTML
     # ---------------------------------------------------------------------
-    if not build_html:
+    if cfg_target_html not in args.targets:
         announce(__file__, "Skipping HTML build.")
     else:
         t1 = datetime.now()
@@ -787,4 +769,4 @@ def run(args):
 
 if __name__ == '__main__':
     """Make module importable as well as run-able."""
-    run(sys.argv[1:])
+    run()

--- a/docs/doxygen_xml.py
+++ b/docs/doxygen_xml.py
@@ -1640,6 +1640,15 @@ class DoxygenXml(object):
         full_path = os.path.join(lvgl_src_dir, 'libs', 'gltf', 'fastgltf', 'lv_fastgltf.hpp')
         exclude_paths.append(full_path)
 
+        # As of 07-Jan-2026, LVGL doc-build now replaces `lv_conf_internal.h`
+        # (which has no Doxygen documentation) with a temporary `lv_conf.h`
+        # generated ONLY for the purpose of doc-builds, which file goes away
+        # after Doxygen is done.  This causes conflicts of symbols between
+        # these 2 files because the former is a "generated copy" of the latter.
+        # So this exclusion removes the file with no documentation in it.
+        full_path = os.path.join(lvgl_src_dir, 'lv_conf_internal.h')
+        exclude_paths.append(full_path)
+
         cfg.set('EXCLUDE', exclude_paths)
 
         # Include TAGFILES if requested.

--- a/docs/src/_templates/components/view-this-page.html
+++ b/docs/src/_templates/components/view-this-page.html
@@ -4,7 +4,8 @@
 {#- Only this block is redefined (overridden) from furo/components/view-this-page.html.
    All else remains intact. -#}
 {% block link_available -%}
-{#- Ensure `page_source_suffix` exists, else `determine_page_view_link()` fails. -#}
+{#- Ensure `page_source_suffix` exists, else `determine_page_view_link()` fails
+    during generation of the `genindex` page at the end. -#}
 {%- if page_source_suffix -%}
   {%- set page_link = determine_page_view_link() -%}
   {%- if "docs/src/API/" in page_link -%}
@@ -12,6 +13,10 @@
     {%- set page_link = page_link.replace("docs/src/API/", "src/") -%}
     {%- set page_link = page_link.replace("_h.rst", ".h") -%}
     {%- set page_link = page_link.replace("?plain=true", "") -%}
+    {#- Redirect "src/lv_conf.h" => "lv_conf_template.h" -#}
+    {%- if page_link.endswith("/src/lv_conf.h") -%}
+      {%- set page_link = page_link.replace("/src/lv_conf.h", "/lv_conf_template.h") -%}
+    {%- endif -%}
   {%- endif -%}
   {{ furo_view_button(page_link) }}
 {%- endif -%}

--- a/docs/src/auxiliary-modules/translation.rst
+++ b/docs/src/auxiliary-modules/translation.rst
@@ -90,7 +90,7 @@ If the tag is not found at all, the tag itself will be used as a fallback as wel
 Dynamically Updating UI Text
 ****************************
 
-When :cpp:expr:`lv_translation_set_language("language")` is called, LVGL sends ``LV_EVENT_TRANSLATION_LANGUAGE_CHANGED`` to every widget, allowing you to update text automatically.
+When :cpp:expr:`lv_translation_set_language("language")` is called, LVGL sends :cpp:enumerator:`LV_EVENT_TRANSLATION_LANGUAGE_CHANGED` to every widget, allowing you to update text automatically.
 
 The new language can be retrieved by either calling :cpp:expr:`lv_translation_get_language()` or by getting the event parameter in the event callback with :cpp:expr:`lv_event_get_param(e)`
 

--- a/docs/src/common-widget-features/coordinates.rst
+++ b/docs/src/common-widget-features/coordinates.rst
@@ -269,7 +269,7 @@ automatically as the parent’s size changes.
 Content
 -------
 
-Use ``LV_SIZE_CONTENT`` to size the widget based on its children:
+Use :c:macro:`LV_SIZE_CONTENT` to size the widget based on its children:
 
 .. code-block:: c
 
@@ -277,8 +277,8 @@ Use ``LV_SIZE_CONTENT`` to size the widget based on its children:
    lv_obj_t * label = lv_label_create(cont);
    lv_label_set_text(label, "Some text");
 
-Ignored for hidden (``LV_OBJ_FLAG_HIDDEN``) or floating (``LV_OBJ_FLAG_FLOATING``)
-widgets.
+Ignored for hidden (:cpp:enumerator:`LV_OBJ_FLAG_HIDDEN`) or floating
+(:cpp:enumerator:`LV_OBJ_FLAG_FLOATING`) widgets.
 
 Layouts
 -------
@@ -294,7 +294,7 @@ Min and Max Size
 
 LVGL supports ``min-width``, ``max-width``, ``min-height``, and ``max-height``.
 
-Use them to set limits when using ``LV_SIZE_CONTENT`` or percentage sizes:
+Use them to set limits when using :c:macro:`LV_SIZE_CONTENT` or percentage sizes:
 
 .. code-block:: c
 
@@ -326,7 +326,7 @@ Useful for hover or press effects.
 Percentage-based translation is relative to the widget’s own size (not the parent).
 
 Coordinate translation applies after layout and affects scrollbars and
-``LV_SIZE_CONTENT``.
+:c:macro:`LV_SIZE_CONTENT`.
 
 
 

--- a/docs/src/common-widget-features/flags.rst
+++ b/docs/src/common-widget-features/flags.rst
@@ -35,7 +35,7 @@ The available flags are:
 - :cpp:enumerator:`LV_OBJ_FLAG_ADV_HITTEST`: Enable more accurate hit (click) testing (e.g., account for rounded corners).
 - :cpp:enumerator:`LV_OBJ_FLAG_IGNORE_LAYOUT`: Exclude the widget from layout positioning.
 - :cpp:enumerator:`LV_OBJ_FLAG_FLOATING`: Do not scroll with the parent and ignore layout.
-- :cpp:enumerator:`LV_OBJ_FLAG_SEND_DRAW_TASK_EVENTS`: Enable sending ``LV_EVENT_DRAW_TASK_ADDED`` events.
+- :cpp:enumerator:`LV_OBJ_FLAG_SEND_DRAW_TASK_EVENTS`: Enable sending :cpp:enumerator:`LV_EVENT_DRAW_TASK_ADDED` events.
 - :cpp:enumerator:`LV_OBJ_FLAG_OVERFLOW_VISIBLE`: Allow children to overflow outside the widget's bounds.
 - :cpp:enumerator:`LV_OBJ_FLAG_RADIO_BUTTON`: Allow only one ``RADIO_BUTTON`` sibling to be checked.
 - :cpp:enumerator:`LV_OBJ_FLAG_FLEX_IN_NEW_TRACK`: Start a new flex track on this item.

--- a/docs/src/common-widget-features/layouts/grid.rst
+++ b/docs/src/common-widget-features/layouts/grid.rst
@@ -140,7 +140,7 @@ Limitations:
 - The sub-grid is resolved only to a depth of 1 level. That is, a grid can have a
   sub-grid child, but that sub-grid cannot have another sub-grid.
 
-- ``LV_GRID_CONTENT`` tracks on the grid are not handled in the sub-grid, only in its
+- :c:macro:`LV_GRID_CONTENT` tracks on the grid are not handled in the sub-grid, only in its
   own grid.
 
 The sub-grid feature works the same as in CSS.  For further information, see

--- a/docs/src/common-widget-features/tree.rst
+++ b/docs/src/common-widget-features/tree.rst
@@ -67,7 +67,7 @@ Setting Names
 -------------
 
 To address these issues, LVGL introduces a powerful Widget naming system that can be enabled
-by setting ``LV_USE_OBJ_NAME`` in ``lv_conf.h``.
+by setting :c:macro:`LV_USE_OBJ_NAME` in ``lv_conf.h``.
 
 A custom name can be assigned using :cpp:expr:`lv_obj_set_name(obj, "name")` or
 :cpp:expr:`lv_obj_set_name_static(obj, "name")`. The "static" variant requires that the passed

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -211,10 +211,6 @@ html_theme = 'furo'
 #
 # Various other builders are derived from the HTML output, and also make use
 # of these options.
-
-# Note:  'display_version' option is now obsolete in the current (08-Oct-2024)
-# version of sphinx-rtd-theme (upgraded for Sphinx v8.x).  The removed line
-# is preserved by commenting it out in case it is ever needed again.
 html_theme_options = {
     "sidebar_hide_name": True,      # True when the logo carries project name
     "light_logo": "images/logo-light.svg",
@@ -453,7 +449,7 @@ todo_include_todos = True
 # See https://sphinx-sitemap.readthedocs.io/en/latest/index.html
 sitemap_url_scheme = "{link}"
 # Prettyfy output using 4 spaces to indent.
-sitemap_prettify = 4
+sitemap_indent = 4
 
 # -------------------------------------------------------------------------
 # Options for breathe extension

--- a/docs/src/debugging/log.rst
+++ b/docs/src/debugging/log.rst
@@ -65,21 +65,21 @@ Using Logging
 
 You use the log module via the following macros:
 
-- ``LV_LOG_TRACE(text)``
-- ``LV_LOG_INFO(text)``
-- ``LV_LOG_WARN(text)``
-- ``LV_LOG_ERROR(text)``
-- ``LV_LOG_USER(text)``
-- ``LV_LOG(text)``
+- :c:macro:`LV_LOG_TRACE`\ (text)
+- :c:macro:`LV_LOG_INFO`\ (text)
+- :c:macro:`LV_LOG_WARN`\ (text)
+- :c:macro:`LV_LOG_ERROR`\ (text)
+- :c:macro:`LV_LOG_USER`\ (text)
+- :c:macro:`LV_LOG`\ (text)
 
 The first 5 macros append the following information to your ``text``:
 
 -  Log Level name ("Trace", "Info", "Warn", "Error", "User")
--  \__FILE\_\_
--  \__LINE\_\_
--  \__func\_\_
+-  ``__FILE__``
+-  ``__LINE__``
+-  ``__func__``
 
-``LV_LOG(text)`` is similar to ``LV_LOG_USER`` but has no extra information added.
+:c:macro:`LV_LOG`\ (text) is similar to :c:macro:`LV_LOG_USER` but has no extra information added.
 
 
 

--- a/docs/src/debugging/sysmon.rst
+++ b/docs/src/debugging/sysmon.rst
@@ -13,9 +13,9 @@ metrics directly on your display. It supports both performance monitoring
 Dependencies
 ************
 
-- Requires ``LV_USE_LABEL = 1`` in lv_conf.h
-- Requires ``LV_USE_OBSERVER = 1`` in lv_conf.h
-- Requires ``LV_USE_SYSMON = 1`` in lv_conf.h
+- Requires :c:macro:`LV_USE_LABEL` = 1 in lv_conf.h
+- Requires :c:macro:`LV_USE_OBSERVER` = 1 in lv_conf.h
+- Requires :c:macro:`LV_USE_SYSMON` = 1 in lv_conf.h
 
 
 
@@ -168,4 +168,4 @@ Timers
 
 - Performance: ``perf_update_timer_cb``
 - Memory: ``mem_update_timer_cb``
-- Default period: 300ms (``LV_SYSMON_REFR_PERIOD_DEF``)
+- Default period: 300ms (:c:macro:`LV_SYSMON_REFR_PERIOD_DEF`)

--- a/docs/src/debugging/test.rst
+++ b/docs/src/debugging/test.rst
@@ -27,7 +27,7 @@ where there are no memory constraints.
 Usage
 *****
 
-The Test module can be enabled by configuring ``LV_USE_TEST`` to a non-zero value,
+The Test module can be enabled by configuring :c:macro:`LV_USE_TEST` to a non-zero value,
 and it consists of the following components:
 
 - Helpers
@@ -56,7 +56,7 @@ widget coordinates are recalculated.
 Memory Usage
 ~~~~~~~~~~~~
 
-If ``LV_USE_STDLIB_MALLOC`` is set to ``LV_STDLIB_BUILTIN``, memory usage and memory leaks can be monitored.
+If :c:macro:`LV_USE_STDLIB_MALLOC` is set to :c:macro:`LV_STDLIB_BUILTIN`, memory usage and memory leaks can be monitored.
 
 .. code-block:: c
 
@@ -137,7 +137,7 @@ This function works in a practical way:
 
 - If the folder(s) referenced in ``fn_ref`` do not exist, they will be created automatically.
 - If the reference image is not found, it will be created automatically from the rendered screen
-  (unless ``LV_TEST_SCREENSHOT_CREATE_REFERENCE_IMAGE`` is ``0``).
+  (unless :c:macro:`LV_TEST_SCREENSHOT_CREATE_REFERENCE_IMAGE` is ``0``).
 - If the comparison fails, an ``<image_name>_err.png`` file will be created with the rendered content next to the reference image.
 - If the comparison fails, the X and Y coordinates of the first divergent pixel, along with the actual and expected colors, will also be printed.
 
@@ -162,10 +162,10 @@ To read and decode PNG images and to store the converted rendered image, a few M
 
 
 The screenshot comparison uses ``lodepng`` which is built-in to LVGL and just needs to be enabled with
-``LV_USE_LODEPNG``.
+:c:macro:`LV_USE_LODEPNG`.
 
 To avoid making the entire Test module dependent on ``lodepng``, screenshot comparison can be individually enabled by
-``LV_USE_TEST_SCREENSHOT_COMPARE``.
+:c:macro:`LV_USE_TEST_SCREENSHOT_COMPARE`.
 
 
 .. _test_api:

--- a/docs/src/integration/bindings/micropython.rst
+++ b/docs/src/integration/bindings/micropython.rst
@@ -227,7 +227,7 @@ Solving the Problem
 ~~~~~~~~~~~~~~~~~~~
 
 - Replace the global/static local var with :cpp:expr:`(LV_GLOBAL_DEFAULT()->_var)`
-- Include ``lv_global.h`` on files that use ``LV_GLOBAL_DEFAULT``
+- Include ``lv_global.h`` on files that use :c:macro:`LV_GLOBAL_DEFAULT`
 - Add ``_var`` to ``lv_global_t`` on ``lv_global.h``
 
 

--- a/docs/src/integration/chip_vendors/arm/arm2d.rst
+++ b/docs/src/integration/chip_vendors/arm/arm2d.rst
@@ -26,7 +26,7 @@ How to Use
 In general:
 
 - you can set the macro :c:macro:`LV_USE_DRAW_ARM2D_SYNC` to ``1`` and
-  :c:macro:`LV_DRAW_SW_ASM` to ``LV_DRAW_SW_ASM_HELIUM`` in ``lv_conf.h`` to
+  :c:macro:`LV_DRAW_SW_ASM` to :c:macro:`LV_DRAW_SW_ASM_HELIUM` in ``lv_conf.h`` to
   enable Arm-2D synchronous acceleration for LVGL.
 - You can set
   the macro :c:macro:`LV_USE_DRAW_ARM2D_ASYNC` to ``1`` in ``lv_conf.h`` to enable

--- a/docs/src/integration/chip_vendors/arm/overview.rst
+++ b/docs/src/integration/chip_vendors/arm/overview.rst
@@ -61,7 +61,7 @@ LVGL has built-in support to improve the performance of software rendering by ut
 Architecture Support
 --------------------
 
-Both 32-bit and 64-bit ARM architectures are supported. Simply set ``LV_USE_DRAW_SW_ASM`` to ``LV_DRAW_SW_ASM_NEON`` in ``lv_conf``.
+Both 32-bit and 64-bit ARM architectures are supported. Simply set :c:macro:`LV_USE_DRAW_SW_ASM` to :c:macro:`LV_DRAW_SW_ASM_NEON` in ``lv_conf``.
 
 .. note::
    All ARM Cortex-A and Cortex-R 64-bit processors include Neon support as a mandatory feature starting with the ARMv8 architecture specification. This makes Neon acceleration universally available on all 64-bit ARM platforms, including current and future ARM architectures.

--- a/docs/src/integration/chip_vendors/stm32/add_lvgl_to_your_stm32_project.rst
+++ b/docs/src/integration/chip_vendors/stm32/add_lvgl_to_your_stm32_project.rst
@@ -94,4 +94,4 @@ can enable LVGL's support for the corresponding RTOS and LVGL will use the
 thread creation and synchronization primitives of the respective RTOS when
 rendering, depending on the renderers enabled.
 
-Set ``LV_USE_OS`` to ``LV_OS_FREERTOS`` or ``LV_OS_CMSIS_RTOS2``.
+Set :c:macro:`LV_USE_OS` to :c:macro:`LV_OS_FREERTOS` or :c:macro:`LV_OS_CMSIS_RTOS2`.

--- a/docs/src/integration/chip_vendors/stm32/dma2d_gpu.rst
+++ b/docs/src/integration/chip_vendors/stm32/dma2d_gpu.rst
@@ -30,9 +30,9 @@ that use standard color formats, no gradient, no transforms, and no radius.
 Usage
 *****
 
-To use DMA2D in your project now, set ``LV_USE_DRAW_DMA2D``
+To use DMA2D in your project now, set :c:macro:`LV_USE_DRAW_DMA2D`
 to ``1`` in ``lv_conf.h``. You will need to specify the header for LVGL
-to include internally for DMA2D definitions. Set ``LV_DRAW_DMA2D_HAL_INCLUDE``
+to include internally for DMA2D definitions. Set :c:macro:`LV_DRAW_DMA2D_HAL_INCLUDE`
 to the corresponding header. E.g., if your STM32 model is an STM32U5, the
 header name will likely be ``"stm32u5xx_hal.h"``. If you're using a framework,
 ensure it will not be in contention with LVGL over the DMA2D peripheral.
@@ -49,9 +49,9 @@ completion of before continuing, LVGL will spin waiting for
 DMA2D to complete. If you would like the CPU to sleep or be scheduled to
 other RTOS tasks while a DMA2D transfer is ongoing, do the following:
 
-1. An RTOS/OS must be present. Set ``LV_USE_OS`` to one of the supported values
+1. An RTOS/OS must be present. Set :c:macro:`LV_USE_OS` to one of the supported values
    in ``lv_conf_template.h`` corresponding to the RTOS you're using.
-2. Set ``LV_USE_DRAW_DMA2D_INTERRUPT`` to ``1`` in ``lv_conf.h``.
+2. Set :c:macro:`LV_USE_DRAW_DMA2D_INTERRUPT` to ``1`` in ``lv_conf.h``.
 3. You must call
    :cpp:expr:`lv_draw_dma2d_transfer_complete_interrupt_handler()`
    when you receive the global interrupt that signals
@@ -61,7 +61,7 @@ other RTOS tasks while a DMA2D transfer is ongoing, do the following:
 Interop with LTDC and NeoChrom
 ******************************
 
-DMA2D usage can be freely mixed with LTDC usage as long as ``LV_ST_LTDC_USE_DMA2D_FLUSH``
+DMA2D usage can be freely mixed with LTDC usage as long as :c:macro:`LV_ST_LTDC_USE_DMA2D_FLUSH`
 is **not** enabled. LTDC will use the DMA2D peripheral for flushing, if that is enabled.
 
 NeoChrom and DMA2D may be enabled at the same time. They are both draw units

--- a/docs/src/integration/chip_vendors/stm32/neochrom.rst
+++ b/docs/src/integration/chip_vendors/stm32/neochrom.rst
@@ -94,15 +94,14 @@ To use vector graphics with NeoChrom, you should enable the following configs in
     LV_USE_MATRIX 1
     LV_USE_FLOAT 1
 
-To use the SVG widget, additionally enable ``LV_USE_SVG``.
+To use the SVG widget, additionally enable :c:macro:`LV_USE_SVG`.
 
-If there is RAM available, SVG performance can be increased by enabling the image cache,
-``LV_CACHE_DEF_SIZE``.
-``LV_CACHE_DEF_SIZE`` is a cache size in bytes. If it is large enough for your SVGs,
+If there is RAM available, SVG performance can be increased by enabling the image cache, :c:macro:`LV_CACHE_DEF_SIZE`.
+:c:macro:`LV_CACHE_DEF_SIZE` is a cache size in bytes. If it is large enough for your SVGs,
 it will cache decoded SVG data so it does not need to be parsed every refresh, significantly
 reducing SVG redraw time.
 
-``LV_USE_DEMO_VECTOR_GRAPHIC`` is a demo you can enable which draws some vector graphics shapes.
+:c:macro:`LV_USE_DEMO_VECTOR_GRAPHIC` is a demo you can enable which draws some vector graphics shapes.
 Gradient and image fills are not supported yet, as well as dashed strokes. These are
 missing from the demo when it is run with the NeoChrom driver.
 

--- a/docs/src/integration/embedded_linux/drivers/drm.rst
+++ b/docs/src/integration/embedded_linux/drivers/drm.rst
@@ -146,7 +146,7 @@ To enable this, set the following options in your ``lv_conf.h`` (or via Kconfig/
     #define LV_USE_OPENGLES              1
     #define LV_USE_DRAW_OPENGLES         1   /* optional but recommended for performance */
 
-When ``LV_LINUX_DRM_USE_EGL`` is enabled, the DRM driver will automatically initialize EGL.  
+When :c:macro:`LV_LINUX_DRM_USE_EGL` is enabled, the DRM driver will automatically initialize EGL.
 No special setup is required beyond the basic DRM initialization shown in :ref:`linux_drm_basic_usage`.
 
 For a detailed overview of EGL usage and configuration, see :ref:`egl_driver`.
@@ -157,7 +157,7 @@ Selecting Display Mode
 
 .. note::
     Custom mode selection is currently only supported when using DRM with EGL 
-    (``LV_LINUX_DRM_USE_EGL`` enabled). When using DRM without EGL, the driver 
+    (:c:macro:`LV_LINUX_DRM_USE_EGL` enabled). When using DRM without EGL, the driver
     will always use the preferred display mode.
 
 By default, the DRM driver automatically selects the preferred display mode for the connected display. However, you can customize this behavior by providing a mode selection callback.

--- a/docs/src/integration/embedded_linux/drivers/egl.rst
+++ b/docs/src/integration/embedded_linux/drivers/egl.rst
@@ -20,7 +20,7 @@ EGL with DRM
 
 EGL can be used together with the DRM driver for hardware-accelerated rendering.
 
-When ``LV_LINUX_DRM_USE_EGL`` is enabled, the DRM driver will automatically set up EGL.  
+When :c:macro:`LV_LINUX_DRM_USE_EGL` is enabled, the DRM driver will automatically set up EGL.
 No additional initialization is required beyond the normal DRM setup.
 
 See :ref:`linux_drm` for configuration and a basic usage example.
@@ -32,7 +32,7 @@ EGL without DRM (Experimental)
 
     This feature is experimental and the API is private. Expect breaking changes.
 
-If you want to use EGL without being tied to DRM, you can enable ``LV_USE_EGL`` using a compiler definition.
+If you want to use EGL without being tied to DRM, you can enable :c:macro:`LV_USE_EGL` using a compiler definition.
 This API is currently private and experimental, and people should expect breaking changes.
 
 .. code-block:: bash

--- a/docs/src/integration/embedded_linux/drivers/fbdev.rst
+++ b/docs/src/integration/embedded_linux/drivers/fbdev.rst
@@ -22,8 +22,8 @@ mode.
 
 .. code-block:: c
 
-	#define LV_USE_LINUX_FBDEV           1
-	#define LV_LINUX_FBDEV_RENDER_MODE   LV_DISPLAY_RENDER_MODE_PARTIAL
+    #define LV_USE_LINUX_FBDEV           1
+    #define LV_LINUX_FBDEV_RENDER_MODE   LV_DISPLAY_RENDER_MODE_PARTIAL
 
 Usage
 -----
@@ -33,12 +33,13 @@ node on the display (usually this is ``/dev/fb0``).
 
 .. code-block:: c
 
-	lv_display_t *disp = lv_linux_fbdev_create();
-	lv_linux_fbdev_set_file(disp, "/dev/fb0");
+    lv_display_t *disp = lv_linux_fbdev_create();
+    lv_linux_fbdev_set_file(disp, "/dev/fb0");
 
-If your screen stays black or only draws partially, you can try enabling direct rendering via ``LV_DISPLAY_RENDER_MODE_DIRECT``. Additionally,
-you can activate a force refresh mode with ``lv_linux_fbdev_set_force_refresh(true)``. This usually has a performance impact though and shouldn't
-be enabled unless really needed.
+If your screen stays black or only draws partially, you can try enabling direct
+rendering via :cpp:enumerator:`LV_DISPLAY_RENDER_MODE_DIRECT`. Additionally, you can
+activate a force refresh mode with ``lv_linux_fbdev_set_force_refresh(true)``. This
+usually has a performance impact though and shouldn't be enabled unless really needed.
 
 Hide the cursor
 ---------------
@@ -47,8 +48,8 @@ You may encounter a blinking cursor on the screen. The method to hide it
 varies depending on the platform. For instance, here is how it can be done
 on a Raspberry Pi:
 
-  1. Edit ``/boot/cmdline.txt`` file.
-  2. Add ``vt.global_cursor_default=0``.
+    1. Edit ``/boot/cmdline.txt`` file.
+    2. Add ``vt.global_cursor_default=0``.
 
 Common mistakes
 ---------------
@@ -74,7 +75,7 @@ device, such as resolution, pixel depth, and timings.
 
 .. code-block::
 
-	fbset -fb /dev/fb0
+    fbset -fb /dev/fb0
 
 To prevent display-related issues, it is recommended to ensure all devices,
 including the HDMI display, are connected and powered on before powering up

--- a/docs/src/integration/embedded_linux/drivers/libinput.rst
+++ b/docs/src/integration/embedded_linux/drivers/libinput.rst
@@ -56,13 +56,13 @@ Usage
 -----
 
 To set up an input device via the libinput driver, all you need to do is call ``lv_libinput_create`` with the respective device type
-(``LV_INDEV_TYPE_POINTER`` or ``LV_INDEV_TYPE_KEYPAD``) and device node path (e.g. ``/dev/input/event5``).
+(:cpp:enumerator:`LV_INDEV_TYPE_POINTER` or :cpp:enumerator:`LV_INDEV_TYPE_KEYPAD`) and device node path (e.g. ``/dev/input/event5``).
 
 .. code-block:: c
 
     lv_indev_t *indev = lv_libinput_create(LV_INDEV_TYPE_POINTER, "/dev/input/event5");
 
-Note that touchscreens are treated as (absolute) pointer devices by the libinput driver and require ``LV_INDEV_TYPE_POINTER``.
+Note that touchscreens are treated as (absolute) pointer devices by the libinput driver and require :cpp:enumerator:`LV_INDEV_TYPE_POINTER`.
 
 Depending on your system, the device node paths might not be stable across reboots. If this is the case, you can use ``lv_libinput_find_dev``
 to find the first device that has a specific capability.

--- a/docs/src/integration/embedded_linux/drivers/wayland.rst
+++ b/docs/src/integration/embedded_linux/drivers/wayland.rst
@@ -164,7 +164,7 @@ Getting started
 #. In ``main.c`` ``#include "lv_drivers/wayland/wayland.h"``
 #. Enable the Wayland driver in ``lv_conf.h`` with ``LV_USE_WAYLAND 1``
 
-#. ``LV_COLOR_DEPTH`` should be set either to ``32`` or ``16`` in ``lv_conf.h``
+#. :c:macro:`LV_COLOR_DEPTH` should be set either to ``32`` or ``16`` in ``lv_conf.h``
 
 #. Add a display using ``lv_wayland_window_create()``,
    possibly with a close callback to track the status of each display:
@@ -307,7 +307,7 @@ The wayland driver is currently under construction, bug reports, contributions a
 
 It is however important to create detailed issues when a problem is encountered, logs and screenshots of the problem are of great help.
 
-Please enable ``LV_USE_LOG`` and launch the simulator executable like so
+Please enable :c:macro:`LV_USE_LOG` and launch the simulator executable like so
 
 .. code::
 

--- a/docs/src/integration/external_display_controllers/eve/gpu.rst
+++ b/docs/src/integration/external_display_controllers/eve/gpu.rst
@@ -227,7 +227,8 @@ are available if needed. They are wrappers around ``EVE_memRead8()``, etc.
 
 Register definitions and other EVE enumerations are available when you include
 ``lvgl.h`` under the prefix namespace ``LV_EVE_``. I.e., ``REG_ID`` is available
-as ``LV_EVE_REG_ID`` and ``EVE_ROM_CHIPID`` is available as ``LV_EVE_EVE_ROM_CHIPID``, etc.
+as :c:macro:`LV_EVE_REG_ID` and :c:macro:`EVE_ROM_CHIPID` is available as
+:c:macro:`LV_EVE_EVE_ROM_CHIPID`, etc.
 
 
 Further Reading

--- a/docs/src/integration/external_display_controllers/gen_mipi.rst
+++ b/docs/src/integration/external_display_controllers/gen_mipi.rst
@@ -299,8 +299,8 @@ The commands must be put into a 'uint8_t' array:
     lv_lcd_generic_mipi_send_cmd_list(my_disp, init_cmd_list);
 
 You can add a delay between the commands by using the pseudo-command
-``LV_LCD_CMD_DELAY_MS``, which must be followed by the delay given in 10ms units.  To
-terminate the command list you must use a delay with a value of ``LV_LCD_CMD_EOF``,
+:c:macro:`LV_LCD_CMD_DELAY_MS`, which must be followed by the delay given in 10ms units.  To
+terminate the command list you must use a delay with a value of :c:macro:`LV_LCD_CMD_EOF`,
 as shown above.
 
 See an actual example of sending a command list

--- a/docs/src/integration/overview/threading.rst
+++ b/docs/src/integration/overview/threading.rst
@@ -91,7 +91,7 @@ Use of MUTEXes requires:
 2.  releasing the MUTEX (unlocking it) afterwards.
 
 If your OS is integrated with LVGL (the macro :c:macro:`LV_USE_OS` has a value
-other than ``LV_OS_NONE`` in ``lv_conf.h``) you can use :cpp:func:`lv_lock()` and
+other than :c:macro:`LV_OS_NONE` in ``lv_conf.h``) you can use :cpp:func:`lv_lock()` and
 :cpp:func:`lv_unlock()` to perform #1 and #2.
 
 When this is the case, :cpp:func:`lv_timer_handler` calls :cpp:func:`lv_lock()`

--- a/docs/src/integration/rtos/nuttx.rst
+++ b/docs/src/integration/rtos/nuttx.rst
@@ -239,8 +239,8 @@ reasonable as NuttX fully implements these standard library APIs. Whether or
 not you choose to use NuttX's ``malloc`` depends on whether you want LVGL
 to allocate from the NuttX global heap or use its own.
 
-Where is ``LV_OS_NUTTX``?
--------------------------
+Where is :c:macro:`LV_OS_NUTTX`?
+--------------------------------
 
 NuttX tries to be POSIX compliant where possible, meaning it supports
 pthreads (POSIX threads). To enable OS features in LVGL on NuttX,

--- a/docs/src/libs/font_support/freetype.rst
+++ b/docs/src/libs/font_support/freetype.rst
@@ -133,7 +133,7 @@ This is achieved by setting the style attributes with the
 You will have to account for the increased width and height of letter due to the added letter outline,
 to avoid letters overlapping space them out using :cpp:func:`lv_style_set_text_letter_space`
 
-To use vector fonts with ThorVG, you will have to enable ``LV_USE_VECTOR_GRAPHICS`` in ``lv_conf.h``
+To use vector fonts with ThorVG, you will have to enable :c:macro:`LV_USE_VECTOR_GRAPHICS` in ``lv_conf.h``
 
 .. note::
 

--- a/docs/src/libs/fs_support/frogfs.rst
+++ b/docs/src/libs/fs_support/frogfs.rst
@@ -70,8 +70,8 @@ blob builds.
 Usage in LVGL
 *************
 
-Set ``LV_USE_FS_FROGFS`` to ``1`` in your ``lv_conf.h``. Set
-``LV_FS_FROGFS_LETTER`` to a letter like ``'F'``.
+Set :c:macro:`LV_USE_FS_FROGFS` to ``1`` in your ``lv_conf.h``. Set
+:c:macro:`LV_FS_FROGFS_LETTER` to a letter like ``'F'``.
 
 .. code-block:: c
 

--- a/docs/src/libs/gltf.rst
+++ b/docs/src/libs/gltf.rst
@@ -357,7 +357,7 @@ In order to read them, you must first register an event callback.
 
 This event callback will be called every time the node properties change.
 
-Property values can only be read from within the ``LV_EVENT_VALUE_CHANGED``
+Property values can only be read from within the :cpp:enumerator:`LV_EVENT_VALUE_CHANGED`
 callback to ensure data validity.
 
 .. code-block:: c
@@ -407,15 +407,20 @@ Note: World position registration incurs additional computational cost due to ma
 
 .. important::
 
-    - The ``LV_EVENT_VALUE_CHANGED`` event fires only when node properties are modified, not every frame 
-    - Getter functions return ``LV_RESULT_INVALID`` if called outside the event callback, ensuring you never read stale data
-    - Calling :cpp:func:`lv_gltf_model_node_get_world_position` without world position registration will return ``LV_RESULT_INVALID``
+    - The :cpp:enumerator:`LV_EVENT_VALUE_CHANGED` event fires only when node
+      properties are modified, not every frame.
+    - Getter functions return :cpp:enumerator:`LV_RESULT_INVALID` if called outside
+      the event callback, ensuring you never read stale data.
+    - Calling :cpp:func:`lv_gltf_model_node_get_world_position` without world
+      position registration will return :cpp:enumerator:`LV_RESULT_INVALID`.
 
 .. tip::
-   When using the root node, the local position will equal the world position, meaning you can subscribe to 
-   :cpp:func:`lv_gltf_model_node_add_event_cb` instead of :cpp:func:`lv_gltf_model_node_add_event_cb_with_world_position`
-   and use :cpp:func:`lv_gltf_model_node_get_local_position` to get the world position without the computational 
-   overhead of matrix calculations.
+
+   When using the root node, the local position will equal the world position, meaning
+   you can subscribe to :cpp:func:`lv_gltf_model_node_add_event_cb` instead of
+   :cpp:func:`lv_gltf_model_node_add_event_cb_with_world_position` and use
+   :cpp:func:`lv_gltf_model_node_get_local_position` to get the world position without
+   the computational overhead of matrix calculations.
 
 Finding Nodes
 -------------
@@ -579,7 +584,7 @@ Animation Speed System
 Animation speeds use integer values to avoid floating-point arithmetic:
 
 - The speed ratio is calculated as: ``speed_value / LV_GLTF_ANIM_SPEED_NORMAL``
-- ``LV_GLTF_ANIM_SPEED_NORMAL`` equals 1000, representing 1.0x (normal) speed
+- :c:macro:`LV_GLTF_ANIM_SPEED_NORMAL` equals 1000, representing 1.0x (normal) speed
 - Values greater than 1000 speed up animations (e.g., 2000 = 2.0x speed)
 - Values less than 1000 slow down animations (e.g., 500 = 0.5x speed)
 

--- a/docs/src/libs/image_support/lz4.rst
+++ b/docs/src/libs/image_support/lz4.rst
@@ -20,10 +20,10 @@ binary data is directly decoded to RAM.
 Which Library
 *************
 
-If ``LV_USE_LZ4_INTERNAL`` is enabled in ``lv_conf.h``, LVGL's internal copy of the
+If :c:macro:`LV_USE_LZ4_INTERNAL` is enabled in ``lv_conf.h``, LVGL's internal copy of the
 LZ4 decompression algorithm is used (``./src/libs/lz4/lz4.c``).
 
-If ``LV_USE_LZ4_EXTERNAL`` is enabled, the LVGL project is assumed to be compiled and
+If :c:macro:`LV_USE_LZ4_EXTERNAL` is enabled, the LVGL project is assumed to be compiled and
 linked with an external LZ4 library that provides the :cpp:func:`LZ4_decompress_safe`
 function.
 
@@ -50,7 +50,7 @@ Usage
 *****
 
 To use the LZ4 Decoder, enable it in ``lv_conf.h`` configuration file by setting
-either ``LV_USE_LZ4_INTERNAL`` or ``LV_USE_LZ4_EXTERNAL`` to ``1``.  LZ4 images can
+either :c:macro:`LV_USE_LZ4_INTERNAL` or :c:macro:`LV_USE_LZ4_EXTERNAL` to ``1``.  LZ4 images can
 then be used in the same way as other images.
 
 .. code-block:: c

--- a/docs/src/libs/video_support/gstreamer.rst
+++ b/docs/src/libs/video_support/gstreamer.rst
@@ -19,7 +19,7 @@ LVGL's GStreamer implementation provides comprehensive media playback capabiliti
 
 **Media Source Support:**
 
-* Local files via file:// URIs
+* Local files via ``file://`` URIs
 * Network streaming with HTTP/HTTPS support
 * RTSP streaming for live video feeds
 * UDP streaming for low-latency applications
@@ -30,7 +30,7 @@ LVGL's GStreamer implementation provides comprehensive media playback capabiliti
 
 **URI Scheme Support:**
 
-Using the URI factory (``LV_GSTREAMER_FACTORY_URI_DECODE``), you can specify various URI schemes as media sources:
+Using the URI factory (:c:macro:`LV_GSTREAMER_FACTORY_URI_DECODE`), you can specify various URI schemes as media sources:
 
 * **Local files**: ``file://path/to/video.mp4``
 * **Web streams**: ``http://example.com/stream.webm``, ``https://secure.example.com/video.mp4``
@@ -89,57 +89,57 @@ Setup
 
    **Option 1: Direct linking with LVGL (Recommended)**
 
-.. code-block:: cmake
+   .. code-block:: cmake
 
-    find_package(PkgConfig REQUIRED)
+        find_package(PkgConfig REQUIRED)
 
-    # Find GStreamer packages
-    pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0)
-    pkg_check_modules(GSTREAMER_VIDEO REQUIRED gstreamer-video-1.0)
-    pkg_check_modules(GSTREAMER_APP REQUIRED gstreamer-app-1.0)
+        # Find GStreamer packages
+        pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0)
+        pkg_check_modules(GSTREAMER_VIDEO REQUIRED gstreamer-video-1.0)
+        pkg_check_modules(GSTREAMER_APP REQUIRED gstreamer-app-1.0)
 
-    # Link with LVGL
-    target_include_directories(lvgl PUBLIC
-        ${GSTREAMER_INCLUDE_DIRS}
-        ${GSTREAMER_VIDEO_INCLUDE_DIRS}
-        ${GSTREAMER_APP_INCLUDE_DIRS})
-    target_link_libraries(lvgl PUBLIC
-        ${GSTREAMER_LIBRARIES}
-        ${GSTREAMER_VIDEO_LIBRARIES}
-        ${GSTREAMER_APP_LIBRARIES})
+        # Link with LVGL
+        target_include_directories(lvgl PUBLIC
+            ${GSTREAMER_INCLUDE_DIRS}
+            ${GSTREAMER_VIDEO_INCLUDE_DIRS}
+            ${GSTREAMER_APP_INCLUDE_DIRS})
+        target_link_libraries(lvgl PUBLIC
+            ${GSTREAMER_LIBRARIES}
+            ${GSTREAMER_VIDEO_LIBRARIES}
+            ${GSTREAMER_APP_LIBRARIES})
 
 4. **Manual Compilation with pkg-config**
 
    You can also compile manually using pkg-config to query the necessary flags:
 
-.. code-block:: bash
+   .. code-block:: bash
 
-    # Get compilation flags
-    gcc $(pkg-config --cflags --libs gstreamer-1.0 gstreamer-video-1.0 gstreamer-app-1.0) \
-        -o your_app your_app.c lvgl.a
+        # Get compilation flags
+        gcc $(pkg-config --cflags --libs gstreamer-1.0 gstreamer-video-1.0 gstreamer-app-1.0) \
+            -o your_app your_app.c lvgl.a
 
 5. **Basic Setup Example**
 
-.. code-block:: c
+   .. code-block:: c
 
-    int main(void)
-    {
-        /* Initialize LVGL */
-        lv_init();
+        int main(void)
+        {
+            /* Initialize LVGL */
+            lv_init();
 
-        /* Setup display driver */
-        lv_display_t *display = lv_display_create(800, 480);
-        /* ... configure display driver ... */
+            /* Setup display driver */
+            lv_display_t *display = lv_display_create(800, 480);
+            /* ... configure display driver ... */
 
-        /* Create and run your GStreamer application */
-        lv_example_gstreamer_1();
+            /* Create and run your GStreamer application */
+            lv_example_gstreamer_1();
 
-        while (1) {
-            lv_timer_handler();
+            while (1) {
+                lv_timer_handler();
+            }
+
+            return 0;
         }
-
-        return 0;
-    }
 
 Usage
 *****
@@ -280,10 +280,10 @@ State Management
 
 The GStreamer widget maintains these states:
 
-- ``LV_GSTREAMER_STATE_NULL``: Initial state, no media loaded
-- ``LV_GSTREAMER_STATE_READY``: Media loaded and ready to play
-- ``LV_GSTREAMER_STATE_PAUSED``: Playback paused
-- ``LV_GSTREAMER_STATE_PLAYING``: Active playback
+- :cpp:enumerator:`LV_GSTREAMER_STATE_NULL`: Initial state, no media loaded
+- :cpp:enumerator:`LV_GSTREAMER_STATE_READY`: Media loaded and ready to play
+- :cpp:enumerator:`LV_GSTREAMER_STATE_PAUSED`: Playback paused
+- :cpp:enumerator:`LV_GSTREAMER_STATE_PLAYING`: Active playback
 
 Media Information Access
 ------------------------

--- a/docs/src/lvgl_version.py
+++ b/docs/src/lvgl_version.py
@@ -19,8 +19,8 @@ def lvgl_version(version_file):
 
     if version_file is not None:
         with open(version_file, 'r') as file:
-            major_re = re.compile(r'define\s+LVGL_VERSION_MAJOR\s+(\d+)')
-            minor_re = re.compile(r'define\s+LVGL_VERSION_MINOR\s+(\d+)')
+            major_re = re.compile(r'#\s*define\s+LVGL_VERSION_MAJOR\s+(\d+)')
+            minor_re = re.compile(r'#\s*define\s+LVGL_VERSION_MINOR\s+(\d+)')
 
             for line in file.readlines():
                 # Skip if line not long enough to match.
@@ -30,6 +30,9 @@ def lvgl_version(version_file):
                 match = major_re.search(line)
                 if match is not None:
                     major = match[1]
+                    # Exit early if we have both values.
+                    if len(major) > 0 and len(minor) > 0:
+                        break
                 else:
                     match = minor_re.search(line)
                     if match is not None:

--- a/docs/src/main-modules/draw/draw_descriptors.rst
+++ b/docs/src/main-modules/draw/draw_descriptors.rst
@@ -394,7 +394,7 @@ shapes, text, or images.  It includes the following fields:
 :spread:    Expands the rectangle in all directions; can be negative.
 :ofs_x:     Horizontal offset.
 :ofs_y:     Vertical offset.
-:opa:       Opacity (0--255 range). Values like ``LV_OPA_TRANSP``, ``LV_OPA_10``,
+:opa:       Opacity (0--255 range). Values like :cpp:enumerator:`LV_OPA_TRANSP`, :cpp:enumerator:`LV_OPA_10`,
             etc., can also be used.
 :bg_cover:  Set to 1 if the background will cover the shadow (a hint for the
             renderer to skip masking).
@@ -421,7 +421,7 @@ image drawing.  It is a complex descriptor with the following options:
 
 :src:              The image source, either a pointer to `lv_image_dsc_t` or a file path.
 :opa:              Opacity in the 0--255 range. Options like
-                   ``LV_OPA_TRANSP``, ``LV_OPA_10``, etc., can also be used.
+                   :cpp:enumerator:`LV_OPA_TRANSP`, :cpp:enumerator:`LV_OPA_10`, etc., can also be used.
 :clip_radius:      Clips the corners of the image with this radius.  Use
                    `LV_RADIUS_CIRCLE` for the maximum radius.
 :rotation:         Image rotation in 0.1-degree units (e.g., 234 means 23.4\ |deg|\ ).
@@ -496,7 +496,7 @@ for controlling text rendering:
 :ofs_y:         Vertical text offset.
 :sel_start:     Index of the first character for selection (character index, not byte
                 index, since some characters can be multi-byte characters).
-                ``LV_DRAW_LABEL_NO_TXT_SEL`` means no selection.
+                :c:macro:`LV_DRAW_LABEL_NO_TXT_SEL` means no selection.
 :sel_end:       Index of the last character for selection.
 :sel_color:     Color of selected characters.
 :sel_bg_color:  Background color for selected characters.
@@ -602,7 +602,7 @@ Triangles are defined by :cpp:type:`lv_draw_triangle_dsc_t`, which includes:
 :p[3]:   3 points for the triangle's vertices.
 :color:  Triangle color.
 :opa:    Triangle opacity.
-:grad:   Gradient options. If ``grad.dir`` is not ``LV_GRAD_DIR_NONE``, the
+:grad:   Gradient options. If ``grad.dir`` is not :cpp:enumerator:`LV_GRAD_DIR_NONE`, the
          ``color`` field is ignored. The ``opa`` field adjusts overall opacity.
 
 Functions for triangle drawing:

--- a/docs/src/main-modules/draw/draw_layers.rst
+++ b/docs/src/main-modules/draw/draw_layers.rst
@@ -36,7 +36,7 @@ The following style properties trigger the creation of a "Simple Layer":
 - ``bitmap_mask_src``
 - ``blend_mode``
 
-In this case, the Widget will be sliced into ``LV_DRAW_SW_LAYER_SIMPLE_BUF_SIZE``
+In this case, the Widget will be sliced into :c:macro:`LV_DRAW_LAYER_SIMPLE_BUF_SIZE`
 sized chunks.
 
 If there is no memory for a new chunk, LVGL will try allocating the layer after
@@ -102,7 +102,7 @@ line, it will:
 
     Result of Clip Corner Style
 
-There is a temporary RAM cost to doing this.  With ``LV_USE_LAYER_DEBUG`` on...
+There is a temporary RAM cost to doing this.  With :c:macro:`LV_USE_LAYER_DEBUG` on...
 
 .. figure:: /_static/images/clip_corner_3_layers_created.png
     :align: center

--- a/docs/src/main-modules/draw/draw_pipeline.rst
+++ b/docs/src/main-modules/draw/draw_pipeline.rst
@@ -109,7 +109,7 @@ functions are in :cpp:func:`lv_init`.
 Thread Priority
 ---------------
 
-If ``LV_USE_OS`` is set to something other than ``LV_OS_NONE``, draw units might use a thread to
+If :c:macro:`LV_USE_OS` is set to something other than :c:macro:`LV_OS_NONE`, draw units might use a thread to
 allow waiting for the completion of rendering in a non-blocking way.
 
 The thread priority can be set using the :c:macro:`LV_DRAW_THREAD_PRIO`

--- a/docs/src/main-modules/fonts/overview.rst
+++ b/docs/src/main-modules/fonts/overview.rst
@@ -133,8 +133,8 @@ Symbols
 *******
 
 LVGL supports some predefined "symbols". A symbol is a specific Unicode character
-in a font with an icon-like image. The symbols have names like ``LV_SYMBOL_OK``,
-``LV_SYMBOL_HOME``, etc. See the full list of predefined symbols below:
+in a font with an icon-like image. The symbols have names like :c:macro:`LV_SYMBOL_OK`,
+:c:macro:`LV_SYMBOL_HOME`, etc. See the full list of predefined symbols below:
 
 .. image:: /_static/images/symbols.png
 

--- a/docs/src/main-modules/fs.rst
+++ b/docs/src/main-modules/fs.rst
@@ -381,7 +381,7 @@ will be updated to reflect the written content.
 ------------------------------------------------------
 
 The driver's ``seek`` will not actually be called unless the ``whence``
-is ``LV_FS_SEEK_END``, in which case ``seek`` and ``tell`` will be called
+is :cpp:enumerator:`LV_FS_SEEK_END`, in which case ``seek`` and ``tell`` will be called
 to determine where the end of the file is.
 
 ``lv_fs_tell`` :sub:`(behavior when cache is enabled)`

--- a/docs/src/main-modules/images/adding_images.rst
+++ b/docs/src/main-modules/images/adding_images.rst
@@ -81,8 +81,8 @@ Another way you can add an image to your project is by using the
 this with a target color format matching the Display the image is going to be sent
 to. Optionally, you can use a command-line argument to cause the image contents to
 be compressed using RLE or LZ4 compression as well.  Of course, the decompression
-logic must be part of your project by enabling appropriate ``LV_USE_RLE``,
-``LV_USE_LZ4_INTERNAL``, and/or ``LV_USE_LZ4_EXTERNAL`` macros in your ``lv_conf.h``
+logic must be part of your project by enabling appropriate :c:macro:`LV_USE_RLE`,
+:c:macro:`LV_USE_LZ4_INTERNAL`, and/or :c:macro:`LV_USE_LZ4_EXTERNAL` macros in your ``lv_conf.h``
 file.
 
 This enables the drawing logic to have a very low RAM footprint because the pixels

--- a/docs/src/main-modules/images/color_formats.rst
+++ b/docs/src/main-modules/images/color_formats.rst
@@ -59,7 +59,7 @@ The following image pixel color formats have built-in decoding support:
     | RAW_ALPHA [2]_         | ?   | n/a        | See :ref:`custom_image_formats`                                 |
     +------------------------+-----+------------+-----------------------------------------------------------------+
 
-.. [1]  I1, I2, I4 and I8 indexed formats require ``LV_DRAW_SW_SUPPORT_ARGB8888`` to
+.. [1]  I1, I2, I4 and I8 indexed formats require :c:macro:`LV_DRAW_SW_SUPPORT_ARGB8888` to
         be configured to ``1`` in your ``lv_conf.h`` file.  Palette colors are
         always ``ARGB8888``.
 

--- a/docs/src/main-modules/indev/button.rst
+++ b/docs/src/main-modules/indev/button.rst
@@ -32,8 +32,8 @@ To assign Hardware Buttons to coordinates, use
 
 The index of the pressed button should be set in ``data->btn_id`` in the ``read_cb``.
 
-``data->state`` should also be set to either ``LV_INDEV_STATE_PRESSED`` or
-``LV_INDEV_STATE_RELEASED``.
+``data->state`` should also be set to either :cpp:enumerator:`LV_INDEV_STATE_PRESSED` or
+:cpp:enumerator:`LV_INDEV_STATE_RELEASED`.
 
 
 

--- a/docs/src/main-modules/indev/gestures.rst
+++ b/docs/src/main-modules/indev/gestures.rst
@@ -75,7 +75,7 @@ gestures are supported:
 - Two fingers rotation
 - Two fingers swipe (infinite)
 
-To enable multi-touch gesture recognition, set the ``LV_USE_GESTURE_RECOGNITION``
+To enable multi-touch gesture recognition, set the :c:macro:`LV_USE_GESTURE_RECOGNITION`
 option in the ``lv_conf.h`` file.
 
 
@@ -125,16 +125,16 @@ Here is a generic example of the ``read_cb``:
 
 LVGL sends events if the gestures are in one of the following states:
 
-- ``LV_INDEV_GESTURE_STATE_RECOGNIZED``: The gesture has been recognized and is now
+- :cpp:enumerator:`LV_INDEV_GESTURE_STATE_RECOGNIZED`: The gesture has been recognized and is now
   active.
-- ``LV_INDEV_GESTURE_STATE_ENDED``: The gesture has ended.
+- :cpp:enumerator:`LV_INDEV_GESTURE_STATE_ENDED`: The gesture has ended.
 
 
 
 Events
 ------
 
-Once a gesture is recognized or ended, a ``LV_EVENT_GESTURE`` is sent. The user can
+Once a gesture is recognized or ended, a :cpp:enumerator:`LV_EVENT_GESTURE` is sent. The user can
 use these functions to gather more information about the gesture:
 
 - :cpp:expr:`lv_event_get_gesture_type(lv_event_t * e)`: Get the type of the gesture.

--- a/docs/src/widgets/arc.rst
+++ b/docs/src/widgets/arc.rst
@@ -152,7 +152,7 @@ value directly.  Note that this is a two-way binding (Subject <===> Widget), so 
 user's direct interaction with the Arc Widget updates the Subject's value and vice
 versa.
 
-It supports integer subjects and, when ``LV_USE_FLOAT`` is enabled, float subjects.
+It supports integer subjects and, when :c:macro:`LV_USE_FLOAT` is enabled, float subjects.
 
 
 - :cpp:expr:`lv_arc_bind_value(arc, &subject)`

--- a/docs/src/widgets/label.rst
+++ b/docs/src/widgets/label.rst
@@ -171,7 +171,7 @@ Very long text
 
 LVGL can efficiently handle very long (e.g. > 40k characters) Labels by
 saving some extra data (~12 bytes) to speed up drawing. To enable this
-feature, set ``LV_LABEL_LONG_TXT_HINT`` to ``1`` in ``lv_conf.h``.
+feature, set :c:macro:`LV_LABEL_LONG_TXT_HINT` to ``1`` in ``lv_conf.h``.
 
 .. _lv_label_custom_scrolling_animations:
 
@@ -220,7 +220,7 @@ the Subject's value is used to update the Label's text as follows:
 
 
 :float Subject:     Subject's float value is used with the ``format_string`` argument.
-                    Requires ``LV_USE_FLOAT``.
+                    Requires :c:macro:`LV_USE_FLOAT`.
                     See :ref:`observer_format_string` for details.
 
 Note that this is a one-way binding (Subject ===> Widget).

--- a/docs/src/widgets/led.rst
+++ b/docs/src/widgets/led.rst
@@ -44,8 +44,8 @@ a predefined ON or OFF value. The :cpp:expr:`lv_led_toggle(led)` toggles between
 the ON and OFF state.
 
 You can set custom LED ON and OFF brightness values by defining macros
-``LV_LED_BRIGHT_MAX`` and ``LV_LED_BRIGHT_MIN`` in your project.  Their default
-values are 80 and 255. These too must be in the range [0..255].
+:c:macro:`LV_LED_BRIGHT_MAX` and :c:macro:`LV_LED_BRIGHT_MIN` in your project.  Their default
+values are 255 and 80. These too must be in the range [0..255].
 
 
 

--- a/docs/src/widgets/msgbox.rst
+++ b/docs/src/widgets/msgbox.rst
@@ -56,7 +56,7 @@ If you want to add an [OK] or [Cancel] or other buttons for the
 user to have a choice of responses, add each button using the
 :cpp:expr:`lv_msgbox_add_footer_button(msgbox, btn_text)` function.  Calling this
 function adds a footer (container) if one was not already present, and it returns a
-pointer to the button created, which can be used to add ``LV_EVENT_CLICKED`` (or
+pointer to the button created, which can be used to add :cpp:enumerator:`LV_EVENT_CLICKED` (or
 other) events to detect and act on the user's response.
 
 Footer buttons so added are evenly spaced and centered.

--- a/docs/src/widgets/spangroup.rst
+++ b/docs/src/widgets/spangroup.rst
@@ -108,7 +108,7 @@ to set text alignment.
 Modes
 -----
 
-**DEPRECATED**, set the width to ``LV_SIZE_CONTENT`` or fixed value to control expanding/wrapping.
+**DEPRECATED**, set the width to :c:macro:`LV_SIZE_CONTENT` or fixed value to control expanding/wrapping.
 
 A Spangroup can be set to one the following modes:
 

--- a/docs/src/xml/integration/arduino.rst
+++ b/docs/src/xml/integration/arduino.rst
@@ -58,11 +58,11 @@ LVGL source files typically use this include pattern:
         #include "lvgl/lvgl.h"
     #endif
 
-The ``LV_LVGL_H_INCLUDE_SIMPLE`` define controls how LVGL headers are included.
+The :c:macro:`LV_LVGL_H_INCLUDE_SIMPLE` define controls how LVGL headers are included.
 However, the Arduino IDE does not provide a way to add custom compiler symbols through its interface.
 Instead, you must modify the ``platform.txt`` file for the specific board core you are using.
 
-To ensure correct compilation, you need to instruct the Arduino build system to define ``LV_LVGL_H_INCLUDE_SIMPLE`` during compilation.
+To ensure correct compilation, you need to instruct the Arduino build system to define :c:macro:`LV_LVGL_H_INCLUDE_SIMPLE` during compilation.
 
 1. Locate the ``platform.txt`` file for your Arduino core.
     Example paths:

--- a/docs/src/xml/integration/c_code.rst
+++ b/docs/src/xml/integration/c_code.rst
@@ -8,7 +8,7 @@ Overview
 ********
 
 When C code is exported from LVGL's UI Editor, no XML is needed at all
-(``LV_USE_XML`` can be ``0``), and it's very similar to the case when the C code is
+(:c:macro:`LV_USE_XML` can be ``0``), and it's very similar to the case when the C code is
 written by hand.
 
 The exported C code can simply be dropped into the project and compiled into the

--- a/docs/src/xml/integration/zephyr.rst
+++ b/docs/src/xml/integration/zephyr.rst
@@ -141,5 +141,5 @@ In the ``CMakeLists.txt`` file of the ``ui_project/`` directory, created by the 
         )
     endif ()
 
-**Important note:** Zephyr automatically defines the ``LV_CONF_INCLUDE_SIMPLE`` symbol during
+**Important note:** Zephyr automatically defines the :c:macro:`LV_CONF_INCLUDE_SIMPLE` symbol during
 the LVGL module build process, so it is not necessary to define it manually in your CMakeLists.txt.

--- a/docs/src/xml/xml/syntax.rst
+++ b/docs/src/xml/xml/syntax.rst
@@ -65,7 +65,7 @@ The following simple built-in types are supported:
 :%:         Percentage.  ``%`` must be appended to the value as the unit.
             (Means the same as :cpp:expr:`lv_pct()`.)
 
-:content:   Means ``LV_SIZE_CONTENT``.
+:content:   Means :c:macro:`LV_SIZE_CONTENT`.
 
 :string:    Simple ``\0``-terminated string.  When multiple strings are used in a
             property or string array, ``'`` should be used.  E.g. ``foo="'a' 'b'"``.


### PR DESCRIPTION
This PR fixes doc-to-api-page links for around 100-150 macros used throughout the documentation, especially those that are defined (and documented) in `lv_conf.h` in a project.  Investigating this started by pursuing why the `LV_USE_TEST` macro on [this page](http://crystal-clear-research.com/lvgl-docs-demo/master/debugging/test.html#usage) was not linking to its documentation.

Each commit in the branch handles one aspect of what was found.

## Most Important Situation

Previously macros from `lv_conf.h` in documentation were not being linked to their API documentation because Doxygen was parsing `lv_conf_internal.h` in which the Doxygen documentation (during the lifetime of `lvgl/scripts/lv_conf_internal_gen.py`) was misplaced (away from the macros being defined) and so Doxygen could not connect the documentation with the symbols.

The solution was to instead have Doxygen parse a temporarily-generated version of `lv_conf.h` (identical to the one Doxygen #include's in order to evaluate conditional compilation directives like #if, #ifdef, #ifndef).

Now the macros from `lv_conf.h` in the documentation provide links to the new [`lv_conf_h.html` page](http://crystal-clear-research.com/lvgl-docs-demo/master/API/lv_conf_h.html#c.LV_USE_TEST) which:

- contains all the macro documentation from `lv_conf.h` and

- the new page's GitHub link directs the reader to `lv_conf_template.h`, which is indeed the source of `lv_conf.h` (since, by design, no `lv_conf.h` exists in the LVGL repository.

## Additional Things Handled

1. In doing this task, I encountered 2 causes for the missing links:

   - the problem described above, and

   - that many of the `LV_USE_...` and other macros from `lv_conf_template.h` and elsewhere were coded as literals instead of with the `:c:macro:` interpreted text role.

    With BOTH of these now handled in this PR, now all the appropriate links for those macros are correctly linked to their documented API entries.  See example for the `LV_USE_TEST` macro on these 2 pages:  [**before**](http://crystal-clear-research.com/lvgl-docs-demo/master/debugging/test.html#usage), and [**after**](http://crystal-clear-research.com/lvgl-docs-demo/master/debugging/test.html#usage).

2. Upgraded `build.py` to use `argparse` library -- reduced code and documentation in `build.py`.  Now type
    ```
    python build.py --help
    ```
    to get the options.  This does not impact the CI command line to build docs.

It is recommended that reviewers example each commit on its own, since each commit message explains the scope and purpose of that commit -- it will make reviewing easier.

cc: @kisvegabor 


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
