### PR TITLE
fix(g2d): fix hardware version check with LV_USE_PXP

### DIFF
--- a/src/draw/nxp/g2d/lv_draw_g2d.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d.c
@@ -28,8 +28,12 @@
  * Note: enum value is the same in either case
  * See https://github.com/nxp-imx/imx-g2d-pxp/commit/d7af84b5c8ad161b6898ffabe23918cb59fe2fe9
  */
-#if (G2D_VERSION_MAJOR >= 2) && (G2D_VERSION_MINOR < 3)
-    #define G2D_HARDWARE_PXP_V1 G2D_HARDWARE_PXP
+#if defined(LV_USE_PXP)
+    #if (G2D_VERSION_MAJOR >= 2) && (G2D_VERSION_MINOR < 3)
+        #define G2D_HARDWARE_PXP_V1 G2D_HARDWARE_PXP
+    #endif
+#else
+    #define G2D_HARDWARE_PXP_V1 0
 #endif
 
 /**********************


### PR DESCRIPTION
Defensive checks as G2D is separate from PXP and there are iMX SoCs without PXP.
