### PR TITLE
[DON'T SQUASH] Copying setters for TEXTAREA_ACCEPTED_CHARS and DROPDOWN_TEXT

### DIFF
--- a/docs/src/widgets/dropdown.rst
+++ b/docs/src/widgets/dropdown.rst
@@ -120,8 +120,9 @@ will be shown on the left, otherwise on the right.
 Show selected
 -------------
 
-The main part can either show the selected item or static text. If
-static is set with :cpp:expr:`lv_dropdown_set_text(dropdown, "Some text")` it
+The main part can either show the selected item or fixed text. If
+fixed text is set with :cpp:expr:`lv_dropdown_set_text(dropdown, "Some text")`
+or :cpp:expr:`lv_dropdown_set_text_static(dropdown, "Some text")` it
 will be shown regardless of the selected item. If the text is ``NULL``
 the selected option is displayed on the button.
 

--- a/docs/src/widgets/textarea.rst
+++ b/docs/src/widgets/textarea.rst
@@ -143,7 +143,8 @@ Accepted characters
 -------------------
 
 You can set a list of accepted characters with
-:cpp:expr:`lv_textarea_set_accepted_chars(textarea, list)` where ``list`` is a
+:cpp:expr:`lv_textarea_set_accepted_chars(textarea, list)` or
+:cpp:expr:`lv_textarea_set_accepted_chars_static(textarea, list)` where ``list`` is a
 pointer to a NUL-terminated string, or NULL to accept all characters.  Characters
 entered not in this list will be ignored.
 

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -161,13 +161,32 @@ lv_obj_t * lv_dropdown_create(lv_obj_t * parent)
  * Setter functions
  *====================*/
 
-void lv_dropdown_set_text(lv_obj_t * obj, const char * txt)
+void lv_dropdown_set_text(lv_obj_t * obj, const char * text)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
     lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
-    if(dropdown->text == txt) return;
 
-    dropdown->text = txt;
+    char * copied_text = NULL;
+    if(text) {
+        copied_text = lv_strdup(text);
+        LV_ASSERT_MALLOC(copied_text);
+    }
+
+    if(!dropdown->static_text) lv_free(dropdown->text);
+    dropdown->static_text = 0;
+    dropdown->text = copied_text;
+
+    lv_obj_invalidate(obj);
+}
+
+void lv_dropdown_set_text_static(lv_obj_t * obj, const char * text)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+    lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
+
+    if(!dropdown->static_text) lv_free(dropdown->text);
+    dropdown->static_text = 1;
+    dropdown->text = (char *)text;
 
     lv_obj_invalidate(obj);
 }
@@ -196,7 +215,7 @@ void lv_dropdown_set_options(lv_obj_t * obj, const char * options)
     size_t len = lv_text_ap_calc_bytes_count(options) + 1;
 #endif
 
