### PR TITLE
feat(gstreamer): send event on end of stream

### DIFF
--- a/docs/src/libs/video_support/gstreamer.rst
+++ b/docs/src/libs/video_support/gstreamer.rst
@@ -172,7 +172,7 @@ Here's how to create a basic GStreamer player and load media:
 Events
 ------
 
--  :cpp:enumerator:`LV_EVENT_STATE_CHANGED` Sent when the stream state changes. The event that originated the event can be retrieved by the event parameter (e.g :cpp:func:`lv_event_get_param`)
+-  :cpp:enumerator:`LV_EVENT_STATE_CHANGED` Sent when the stream state changes. The stream state can be retrieved via :cpp:expr:`lv_gstreamer_get_stream_state(e)`.
 
 Event Handling
 --------------

--- a/docs/src/libs/video_support/gstreamer.rst
+++ b/docs/src/libs/video_support/gstreamer.rst
@@ -168,6 +168,45 @@ Here's how to create a basic GStreamer player and load media:
     /* Start playback */
     lv_gstreamer_play(streamer);
 
+
+Events
+------
+
+-  :cpp:enumerator:`LV_EVENT_READY` Sent when the stream is parsed and the first frame is ready.
+-  :cpp:enumerator:`LV_EVENT_STATE_CHANGED` Sent when the stream state changes (e.g. end of stream is reached).
+
+
+Event Handling
+--------------
+
+Handle GStreamer events using LVGL's event system:
+
+.. code-block:: c
+
+    static void gstreamer_event_cb(lv_event_t * e)
+    {
+        lv_event_code_t code = lv_event_get_code(e);
+        lv_obj_t * streamer = lv_event_get_target_obj(e);
+
+        if(code == LV_EVENT_READY) {
+                LV_LOG_USER("Stream ready - Duration: %" LV_PRIu32 " ms",
+                           lv_gstreamer_get_duration(streamer));
+                LV_LOG_USER("Resolution: %" LV_PRId32 "x%" LV_PRId32,
+                           lv_image_get_src_width(streamer),
+                           lv_image_get_src_height(streamer));
+        } else if (code == LV_EVENT_STATE_CHANGED) {
+                LV_LOG_USER("Stream is over");
+        }
+    }
+
+    /* Add event callback */
+    lv_obj_add_event_cb(streamer, gstreamer_event_cb, LV_EVENT_READY, NULL);
+    lv_obj_add_event_cb(streamer, gstreamer_event_cb, LV_EVENT_STATE_CHANGED, NULL);
+
+
+
+
+
 Media Source Configuration
 --------------------------
 
@@ -242,29 +281,6 @@ Manage audio volume with built-in controls:
     /* Get current volume */
     uint8_t volume = lv_gstreamer_get_volume(streamer);
 
-Event Handling
---------------
-
-Handle GStreamer events using LVGL's event system:
-
-.. code-block:: c
-
-    static void gstreamer_event_cb(lv_event_t * e)
-    {
-        lv_event_code_t code = lv_event_get_code(e);
-        lv_obj_t * streamer = lv_event_get_target_obj(e);
-
-        if(code == LV_EVENT_READY) {
-                LV_LOG_USER("Stream ready - Duration: %" LV_PRIu32 " ms",
-                           lv_gstreamer_get_duration(streamer));
-                LV_LOG_USER("Resolution: %" LV_PRId32 "x%" LV_PRId32,
-                           lv_image_get_src_width(streamer),
-                           lv_image_get_src_height(streamer));
-        }
-    }
-
-    /* Add event callback */
-    lv_obj_add_event_cb(streamer, gstreamer_event_cb, LV_EVENT_ALL, NULL);
 
 Widget Architecture
 *******************

--- a/docs/src/libs/video_support/gstreamer.rst
+++ b/docs/src/libs/video_support/gstreamer.rst
@@ -172,9 +172,7 @@ Here's how to create a basic GStreamer player and load media:
 Events
 ------
 
