### PR TITLE
fix(run_tests.sh): fix gcov versions mismatch issue

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -70,18 +70,40 @@ fi
 # Get versions of g++, gcc, and gcov
 gpp_version=$(g++ -dumpversion)
 gcc_version=$(gcc -dumpversion)
-gcov_version=$(gcov -dumpversion | grep -oP '\d+\.\d+.\d+' | head -n 1 | cut -d'.' -f1) # only major version
 
-# Check if g++, gcc, and gcov versions are the same
-if [ "$gpp_version" != "$gcc_version" ] || [ "$gcc_version" != "$gcov_version" ]; then
+# Prefer the gcov that matches the active gcc major version (e.g. gcov-13)
+gcc_major=$(echo "$gcc_version" | cut -d'.' -f1)
+gcov_cmd="gcov"
+if command -v "gcov-${gcc_major}" >/dev/null 2>&1; then
+    gcov_cmd="gcov-${gcc_major}"
+fi
+
+# Export for downstream scripts/tools (gcovr respects GCOV)
+export GCOV="$gcov_cmd"
+
+# Determine gcov major version (robust against different output formats)
+# - Some distros print just "13" for -dumpversion
+# - Others may print a banner like "gcov (Ubuntu 13.2.0-...) 13.2.0"
+gcov_version=$($gcov_cmd -dumpversion 2>&1 | head -n 1 | grep -oE '[0-9]+' | head -n 1)
+
+if [ -z "$gcov_version" ]; then
+    echo "gcov not found or not working (tried: $gcov_cmd)."
+    echo "Install a matching gcov (e.g. gcc-$gcc_major package) or ensure it is in PATH."
+    exit 1
+fi
+
+# Check if g++, gcc, and gcov versions are the same (major version match)
+gpp_major=$(echo "$gpp_version" | cut -d'.' -f1)
+if [ "$gpp_major" != "$gcc_major" ] || [ "$gcc_major" != "$gcov_version" ]; then
     echo "Versions mismatch detected:"
     echo "g++ version: $gpp_version"
     echo "gcc version: $gcc_version"
+    echo "gcov command: $gcov_cmd"
     echo "gcov version: $gcov_version"
-    echo "g++, gcc, and gcov must have the same version."
+    echo "g++, gcc, and gcov must have the same major version."
     exit 1
 else
-    echo "g++, gcc, and gcov versions match: $gpp_version"
+    echo "g++, gcc, and gcov versions match (major): $gcc_major (gcov: $gcov_cmd)"
 fi
 
 if [ "$skip_tests" = true ]; then


### PR DESCRIPTION
fix gcov versions mismatch issue

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
