### PR TITLE
feat(drm/egl): auto infer drm egl config from use_opengles

### DIFF
--- a/docs/src/integration/embedded_linux/drivers/drm.rst
+++ b/docs/src/integration/embedded_linux/drivers/drm.rst
@@ -141,12 +141,10 @@ To enable this, set the following options in your ``lv_conf.h`` (or via Kconfig/
 .. code-block:: c
 
     #define LV_USE_LINUX_DRM             1
-    #define LV_USE_LINUX_DRM_GBM_BUFFERS 1
-    #define LV_LINUX_DRM_USE_EGL         1
     #define LV_USE_OPENGLES              1
     #define LV_USE_DRAW_OPENGLES         1   /* optional but recommended for performance */
 
-When :c:macro:`LV_LINUX_DRM_USE_EGL` is enabled, the DRM driver will automatically initialize EGL.
+When :c:macro:`LV_USE_OPENGLES` is enabled, the DRM driver will automatically initialize EGL.
 No special setup is required beyond the basic DRM initialization shown in :ref:`linux_drm_basic_usage`.
 
 For a detailed overview of EGL usage and configuration, see :ref:`egl_driver`.
@@ -157,7 +155,7 @@ Selecting Display Mode
 
 .. note::
     Custom mode selection is currently only supported when using DRM with EGL 
-    (:c:macro:`LV_LINUX_DRM_USE_EGL` enabled). When using DRM without EGL, the driver
+    (:c:macro:`LV_USE_OPENGLES` enabled). When using DRM without EGL, the driver
     will always use the preferred display mode.
 
 By default, the DRM driver automatically selects the preferred display mode for the connected display. However, you can customize this behavior by providing a mode selection callback.

--- a/docs/src/integration/embedded_linux/drivers/egl.rst
+++ b/docs/src/integration/embedded_linux/drivers/egl.rst
@@ -20,7 +20,7 @@ EGL with DRM
 
 EGL can be used together with the DRM driver for hardware-accelerated rendering.
 
-When :c:macro:`LV_LINUX_DRM_USE_EGL` is enabled, the DRM driver will automatically set up EGL.
+When :c:macro:`LV_USE_OPENGLES` is enabled, the DRM driver will automatically set up EGL.
 No additional initialization is required beyond the normal DRM setup.
 
 See :ref:`linux_drm` for configuration and a basic usage example.

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -1339,8 +1339,6 @@
      * The GBM library aims to provide a platform independent memory management system
      * it supports the major GPU vendors - This option requires linking with libgbm */
     #define LV_USE_LINUX_DRM_GBM_BUFFERS 0
-
-    #define LV_LINUX_DRM_USE_EGL     0
 #endif
 
 /** Interface for TFT_eSPI */

--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -245,8 +245,14 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
     #define LV_WAYLAND_USE_EGL 0
 #endif
 
-#if LV_USE_LINUX_DRM == 0
-    #define LV_LINUX_DRM_USE_EGL     0
+#if LV_USE_LINUX_DRM
+    #if LV_USE_OPENGLES
+        #define LV_LINUX_DRM_USE_EGL 1
+    #else
+        #define LV_LINUX_DRM_USE_EGL 0
+    #endif /* LV_USE_OPENGLES */
+#else
+    #define LV_LINUX_DRM_USE_EGL 0
 #endif /*LV_USE_LINUX_DRM*/
 
 #if LV_USE_SYSMON == 0

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -4292,14 +4292,6 @@
             #define LV_USE_LINUX_DRM_GBM_BUFFERS 0
         #endif
     #endif
-
-    #ifndef LV_LINUX_DRM_USE_EGL
-        #ifdef CONFIG_LV_LINUX_DRM_USE_EGL
-            #define LV_LINUX_DRM_USE_EGL CONFIG_LV_LINUX_DRM_USE_EGL
-        #else
-            #define LV_LINUX_DRM_USE_EGL     0
-        #endif
-    #endif
 #endif
 
 /** Interface for TFT_eSPI */
@@ -4853,8 +4845,14 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
     #define LV_WAYLAND_USE_EGL 0
 #endif
 
-#if LV_USE_LINUX_DRM == 0
-    #define LV_LINUX_DRM_USE_EGL     0
+#if LV_USE_LINUX_DRM
+    #if LV_USE_OPENGLES
+        #define LV_LINUX_DRM_USE_EGL 1
+    #else
+        #define LV_LINUX_DRM_USE_EGL 0
+    #endif /* LV_USE_OPENGLES */
+#else
+    #define LV_LINUX_DRM_USE_EGL 0
 #endif /*LV_USE_LINUX_DRM*/
 
 #if LV_USE_SYSMON == 0


### PR DESCRIPTION
This standardizes the way the EGL backend is enabled

With both SDL and Wayland, EGL is automatically enabled when LV_USE_OPENGLES is enabled (no extra config to set), this PR does the same thing with DRM