### PR TITLE
feat(gstreamer): add support for sources with no audio

### DIFF
--- a/src/libs/gstreamer/lv_gstreamer.c
+++ b/src/libs/gstreamer/lv_gstreamer.c
@@ -26,18 +26,25 @@
  *      TYPEDEFS
  **********************/
 
+typedef struct {
+    const char * factory;
+    const char * name;
+    GstElement ** store;
+} lv_gstreamer_pipeline_element_t;
+
 /**********************
  *  STATIC PROTOTYPES
  **********************/
 
 static void lv_gstreamer_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj);
 static void lv_gstreamer_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj);
-static lv_result_t gstreamer_create_pipeline(lv_gstreamer_t * streamer, GstElement * pipeline, GstElement * head);
 static void on_decode_pad_added(GstElement * element, GstPad * pad, gpointer user_data);
 static GstFlowReturn on_new_sample(GstElement * sink, gpointer user_data);
 static void gstreamer_timer_cb(lv_timer_t * timer);
 static void gstreamer_poll_bus(lv_gstreamer_t * streamer);
 static void gstreamer_update_frame(lv_gstreamer_t * streamer);
+static lv_result_t gstreamer_make_and_add_to_pipeline(lv_gstreamer_t * streamer,
+                                                      const lv_gstreamer_pipeline_element_t * elements, size_t element_count);
 
 /**********************
  *  STATIC VARIABLES
@@ -95,7 +102,7 @@ lv_result_t lv_gstreamer_set_src(lv_obj_t * obj, const char * factory_name, cons
     LV_ASSERT_NULL(factory_name);
 
     if(!obj || !factory_name) {
-        LV_LOG_WARN("Refusing to set source with invalid params. Obj: %p Factory Name: %s", obj, factory_name);
+        LV_LOG_WARN("Refusing to set source with invalid params. Obj: %p Factory Name: %s", (void *)obj, factory_name);
         return LV_RESULT_INVALID;
     }
 
@@ -153,12 +160,11 @@ lv_result_t lv_gstreamer_set_src(lv_obj_t * obj, const char * factory_name, cons
         head = decodebin;
     }
 
-    lv_result_t res = gstreamer_create_pipeline(streamer, pipeline, head);
-    if(res == LV_RESULT_INVALID) {
-        LV_LOG_ERROR("Pipeline creation failed");
-        gst_object_unref(pipeline);
-        return res;
-    }
+    /* At this point we don't yet know the input format
+     * Once the source starts receiving the data, it will create the necessary pads,
+     * i.e one pad for audio and one for video
+     * We add a callback so that we automatically connect to the data once it's figured out*/
+    g_signal_connect(head, "pad-added", G_CALLBACK(on_decode_pad_added), streamer);
 
     streamer->pipeline = pipeline;
     return LV_RESULT_OK;
