### PR TITLE
feat(arclabel): support lv_arclabel_get_text_angle to get real rendered text size in degree

### DIFF
--- a/src/widgets/arclabel/lv_arclabel.h
+++ b/src/widgets/arclabel/lv_arclabel.h
@@ -273,6 +273,17 @@ lv_arclabel_overflow_t lv_arclabel_get_overflow(lv_obj_t * obj);
  */
 bool lv_arclabel_get_end_overlap(lv_obj_t * obj);
 
+/**
+ * Get the text angle for an arc label object.
+ * @note            The text angle is calculated at runtime. You can get the updated value
+ *                  after the arclabel's size has been updated.
+ *                  Returns the real rendered text angle in degrees except in
+ *                  `LV_ARCLABEL_OVERFLOW_VISIBLE` mode.
+ * @param obj       pointer to an arc label object
+ * @return          the text angle (if `LV_USE_FLOAT` is enabled it can be fractional too.)
+ */
+lv_value_precise_t lv_arclabel_get_text_angle(lv_obj_t * obj);
+
 /*=====================
  * Other functions
  *====================*/

--- a/tests/src/test_cases/widgets/test_arclabel.c
+++ b/tests/src/test_cases/widgets/test_arclabel.c
@@ -165,10 +165,13 @@ void test_arclabel_overflow(void)
         lv_arclabel_set_dir(arclabel, LV_ARCLABEL_DIR_CLOCKWISE);
         lv_arclabel_set_overflow(arclabel, overflows[i]);
         lv_obj_center(arclabel);
-    }
 
+        lv_obj_refr_size(arclabel);
+        TEST_ASSERT_GREATER_THAN_FLOAT(178, lv_arclabel_get_text_angle(arclabel));
+    }
     TEST_ASSERT_EQUAL_SCREENSHOT("widgets/arclabel_overflow" EXT_NAME);
 }
+
 void test_arclabel_opacity(void)
 {
     if(!font) {
@@ -220,4 +223,5 @@ void test_arclabel_opacity(void)
     }
     TEST_ASSERT_EQUAL_SCREENSHOT("widgets/arclabel_opacity" EXT_NAME);
 }
+
 #endif


### PR DESCRIPTION
```cpp
/**
 * Get the text angle for an arc label object.
 * @note            The text angle is updated in the runtime. You can get the updated value
 *                  after the arc label's size has been updated.
 *                  Get the real rendered text size in angel except
 *                  `LV_ARCLABEL_OVERFLOW_VISIBLE` mode
 * @param obj       pointer to an arc label object
 * @return          the text angle (if `LV_USE_FLOAT` is enabled it can be fractional too.)
 */
lv_value_precise_t lv_arclabel_get_text_angle(lv_obj_t * obj);
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