-    if(dropdown->options != NULL && dropdown->static_txt == 0) {
+    if(dropdown->options != NULL && dropdown->static_options == 0) {
         lv_free(dropdown->options);
         dropdown->options = NULL;
     }
@@ -213,7 +232,7 @@ void lv_dropdown_set_options(lv_obj_t * obj, const char * options)
 #endif
 
     /*Now the text is dynamically allocated*/
-    dropdown->static_txt = 0;
+    dropdown->static_options = 0;
 
     lv_obj_invalidate(obj);
     if(dropdown->list) lv_obj_invalidate(dropdown->list);
@@ -236,12 +255,12 @@ void lv_dropdown_set_options_static(lv_obj_t * obj, const char * options)
     dropdown->sel_opt_id      = 0;
     dropdown->sel_opt_id_orig = 0;
 
-    if(dropdown->static_txt == 0 && dropdown->options != NULL) {
+    if(dropdown->static_options == 0 && dropdown->options != NULL) {
         lv_free(dropdown->options);
         dropdown->options = NULL;
     }
 
-    dropdown->static_txt = 1;
+    dropdown->static_options = 1;
     dropdown->options = (char *)options;
 
     lv_obj_invalidate(obj);
@@ -256,7 +275,7 @@ void lv_dropdown_add_option(lv_obj_t * obj, const char * option, uint32_t pos)
     lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
 
     /*Convert static options to dynamic*/
-    if(dropdown->static_txt != 0) {
+    if(dropdown->static_options != 0) {
         char * static_options = dropdown->options;
         if(dropdown->options) {
             dropdown->options = lv_strdup(static_options);
@@ -266,7 +285,7 @@ void lv_dropdown_add_option(lv_obj_t * obj, const char * option, uint32_t pos)
         }
         LV_ASSERT_MALLOC(dropdown->options);
         if(dropdown->options == NULL) return;
-        dropdown->static_txt = 0;
+        dropdown->static_options = 0;
     }
 
     /*Allocate space for the new option*/
@@ -326,11 +345,11 @@ void lv_dropdown_clear_options(lv_obj_t * obj)
     lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
     if(dropdown->options == NULL) return;
 
-    if(dropdown->static_txt == 0)
+    if(dropdown->static_options == 0)
         lv_free(dropdown->options);
 
     dropdown->options = NULL;
-    dropdown->static_txt = 1;
+    dropdown->static_options = 1;
     dropdown->option_cnt = 0;
 
     lv_obj_invalidate(obj);
@@ -677,8 +696,9 @@ static void lv_dropdown_constructor(const lv_obj_class_t * class_p, lv_obj_t * o
     dropdown->options     = NULL;
     dropdown->symbol         = LV_SYMBOL_DOWN;
     dropdown->text         = NULL;
-    dropdown->static_txt = 1;
+    dropdown->static_options = 1;
     dropdown->selected_highlight = 1;
+    dropdown->static_text = 1;
     dropdown->sel_opt_id      = 0;
     dropdown->sel_opt_id_orig = 0;
     dropdown->pr_opt_id = LV_DROPDOWN_PR_NONE;
@@ -707,10 +727,11 @@ static void lv_dropdown_destructor(const lv_obj_class_t * class_p, lv_obj_t * ob
         dropdown->list = NULL;
     }
 
-    if(!dropdown->static_txt) {
-        lv_free(dropdown->options);
-        dropdown->options = NULL;
-    }
+    if(!dropdown->static_options) lv_free(dropdown->options);
+    dropdown->options = NULL;
+
+    if(!dropdown->static_text) lv_free(dropdown->text);
+    dropdown->text = NULL;
 }
 
 static void lv_dropdownlist_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)

--- a/src/widgets/dropdown/lv_dropdown.h
+++ b/src/widgets/dropdown/lv_dropdown.h
@@ -70,9 +70,18 @@ lv_obj_t * lv_dropdown_create(lv_obj_t * parent);
  * If set to `NULL` the selected option's text will be displayed on the button.
  * If set to a specific text then that text will be shown regardless of the selected option.
  * @param obj       pointer to a drop-down list object
- * @param txt       the text as a string (Only its pointer is saved)
+ * @param text      the text as a string (Copy is saved)
  */
-void lv_dropdown_set_text(lv_obj_t * obj, const char * txt);
+void lv_dropdown_set_text(lv_obj_t * obj, const char * text);
+
+/**
+ * Set text of the drop-down list's button.
+ * If set to `NULL` the selected option's text will be displayed on the button.
+ * If set to a specific text then that text will be shown regardless of the selected option.
+ * @param obj       pointer to a drop-down list object
+ * @param text      the text as a string (Only its pointer is saved)
+ */
+void lv_dropdown_set_text_static(lv_obj_t * obj, const char * text);
 
 /**
  * Set the options in a drop-down list from a string.

--- a/src/widgets/dropdown/lv_dropdown_private.h
+++ b/src/widgets/dropdown/lv_dropdown_private.h
@@ -34,7 +34,7 @@ extern "C" {
 struct _lv_dropdown_t {
     lv_obj_t obj;
     lv_obj_t * list;                /**< The dropped down list*/
-    const char * text;              /**< Text to display on the dropdown's button*/
+    char * text;                    /**< Text to display on the dropdown's button*/
     const void * symbol;            /**< Arrow or other icon when the drop-down list is closed*/
     char * options;                 /**< Options in a '\n' separated list*/
     uint32_t option_cnt;            /**< Number of options*/
@@ -42,8 +42,9 @@ struct _lv_dropdown_t {
     uint32_t sel_opt_id_orig;       /**< Store the original index on focus*/
     uint32_t pr_opt_id;             /**< Index of the currently pressed option*/
     uint8_t dir               : 4;  /**< Direction in which the list should open*/
-    uint8_t static_txt        : 1;  /**< 1: Only a pointer is saved in `options`*/
+    uint8_t static_options    : 1;  /**< 1: Only a pointer is saved in `options`*/
     uint8_t selected_highlight: 1;  /**< 1: Make the selected option highlighted in the list*/
+    uint8_t static_text       : 1;  /**< 1: Only a pointer is saved in `text`*/
 };
 
 struct _lv_dropdown_list_t {

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -559,8 +559,28 @@ void lv_textarea_set_accepted_chars(lv_obj_t * obj, const char * list)
 
     lv_textarea_t * ta = (lv_textarea_t *)obj;
 
-    ta->accepted_chars = list;
+    char * copied_list = NULL;
+    if(list) {
+        copied_list = lv_strdup(list);
+        LV_ASSERT_MALLOC(copied_list);
+    }
+
+    if(!ta->static_accepted_chars) lv_free(ta->accepted_chars);
+    ta->static_accepted_chars = 0;
+    ta->accepted_chars = copied_list;
 }
+
+void lv_textarea_set_accepted_chars_static(lv_obj_t * obj, const char * list)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_textarea_t * ta = (lv_textarea_t *)obj;
+
+    if(!ta->static_accepted_chars) lv_free(ta->accepted_chars);
+    ta->static_accepted_chars = 1;
+    ta->accepted_chars = (char *)list;
+}
+
 
 void lv_textarea_set_max_length(lv_obj_t * obj, uint32_t num)
 {
@@ -893,6 +913,7 @@ static void lv_textarea_constructor(const lv_obj_class_t * class_p, lv_obj_t * o
     ta->pwd_bullet        = NULL;
     ta->pwd_show_time     = LV_TEXTAREA_DEF_PWD_SHOW_TIME;
     ta->accepted_chars    = NULL;
+    ta->static_accepted_chars = 1;
     ta->max_length        = 0;
     ta->cursor.show      = 1;
     /*It will be set to zero later (with zero value lv_textarea_set_cursor_pos(obj, 0); wouldn't do anything as there is no difference)*/
@@ -938,6 +959,8 @@ static void lv_textarea_destructor(const lv_obj_class_t * class_p, lv_obj_t * ob
         lv_free(ta->placeholder_txt);
         ta->placeholder_txt = NULL;
     }
+    if(!ta->static_accepted_chars) lv_free(ta->accepted_chars);
+    ta->accepted_chars = NULL;
 }
 
 static void lv_textarea_event(const lv_obj_class_t * class_p, lv_event_t * e)

--- a/src/widgets/textarea/lv_textarea.h
+++ b/src/widgets/textarea/lv_textarea.h
@@ -158,9 +158,16 @@ void lv_textarea_set_one_line(lv_obj_t * obj, bool en);
 /**
  * Set a list of characters. Only these characters will be accepted by the text area
  * @param obj       pointer to a text area object
- * @param list      list of characters. Only the pointer is saved. E.g. "+-.,0123456789"
+ * @param list      list of characters. A copy is saved. Example: "+-.,0123456789"
  */
 void lv_textarea_set_accepted_chars(lv_obj_t * obj, const char * list);
+
+/**
+ * Set a list of characters. Only these characters will be accepted by the text area
+ * @param obj       pointer to a text area object
+ * @param list      list of characters. Only the pointer is saved. Example: "+-.,0123456789"
+ */
+void lv_textarea_set_accepted_chars_static(lv_obj_t * obj, const char * list);
 
 /**
  * Set max length of a Text Area.

--- a/src/widgets/textarea/lv_textarea_private.h
+++ b/src/widgets/textarea/lv_textarea_private.h
@@ -34,7 +34,7 @@ struct _lv_textarea_t {
     char * placeholder_txt;      /**< Place holder label. only visible if text is an empty string */
     char * pwd_tmp;              /**< Used to store the original text in password mode */
     char * pwd_bullet;           /**< Replacement characters displayed in password mode */
-    const char * accepted_chars; /**< Only these characters will be accepted. NULL: accept all */
+    char * accepted_chars;       /**< Only these characters will be accepted. NULL: accept all */
     uint32_t max_length;         /**< The max. number of characters. 0: no limit */
     uint32_t pwd_show_time;      /**< Time to show characters in password mode before change them to '*' */
     struct {
@@ -55,6 +55,7 @@ struct _lv_textarea_t {
 #endif
     uint8_t pwd_mode : 1;         /**< Replace characters with '*' */
     uint8_t one_line : 1;         /**< One line mode (ignore line breaks) */
+    uint8_t static_accepted_chars : 1; /**<1: Only a pointer is saved in `accepted_chars` */
 };
 
 

--- a/tests/src/test_cases/widgets/test_dropdown.c
+++ b/tests/src/test_cases/widgets/test_dropdown.c
@@ -373,7 +373,7 @@ void test_dropdown_render_2(void)
     lv_dropdown_open(dd1);
 
     lv_obj_t * dd2 = lv_dropdown_create(lv_screen_active());
-    lv_dropdown_set_text(dd2, "Go Up");
+    lv_dropdown_set_text_static(dd2, "Go Up");
     lv_dropdown_set_options(dd2, "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15");
     lv_dropdown_set_symbol(dd2, NULL);
     lv_obj_align(dd2, LV_ALIGN_LEFT_MID, 150, 50);
@@ -403,7 +403,7 @@ void test_dropdown_render_2(void)
     lv_dropdown_open(dd5);
 
     lv_obj_t * dd6 = lv_dropdown_create(lv_screen_active());
-    lv_dropdown_set_text(dd6, "Right");
+    lv_dropdown_set_text_static(dd6, "Right");
     lv_dropdown_set_options(dd6, "1aaa\n2aa\n3aa");
     lv_dropdown_set_dir(dd6, LV_DIR_RIGHT);
     lv_dropdown_set_symbol(dd6, LV_SYMBOL_RIGHT);
@@ -412,7 +412,7 @@ void test_dropdown_render_2(void)
     lv_obj_set_style_text_align(lv_dropdown_get_list(dd6), LV_TEXT_ALIGN_RIGHT, 0);
 
     lv_obj_t * dd7 = lv_dropdown_create(lv_screen_active());
-    lv_dropdown_set_text(dd7, "Left");
+    lv_dropdown_set_text_static(dd7, "Left");
     lv_dropdown_set_options(dd7, "1aaa\n2\n3");
     lv_dropdown_set_dir(dd7, LV_DIR_LEFT);
     lv_dropdown_set_symbol(dd7, LV_SYMBOL_LEFT);


### PR DESCRIPTION
For #9606:

* `lv_textarea_set_accepted_chars()` now copies, a new `lv_textarea_set_accepted_chars_static()` does not.
* `lv_dropdown_set_text()` now copies, a new `lv_dropdown_set_text_static()` does not. Clean up the naming of the internal `dropdown->static_txt` flag, which actually refers to the options.

Properties and XML use the new copying behavior.

Do not squash.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