--  :cpp:enumerator:`LV_EVENT_READY` Sent when the stream is parsed and the first frame is ready.
--  :cpp:enumerator:`LV_EVENT_STATE_CHANGED` Sent when the stream state changes (e.g. end of stream is reached).
-
+-  :cpp:enumerator:`LV_EVENT_STATE_CHANGED` Sent when the stream state changes. The event that originated the event can be retrieved by the event parameter (e.g :cpp:func:`lv_event_get_param`)
 
 Event Handling
 --------------
@@ -185,22 +183,38 @@ Handle GStreamer events using LVGL's event system:
 
     static void gstreamer_event_cb(lv_event_t * e)
     {
+
         lv_event_code_t code = lv_event_get_code(e);
         lv_obj_t * streamer = lv_event_get_target_obj(e);
 
-        if(code == LV_EVENT_READY) {
+        if(code != LV_EVENT_STATE_CHANGED) {
+            return;
+        }
+
+        lv_gstreamer_stream_state_t stream_state = lv_gstreamer_get_stream_state(e);
+        switch(stream_state) {
+            case LV_GSTREAMER_STREAM_STATE_START:
                 LV_LOG_USER("Stream ready - Duration: %" LV_PRIu32 " ms",
-                           lv_gstreamer_get_duration(streamer));
-                LV_LOG_USER("Resolution: %" LV_PRId32 "x%" LV_PRId32,
-                           lv_image_get_src_width(streamer),
-                           lv_image_get_src_height(streamer));
-        } else if (code == LV_EVENT_STATE_CHANGED) {
+                        lv_gstreamer_get_duration(streamer));
+                LV_LOG_USER("\tStream resolution %" LV_PRId32 "x%" LV_PRId32, lv_image_get_src_width(streamer),
+                        lv_image_get_src_height(streamer));
+                break;
+            case LV_GSTREAMER_STREAM_STATE_END:
                 LV_LOG_USER("Stream is over");
+                break;
+            case LV_GSTREAMER_STREAM_STATE_PLAY:
+                LV_LOG_USER("Stream set to play");
+                break;
+            case LV_GSTREAMER_STREAM_STATE_PAUSE:
+                LV_LOG_USER("Stream set to pause");
+                break;
+            case LV_GSTREAMER_STREAM_STATE_STOP:
+                LV_LOG_USER("Stream set to stop");
+                break;
         }
     }
 
     /* Add event callback */
-    lv_obj_add_event_cb(streamer, gstreamer_event_cb, LV_EVENT_READY, NULL);
     lv_obj_add_event_cb(streamer, gstreamer_event_cb, LV_EVENT_STATE_CHANGED, NULL);
 
 

--- a/examples/libs/gstreamer/lv_example_gstreamer_1.c
+++ b/examples/libs/gstreamer/lv_example_gstreamer_1.c
@@ -18,7 +18,7 @@ static void update_duration_label(lv_obj_t * label, uint32_t duration);
 static void volume_observer_cb(lv_observer_t * observer, lv_subject_t * subject);
 static void update_position_slider(lv_timer_t * timer);
 static void play_pause_pressed(lv_event_t * e);
-static void streamer_ready(lv_event_t * e);
+static void stream_state_changed(lv_event_t * e);
 
 /**
  * Loads a video from the internet using the gstreamer widget
@@ -46,13 +46,6 @@ void lv_example_gstreamer_1(void)
 
     lv_obj_center(event_data.streamer);
 
-    /* The LV_EVENT_READY will fire when the stream is ready at that point you can query the stream
-     * information like its resolution and duration. See `streamer_ready` */
-    lv_obj_add_event_cb(event_data.streamer, streamer_ready, LV_EVENT_READY, &event_data);
-
-    /* Play the stream immediately */
-    lv_gstreamer_play(event_data.streamer);
-
     /* Create a slider to modify the stream volume and a label to visualize the current value */
     volume_setter_create(&event_data);
 
@@ -60,6 +53,13 @@ void lv_example_gstreamer_1(void)
      * One for the current position in the stream and the other for the total duration of the stream
      * Also add a pause/play button*/
     control_bar_create(&event_data);
