### PR TITLE
fix(textarea): fix the issue of textarea placeholder

### DIFF
--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -1399,17 +1399,13 @@ static void draw_placeholder(lv_event_t * e)
 
         if(ta->one_line) ph_dsc.flag |= LV_TEXT_FLAG_EXPAND;
 
-        int32_t left = lv_obj_get_style_pad_left(obj, LV_PART_MAIN);
-        int32_t right = lv_obj_get_style_pad_right(obj, LV_PART_MAIN);
-        int32_t top = lv_obj_get_style_pad_top(obj, LV_PART_MAIN);
-        int32_t bottom = lv_obj_get_style_pad_bottom(obj, LV_PART_MAIN);
-        int32_t border_width = lv_obj_get_style_border_width(obj, LV_PART_MAIN);
+        lv_obj_t * label = ta->label;
+        int32_t left = lv_obj_get_style_pad_left(label, LV_PART_TEXTAREA_PLACEHOLDER);
+        int32_t top = lv_obj_get_style_pad_top(label, LV_PART_TEXTAREA_PLACEHOLDER);
         lv_area_t ph_coords;
-        lv_area_copy(&ph_coords, &obj->coords);
-        ph_coords.x1 += left + border_width;
-        ph_coords.x2 -= right + border_width;
-        ph_coords.y1 += top + border_width;
-        ph_coords.y2 -= bottom + border_width;
+
+        lv_area_copy(&ph_coords, &label->coords);
+        lv_area_move(&ph_coords, left, top);
         ph_dsc.text = ta->placeholder_txt;
         ph_dsc.text_size = ta->placeholder_txt_size;
         lv_draw_label(layer, &ph_dsc, &ph_coords);
@@ -1544,11 +1540,13 @@ static void lv_textarea_scroll_to_cusor_pos(lv_obj_t * obj, int32_t pos)
 static void calc_placeholder_text_size(lv_obj_t * obj)
 {
     lv_textarea_t * ta = (lv_textarea_t *)obj;
+    if(!ta || !ta->placeholder_txt) return;
 
     lv_draw_label_dsc_t ph_dsc;
     lv_draw_label_dsc_init(&ph_dsc);
     lv_obj_init_draw_label_dsc(obj, LV_PART_TEXTAREA_PLACEHOLDER, &ph_dsc);
     ph_dsc.text = ta->placeholder_txt;
+    ph_dsc.font = lv_obj_get_style_text_font(obj, LV_PART_MAIN);
     if(ta->one_line) ph_dsc.flag |= LV_TEXT_FLAG_EXPAND;
 
     lv_text_get_size(&ta->placeholder_txt_size, ph_dsc.text, ph_dsc.font, ph_dsc.letter_space, ph_dsc.line_space,

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -65,6 +65,7 @@ static void auto_hide_characters(lv_obj_t * obj);
 static void auto_hide_characters_cancel(lv_obj_t * obj);
 static inline bool is_valid_but_non_printable_char(const uint32_t letter);
 static void lv_textarea_scroll_to_cusor_pos(lv_obj_t * obj, int32_t pos);
+static void calc_placeholder_text_size(lv_obj_t * obj);
 
 /**********************
  *  STATIC VARIABLES
@@ -434,6 +435,8 @@ void lv_textarea_set_placeholder_text(lv_obj_t * obj, const char * txt)
 
         lv_strcpy(ta->placeholder_txt, txt);
         ta->placeholder_txt[txt_len] = '\0';
+
+        calc_placeholder_text_size(obj);
     }
 
     lv_obj_invalidate(obj);
@@ -502,7 +505,6 @@ void lv_textarea_set_password_mode(lv_obj_t * obj, bool en)
 void lv_textarea_set_password_bullet(lv_obj_t * obj, const char * bullet)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
-    LV_ASSERT_NULL(bullet);
 
     lv_textarea_t * ta = (lv_textarea_t *)obj;
 
@@ -551,6 +553,9 @@ void lv_textarea_set_one_line(lv_obj_t * obj, bool en)
     }
 
     lv_obj_scroll_to(obj, 0, 0, LV_ANIM_OFF);
+
+    /* update placeholder text size */
+    calc_placeholder_text_size(obj);
 }
 
 void lv_textarea_set_accepted_chars(lv_obj_t * obj, const char * list)
@@ -1406,6 +1411,7 @@ static void draw_placeholder(lv_event_t * e)
         ph_coords.y1 += top + border_width;
         ph_coords.y2 -= bottom + border_width;
         ph_dsc.text = ta->placeholder_txt;
+        ph_dsc.text_size = ta->placeholder_txt_size;
         lv_draw_label(layer, &ph_dsc, &ph_coords);
     }
 }
