### PR TITLE
fix(draw/line): fix buffer overflow when point is outside display area

### DIFF
--- a/src/draw/sw/lv_draw_sw_line.c
+++ b/src/draw/sw/lv_draw_sw_line.c
@@ -345,8 +345,7 @@ static void LV_ATTRIBUTE_FAST_MEM draw_line_skew(lv_draw_task_t * t, const lv_dr
 
     /*Draw the background line by line*/
     int32_t h;
-    uint32_t hor_res = (uint32_t)lv_display_get_horizontal_resolution(lv_refr_get_disp_refreshing());
-    size_t mask_buf_size = LV_MIN(lv_area_get_size(&blend_area), hor_res);
+    size_t mask_buf_size = LV_MIN((int32_t)lv_area_get_size(&blend_area), lv_area_get_width(&blend_area));
     lv_opa_t * mask_buf = lv_malloc(mask_buf_size);
 
     int32_t y2 = blend_area.y2;

--- a/src/draw/sw/lv_draw_sw_mask.c
+++ b/src/draw/sw/lv_draw_sw_mask.c
@@ -548,7 +548,7 @@ static lv_draw_sw_mask_res_t LV_ATTRIBUTE_FAST_MEM line_mask_flat(lv_opa_t * mas
         if(k < 0) {
             return LV_DRAW_SW_MASK_RES_TRANSP;
         }
-        if(k <= len) {
+        if(k < len) {
             lv_memzero(&mask_buf[k], len - k);
         }
     }

--- a/tests/src/lv_test_init.c
+++ b/tests/src/lv_test_init.c
@@ -5,9 +5,6 @@
 #include <assert.h>
 #include "../unity/unity.h"
 
-#define HOR_RES 800
-#define VER_RES 480
-
 static void test_log_print_cb(lv_log_level_t level, const char * buf);
 
 void lv_test_init(void)
@@ -21,7 +18,7 @@ void lv_test_init(void)
     lv_profiler_builtin_set_enable(false);
 #endif
 
-    lv_test_display_create(HOR_RES, VER_RES);
+    lv_test_display_create(LV_TEST_DISPLAY_HOR_RES, LV_TEST_DISPLAY_VER_RES);
     lv_test_indev_create_all();
     lv_test_fs_init();
 

--- a/tests/src/lv_test_init.h
+++ b/tests/src/lv_test_init.h
@@ -9,6 +9,9 @@ extern "C" {
 #include <stdio.h>
 #include <../lvgl.h>
 
+#define LV_TEST_DISPLAY_HOR_RES 800
+#define LV_TEST_DISPLAY_VER_RES 480
+
 void lv_test_init(void);
 void lv_test_deinit(void);
 

--- a/tests/src/test_cases/widgets/test_canvas.c
+++ b/tests/src/test_cases/widgets/test_canvas.c
@@ -1,6 +1,7 @@
 #if LV_BUILD_TEST
 #include "../lvgl.h"
 #include "../../lvgl_private.h"
+#include "lv_test_init.h"
 
 #include "unity/unity.h"
 
@@ -759,6 +760,39 @@ void test_canvas_out_of_area(void)
     TEST_ASSERT_EQUAL_UINT8(0x00, px.green);
     TEST_ASSERT_EQUAL_UINT8(0x00, px.blue);
     TEST_ASSERT_EQUAL_UINT8(0x00, px.alpha);
+}
+
+void test_line_bigger_than_display_resolution(void)
+{
+    int32_t hor_res = lv_display_get_horizontal_resolution(lv_display_get_default());
+    int32_t ver_res = lv_display_get_vertical_resolution(lv_display_get_default());
+    LV_DRAW_BUF_DEFINE_STATIC(draw_buf, LV_TEST_DISPLAY_HOR_RES + 1, LV_TEST_DISPLAY_VER_RES + 1, LV_COLOR_FORMAT_NATIVE);
+    LV_DRAW_BUF_INIT_STATIC(draw_buf);
+    draw_buf.header.stride = LV_STRIDE_AUTO;
+
+    lv_obj_t * canvas = lv_canvas_create(lv_screen_active());
+    lv_canvas_set_draw_buf(canvas, &draw_buf);
+    lv_canvas_fill_bg(canvas, lv_color_hex3(0xccc), LV_OPA_COVER);
+    lv_obj_center(canvas);
+
+    lv_layer_t layer;
+    lv_canvas_init_layer(canvas, &layer);
+
+    lv_draw_line_dsc_t dsc;
+    lv_draw_line_dsc_init(&dsc);
+    dsc.color = lv_palette_main(LV_PALETTE_RED);
+    dsc.width = 4;
+    dsc.round_end = 1;
+    dsc.round_start = 1;
+    dsc.p1.x = 0;
+    dsc.p1.y = 0;
+    dsc.p2.x = hor_res + 1;
+    dsc.p2.y = ver_res + 1;
+    lv_draw_line(&layer, &dsc);
+    lv_canvas_finish_layer(canvas, &layer);
+
+    /* Test passes if no crash occurs when drawing a line with endpoint
+     * at (hor_res+1, ver_res+1) on a buffer of size (hor_res+1)x(ver_res+1)*/
 }
 
 #endif


### PR DESCRIPTION
Fixes #9665 <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
