### PR TITLE
feat(msgbox): add support for formatted text

### DIFF
--- a/docs/src/widgets/msgbox.rst
+++ b/docs/src/widgets/msgbox.rst
@@ -84,6 +84,7 @@ Functions that add something to the message box return a pointer to the newly ad
 .. code:: c
 
    lv_obj_t * lv_msgbox_add_text(lv_obj_t * msgbox, const char * text);
+   lv_obj_t * lv_msgbox_add_text_fmt(lv_obj_t * obj, const char * fmt, ...);
    lv_obj_t * lv_msgbox_add_title(lv_obj_t * msgbox, const char * title);
    lv_obj_t * lv_msgbox_add_close_button(lv_obj_t * msgbox);
    lv_obj_t * lv_msgbox_add_header_button(lv_obj_t * msgbox, const void * symbol);

--- a/src/widgets/msgbox/lv_msgbox.c
+++ b/src/widgets/msgbox/lv_msgbox.c
@@ -205,18 +205,13 @@ lv_obj_t * lv_msgbox_add_text(lv_obj_t * obj, const char * text)
 
 lv_obj_t * lv_msgbox_add_text_fmt(lv_obj_t * obj, const char * fmt, ...)
 {
-    va_list args;
-
-    va_start(args, fmt);
     lv_msgbox_t * mbox = (lv_msgbox_t *)obj;
-    lv_obj_t * label = lv_label_create(mbox->content);
-    const char * text = lv_text_set_text_vfmt(fmt, args);
-    va_end(args);
 
-    if(text) {
-        lv_label_set_text(label, text);
-        lv_obj_set_width(label, lv_pct(100));
-    }
+    va_list args;
+    va_start(args, fmt);
+    lv_obj_t * label = lv_label_create(mbox->content);
+    lv_label_set_text_vfmt(label, fmt, args);
+    va_end(args);
 
     return label;
 }

--- a/src/widgets/msgbox/lv_msgbox.c
+++ b/src/widgets/msgbox/lv_msgbox.c
@@ -211,6 +211,7 @@ lv_obj_t * lv_msgbox_add_text_fmt(lv_obj_t * obj, const char * fmt, ...)
     va_start(args, fmt);
     lv_obj_t * label = lv_label_create(mbox->content);
     lv_label_set_text_vfmt(label, fmt, args);
+    lv_obj_set_width(label, lv_pct(100));
     va_end(args);
 
     return label;

--- a/src/widgets/msgbox/lv_msgbox.c
+++ b/src/widgets/msgbox/lv_msgbox.c
@@ -210,9 +210,13 @@ lv_obj_t * lv_msgbox_add_text_fmt(lv_obj_t * obj, const char * fmt, ...)
     va_start(args, fmt);
     lv_msgbox_t * mbox = (lv_msgbox_t *)obj;
     lv_obj_t * label = lv_label_create(mbox->content);
-    lv_label_set_text(label, lv_text_set_text_vfmt(fmt, args));
-    lv_obj_set_width(label, lv_pct(100));
+    const char * text = lv_text_set_text_vfmt(fmt, args);
     va_end(args);
+
+    if(text) {
+        lv_label_set_text(label, text);
+        lv_obj_set_width(label, lv_pct(100));
+    }
 
     return label;
 }

--- a/src/widgets/msgbox/lv_msgbox.c
+++ b/src/widgets/msgbox/lv_msgbox.c
@@ -14,6 +14,7 @@
 #include "../label/lv_label.h"
 #include "../image/lv_image.h"
 #include "../../misc/lv_assert.h"
+#include "../../misc/lv_text_private.h"
 #include "../../display/lv_display.h"
 #include "../../layouts/flex/lv_flex.h"
 #include "../../stdlib/lv_string.h"
@@ -198,6 +199,20 @@ lv_obj_t * lv_msgbox_add_text(lv_obj_t * obj, const char * text)
     lv_obj_t * label = lv_label_create(mbox->content);
     lv_label_set_text(label, text);
     lv_obj_set_width(label, lv_pct(100));
+
+    return label;
+}
+
+lv_obj_t * lv_msgbox_add_text_fmt(lv_obj_t * obj, const char * fmt, ...)
+{
+    va_list args;
+
+    va_start(args, fmt);
+    lv_msgbox_t * mbox = (lv_msgbox_t *)obj;
+    lv_obj_t * label = lv_label_create(mbox->content);
+    lv_label_set_text(label, lv_text_set_text_vfmt(fmt, args));
+    lv_obj_set_width(label, lv_pct(100));
+    va_end(args);
 
     return label;
 }

