### PR TITLE
feat(ibl_sampler): fallback to default env image and remove unnecessary allocation

### DIFF
--- a/src/libs/gltf/gltf_environment/lv_gltf_ibl_sampler.c
+++ b/src/libs/gltf/gltf_environment/lv_gltf_ibl_sampler.c
@@ -207,6 +207,10 @@ static lv_result_t ibl_sampler_load(lv_gltf_ibl_sampler_t * sampler, const char 
         extern unsigned char chromatic_jpg[];
         extern unsigned int chromatic_jpg_len;
         data = stbi_loadf_from_memory(chromatic_jpg, chromatic_jpg_len, &src_width, &src_height, &src_nrChannels, 3);
+        if(!data) {
+            LV_LOG_ERROR("Failed to load fallback env image");
+            return LV_RESULT_INVALID;
+        }
     }
 
     {

--- a/src/libs/gltf/gltf_environment/lv_gltf_ibl_sampler.c
+++ b/src/libs/gltf/gltf_environment/lv_gltf_ibl_sampler.c
@@ -38,7 +38,7 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static void ibl_sampler_load(lv_gltf_ibl_sampler_t * sampler, const char * path);
+static lv_result_t ibl_sampler_load(lv_gltf_ibl_sampler_t * sampler, const char * path);
 static void ibl_sampler_filter(lv_gltf_ibl_sampler_t * sampler);
 static void ibl_sampler_destroy(lv_gltf_ibl_sampler_t * sampler);
 static bool ibl_gl_has_extension(const char * extension);
@@ -153,7 +153,11 @@ lv_gltf_environment_t * lv_gltf_environment_create(lv_gltf_ibl_sampler_t * sampl
         LV_LOG_WARN("Failed to create environment");
         return NULL;
     }
-    ibl_sampler_load(sampler, file_path);
+    if(ibl_sampler_load(sampler, file_path) != LV_RESULT_OK) {
+        LV_LOG_WARN("Failed to initialize ibl sampler");
+        lv_free(env);
+        return NULL;
+    }
     ibl_sampler_filter(sampler);
 
     env->diffuse = sampler->lambertian_texture_id;
@@ -178,7 +182,7 @@ void lv_gltf_environment_delete(lv_gltf_environment_t * env)
  *   STATIC FUNCTIONS
  **********************/
 
-static void ibl_sampler_load(lv_gltf_ibl_sampler_t * sampler, const char * path)
+static lv_result_t ibl_sampler_load(lv_gltf_ibl_sampler_t * sampler, const char * path)
 {
     // vv -- WebGL Naming
     if(ibl_gl_has_extension("GL_NV_float") && ibl_gl_has_extension("GL_ARB_color_buffer_float")) {
@@ -191,11 +195,15 @@ static void ibl_sampler_load(lv_gltf_ibl_sampler_t * sampler, const char * path)
 
     int32_t src_width, src_height, src_nrChannels;
 
-    float * data;
-    if(path != NULL) {
+    float * data = NULL;
+    if(path) {
         data = stbi_loadf(path, &src_width, &src_height, &src_nrChannels, 3);
     }
-    else {
+
+    if(!data) {
+        if(path) {
+            LV_LOG_WARN("Failed to load environment image. Falling back to default");
+        }
         extern unsigned char chromatic_jpg[];
         extern unsigned int chromatic_jpg_len;
         data = stbi_loadf_from_memory(chromatic_jpg, chromatic_jpg_len, &src_width, &src_height, &src_nrChannels, 3);
@@ -203,17 +211,14 @@ static void ibl_sampler_load(lv_gltf_ibl_sampler_t * sampler, const char * path)
 
     {
         lv_gltf_ibl_image_t panorama_image = {
-            .data = (float *)lv_malloc(src_width * src_height * 3 * sizeof(float)),
+            .data = data,
             .data_len = src_width * src_height * 3,
             .width = src_width,
             .height = src_height,
         };
-        LV_ASSERT_MALLOC(panorama_image.data);
 
-        lv_memcpy(panorama_image.data, data, panorama_image.data_len * sizeof(*panorama_image.data));
-        stbi_image_free(data);
         sampler->input_texture_id = ibl_load_texture_hdr(sampler, &panorama_image);
-        lv_free(panorama_image.data);
+        stbi_image_free(data);
     }
 
     GL_CALL(glGenFramebuffers(1, &sampler->framebuffer));
@@ -229,6 +234,7 @@ static void ibl_sampler_load(lv_gltf_ibl_sampler_t * sampler, const char * path)
     GL_CALL(glBindTexture(GL_TEXTURE_CUBE_MAP, sampler->sheen_texture_id));
     GL_CALL(glGenerateMipmap(GL_TEXTURE_CUBE_MAP));
     sampler->mipmap_levels = ibl_count_bits(sampler->cube_map_resolution) + 1 - sampler->lowest_mip_level;
+    return LV_RESULT_OK;
 }
 
 static void ibl_sampler_filter(lv_gltf_ibl_sampler_t * sampler)


### PR DESCRIPTION
The code would dynamically allocate the image data twice for no reason