### PR TITLE
fix(widget/span): undefined lv_subject_t if LV_USE_OBSERVER undefined

### DIFF
--- a/src/widgets/span/lv_span.c
+++ b/src/widgets/span/lv_span.c
@@ -44,11 +44,13 @@ struct _snippet_stack {
     uint32_t        index;
 };
 
+#if LV_USE_OBSERVER
 typedef struct {
     lv_subject_t * subject;
     void * element; /**< span of a span group*/
     const char * fmt;
 } bind_element_string_t;
+#endif
 
 /**********************
  *  STATIC PROTOTYPES


### PR DESCRIPTION
This commit fixes a compilation error that occurred when `LV_USE_OBSERVER` is not defined. The bind_element_string_t structure uses the `lv_subject_t`  type, which is only available when the observer feature is enabled.

Changes
* Wrapped the `bind_element_string_t` typedef in [lv_span.c:47-52] with `#if LV_USE_OBSERVER` guard
* Ensures the code compiles correctly when observer functionality is disabled 

Impact
* Scope: Minimal - affects only the span widget internal structure
* Compatibility: Fixes build errors in configurations without observer support
* Testing: Should verify builds with `LV_USE_OBSERVER` both enabled and disabled

This is a straightforward fix that properly conditionally compiles code that depends on the observer feature.