### PR TITLE
fix(opengles_shader): fix index out of bounds

### DIFF
--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_program.c
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_program.c
@@ -64,15 +64,24 @@ lv_opengl_shader_program_t * lv_opengl_shader_program_create(unsigned int _progr
 void lv_opengl_shader_program_destroy(lv_opengl_shader_program_t * program)
 {
 #ifndef __EMSCRIPTEN__
-    GLuint shader_names[10];
-    GLsizei shader_count;
-    GL_CALL(glGetAttachedShaders(program->id, 10, &shader_count,
-                                 shader_names));
+    GLint shader_num = 0;
+    GL_CALL(glGetProgramiv(program->id, GL_ATTACHED_SHADERS, &shader_num));
 
-    // Detach and delete each shader
-    for(GLsizei i = 0; i < shader_count; ++i) {
-        if(shader_names[i] != 0)
-            GL_CALL(glDetachShader(program->id, shader_names[i]));
+    if(shader_num > 0) {
+        GLuint * shader_names = lv_malloc(shader_num * sizeof(GLuint));
+
+        if(shader_names) {
+            GLsizei shader_count;
+            GL_CALL(glGetAttachedShaders(program->id, shader_num, &shader_count,
+                                         shader_names));
+
+            // Detach and delete each shader
+            for(GLsizei i = 0; i < shader_count && i < shader_num; ++i) {
+                if(shader_names[i] != 0)
+                    GL_CALL(glDetachShader(program->id, shader_names[i]));
+            }
+            lv_free(shader_names);
+        }
     }
 #endif
 


### PR DESCRIPTION
Found in PR: https://github.com/lvgl/lvgl/pull/9571

The program crashed when it exited:

```bash
lvgl/src/drivers/opengles/opengl_shader/lv_opengl_shader_program.c:74:24: runtime error: index 10 out of bounds for type 'GLuint [10]'
lvgl/src/drivers/opengles/opengl_shader/lv_opengl_shader_program.c:74:24: runtime error: load of address 0x7f2185a6f1d8 with insufficient space for an object of type 'GLuint'
0x7f2185a6f1d8: note: pointer points here
 00 00 00 00  00 00 00 00 00 00 00 00  00 00 80 3f 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00
              ^ 
=================================================================
==145829==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7f2185a6f1d8 at pc 0x55b901552420 bp 0x7ffd560171d0 sp 0x7ffd560171c0
READ of size 4 at 0x7f2185a6f1d8 thread T0
    #0 0x55b90155241f in lv_opengl_shader_program_destroy lvgl/src/drivers/opengles/opengl_shader/lv_opengl_shader_program.c:74
    #1 0x55b90154ec00 in lv_opengl_shader_manager_deinit lvgl/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c:372
    #2 0x55b901803ab3 in lv_gltf_destructor lvgl/src/libs/gltf/gltf_view/lv_gltf_view.cpp:678
    #3 0x55b90123026a in lv_obj_destruct lvgl/src/core/lv_obj_class.c:145
    #4 0x55b90127fc04 in obj_delete_core lvgl/src/core/lv_obj_tree.c:723
    #5 0x55b90127f7b5 in obj_delete_core lvgl/src/core/lv_obj_tree.c:688
    #6 0x55b901277bcd in lv_obj_delete lvgl/src/core/lv_obj_tree.c:75
    #7 0x55b9012a2b13 in lv_display_delete lvgl/src/display/lv_display.c:223
    #8 0x55b9012fc95d in sdl_event_handler lvgl/src/drivers/sdl/lv_sdl_window.c:415
    #9 0x55b90137d1c9 in lv_timer_exec lvgl/src/misc/lv_timer.c:353
    #10 0x55b90137b0d0 in lv_timer_handler lvgl/src/misc/lv_timer.c:107
    #11 0x55b901212d8d in main main.c:134
    #12 0x7f2188429d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #13 0x7f2188429e3f in __libc_start_main_impl ../csu/libc-start.c:392
    #14 0x55b9012113e4 in _start (build/Simulator+0xe233e4) (BuildId: fe26ba2deb314addf73b72c7a33b6fe067e7a57a)

Address 0x7f2185a6f1d8 is located in stack of thread T0 at offset 88 in frame
    #0 0x55b901552180 in lv_opengl_shader_program_destroy lvgl/src/drivers/opengles/opengl_shader/lv_opengl_shader_program.c:65

  This frame has 2 object(s):
    [32, 36) 'shader_count' (line 68)
    [48, 88) 'shader_names' (line 67) <== Memory access at offset 88 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow lvgl/src/drivers/opengles/opengl_shader/lv_opengl_shader_program.c:74 in lv_opengl_shader_program_destroy
Shadow bytes around the buggy address:
  0x7f2185a6ef00: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00
  0x7f2185a6ef80: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x7f2185a6f000: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00
  0x7f2185a6f080: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00
  0x7f2185a6f100: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00
=>0x7f2185a6f180: f1 f1 f1 f1 04 f2 00 00 00 00 00[f3]f3 f3 f3 f3
  0x7f2185a6f200: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00
  0x7f2185a6f280: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00
  0x7f2185a6f300: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00
  0x7f2185a6f380: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00
  0x7f2185a6f400: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==145829==ABORTING
```

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
