### PR TITLE
fix(gltf): add missing LV_RESULT_INVALID check

### DIFF
--- a/src/libs/gltf/gltf_view/lv_gltf_view_shader.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_shader.cpp
@@ -200,11 +200,11 @@ lv_result_t lv_gltf_view_shader_injest_discover_defines(lv_array_t * result, lv_
                 return LV_RESULT_INVALID;
             }
             if(add_texture_defines(result, material.specularGlossiness->diffuseTexture, "HAS_DIFFUSE_MAP",
-                                   "HAS_DIFFUSE_UV_TRANSFORM")) {
+                                   "HAS_DIFFUSE_UV_TRANSFORM") == LV_RESULT_INVALID) {
                 return LV_RESULT_INVALID;
             }
             if(add_texture_defines(result, material.specularGlossiness->specularGlossinessTexture,
-                                   "HAS_SPECULARGLOSSINESS_MAP", "HAS_SPECULARGLOSSINESS_UV_TRANSFORM")) {
+                                   "HAS_SPECULARGLOSSINESS_MAP", "HAS_SPECULARGLOSSINESS_UV_TRANSFORM") == LV_RESULT_INVALID) {
                 return LV_RESULT_INVALID;
             }
         }


### PR DESCRIPTION
`add_texture_defines` was returning `LV_RESULT_OK` but we were checking for it as a boolean so we were mistakenly returning `LV_RESULT_INVALID`