### PR TITLE
feat(opengl): auto initialize nanovg draw unit

### DIFF
--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -16,6 +16,7 @@
 #include "lv_opengles_private.h"
 
 #include "../../display/lv_display_private.h"
+#include "../../draw/nanovg/lv_draw_nanovg.h"
 #include "../../misc/lv_area_private.h"
 #include "opengl_shader/lv_opengl_shader_internal.h"
 #include "assets/lv_opengles_shader.h"
@@ -125,6 +126,10 @@ void lv_opengles_init(void)
     lv_opengles_vertex_buffer_unbind();
     lv_opengles_index_buffer_unbind();
     lv_opengles_shader_unbind();
+
+#if LV_USE_DRAW_NANOVG
+    lv_draw_nanovg_init();
+#endif /*LV_USE_DRAW_NANOVG*/
 
     is_init = true;
 }


### PR DESCRIPTION
Makes it simpler to integrate nanovg by initializing it inside the opengles driver. At this point, an opengl context has been initialized and as such we can safely initialize the nanovg draw unit

cc @FASTSHIFT 