+
+    /* The LV_EVENT_STATE_CHANGED will fire when the stream is ready at that point we can query the stream
+     * information like its resolution and duration. See `streamer_ready` */
+    lv_obj_add_event_cb(event_data.streamer, stream_state_changed, LV_EVENT_STATE_CHANGED, &event_data);
+
+    /* Play the stream immediately */
+    lv_gstreamer_play(event_data.streamer);
 
     /* Create a timer that will update the slider position based on the stream position
      * Make it 3 times faster than the refresh rate for a smoother effect */
@@ -126,7 +126,6 @@ static void control_bar_create(event_data_t * event_data)
     lv_obj_center(event_data->pp_button);
     lv_obj_add_event_cb(event_data->pp_button, play_pause_pressed, LV_EVENT_CLICKED, event_data);
     event_data->button_label = lv_label_create(event_data->pp_button);
-    lv_label_set_text_static(event_data->button_label, LV_SYMBOL_PAUSE);
 
     lv_obj_t * position_slider = lv_bar_create(cont);
     lv_bar_set_range(position_slider, 0, 1000);
@@ -173,30 +172,52 @@ static void play_pause_pressed(lv_event_t * e)
 {
     event_data_t * event_data = (event_data_t *)lv_event_get_user_data(e);
 
-    if(lv_streq(lv_label_get_text(event_data->button_label), LV_SYMBOL_PLAY)) {
-        lv_label_set_text(event_data->button_label, LV_SYMBOL_PAUSE);
+    if(lv_streq(lv_label_get_text(event_data->button_label), LV_SYMBOL_REFRESH)) {
+        lv_gstreamer_set_position(event_data->streamer, 0);
+        lv_gstreamer_play(event_data->streamer);
+    }
+    else if(lv_streq(lv_label_get_text(event_data->button_label), LV_SYMBOL_PLAY)) {
         lv_gstreamer_play(event_data->streamer);
     }
     else {
-        lv_label_set_text(event_data->button_label, LV_SYMBOL_PLAY);
         lv_gstreamer_pause(event_data->streamer);
     }
 }
-static void streamer_ready(lv_event_t * e)
+static void stream_state_changed(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
     event_data_t * event_data = (event_data_t *)lv_event_get_user_data(e);
+
     lv_obj_t * btn = event_data->pp_button;
     lv_obj_t * streamer = event_data->streamer;
 
-    if(code == LV_EVENT_READY) {
-        lv_obj_align(btn, LV_ALIGN_BOTTOM_MID, 0, 0);
-        uint32_t duration = lv_gstreamer_get_duration(streamer);
-        LV_LOG_USER("Video is starting");
-        LV_LOG_USER("\tStream resolution %" LV_PRId32 "x%" LV_PRId32, lv_image_get_src_width(streamer),
-                    lv_image_get_src_height(streamer));
-        LV_LOG_USER("\tStream duration %" LV_PRIu32, duration);
-        update_duration_label(event_data->duration_label, duration);
+    if(code != LV_EVENT_STATE_CHANGED) {
+        return;
+    }
+
+    lv_gstreamer_stream_state_t stream_state = lv_gstreamer_get_stream_state(e);
+    switch(stream_state) {
+        case LV_GSTREAMER_STREAM_STATE_START: {
+                lv_obj_align(btn, LV_ALIGN_BOTTOM_MID, 0, 0);
+                uint32_t duration = lv_gstreamer_get_duration(streamer);
+                LV_LOG_USER("Stream is starting");
+                LV_LOG_USER("\tStream resolution %" LV_PRId32 "x%" LV_PRId32, lv_image_get_src_width(streamer),
+                            lv_image_get_src_height(streamer));
+                LV_LOG_USER("\tStream duration %" LV_PRIu32, duration);
+                update_duration_label(event_data->duration_label, duration);
+                break;
+            }
+        case LV_GSTREAMER_STREAM_STATE_END:
+            LV_LOG_USER("Stream is over");
+            lv_label_set_text_static(event_data->button_label, LV_SYMBOL_REFRESH);
+            break;
+        case LV_GSTREAMER_STREAM_STATE_PLAY:
+            lv_label_set_text_static(event_data->button_label, LV_SYMBOL_PAUSE);
+            break;
+        case LV_GSTREAMER_STREAM_STATE_PAUSE:
+        case LV_GSTREAMER_STREAM_STATE_STOP:
+            lv_label_set_text_static(event_data->button_label, LV_SYMBOL_PLAY);
+            break;
     }
 }
 

--- a/examples/libs/gstreamer/lv_example_gstreamer_1.c
+++ b/examples/libs/gstreamer/lv_example_gstreamer_1.c
@@ -189,7 +189,6 @@ static void stream_state_changed(lv_event_t * e)
     lv_event_code_t code = lv_event_get_code(e);
     event_data_t * event_data = (event_data_t *)lv_event_get_user_data(e);
 
-    lv_obj_t * btn = event_data->pp_button;
     lv_obj_t * streamer = event_data->streamer;
 
     if(code != LV_EVENT_STATE_CHANGED) {
@@ -199,7 +198,6 @@ static void stream_state_changed(lv_event_t * e)
     lv_gstreamer_stream_state_t stream_state = lv_gstreamer_get_stream_state(e);
     switch(stream_state) {
         case LV_GSTREAMER_STREAM_STATE_START: {
-                lv_obj_align(btn, LV_ALIGN_BOTTOM_MID, 0, 0);
                 uint32_t duration = lv_gstreamer_get_duration(streamer);
                 LV_LOG_USER("Stream is starting");
                 LV_LOG_USER("\tStream resolution %" LV_PRId32 "x%" LV_PRId32, lv_image_get_src_width(streamer),

--- a/examples/libs/gstreamer/lv_example_gstreamer_1.c
+++ b/examples/libs/gstreamer/lv_example_gstreamer_1.c
@@ -126,6 +126,7 @@ static void control_bar_create(event_data_t * event_data)
     lv_obj_center(event_data->pp_button);
     lv_obj_add_event_cb(event_data->pp_button, play_pause_pressed, LV_EVENT_CLICKED, event_data);
     event_data->button_label = lv_label_create(event_data->pp_button);
+    lv_label_set_text_static(event_data->button_label, LV_SYMBOL_PAUSE);
 
     lv_obj_t * position_slider = lv_bar_create(cont);
     lv_bar_set_range(position_slider, 0, 1000);

--- a/src/libs/gstreamer/lv_gstreamer.h
+++ b/src/libs/gstreamer/lv_gstreamer.h
@@ -73,6 +73,14 @@ typedef enum {
     LV_GSTREAMER_STATE_PLAYING
 } lv_gstreamer_state_t;
 
+typedef enum {
+    LV_GSTREAMER_STREAM_STATE_START,
+    LV_GSTREAMER_STREAM_STATE_PLAY,
+    LV_GSTREAMER_STREAM_STATE_PAUSE,
+    LV_GSTREAMER_STREAM_STATE_STOP,
+    LV_GSTREAMER_STREAM_STATE_END
+} lv_gstreamer_stream_state_t;
+
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
@@ -169,6 +177,13 @@ uint8_t lv_gstreamer_get_volume(lv_obj_t * gstreamer);
  *                      - 512:   2x
  */
 void lv_gstreamer_set_rate(lv_obj_t * gstreamer, uint32_t rate);
+
+/**
+ * Retrieve the stream state from a STATE_CHANGED event callback
+ * @param e     pointer to the event
+ * @return the stream state or -1 if `e` is invalid (i.e. NULL or does not match expected event)
+ */
+lv_gstreamer_stream_state_t lv_gstreamer_get_stream_state(lv_event_t * e);
 
 
 /**********************


### PR DESCRIPTION
This allows the user to automatically start a new stream when the previous one is over

It correctly handles the case where the gstreamer object is deleted inside the user's event handler