### PR TITLE
fix(svg): set stride in decoder info to prevent warning

### DIFF
--- a/src/libs/svg/lv_svg_decoder.c
+++ b/src/libs/svg/lv_svg_decoder.c
@@ -185,6 +185,7 @@ static lv_result_t svg_decoder_info(lv_image_decoder_t * decoder, lv_image_decod
         header->cf = LV_COLOR_FORMAT_ARGB8888;
         header->w = width;
         header->h = height;
+        header->stride = width * 4;
         header->flags |= LV_IMAGE_FLAGS_CUSTOM_DRAW;
 
         decoder->custom_draw_cb = svg_draw;


### PR DESCRIPTION
Fixes #9651

## Description
This PR fixes a persistent warning ("Image decoder didn't set stride") when using the SVG decoder.
The  function was correctly setting the width, height, and color format but neglecting to calculate and set the stride.

## Fix
Explicitly sets  since the color format is hardcoded to .

## Verification
tested on ESP32-C6 with LVGL 9.x.