--- a/src/widgets/msgbox/lv_msgbox.c
+++ b/src/widgets/msgbox/lv_msgbox.c
@@ -210,15 +210,11 @@ lv_obj_t * lv_msgbox_add_text_fmt(lv_obj_t * obj, const char * fmt, ...)
     va_start(args, fmt);
     lv_msgbox_t * mbox = (lv_msgbox_t *)obj;
     lv_obj_t * label = lv_label_create(mbox->content);
-    const char * text = lv_text_set_text_vfmt(fmt, args);
+    lv_label_set_text(label, lv_text_set_text_vfmt(fmt, args));
+    lv_obj_set_width(label, lv_pct(100));
     va_end(args);
 
-    if(text) {
-        lv_label_set_text(label, text);
-        lv_obj_set_width(label, lv_pct(100));
-    }
-
-    return text ? label : NULL;
+    return label;
 }
 
 lv_obj_t * lv_msgbox_add_footer_button(lv_obj_t * obj, const char * text)

--- a/src/widgets/msgbox/lv_msgbox.c
+++ b/src/widgets/msgbox/lv_msgbox.c
@@ -213,7 +213,7 @@ lv_obj_t * lv_msgbox_add_text_fmt(lv_obj_t * obj, const char * fmt, ...)
     const char * text = lv_text_set_text_vfmt(fmt, args);
     va_end(args);
 
-    if (text) {
+    if(text) {
         lv_label_set_text(label, text);
         lv_obj_set_width(label, lv_pct(100));
     }

--- a/src/widgets/msgbox/lv_msgbox.c
+++ b/src/widgets/msgbox/lv_msgbox.c
@@ -210,11 +210,15 @@ lv_obj_t * lv_msgbox_add_text_fmt(lv_obj_t * obj, const char * fmt, ...)
     va_start(args, fmt);
     lv_msgbox_t * mbox = (lv_msgbox_t *)obj;
     lv_obj_t * label = lv_label_create(mbox->content);
-    lv_label_set_text(label, lv_text_set_text_vfmt(fmt, args));
-    lv_obj_set_width(label, lv_pct(100));
+    const char * text = lv_text_set_text_vfmt(fmt, args);
     va_end(args);
 
-    return label;
+    if (text) {
+        lv_label_set_text(label, text);
+        lv_obj_set_width(label, lv_pct(100));
+    }
+
+    return text ? label : NULL;
 }
 
 lv_obj_t * lv_msgbox_add_footer_button(lv_obj_t * obj, const char * text)

--- a/src/widgets/msgbox/lv_msgbox.h
+++ b/src/widgets/msgbox/lv_msgbox.h
@@ -68,9 +68,9 @@ lv_obj_t * lv_msgbox_add_text(lv_obj_t * obj, const char * text);
  * Add a formatted text to the content area of message box. Multiple texts will be created below each other.
  * @param obj           pointer to a message box
  * @param fmt           `printf`-like format string
- * @return              the created button
+ * @return              the created label
  */
