### PR TITLE
feat(obj): allow null class names if obj_name isn't set

### DIFF
--- a/src/core/lv_obj_class.c
+++ b/src/core/lv_obj_class.c
@@ -196,7 +196,9 @@ void lv_obj_set_external_data(lv_obj_t * obj, void * data, void (* free_cb)(void
 
 static void lv_obj_construct(const lv_obj_class_t * class_p, lv_obj_t * obj)
 {
-    LV_ASSERT_NULL(class_p->name);
+    if(LV_USE_OBJ_NAME) {
+        LV_ASSERT_NULL(class_p->name);
+    }
 
 #if LV_USE_EXT_DATA
     obj->ext_data.free_cb = NULL;

--- a/src/core/lv_obj_id_builtin.c
+++ b/src/core/lv_obj_id_builtin.c
@@ -93,11 +93,10 @@ void lv_obj_free_id(lv_obj_t * obj)
 
 const char * lv_obj_stringify_id(lv_obj_t * obj, char * buf, uint32_t len)
 {
-    const char * name;
     if(obj == NULL || obj->class_p == NULL) return NULL;
     if(buf == NULL) return NULL;
 
-    name = obj->class_p->name;
+    const char * name = obj->class_p->name;
     if(name == NULL) name = "nameless";
 
     lv_snprintf(buf, len, "%s%" LV_PRIu32 "", name, (uint32_t)(lv_uintptr_t)obj->id);


### PR DESCRIPTION
Fixes #9649 <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
