### PR TITLE
fix: remove unused code and fix code signature warning

### DIFF
--- a/src/draw/nanovg/lv_draw_nanovg_label.c
+++ b/src/draw/nanovg/lv_draw_nanovg_label.c
@@ -136,23 +136,6 @@ void lv_draw_nanovg_label(lv_draw_task_t * t, const lv_draw_label_dsc_t * dsc, c
 *   STATIC FUNCTIONS
 **********************/
 
-static inline void convert_letter_matrix(lv_matrix_t * matrix, const lv_draw_glyph_dsc_t * dsc)
-{
-    lv_matrix_translate(matrix, dsc->letter_coords->x1, dsc->letter_coords->y1);
-
-    if(!dsc->rotation) {
-        return;
-    }
-
-    const lv_point_t pivot = {
-        .x = dsc->pivot.x,
-        .y = dsc->g->box_h + dsc->g->ofs_y
-    };
-    lv_matrix_translate(matrix, pivot.x, pivot.y);
-    lv_matrix_rotate(matrix, dsc->rotation / 10.0f);
-    lv_matrix_translate(matrix, -pivot.x, -pivot.y);
-}
-
 static bool draw_letter_clip_areas(lv_draw_task_t * t, const lv_draw_glyph_dsc_t * dsc, lv_area_t * letter_area,
                                    lv_area_t * cliped_area)
 {

--- a/src/drivers/opengles/lv_opengles_debug.c
+++ b/src/drivers/opengles/lv_opengles_debug.c
@@ -39,7 +39,7 @@
  **********************/
 
 #if LV_USE_OPENGLES_DEBUG
-void GLClearError()
+void GLClearError(void)
 {
     while(glGetError() != GL_NO_ERROR);
 }


### PR DESCRIPTION
This PR removes an unused internal function `convert_letter_matrix` from the NanoVG drawing backend. The function was originally intended to handle transformation matrices for characters but is currently idle, and its logic is insufficient to support the planned FreeType vector character rendering in future implementations.  

## Why remove `convert_letter_matrix`?

- **Code Redundancy**: The function has no callers in the current `lv_draw_nanovg_label.c`.  

## Current Status of Vector Rendering
 
Currently, the NanoVG backend only retains TODO comments when processing the `LV_FONT_GLYPH_FORMAT_VECTOR` format. Vector fonts cannot be displayed due to the following missing key components:  
- **Event Chain Not Connected**: No callback has been registered for FreeType outline generation events.  
- **Path Conversion Isolation**: The existing `lv_path_to_nvg` utility function is privatized in `lv_draw_nanovg_vector.c` and cannot be reused by Label drawing logic.  

## Roadmap for Future Implementation

1. **Infrastructure Refactoring**:  
   - Elevate `lv_path_to_nvg` to a backend-internal shared function.  
   - Register a global FreeType outline conversion callback in `lv_draw_nanovg_label_init`.
2. **Implement `draw_letter_outline`**:  
   - Introduce a dedicated transformation matrix for the FreeType coordinate system (handling 1/64-pixel precision, Y-axis inversion, etc.).  
   - Integrate NanoVG’s `nvgFill` process to achieve high-performance vector character rendering.  

## Others

- **Route A: Backend-specific implementation (short-term solution)**  
  - Register a FreeType outline conversion callback in `lv_draw_nanovg_label.c`.  
  - Promote the utility function `lv_path_to_nvg` from `lv_draw_nanovg_vector.c` to a backend-shared function for rendering characters.  

- **Route B: Integration based on a universal vector path API (recommended solution - architectural optimization)**  
  - **Unified path creation**: Modify the FreeType integration layer to directly utilize the `lv_vector` API (e.g., `lv_vector_path_t`) for building standard paths.  
  - **Cross-backend reuse**:  
    - **NanoVG**: Directly reuse the existing `lv_path_to_nvg` logic to convert standard paths into NanoVG instructions.  
    - **Consistency**: Other rendering modules (e.g., Image, Line) can also share this path format.  
  - **Code simplification**: Completely eliminate duplicate FreeType event handling logic in backends such as SW, VG-Lite, and NanoVG, achieving full decoupling of "data generation" from "low-level rendering."

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
