### PR TITLE
fix(glfw): add gl_rgb565 fallback definition

### DIFF
--- a/src/drivers/opengles/lv_opengles_private.h
+++ b/src/drivers/opengles/lv_opengles_private.h
@@ -81,6 +81,11 @@ extern "C" {
 #define GL_RGBA8 0x8058
 #endif
 
+/* In Desktop GL GL_RGB565 is not supported. Use RGB instead */
+#if LV_USE_GLFW
+#define GL_RGB565 GL_RGB
+#endif
+
 #if !defined(glClearDepthf) && defined(glClearDepth)
 #define glClearDepthf glClearDepth
 #endif


### PR DESCRIPTION
Fixes the current CI failure

```
In file included from /home/lvgl/lv_ej_workspace/lv_port_linux/lvgl/src/drivers/opengles/lv_opengles_texture.c:13:
/home/lvgl/lv_ej_workspace/lv_port_linux/lvgl/src/drivers/opengles/lv_opengles_texture.c: In function ‘flush_cb’:
/home/lvgl/lv_ej_workspace/lv_port_linux/lvgl/src/drivers/opengles/lv_opengles_texture.c:273:48: error: ‘GL_RGB565’ undeclared (first use in this function); did you mean ‘GL_RGB16F’?
  273 |         GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB565, disp->hor_res, disp->ver_res, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5,
      |                                                ^~~~~~~~~
/home/lvgl/lv_ej_workspace/lv_port_linux/lvgl/src/drivers/opengles/lv_opengles_debug.h:47:9: note: in definition of macro ‘GL_CALL’
   47 |         x;\
      |         ^
/home/lvgl/lv_ej_workspace/lv_port_linux/lvgl/src/drivers/opengles/lv_opengles_texture.c:273:48: note: each undeclared identifier is reported only once for each function it appears in
  273 |         GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB565, disp->hor_res, disp->ver_res, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5,
      |                                                ^~~~~~~~~
/home/lvgl/lv_ej_workspace/lv_port_linux/lvgl/src/drivers/opengles/lv_opengles_debug.h:47:9: note: in definition of macro ‘GL_CALL’
   47 |         x;\
      |         ^
[ 63%] Building C object lvgl/CMakeFiles/lvgl.dir/src/drivers/wayland/lv_wayland.c.o
```