### PR TITLE
fix(ibl_sampler): restore gl state and add missing ressources deletion

### DIFF
--- a/src/libs/gltf/gltf_environment/lv_gltf_ibl_sampler.c
+++ b/src/libs/gltf/gltf_environment/lv_gltf_ibl_sampler.c
@@ -238,10 +238,12 @@ static void ibl_sampler_filter(lv_gltf_ibl_sampler_t * sampler)
     GLint prev_program;
     GLint prev_texture_2d;
     GLint prev_texture_cube;
+    GLint prev_active_texture;
 
     GL_CALL(glGetIntegerv(GL_FRAMEBUFFER_BINDING, &prev_framebuffer));
     GL_CALL(glGetIntegerv(GL_VIEWPORT, prev_viewport));
     GL_CALL(glGetIntegerv(GL_CURRENT_PROGRAM, &prev_program));
+    GL_CALL(glGetIntegerv(GL_ACTIVE_TEXTURE, &prev_active_texture));
     GL_CALL(glGetIntegerv(GL_TEXTURE_BINDING_2D, &prev_texture_2d));
     GL_CALL(glGetIntegerv(GL_TEXTURE_BINDING_CUBE_MAP, &prev_texture_cube));
 
@@ -256,6 +258,7 @@ static void ibl_sampler_filter(lv_gltf_ibl_sampler_t * sampler)
     GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, prev_framebuffer));
     GL_CALL(glViewport(prev_viewport[0], prev_viewport[1], prev_viewport[2], prev_viewport[3]));
     GL_CALL(glUseProgram(prev_program));
+    GL_CALL(glActiveTexture(prev_active_texture));
     GL_CALL(glBindTexture(GL_TEXTURE_2D, prev_texture_2d));
     GL_CALL(glBindTexture(GL_TEXTURE_CUBE_MAP, prev_texture_cube));
 }
@@ -265,17 +268,17 @@ static void ibl_sampler_destroy(lv_gltf_ibl_sampler_t * sampler)
         GL_CALL(glDeleteFramebuffers(1, &sampler->framebuffer));
         sampler->framebuffer = 0;
     }
-    
+
     if(sampler->input_texture_id != 0) {
         GL_CALL(glDeleteTextures(1, &sampler->input_texture_id));
         sampler->input_texture_id = 0;
     }
-    
+
     if(sampler->cube_map_texture_id != 0) {
         GL_CALL(glDeleteTextures(1, &sampler->cube_map_texture_id));
         sampler->cube_map_texture_id = 0;
     }
-    
+
     GL_CALL(glDeleteBuffers(1, &sampler->fullscreen_vertex_buffer));
     GL_CALL(glDeleteBuffers(1, &sampler->fullscreen_tex_coord_buffer));
     lv_opengl_shader_manager_deinit(&sampler->shader_manager);


### PR DESCRIPTION
This was causing conflicts with the NanoVG draw unit and would cause black screens if the screen didn't have any 3D work to do