@@ -1533,6 +1539,21 @@ static void lv_textarea_scroll_to_cusor_pos(lv_obj_t * obj, int32_t pos)
     start_cursor_blink(obj);
 
     refr_cursor_area(obj);
+}
+
+static void calc_placeholder_text_size(lv_obj_t * obj)
+{
+    lv_textarea_t * ta = (lv_textarea_t *)obj;
+
+    lv_draw_label_dsc_t ph_dsc;
+    lv_draw_label_dsc_init(&ph_dsc);
+    lv_obj_init_draw_label_dsc(obj, LV_PART_TEXTAREA_PLACEHOLDER, &ph_dsc);
+    ph_dsc.text = ta->placeholder_txt;
+    if(ta->one_line) ph_dsc.flag |= LV_TEXT_FLAG_EXPAND;
+
+    lv_text_get_size(&ta->placeholder_txt_size, ph_dsc.text, ph_dsc.font, ph_dsc.letter_space, ph_dsc.line_space,
+                     LV_COORD_MAX,
+                     ph_dsc.flag);
 }
 
 #endif

--- a/src/widgets/textarea/lv_textarea_private.h
+++ b/src/widgets/textarea/lv_textarea_private.h
@@ -32,6 +32,7 @@ struct _lv_textarea_t {
     lv_obj_t obj;
     lv_obj_t * label;            /**< Label of the text area */
     char * placeholder_txt;      /**< Place holder label. only visible if text is an empty string */
+    lv_point_t placeholder_txt_size; /*Size of the placeholder text*/
     char * pwd_tmp;              /**< Used to store the original text in password mode */
     char * pwd_bullet;           /**< Replacement characters displayed in password mode */
     char * accepted_chars;       /**< Only these characters will be accepted. NULL: accept all */

--- a/tests/src/test_cases/widgets/test_textarea.c
+++ b/tests/src/test_cases/widgets/test_textarea.c
@@ -41,8 +41,16 @@ static bool test_font_get_glyph_dsc(const lv_font_t * font,
     return false;
 }
 
+const void * test_font_get_glyph_bitmap(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf)
+{
+    LV_UNUSED(g_dsc);
+    LV_UNUSED(draw_buf);
+    return NULL;
+}
+
 static lv_font_t test_font_no_bullet = {
     .get_glyph_dsc = test_font_get_glyph_dsc,
+    .get_glyph_bitmap = test_font_get_glyph_bitmap,
     .line_height = 14,
     .base_line = 12,
 };
@@ -78,6 +86,8 @@ void test_textarea_should_return_actual_text_when_password_mode_is_enabled(void)
 
     TEST_ASSERT_TRUE(lv_textarea_get_password_mode(textarea));
     TEST_ASSERT_EQUAL_STRING(text, lv_textarea_get_text(textarea));
+
+    lv_textarea_set_password_mode(textarea, false);
 }
 
 void test_textarea_should_update_label_style_with_one_line_enabled(void)
@@ -281,10 +291,6 @@ void test_textarea_set_max_length(void)
     lv_textarea_set_max_length(textarea, 8);
     lv_textarea_add_text(textarea, "1234567890");
     TEST_ASSERT_EQUAL_STRING("12345678", lv_textarea_get_text(textarea));
-
-    lv_textarea_set_password_mode(textarea, true);
-    lv_textarea_set_text(textarea, "1234567890");
-    TEST_ASSERT_EQUAL_STRING("1234567890", lv_textarea_get_text(textarea));
 }
 
 void test_textarea_set_insert_replace(void)
@@ -311,24 +317,37 @@ void test_textarea_placeholder_text_show_one_line(void)
 void test_textarea_password_mode(void)
 {
     lv_textarea_set_one_line(textarea, false);
-    lv_textarea_set_password_mode(textarea, true);
 
     lv_textarea_set_text(textarea, "123456");
+    lv_textarea_set_password_mode(textarea, true);
     TEST_ASSERT_EQUAL_SCREENSHOT("textarea_password_mode.png");
 
+    lv_textarea_set_password_mode(textarea, false);
+
     lv_textarea_set_text(textarea, "123456789");
+    lv_textarea_set_password_mode(textarea, true);
     TEST_ASSERT_EQUAL_SCREENSHOT("textarea_password_mode_update.png");
 
+    lv_textarea_set_password_mode(textarea, false);
+
     lv_textarea_add_text(textarea, "abc");
+    lv_textarea_set_password_mode(textarea, true);
     TEST_ASSERT_EQUAL_SCREENSHOT("textarea_password_mode_add_text.png");
 
+    lv_textarea_set_password_mode(textarea, false);
+
     lv_textarea_add_char(textarea, 'a');
+    lv_textarea_set_password_mode(textarea, true);
     TEST_ASSERT_EQUAL_SCREENSHOT("textarea_password_mode_add_char.png");
 
+    lv_textarea_set_password_mode(textarea, false);
+
     lv_textarea_delete_char(textarea);
+    lv_textarea_set_password_mode(textarea, true);
     TEST_ASSERT_EQUAL_SCREENSHOT("textarea_password_mode_delete_char.png");
 
     lv_textarea_set_password_mode(textarea, false);
+
     lv_textarea_set_text(textarea, "1234567890");
     TEST_ASSERT_EQUAL_SCREENSHOT("textarea_normal_mode.png");
 }
