### PR TITLE
fix(LTDC): warn when rotating and DRAW_SW is disabled

### DIFF
--- a/src/drivers/display/st_ltdc/lv_st_ltdc.c
+++ b/src/drivers/display/st_ltdc/lv_st_ltdc.c
@@ -211,10 +211,14 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_m
 #endif
         }
         else {
+#if LV_USE_DRAW_SW
             uint32_t area_stride = px_size * area_width;
             lv_draw_sw_rotate(px_map, first_pixel, area_width, area_height, area_stride, fb_stride, rotation, cf);
             clean_dcache();
             g_data.disp_flushed_in_flush_cb[layer_idx] = true;
+#else
+            LV_LOG_WARN("LV_USE_DRAW_SW needs to be enabled to rotate the display's content");
+#endif
         }
     }
 }

--- a/src/drivers/display/st_ltdc/lv_st_ltdc.c
+++ b/src/drivers/display/st_ltdc/lv_st_ltdc.c
@@ -218,6 +218,7 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_m
             g_data.disp_flushed_in_flush_cb[layer_idx] = true;
 #else
             LV_LOG_WARN("LV_USE_DRAW_SW needs to be enabled to rotate the display's content");
+            g_data.disp_flushed_in_flush_cb[layer_idx] = true;
 #endif
         }
     }


### PR DESCRIPTION
LTDC rotation depends on draw_sw's rotation function.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
