### PR TITLE
fix(gstreamer): empty frame queue on destruction

### DIFF
--- a/src/libs/gstreamer/lv_gstreamer.c
+++ b/src/libs/gstreamer/lv_gstreamer.c
@@ -500,8 +500,15 @@ static void lv_gstreamer_destructor(const lv_obj_class_t * class_p, lv_obj_t * o
     if(streamer->last_sample) {
         gst_sample_unref(streamer->last_sample);
     }
+    if(streamer->frame_queue) {
+        GstSample * sample;
+        while((sample = g_async_queue_try_pop(streamer->frame_queue)) != NULL) {
+            gst_sample_unref(sample);
+        }
+        g_async_queue_unref(streamer->frame_queue);
+        streamer->frame_queue = NULL;
+    }
     lv_timer_delete(streamer->gstreamer_timer);
-    g_async_queue_unref(streamer->frame_queue);
 }
 
 static lv_result_t gstreamer_make_and_add_to_pipeline(lv_gstreamer_t * streamer,


### PR DESCRIPTION
Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
