### PR TITLE
fix(gltf): avoid resetting value_changed node attribute

### DIFF
--- a/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
@@ -1405,7 +1405,7 @@ static void lv_gltf_view_recache_all_transforms(lv_gltf_model_t * model)
                     lv_memcpy(target_scale, local_scale.data(), sizeof(*target_scale));
                     value_changed = true;
                 }
-                node->read_attrs->value_changed = value_changed;
+                node->read_attrs->value_changed |= value_changed;
             }
         }
 


### PR DESCRIPTION
`value_changed` should only be set to false when we send then new values which is done here: https://github.com/lvgl/lvgl/blob/0a6de47190ec298457bf04be0adcb56d2f032c38/src/libs/gltf/gltf_data/lv_gltf_model_node.cpp#L170