### PR TITLE
fix(thorvg): fix compiler error `-Werror=type-limits`

### DIFF
--- a/src/libs/thorvg/tvgCompressor.cpp
+++ b/src/libs/thorvg/tvgCompressor.cpp
@@ -463,14 +463,16 @@ size_t b64Decode(const char* encoded, const size_t len, char** decoded)
         auto value2 = B64_INDEX[(size_t)encoded[1]];
         output[idx++] = (value1 << 2) + ((value2 & 0x30) >> 4);
 
-        if (!encoded[2] || encoded[3] < 0 || encoded[2] == '=' || encoded[2] == '.') break;
-        auto value3 = B64_INDEX[(size_t)encoded[2]];
+		if (!encoded[2] || encoded[2] == '=' || encoded[2] == '.')
+			break;
+		auto value3 = B64_INDEX[(size_t)encoded[2]];
         output[idx++] = ((value2 & 0x0f) << 4) + ((value3 & 0x3c) >> 2);
 
-        if (!encoded[3] || encoded[3] < 0 || encoded[3] == '=' || encoded[3] == '.') break;
-        auto value4 = B64_INDEX[(size_t)encoded[3]];
-        output[idx++] = ((value3 & 0x03) << 6) + value4;
-        encoded += 4;
+		if (!encoded[3] || encoded[3] == '=' || encoded[3] == '.')
+			break;
+		auto value4 = B64_INDEX[(size_t)encoded[3]];
+		output[idx++] = ((value3 & 0x03) << 6) + value4;
+		encoded += 4;
     }
     *decoded = output;
     return idx;


### PR DESCRIPTION
Compiling on ARM gives this compiler error when running the tests

```
lvgl/src/libs/thorvg/tvgCompressor.cpp:466:39: error: comparison is always false due to limited range of data type [-Werror=type-limits]
  466 |         if (!encoded[2] || encoded[3] < 0 || encoded[2] == '=' || encoded[2] == '.') break;
      |                            ~~~~~~~~~~~^~~
At global scope:
```