### PR TITLE
fix(blur): fix regression causing VS compiler error

### DIFF
--- a/src/draw/sw/lv_draw_sw_blur.c
+++ b/src/draw/sw/lv_draw_sw_blur.c
@@ -235,7 +235,7 @@ void lv_draw_sw_blur(lv_draw_task_t * t, const lv_draw_blur_dsc_t * dsc, const l
             }
 
             uint8_t * buf_line_end = lv_draw_buf_goto_xy(t->target_layer->draw_buf, x_end, y);
-            blur_1_bytes_init(sum, buf_line_end, sample_len_limited, - px_size * skip_cnt);
+            blur_1_bytes_init(sum, buf_line_end, sample_len_limited, -(int32_t)px_size * skip_cnt);
             buf_prev = buf_line_end[0] + 1; /*Make sure that it's not equal in the first round*/
 
             for(x = x_start; x <= x_end; x += skip_cnt) {
@@ -324,7 +324,7 @@ void lv_draw_sw_blur(lv_draw_task_t * t, const lv_draw_blur_dsc_t * dsc, const l
             }
 
             volatile uint8_t * buf_line_end = lv_draw_buf_goto_xy(t->target_layer->draw_buf, x_end, y);
-            blur_3_bytes_init(sum, buf_line_end, sample_len_limited, - px_size * skip_cnt);
+            blur_3_bytes_init(sum, buf_line_end, sample_len_limited, -(int32_t)px_size * skip_cnt);
 
             for(x = x_start; x <= x_end; x += skip_cnt) {
                 blur_3_bytes(sum, buf_line_end, intensity);


### PR DESCRIPTION
Reason this is necessary:  Visual Studio emits an error when trying to compile `lv_draw_sw_blur.c`.  This is the same error that was fixed with PR #9391, but regressed with commit bb3233b under PR #9331.

```c
uint32_t px_size;
int32_t skip_cnt;
. . .
blur_3_bytes_init(sum, buf_line, sample_len_limited, - px_size * skip_cnt);
```
Expression -px_size * skip_cnt is rejected by MSVC as an error:

    "negating an unsigned value is still unsigned."

This becomes more visible if I simply prefix the variable names with their types:
```c
-ui32_px_size * i32_skip_cnt
```

The reason it CANNOT and SHOULD NOT be solved by moving the unary '-' negation to the other variable is this:  doing so would not only leave the "hidden problem" intact, but would introduce a new problem illustrated by plugging in 4 and 128 for the 2 variables respectively:

```
    Action                          Result Value                           Expression Type
1.  negate 128 (signed)             -128                                   int32_t
2.  promote -128 to unsigned        4294967168U (0xFFFFFF80)               uint32_t  <== new problem
3.  unsigned mult 4U * 4294967168U  17179868672U (0x3FFFFFE00 overflow!)   uint32_t  <== hidden problem
4.  pass to a int32_t arg           -512 (by truncation)                   int32_t
```

The correct fix suppresses step 2 above by having both values being signed:
```c
-(int32_t)ui32_px_size * i32_skip_cnt
```

Resulting in:
```
    Action                      Result Value               Expression Type
1.  demote 4U to 4 (signed)     4                          int32_t
2.  negating 4                  -4                         int32_t
3.  signed mult -4 * 128        -512                       int32_t
4.  pass to a int32_t arg       -512 (no alteration)       int32_t
```

Kind regards,
Vic

cc:  @kisvegabor 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
