### PR TITLE
chore(docs): lock sphinx version to 8.2.3

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx
+Sphinx<=8.2.3
 breathe
 imagesize
 importlib-metadata


### PR DESCRIPTION
By default Sphinx 9.1.0 is installed on my system which isn't compatible with mermaid
This locks the sphinx version to 8.2.3 for now

```bash 
* Platform:         linux; (Linux-6.18.5-100.fc42.x86_64-x86_64-with-glibc2.41)
* Python version:   3.13.11 (CPython)
* Sphinx version:   9.1.0
* Docutils version: 0.21.2
* Jinja2 version:   3.1.6
* Pygments version: 2.19.2

Last Messages
=============

None.

Loaded Extensions
=================

None.

Traceback
=========

    Traceback (most recent call last):
      File "/home/andre/dev/lvgl/lv_port_linux/lvgl/docs/env/lib64/python3.13/site-packages/sphinx/registry.py", line 550, in load_extension
        mod = import_module(extname)
      File "/usr/lib64/python3.13/importlib/__init__.py", line 88, in import_module
        return _bootstrap._gcd_import(name[level:], package, level)
               ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
      File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
      File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
      File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
      File "<frozen importlib._bootstrap_external>", line 1023, in exec_module
      File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
      File "/home/andre/dev/lvgl/lv_port_linux/lvgl/docs/env/lib64/python3.13/site-packages/sphinxcontrib/mermaid.py", line 33, in <module>
        from .autoclassdiag import class_diagram
      File "/home/andre/dev/lvgl/lv_port_linux/lvgl/docs/env/lib64/python3.13/site-packages/sphinxcontrib/autoclassdiag.py", line 3, in <module>
        from sphinx.util import ExtensionError, import_object
    ImportError: cannot import name 'ExtensionError' from 'sphinx.util' (/home/andre/dev/lvgl/lv_port_linux/lvgl/docs/env/lib64/python3.13/site-packages/sphinx/util/__init__.py)
    
    The above exception was the direct cause of the following exception:
    
    Traceback (most recent call last):
      File "/home/andre/dev/lvgl/lv_port_linux/lvgl/docs/env/lib64/python3.13/site-packages/sphinx/cmd/build.py", line 414, in build_main
        app = Sphinx(
            srcdir=args.sourcedir,
        ...<14 lines>...
            exception_on_warning=args.exception_on_warning,
        )
      File "/home/andre/dev/lvgl/lv_port_linux/lvgl/docs/env/lib64/python3.13/site-packages/sphinx/application.py", line 299, in __init__
        self.setup_extension(extension)
        ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
      File "/home/andre/dev/lvgl/lv_port_linux/lvgl/docs/env/lib64/python3.13/site-packages/sphinx/application.py", line 505, in setup_extension
        self.registry.load_extension(self, extname)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
      File "/home/andre/dev/lvgl/lv_port_linux/lvgl/docs/env/lib64/python3.13/site-packages/sphinx/registry.py", line 553, in load_extension
        raise ExtensionError(
            __('Could not import extension %s') % extname, err
        ) from err
    sphinx.errors.ExtensionError: Could not import extension sphinxcontrib.mermaid (exception: cannot import name 'ExtensionError' from 'sphinx.util' (/home/andre/dev/lvgl/lv_port_linux/lvgl/docs/env/lib64/python3.13/site-packages/sphinx/util/__init__.py))
```
