### PR TITLE
fix(gltf): fix memory leaks caused by incomplete resource cleanup

### DIFF
--- a/src/libs/gltf/gltf_data/lv_gltf_data.cpp
+++ b/src/libs/gltf/gltf_data/lv_gltf_data.cpp
@@ -88,6 +88,22 @@ void lv_gltf_data_delete(lv_gltf_model_t * data)
         lv_gltf_model_node_t * node  = (lv_gltf_model_node_t *) lv_array_at(&data->nodes, i);
         lv_gltf_model_node_deinit(node);
     }
+    lv_array_deinit(&data->nodes);
+    lv_array_deinit(&data->compiled_shaders);
+
+    /* Explicitly call destructors for C++ objects initialized with placement new */
+    data->textures.~vector();
+    data->meshes.~vector();
+    data->node_by_light_index.~vector();
+    data->local_mesh_to_center_points_by_primitive.~map();
+    data->skin_tex.~vector();
+    data->validated_skins.~vector();
+    data->blended_nodes_by_material_index.~map();
+    data->opaque_nodes_by_material_index.~map();
+    data->node_transform_cache.~map();
+    data->channel_set_cache.~map();
+    data->asset.~Asset();
+
     lv_free(data);
 }
 

--- a/src/libs/gltf/gltf_view/lv_gltf_view.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view.cpp
@@ -683,6 +683,7 @@ static void lv_gltf_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
     for(size_t i = 0; i < n; ++i) {
         lv_gltf_data_delete(*(lv_gltf_model_t **)lv_array_at(&view->models, i));
     }
+    lv_array_deinit(&view->models);
     if(view->environment && view->owns_environment) {
         lv_gltf_environment_delete(view->environment);
     }


### PR DESCRIPTION
For C++ objects allocated using `lv_malloc`, the destructor needs to be explicitly called to clean up resources, or `lv_gltf_model_t` should be allocated directly using `new`/`delete` to avoid manually managing constructors and destructors.

`lv_array` also requires actively calling `lv_array_deinit` to clean up memory.

Memleak backtrace: [memleak_backtrace.txt](https://github.com/user-attachments/files/24561939/memleak_backtrace.txt)

cc @AndreCostaaa 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
