### PR TITLE
fix(fbdev): add missing errno.h include

### DIFF
--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -17,6 +17,7 @@
 #include <sys/mman.h>
 #include <sys/ioctl.h>
 #include <time.h>
+#include <errno.h>
 
 #if LV_LINUX_FBDEV_BSD
     #include <sys/fcntl.h>


### PR DESCRIPTION
Fixes #9672 : fix build faild when disabled LV_LINUX_FBDEV_MMAP