-lv_obj_t * lv_msgbox_add_text_fmt(lv_obj_t * obj, const char * fmt, ...);
+lv_obj_t * lv_msgbox_add_text_fmt(lv_obj_t * obj, const char * fmt, ...) LV_FORMAT_ATTRIBUTE(2, 3);
 
 /**
  * Add a button to the footer of to the message box. It also creates a footer.

--- a/src/widgets/msgbox/lv_msgbox.h
+++ b/src/widgets/msgbox/lv_msgbox.h
@@ -65,6 +65,14 @@ lv_obj_t * lv_msgbox_add_header_button(lv_obj_t * obj, const void * icon);
 lv_obj_t * lv_msgbox_add_text(lv_obj_t * obj, const char * text);
 
 /**
+ * Add a formatted text to the content area of message box. Multiple texts will be created below each other.
+ * @param obj           pointer to a message box
+ * @param fmt           `printf`-like format string
+ * @return              the created button
+ */
+lv_obj_t * lv_msgbox_add_text_fmt(lv_obj_t * obj, const char * fmt, ...);
+
+/**
  * Add a button to the footer of to the message box. It also creates a footer.
  * @param obj           pointer to a message box
  * @param text          the text of the button

--- a/tests/src/test_cases/widgets/test_msgbox.c
+++ b/tests/src/test_cases/widgets/test_msgbox.c
@@ -38,7 +38,6 @@ void test_msgbox_creation_successful_with_close_button(void)
     msgbox = lv_msgbox_create(active_screen);
     lv_msgbox_add_title(msgbox, "The title");
     lv_msgbox_add_text(msgbox, "The text");
-    lv_msgbox_add_text_fmt(msgbox, "The fmt text");
     lv_msgbox_add_footer_button(msgbox, "Apply");
     lv_msgbox_add_footer_button(msgbox, "Close");
     lv_msgbox_add_header_button(msgbox, LV_SYMBOL_AUDIO);
@@ -54,7 +53,6 @@ void test_msgbox_creation_successful_no_close_button(void)
     msgbox = lv_msgbox_create(NULL);
     lv_msgbox_add_title(msgbox, "The title");
     lv_msgbox_add_text(msgbox, "The text");
-    lv_msgbox_add_text_fmt(msgbox, "The fmt text");
     lv_msgbox_add_footer_button(msgbox, "Apply");
     lv_msgbox_add_footer_button(msgbox, "Close");
     lv_msgbox_add_header_button(msgbox, LV_SYMBOL_AUDIO);
@@ -70,7 +68,7 @@ void test_msgbox_creation_successful_modal(void)
     msgbox = lv_msgbox_create(NULL);
     lv_msgbox_add_title(msgbox, "The title");
     lv_msgbox_add_text(msgbox, "The text");
-    lv_msgbox_add_text_fmt(msgbox, "The fmt text");
+    lv_msgbox_add_text_fmt(msgbox, "The %s text", "fmt");
     lv_msgbox_add_footer_button(msgbox, "Apply");
     lv_msgbox_add_footer_button(msgbox, "Close");
     lv_msgbox_add_header_button(msgbox, LV_SYMBOL_AUDIO);
@@ -90,7 +88,7 @@ void test_msgbox_get_title(void)
     msgbox = lv_msgbox_create(active_screen);
     lv_msgbox_add_title(msgbox, "The title");
     lv_msgbox_add_text(msgbox, "The text");
-    lv_msgbox_add_text_fmt(msgbox, "The fmt text");
+    lv_msgbox_add_text_fmt(msgbox, "The %s text", "fmt");
     lv_msgbox_add_footer_button(msgbox, "Apply");
     lv_msgbox_add_footer_button(msgbox, "Close");
     lv_msgbox_add_header_button(msgbox, LV_SYMBOL_AUDIO);
@@ -113,7 +111,7 @@ void test_msgbox_close(void)
 {
     msgbox = lv_msgbox_create(active_screen);
     lv_msgbox_add_text(msgbox, "The text");
-    lv_msgbox_add_text_fmt(msgbox, "The fmt text");
+    lv_msgbox_add_text_fmt(msgbox, "The %s text", "fmt");
 
     lv_msgbox_close(msgbox);
 
@@ -125,7 +123,7 @@ void test_msgbox_close_modal(void)
 {
     msgbox = lv_msgbox_create(NULL);
     lv_msgbox_add_text(msgbox, "The text");
-    lv_msgbox_add_text_fmt(msgbox, "The fmt text");
+    lv_msgbox_add_text_fmt(msgbox, "The %s text", "fmt");
 
     lv_msgbox_close(msgbox);
 
@@ -137,7 +135,7 @@ void test_msgbox_close_async(void)
 {
     msgbox = lv_msgbox_create(active_screen);
     lv_msgbox_add_text(msgbox, "The text");
-    lv_msgbox_add_text_fmt(msgbox, "The fmt text");
+    lv_msgbox_add_text_fmt(msgbox, "The %s text", "fmt");
 
     // lv_msgbox_close deletes the message box
     TEST_ASSERT_NOT_NULL(msgbox);
@@ -147,7 +145,7 @@ void test_msgbox_close_async_modal(void)
 {
     msgbox = lv_msgbox_create(NULL);
     lv_msgbox_add_text(msgbox, "The text");
-    lv_msgbox_add_text_fmt(msgbox, "The fmt text");
+    lv_msgbox_add_text_fmt(msgbox, "The %s text", "fmt");
 
     // lv_msgbox_close deletes the message box
     TEST_ASSERT_NOT_NULL(msgbox);
@@ -159,7 +157,7 @@ void test_msgbox_content_auto_height(void)
     msgbox = lv_msgbox_create(NULL);
     lv_msgbox_add_title(msgbox, "The title");
     lv_msgbox_add_text(msgbox, "The text");
-    lv_msgbox_add_text_fmt(msgbox, "The fmt text");
+    lv_msgbox_add_text_fmt(msgbox, "The %s text", "fmt");
     lv_msgbox_add_footer_button(msgbox, "Apply");
     lv_msgbox_add_footer_button(msgbox, "Close");
     lv_msgbox_add_header_button(msgbox, LV_SYMBOL_AUDIO);

--- a/tests/src/test_cases/widgets/test_msgbox.c
+++ b/tests/src/test_cases/widgets/test_msgbox.c
@@ -38,6 +38,7 @@ void test_msgbox_creation_successful_with_close_button(void)
     msgbox = lv_msgbox_create(active_screen);
     lv_msgbox_add_title(msgbox, "The title");
     lv_msgbox_add_text(msgbox, "The text");
+    lv_msgbox_add_text_fmt(msgbox, "The fmt text");
     lv_msgbox_add_footer_button(msgbox, "Apply");
     lv_msgbox_add_footer_button(msgbox, "Close");
     lv_msgbox_add_header_button(msgbox, LV_SYMBOL_AUDIO);
@@ -53,6 +54,7 @@ void test_msgbox_creation_successful_no_close_button(void)
     msgbox = lv_msgbox_create(NULL);
     lv_msgbox_add_title(msgbox, "The title");
     lv_msgbox_add_text(msgbox, "The text");
+    lv_msgbox_add_text_fmt(msgbox, "The fmt text");
     lv_msgbox_add_footer_button(msgbox, "Apply");
     lv_msgbox_add_footer_button(msgbox, "Close");
     lv_msgbox_add_header_button(msgbox, LV_SYMBOL_AUDIO);
@@ -68,6 +70,7 @@ void test_msgbox_creation_successful_modal(void)
     msgbox = lv_msgbox_create(NULL);
     lv_msgbox_add_title(msgbox, "The title");
     lv_msgbox_add_text(msgbox, "The text");
+    lv_msgbox_add_text_fmt(msgbox, "The fmt text");
     lv_msgbox_add_footer_button(msgbox, "Apply");
     lv_msgbox_add_footer_button(msgbox, "Close");
     lv_msgbox_add_header_button(msgbox, LV_SYMBOL_AUDIO);
@@ -87,6 +90,7 @@ void test_msgbox_get_title(void)
     msgbox = lv_msgbox_create(active_screen);
     lv_msgbox_add_title(msgbox, "The title");
     lv_msgbox_add_text(msgbox, "The text");
+    lv_msgbox_add_text_fmt(msgbox, "The fmt text");
     lv_msgbox_add_footer_button(msgbox, "Apply");
     lv_msgbox_add_footer_button(msgbox, "Close");
     lv_msgbox_add_header_button(msgbox, LV_SYMBOL_AUDIO);
@@ -109,6 +113,7 @@ void test_msgbox_close(void)
 {
     msgbox = lv_msgbox_create(active_screen);
     lv_msgbox_add_text(msgbox, "The text");
+    lv_msgbox_add_text_fmt(msgbox, "The fmt text");
 
     lv_msgbox_close(msgbox);
 
@@ -120,6 +125,7 @@ void test_msgbox_close_modal(void)
 {
     msgbox = lv_msgbox_create(NULL);
     lv_msgbox_add_text(msgbox, "The text");
+    lv_msgbox_add_text_fmt(msgbox, "The fmt text");
 
     lv_msgbox_close(msgbox);
 
@@ -131,6 +137,7 @@ void test_msgbox_close_async(void)
 {
     msgbox = lv_msgbox_create(active_screen);
     lv_msgbox_add_text(msgbox, "The text");
+    lv_msgbox_add_text_fmt(msgbox, "The fmt text");
 
     // lv_msgbox_close deletes the message box
     TEST_ASSERT_NOT_NULL(msgbox);
@@ -140,6 +147,7 @@ void test_msgbox_close_async_modal(void)
 {
     msgbox = lv_msgbox_create(NULL);
     lv_msgbox_add_text(msgbox, "The text");
+    lv_msgbox_add_text_fmt(msgbox, "The fmt text");
 
     // lv_msgbox_close deletes the message box
     TEST_ASSERT_NOT_NULL(msgbox);
@@ -151,6 +159,7 @@ void test_msgbox_content_auto_height(void)
     msgbox = lv_msgbox_create(NULL);
     lv_msgbox_add_title(msgbox, "The title");
     lv_msgbox_add_text(msgbox, "The text");
+    lv_msgbox_add_text_fmt(msgbox, "The fmt text");
     lv_msgbox_add_footer_button(msgbox, "Apply");
     lv_msgbox_add_footer_button(msgbox, "Close");
     lv_msgbox_add_header_button(msgbox, LV_SYMBOL_AUDIO);


### PR DESCRIPTION
For some variable messages, we can save the space of an array and use it quickly. E.g.:
```
    char s[32] = {0};
    sprintf(s, "Hello %d", i);
    lv_msgbox_add_text(msg, s);
```
to
```
    lv_msgbox_add_text_fmt(msg, "Hello %d", i);
```