@@ -201,7 +207,6 @@ void lv_gstreamer_pause(lv_obj_t * obj)
 
 void lv_gstreamer_stop(lv_obj_t * obj)
 {
-
     LV_ASSERT_OBJ(obj, MY_CLASS);
     if(!obj) {
         return;
@@ -306,7 +311,7 @@ void lv_gstreamer_set_volume(lv_obj_t * obj, uint8_t volume)
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_gstreamer_t * streamer = (lv_gstreamer_t *)obj;
 
-    if(!streamer->pipeline) {
+    if(!streamer->audio_volume) {
         return;
     }
 
@@ -318,7 +323,7 @@ uint8_t lv_gstreamer_get_volume(lv_obj_t * obj)
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_gstreamer_t * streamer = (lv_gstreamer_t *)obj;
 
-    if(!streamer->pipeline) {
+    if(!streamer->audio_volume) {
         return 0;
     }
 
@@ -328,21 +333,15 @@ uint8_t lv_gstreamer_get_volume(lv_obj_t * obj)
     return (uint8_t)(volume * 100.f);
 }
 
-/**
- * Set the speed rate of this gstreamer
- * @param gstreamer     pointer to a gstreamer object
- * @param rate      the rate factor.  Example values:
- *                      - 256:   1x
- *                      - <256:  slow down
- *                      - >256:  speed up
- *                      - 128:   0.5x
- *                      - 512:   2x
- */
 void lv_gstreamer_set_rate(lv_obj_t * obj, uint32_t rate)
 {
 
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_gstreamer_t * streamer = (lv_gstreamer_t *)obj;
+
+    if(!streamer->pipeline) {
+        return;
+    }
 
     gdouble gst_rate = (gdouble)rate / 256.0;
 
@@ -407,8 +406,8 @@ static void gstreamer_poll_bus(lv_gstreamer_t * streamer)
             case GST_MESSAGE_STATE_CHANGED: {
                     GstState old_state, new_state;
                     gst_message_parse_state_changed(msg, &old_state, &new_state, NULL);
-                    LV_LOG_TRACE("State changed: %s -> %s", gst_element_state_get_name(old_state),
-                                 gst_element_state_get_name(new_state));
+                    LV_LOG_INFO("State changed: %s -> %s", gst_element_state_get_name(old_state),
+                                gst_element_state_get_name(new_state));
                     break;
                 }
             default:
@@ -505,32 +504,9 @@ static void lv_gstreamer_destructor(const lv_obj_class_t * class_p, lv_obj_t * o
     g_async_queue_unref(streamer->frame_queue);
 }
 
-static lv_result_t gstreamer_create_pipeline(lv_gstreamer_t * streamer, GstElement * pipeline,
-                                             GstElement * decode_element)
+static lv_result_t gstreamer_make_and_add_to_pipeline(lv_gstreamer_t * streamer,
+                                                      const lv_gstreamer_pipeline_element_t * elements, size_t element_count)
 {
-
-    /* The caller has already added head and whatever comes before it to the pipeline.
-     * So inside this function, we only need to handle adding the elements that are created here */
-    GstElement * video_app_sink;
-    GstElement * video_rate;
-    GstElement * video_queue;
-    GstElement * audio_resample;
-    GstElement * audio_sink;
-    struct {
-        const char * factory;
-        const char * name;
-        GstElement ** store;
-    } const elements[] = {
-        {"videoconvert",  "lv_gstreamer_video_convert",  &streamer->video_convert},
-        {"audioconvert",  "lv_gstreamer_audio_convert",  &streamer->audio_convert},
-        {"volume",        "lv_gstreamer_audio_volume",   &streamer->audio_volume},
-        {"videorate",     "lv_gstreamer_video_rate",     &video_rate},
-        {"queue",         "lv_gstreamer_video_queue",    &video_queue},
-        {"appsink",       "lv_gstreamer_video_sink",     &video_app_sink},
-        {"audioresample", "lv_gstreamer_audio_resample", &audio_resample},
-        {"autoaudiosink", "lv_gstreamer_audio_sink",     &audio_sink},
-    };
-    const size_t element_count = sizeof(elements) / sizeof(elements[0]);
     for(size_t i = 0; i < element_count; ++i) {
         GstElement * el = gst_element_factory_make(elements[i].factory, elements[i].name);
         if(!el) {
@@ -540,42 +516,12 @@ static lv_result_t gstreamer_create_pipeline(lv_gstreamer_t * streamer, GstEleme
             return LV_RESULT_INVALID;
         }
         *(elements[i].store) = el;
-        if(!gst_bin_add(GST_BIN(pipeline), el)) {
+        if(!gst_bin_add(GST_BIN(streamer->pipeline), el)) {
             gst_object_unref(el);
             LV_LOG_ERROR("Failed to add %s element to pipeline", elements[i].name);
             return LV_RESULT_INVALID;
         }
     }
-
-    /* Here we set the fps we want the pipeline to produce and the color format
-     * This is achieved by the video_convert and video_rate elements that will automaticall throttle and
-     * convert the image to the format we desire*/
-    uint32_t target_fps = 1000 / LV_DEF_REFR_PERIOD;
-    char caps[128];
-    lv_snprintf(caps, sizeof(caps), "video/x-raw,format=%s,framerate=%" LV_PRIu32 "/1", GST_FORMAT, target_fps);
-
-    GstCaps * appsink_caps = gst_caps_from_string(caps);
-    g_object_set(G_OBJECT(video_app_sink), "emit-signals", TRUE, "sync", TRUE, "max-buffers", 1, "drop", TRUE, "caps",
-                 appsink_caps, NULL);
-    gst_caps_unref(appsink_caps);
-
-    if(!gst_element_link_many(streamer->video_convert, video_rate, video_queue, video_app_sink, NULL)) {
-        LV_LOG_ERROR("Failed to link video convert to sink");
-        return LV_RESULT_INVALID;
-    }
-
-    if(!gst_element_link_many(streamer->audio_convert, audio_resample, streamer->audio_volume, audio_sink, NULL)) {
-        LV_LOG_ERROR("Failed to link audio convert to sink");
-        return LV_RESULT_INVALID;
-    }
-
-    g_signal_connect(video_app_sink, "new-sample", G_CALLBACK(on_new_sample), streamer);
-
-    /* At this point we don't yet know the input format
-     * Once the source starts receiving the data, it will create the necessary pads,
-     * i.e one pad for audio and one for video
-     * We add a callback so that we automatically connect to the data once it's figured out*/
-    g_signal_connect(decode_element, "pad-added", G_CALLBACK(on_decode_pad_added), streamer);
     return LV_RESULT_OK;
 }
 
@@ -591,18 +537,75 @@ static void on_decode_pad_added(GstElement * element, GstPad * pad, gpointer use
     LV_LOG_TRACE("Pad discovered %s", name);
 
     if(g_str_has_prefix(name, "video/")) {
-        GstPad * video_convert_sink_pad = gst_element_get_static_pad(streamer->video_convert, "sink");
-        if(!gst_pad_is_linked(video_convert_sink_pad)) {
-            if(gst_pad_link(pad, video_convert_sink_pad) != GST_PAD_LINK_OK) {
-                LV_LOG_ERROR("Failed to link discovered pad '%s' to videoconvert", name);
+        if(!streamer->video_convert) {
+            GstElement * video_app_sink;
+            GstElement * video_rate;
+            GstElement * video_queue;
+            const lv_gstreamer_pipeline_element_t elements[] = {
+                {"videoconvert",  "lv_gstreamer_video_convert",  &streamer->video_convert},
+                {"videorate",     "lv_gstreamer_video_rate",     &video_rate},
+                {"queue",         "lv_gstreamer_video_queue",    &video_queue},
+                {"appsink",       "lv_gstreamer_video_sink",     &video_app_sink},
+            };
+            const size_t element_count = sizeof(elements) / sizeof(elements[0]);
+            if(gstreamer_make_and_add_to_pipeline(streamer, elements, element_count) != LV_RESULT_OK) {
+                goto exit;
             }
+
+            /* Here we set the fps we want the pipeline to produce and the color format
+             * This is achieved by the video_convert and video_rate elements that will automatically throttle and
+             * convert the image to the format we desire*/
+            uint32_t target_fps = 1000 / LV_DEF_REFR_PERIOD;
+            char caps_str[128];
+            lv_snprintf(caps_str, sizeof(caps_str), "video/x-raw,format=%s,framerate=%" LV_PRIu32 "/1", GST_FORMAT, target_fps);
+
+            GstCaps * appsink_caps = gst_caps_from_string(caps_str);
+            g_object_set(G_OBJECT(video_app_sink), "emit-signals", TRUE, "sync", TRUE, "max-buffers", 1, "drop", TRUE, "caps",
+                         appsink_caps, NULL);
+            gst_caps_unref(appsink_caps);
+
+            if(!gst_element_link_many(streamer->video_convert, video_rate, video_queue, video_app_sink, NULL)) {
+                LV_LOG_ERROR("Failed to link video convert to sink");
+                goto exit;
+            }
+            for(size_t i = 0; i < element_count; ++i) {
+                gst_element_sync_state_with_parent(*elements[i].store);
+            }
+            g_signal_connect(video_app_sink, "new-sample", G_CALLBACK(on_new_sample), streamer);
         }
-        else {
+
+        GstPad * video_convert_sink_pad = gst_element_get_static_pad(streamer->video_convert, "sink");
+        if(gst_pad_is_linked(video_convert_sink_pad)) {
             LV_LOG_WARN("Received another video pad '%s' but our video pipeline is already linked - Ignoring", name);
+        }
+        else if(gst_pad_link(pad, video_convert_sink_pad) != GST_PAD_LINK_OK) {
+            LV_LOG_ERROR("Failed to link discovered pad '%s' to videoconvert", name);
         }
         gst_object_unref(video_convert_sink_pad);
     }
     else if(g_str_has_prefix(name, "audio/")) {
+        if(!streamer->audio_convert) {
+            GstElement * audio_resample;
+            GstElement * audio_sink;
+            const lv_gstreamer_pipeline_element_t elements[] = {
+                {"audioconvert",  "lv_gstreamer_audio_convert",  &streamer->audio_convert},
+                {"volume",        "lv_gstreamer_audio_volume",   &streamer->audio_volume},
+                {"audioresample", "lv_gstreamer_audio_resample", &audio_resample},
+                {"autoaudiosink", "lv_gstreamer_audio_sink",     &audio_sink},
+            };
+            const size_t element_count = sizeof(elements) / sizeof(elements[0]);
+            if(gstreamer_make_and_add_to_pipeline(streamer, elements, element_count) != LV_RESULT_OK) {
+                goto exit;
+            }
+            if(!gst_element_link_many(streamer->audio_convert, audio_resample, streamer->audio_volume, audio_sink, NULL)) {
+                LV_LOG_ERROR("Failed to link audio convert to sink");
+                goto exit;
+            }
+            for(size_t i = 0; i < element_count; ++i) {
+                gst_element_sync_state_with_parent(*elements[i].store);
+            }
+        }
+
         GstPad * audio_convert_sink_pad = gst_element_get_static_pad(streamer->audio_convert, "sink");
         if(!gst_pad_is_linked(audio_convert_sink_pad)) {
             if(gst_pad_link(pad, audio_convert_sink_pad) != GST_PAD_LINK_OK) {
@@ -615,6 +618,7 @@ static void on_decode_pad_added(GstElement * element, GstPad * pad, gpointer use
         gst_object_unref(audio_convert_sink_pad);
     }
 
+exit:
     gst_caps_unref(caps);
 }
 

--- a/src/libs/gstreamer/lv_gstreamer.h
+++ b/src/libs/gstreamer/lv_gstreamer.h
@@ -23,7 +23,6 @@ extern "C" {
  *      DEFINES
  *********************/
 
-LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_gstreamer_class;
 
 /* Using the `URI` "factory", we can specify various URI schemes as media sources including
  * - local files (file://)
@@ -39,8 +38,6 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_gstreamer_class;
 #define LV_GSTREAMER_FACTORY_FILE            "filesrc"
 #define LV_GSTREAMER_PROPERTY_FILE            "location"
 
-/** These sources are untested. For most of them, URI_DECODE can probably be used instead */
-#ifdef LV_GSTREAMER_ENABLE_UNTESTED_SOURCES
 #define LV_GSTREAMER_FACTORY_HTTP            "souphttpsrc"
 #define LV_GSTREAMER_PROPERTY_HTTP            "location"
 
@@ -64,7 +61,6 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_gstreamer_class;
 
 #define LV_GSTREAMER_FACTORY_APP             "appsrc"
 #define LV_GSTREAMER_PROPERTY_APP             NULL
-#endif
 
 /**********************
  *      TYPEDEFS

--- a/src/libs/gstreamer/lv_gstreamer_internal.h
+++ b/src/libs/gstreamer/lv_gstreamer_internal.h
@@ -59,6 +59,8 @@ typedef struct {
 
 typedef struct _lv_gstreamer_t lv_gstreamer_t;
 
+LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_gstreamer_class;
+
 /**********************
  * GLOBAL PROTOTYPES
  **********************/


### PR DESCRIPTION
This PR moves the pipeline creation to the stage where we discover new pads

We get a pad when the data source is discovered, this allows us to dynamically skip creating the audio part of the pipeline for sources that don't provide an audio source for instance

Now camera input support works, videos without audio, etc...