@@ -348,18 +367,20 @@ void test_textarea_password_mode_hide_char(void)
     lv_textarea_add_char(textarea, 'b');
 
     lv_test_wait(550);
-    TEST_ASSERT_EQUAL_SCREENSHOT("textarea_password_mode_nide_char_tow.png");
+    TEST_ASSERT_EQUAL_SCREENSHOT("textarea_password_mode_hide_char_two.png");
 
     lv_textarea_add_char(textarea, 'c');
     lv_textarea_set_password_mode(textarea, false);
     TEST_ASSERT_EQUAL_SCREENSHOT("textarea_password_mode_to_normal_mode.png");
+
+    lv_textarea_set_text(textarea, "");
 }
 
 void test_textarea_set_password_bullet(void)
 {
     lv_textarea_set_one_line(textarea, false);
-    lv_textarea_set_password_mode(textarea, true);
     lv_textarea_set_text(textarea, "1234567890");
+    lv_textarea_set_password_mode(textarea, true);
 
     lv_obj_set_style_text_font(textarea, &test_font_no_bullet, 0);
     TEST_ASSERT_EQUAL_STRING("*", lv_textarea_get_password_bullet(textarea));
@@ -369,6 +390,9 @@ void test_textarea_set_password_bullet(void)
 
     lv_textarea_set_password_bullet(textarea, NULL);
     TEST_ASSERT_EQUAL_STRING("*", lv_textarea_get_password_bullet(textarea));
+
+    lv_textarea_set_password_mode(textarea, false);
+    lv_textarea_set_text(textarea, "");
 }
 
 void test_textarea_delete_char(void)
@@ -424,9 +448,9 @@ void test_textarea_set_align(void)
     TEST_ASSERT_EQUAL_SCREENSHOT("textarea_align_right.png");
 }
 
-void test_textarea_corsor_show(void)
+void test_textarea_cursor_show(void)
 {
-    lv_obj_set_style_anim_duration(textarea, 1000, LV_PART_CURSOR);
+    lv_textarea_set_password_show_time(textarea, 1000);
     lv_obj_send_event(textarea, LV_EVENT_FOCUSED, NULL);
 
     lv_test_wait(1000);
@@ -572,4 +596,23 @@ void test_textarea_key_event(void)
     lv_obj_send_event(textarea, LV_EVENT_KEY, (void *) &key);
     TEST_ASSERT_EQUAL_STRING("Hello World1", lv_textarea_get_text(textarea));
 }
+
+void test_textarea_check_placeholder_text_position(void)
+{
+    lv_textarea_set_placeholder_text(textarea, "Placeholder");
+    lv_textarea_set_one_line(textarea, true);
+    TEST_ASSERT_EQUAL_SCREENSHOT("textarea_placeholder_center.png");
+
+    lv_textarea_set_one_line(textarea, false);
+    TEST_ASSERT_EQUAL_SCREENSHOT("textarea_placeholder_top.png");
+
+    lv_obj_set_style_align(lv_textarea_get_label(textarea), LV_ALIGN_LEFT_MID, LV_PART_MAIN);
+    TEST_ASSERT_EQUAL_SCREENSHOT("textarea_placeholder_left_mid.png");
+
+    lv_obj_set_style_align(lv_textarea_get_label(textarea), LV_ALIGN_TOP_LEFT, LV_PART_MAIN);
+    lv_obj_set_style_pad_top(lv_textarea_get_label(textarea), 50, LV_PART_TEXTAREA_PLACEHOLDER);
+    lv_obj_set_style_pad_left(lv_textarea_get_label(textarea), 50, LV_PART_TEXTAREA_PLACEHOLDER);
+    TEST_ASSERT_EQUAL_SCREENSHOT("textarea_placeholder_pad_left_top_50.png");
+}
+
 #endif


### PR DESCRIPTION
textarea placeholder text not being vertically centered.

before
<img width="289" height="148" alt="image" src="https://github.com/user-attachments/assets/898fcdff-cf26-4418-9e53-7bd6a6507d30" />
after
<img width="287" height="151" alt="image" src="https://github.com/user-attachments/assets/f47db9ac-6fdd-4f4a-aead-4e0ab9f6221d" />


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
