### PR TITLE
docs(style_api_gen): add missing * to style API documentation

### DIFF
--- a/scripts/style_api_gen.py
+++ b/scripts/style_api_gen.py
@@ -801,10 +801,10 @@ def local_style_set_doxygen_comment(p):
     print(' * @param  obj        Pointer to Widget')
     print_value_param(p, indent='   ')
     print(' * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:')
-    print('                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`')
-    print('                          - `LV_STATE_PRESSED`')
-    print('                          - `LV_PART_KNOB`')
-    print('                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`')
+    print(' *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`')
+    print(' *                        - `LV_STATE_PRESSED`')
+    print(' *                        - `LV_PART_KNOB`')
+    print(' *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`')
     print(' */')
 
 

--- a/src/core/lv_obj_style_gen.h
+++ b/src/core/lv_obj_style_gen.h
@@ -1807,10 +1807,10 @@ static inline int32_t lv_obj_get_style_grid_cell_row_span(const lv_obj_t * obj, 
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -1821,10 +1821,10 @@ void lv_obj_set_style_width(lv_obj_t * obj, int32_t value, lv_style_selector_t s
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_min_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -1835,10 +1835,10 @@ void lv_obj_set_style_min_width(lv_obj_t * obj, int32_t value, lv_style_selector
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_max_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -1849,10 +1849,10 @@ void lv_obj_set_style_max_width(lv_obj_t * obj, int32_t value, lv_style_selector
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_height(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -1863,10 +1863,10 @@ void lv_obj_set_style_height(lv_obj_t * obj, int32_t value, lv_style_selector_t 
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_min_height(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -1877,10 +1877,10 @@ void lv_obj_set_style_min_height(lv_obj_t * obj, int32_t value, lv_style_selecto
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_max_height(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -1891,10 +1891,10 @@ void lv_obj_set_style_max_height(lv_obj_t * obj, int32_t value, lv_style_selecto
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_length(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -1906,10 +1906,10 @@ void lv_obj_set_style_length(lv_obj_t * obj, int32_t value, lv_style_selector_t 
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_x(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -1921,10 +1921,10 @@ void lv_obj_set_style_x(lv_obj_t * obj, int32_t value, lv_style_selector_t selec
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_y(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -1939,10 +1939,10 @@ void lv_obj_set_style_y(lv_obj_t * obj, int32_t value, lv_style_selector_t selec
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_align(lv_obj_t * obj, lv_align_t value, lv_style_selector_t selector);
 
@@ -1953,10 +1953,10 @@ void lv_obj_set_style_align(lv_obj_t * obj, lv_align_t value, lv_style_selector_
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_transform_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -1967,10 +1967,10 @@ void lv_obj_set_style_transform_width(lv_obj_t * obj, int32_t value, lv_style_se
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_transform_height(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -1982,10 +1982,10 @@ void lv_obj_set_style_transform_height(lv_obj_t * obj, int32_t value, lv_style_s
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_translate_x(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -1997,10 +1997,10 @@ void lv_obj_set_style_translate_x(lv_obj_t * obj, int32_t value, lv_style_select
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_translate_y(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2011,10 +2011,10 @@ void lv_obj_set_style_translate_y(lv_obj_t * obj, int32_t value, lv_style_select
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_translate_radial(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2025,10 +2025,10 @@ void lv_obj_set_style_translate_radial(lv_obj_t * obj, int32_t value, lv_style_s
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_transform_scale_x(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2039,10 +2039,10 @@ void lv_obj_set_style_transform_scale_x(lv_obj_t * obj, int32_t value, lv_style_
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_transform_scale_y(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2052,10 +2052,10 @@ void lv_obj_set_style_transform_scale_y(lv_obj_t * obj, int32_t value, lv_style_
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_transform_rotation(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2065,10 +2065,10 @@ void lv_obj_set_style_transform_rotation(lv_obj_t * obj, int32_t value, lv_style
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_transform_pivot_x(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2078,10 +2078,10 @@ void lv_obj_set_style_transform_pivot_x(lv_obj_t * obj, int32_t value, lv_style_
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_transform_pivot_y(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2092,10 +2092,10 @@ void lv_obj_set_style_transform_pivot_y(lv_obj_t * obj, int32_t value, lv_style_
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_transform_skew_x(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2106,10 +2106,10 @@ void lv_obj_set_style_transform_skew_x(lv_obj_t * obj, int32_t value, lv_style_s
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_transform_skew_y(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2119,10 +2119,10 @@ void lv_obj_set_style_transform_skew_y(lv_obj_t * obj, int32_t value, lv_style_s
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_pad_top(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2132,10 +2132,10 @@ void lv_obj_set_style_pad_top(lv_obj_t * obj, int32_t value, lv_style_selector_t
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_pad_bottom(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2145,10 +2145,10 @@ void lv_obj_set_style_pad_bottom(lv_obj_t * obj, int32_t value, lv_style_selecto
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_pad_left(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2158,10 +2158,10 @@ void lv_obj_set_style_pad_left(lv_obj_t * obj, int32_t value, lv_style_selector_
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_pad_right(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2171,10 +2171,10 @@ void lv_obj_set_style_pad_right(lv_obj_t * obj, int32_t value, lv_style_selector
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_pad_row(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2184,10 +2184,10 @@ void lv_obj_set_style_pad_row(lv_obj_t * obj, int32_t value, lv_style_selector_t
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_pad_column(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2197,10 +2197,10 @@ void lv_obj_set_style_pad_column(lv_obj_t * obj, int32_t value, lv_style_selecto
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_pad_radial(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2210,10 +2210,10 @@ void lv_obj_set_style_pad_radial(lv_obj_t * obj, int32_t value, lv_style_selecto
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_margin_top(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2223,10 +2223,10 @@ void lv_obj_set_style_margin_top(lv_obj_t * obj, int32_t value, lv_style_selecto
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_margin_bottom(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2236,10 +2236,10 @@ void lv_obj_set_style_margin_bottom(lv_obj_t * obj, int32_t value, lv_style_sele
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_margin_left(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2249,10 +2249,10 @@ void lv_obj_set_style_margin_left(lv_obj_t * obj, int32_t value, lv_style_select
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_margin_right(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2262,10 +2262,10 @@ void lv_obj_set_style_margin_right(lv_obj_t * obj, int32_t value, lv_style_selec
  * @param  obj        Pointer to Widget
  * @param  value      Color to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_bg_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
 
@@ -2277,10 +2277,10 @@ void lv_obj_set_style_bg_color(lv_obj_t * obj, lv_color_t value, lv_style_select
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_bg_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
 
@@ -2290,10 +2290,10 @@ void lv_obj_set_style_bg_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t
  * @param  obj        Pointer to Widget
  * @param  value      Color to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_bg_grad_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
 
@@ -2304,10 +2304,10 @@ void lv_obj_set_style_bg_grad_color(lv_obj_t * obj, lv_color_t value, lv_style_s
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_bg_grad_dir(lv_obj_t * obj, lv_grad_dir_t value, lv_style_selector_t selector);
 
@@ -2318,10 +2318,10 @@ void lv_obj_set_style_bg_grad_dir(lv_obj_t * obj, lv_grad_dir_t value, lv_style_
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_bg_main_stop(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2332,10 +2332,10 @@ void lv_obj_set_style_bg_main_stop(lv_obj_t * obj, int32_t value, lv_style_selec
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_bg_grad_stop(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2345,10 +2345,10 @@ void lv_obj_set_style_bg_grad_stop(lv_obj_t * obj, int32_t value, lv_style_selec
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_bg_main_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
 
@@ -2358,10 +2358,10 @@ void lv_obj_set_style_bg_main_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selec
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_bg_grad_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
 
@@ -2374,10 +2374,10 @@ void lv_obj_set_style_bg_grad_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selec
  * @param  obj        Pointer to Widget
  * @param  value      Pointer to gradient descriptor
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_bg_grad(lv_obj_t * obj, const lv_grad_dsc_t * value, lv_style_selector_t selector);
 
@@ -2388,10 +2388,10 @@ void lv_obj_set_style_bg_grad(lv_obj_t * obj, const lv_grad_dsc_t * value, lv_st
  * @param  obj        Pointer to Widget
  * @param  value      Pointer to image source
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_bg_image_src(lv_obj_t * obj, const void * value, lv_style_selector_t selector);
 
@@ -2403,10 +2403,10 @@ void lv_obj_set_style_bg_image_src(lv_obj_t * obj, const void * value, lv_style_
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_bg_image_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
 
@@ -2416,10 +2416,10 @@ void lv_obj_set_style_bg_image_opa(lv_obj_t * obj, lv_opa_t value, lv_style_sele
  * @param  obj        Pointer to Widget
  * @param  value      Color to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_bg_image_recolor(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
 
@@ -2432,10 +2432,10 @@ void lv_obj_set_style_bg_image_recolor(lv_obj_t * obj, lv_color_t value, lv_styl
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_bg_image_recolor_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
 
@@ -2445,10 +2445,10 @@ void lv_obj_set_style_bg_image_recolor_opa(lv_obj_t * obj, lv_opa_t value, lv_st
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_bg_image_tiled(lv_obj_t * obj, bool value, lv_style_selector_t selector);
 
@@ -2458,10 +2458,10 @@ void lv_obj_set_style_bg_image_tiled(lv_obj_t * obj, bool value, lv_style_select
  * @param  obj        Pointer to Widget
  * @param  value      Color to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_border_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
 
@@ -2473,10 +2473,10 @@ void lv_obj_set_style_border_color(lv_obj_t * obj, lv_color_t value, lv_style_se
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_border_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
 
@@ -2486,10 +2486,10 @@ void lv_obj_set_style_border_opa(lv_obj_t * obj, lv_opa_t value, lv_style_select
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_border_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2501,10 +2501,10 @@ void lv_obj_set_style_border_width(lv_obj_t * obj, int32_t value, lv_style_selec
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_border_side(lv_obj_t * obj, lv_border_side_t value, lv_style_selector_t selector);
 
@@ -2515,10 +2515,10 @@ void lv_obj_set_style_border_side(lv_obj_t * obj, lv_border_side_t value, lv_sty
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_border_post(lv_obj_t * obj, bool value, lv_style_selector_t selector);
 
@@ -2528,10 +2528,10 @@ void lv_obj_set_style_border_post(lv_obj_t * obj, bool value, lv_style_selector_
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_outline_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2541,10 +2541,10 @@ void lv_obj_set_style_outline_width(lv_obj_t * obj, int32_t value, lv_style_sele
  * @param  obj        Pointer to Widget
  * @param  value      Color to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_outline_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
 
@@ -2556,10 +2556,10 @@ void lv_obj_set_style_outline_color(lv_obj_t * obj, lv_color_t value, lv_style_s
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_outline_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
 
@@ -2569,10 +2569,10 @@ void lv_obj_set_style_outline_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selec
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_outline_pad(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2582,10 +2582,10 @@ void lv_obj_set_style_outline_pad(lv_obj_t * obj, int32_t value, lv_style_select
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_shadow_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2595,10 +2595,10 @@ void lv_obj_set_style_shadow_width(lv_obj_t * obj, int32_t value, lv_style_selec
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_shadow_offset_x(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2608,10 +2608,10 @@ void lv_obj_set_style_shadow_offset_x(lv_obj_t * obj, int32_t value, lv_style_se
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_shadow_offset_y(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2622,10 +2622,10 @@ void lv_obj_set_style_shadow_offset_y(lv_obj_t * obj, int32_t value, lv_style_se
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_shadow_spread(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2635,10 +2635,10 @@ void lv_obj_set_style_shadow_spread(lv_obj_t * obj, int32_t value, lv_style_sele
  * @param  obj        Pointer to Widget
  * @param  value      Color to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_shadow_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
 
@@ -2650,10 +2650,10 @@ void lv_obj_set_style_shadow_color(lv_obj_t * obj, lv_color_t value, lv_style_se
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_shadow_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
 
@@ -2665,10 +2665,10 @@ void lv_obj_set_style_shadow_opa(lv_obj_t * obj, lv_opa_t value, lv_style_select
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_image_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
 
@@ -2678,10 +2678,10 @@ void lv_obj_set_style_image_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selecto
  * @param  obj        Pointer to Widget
  * @param  value      Color to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_image_recolor(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
 
@@ -2693,10 +2693,10 @@ void lv_obj_set_style_image_recolor(lv_obj_t * obj, lv_color_t value, lv_style_s
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_image_recolor_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
 
@@ -2708,10 +2708,10 @@ void lv_obj_set_style_image_recolor_opa(lv_obj_t * obj, lv_opa_t value, lv_style
  * @param  obj        Pointer to Widget
  * @param  value      Pointer to image color key
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_image_colorkey(lv_obj_t * obj, const lv_image_colorkey_t * value, lv_style_selector_t selector);
 
@@ -2721,10 +2721,10 @@ void lv_obj_set_style_image_colorkey(lv_obj_t * obj, const lv_image_colorkey_t *
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_line_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2734,10 +2734,10 @@ void lv_obj_set_style_line_width(lv_obj_t * obj, int32_t value, lv_style_selecto
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_line_dash_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2748,10 +2748,10 @@ void lv_obj_set_style_line_dash_width(lv_obj_t * obj, int32_t value, lv_style_se
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_line_dash_gap(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2761,10 +2761,10 @@ void lv_obj_set_style_line_dash_gap(lv_obj_t * obj, int32_t value, lv_style_sele
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_line_rounded(lv_obj_t * obj, bool value, lv_style_selector_t selector);
 
@@ -2774,10 +2774,10 @@ void lv_obj_set_style_line_rounded(lv_obj_t * obj, bool value, lv_style_selector
  * @param  obj        Pointer to Widget
  * @param  value      Color to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_line_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
 
@@ -2787,10 +2787,10 @@ void lv_obj_set_style_line_color(lv_obj_t * obj, lv_color_t value, lv_style_sele
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_line_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
 
@@ -2800,10 +2800,10 @@ void lv_obj_set_style_line_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_arc_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2813,10 +2813,10 @@ void lv_obj_set_style_arc_width(lv_obj_t * obj, int32_t value, lv_style_selector
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_arc_rounded(lv_obj_t * obj, bool value, lv_style_selector_t selector);
 
@@ -2826,10 +2826,10 @@ void lv_obj_set_style_arc_rounded(lv_obj_t * obj, bool value, lv_style_selector_
  * @param  obj        Pointer to Widget
  * @param  value      Color to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_arc_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
 
@@ -2839,10 +2839,10 @@ void lv_obj_set_style_arc_color(lv_obj_t * obj, lv_color_t value, lv_style_selec
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_arc_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
 
@@ -2853,10 +2853,10 @@ void lv_obj_set_style_arc_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_
  * @param  obj        Pointer to Widget
  * @param  value      Pointer to image source
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_arc_image_src(lv_obj_t * obj, const void * value, lv_style_selector_t selector);
 
@@ -2866,10 +2866,10 @@ void lv_obj_set_style_arc_image_src(lv_obj_t * obj, const void * value, lv_style
  * @param  obj        Pointer to Widget
  * @param  value      Color to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_text_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
 
@@ -2881,10 +2881,10 @@ void lv_obj_set_style_text_color(lv_obj_t * obj, lv_color_t value, lv_style_sele
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_text_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
 
@@ -2894,10 +2894,10 @@ void lv_obj_set_style_text_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector
  * @param  obj        Pointer to Widget
  * @param  value      Pointer to font
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_text_font(lv_obj_t * obj, const lv_font_t * value, lv_style_selector_t selector);
 
@@ -2907,10 +2907,10 @@ void lv_obj_set_style_text_font(lv_obj_t * obj, const lv_font_t * value, lv_styl
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_text_letter_space(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2920,10 +2920,10 @@ void lv_obj_set_style_text_letter_space(lv_obj_t * obj, int32_t value, lv_style_
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_text_line_space(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2934,10 +2934,10 @@ void lv_obj_set_style_text_line_space(lv_obj_t * obj, int32_t value, lv_style_se
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_text_decor(lv_obj_t * obj, lv_text_decor_t value, lv_style_selector_t selector);
 
@@ -2950,10 +2950,10 @@ void lv_obj_set_style_text_decor(lv_obj_t * obj, lv_text_decor_t value, lv_style
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_text_align(lv_obj_t * obj, lv_text_align_t value, lv_style_selector_t selector);
 
@@ -2963,10 +2963,10 @@ void lv_obj_set_style_text_align(lv_obj_t * obj, lv_text_align_t value, lv_style
  * @param  obj        Pointer to Widget
  * @param  value      Color to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_text_outline_stroke_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
 
@@ -2976,10 +2976,10 @@ void lv_obj_set_style_text_outline_stroke_color(lv_obj_t * obj, lv_color_t value
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_text_outline_stroke_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -2991,10 +2991,10 @@ void lv_obj_set_style_text_outline_stroke_width(lv_obj_t * obj, int32_t value, l
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_text_outline_stroke_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
 
@@ -3005,10 +3005,10 @@ void lv_obj_set_style_text_outline_stroke_opa(lv_obj_t * obj, lv_opa_t value, lv
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_blur_radius(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -3020,10 +3020,10 @@ void lv_obj_set_style_blur_radius(lv_obj_t * obj, int32_t value, lv_style_select
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_blur_backdrop(lv_obj_t * obj, bool value, lv_style_selector_t selector);
 
@@ -3035,10 +3035,10 @@ void lv_obj_set_style_blur_backdrop(lv_obj_t * obj, bool value, lv_style_selecto
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_blur_quality(lv_obj_t * obj, lv_blur_quality_t value, lv_style_selector_t selector);
 
@@ -3049,10 +3049,10 @@ void lv_obj_set_style_blur_quality(lv_obj_t * obj, lv_blur_quality_t value, lv_s
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_drop_shadow_radius(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -3062,10 +3062,10 @@ void lv_obj_set_style_drop_shadow_radius(lv_obj_t * obj, int32_t value, lv_style
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_drop_shadow_offset_x(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -3075,10 +3075,10 @@ void lv_obj_set_style_drop_shadow_offset_x(lv_obj_t * obj, int32_t value, lv_sty
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_drop_shadow_offset_y(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -3088,10 +3088,10 @@ void lv_obj_set_style_drop_shadow_offset_y(lv_obj_t * obj, int32_t value, lv_sty
  * @param  obj        Pointer to Widget
  * @param  value      Color to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_drop_shadow_color(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
 
@@ -3101,10 +3101,10 @@ void lv_obj_set_style_drop_shadow_color(lv_obj_t * obj, lv_color_t value, lv_sty
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_drop_shadow_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
 
@@ -3116,10 +3116,10 @@ void lv_obj_set_style_drop_shadow_opa(lv_obj_t * obj, lv_opa_t value, lv_style_s
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_drop_shadow_quality(lv_obj_t * obj, lv_blur_quality_t value, lv_style_selector_t selector);
 
@@ -3130,10 +3130,10 @@ void lv_obj_set_style_drop_shadow_quality(lv_obj_t * obj, lv_blur_quality_t valu
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_radius(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -3143,10 +3143,10 @@ void lv_obj_set_style_radius(lv_obj_t * obj, int32_t value, lv_style_selector_t 
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_radial_offset(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -3157,10 +3157,10 @@ void lv_obj_set_style_radial_offset(lv_obj_t * obj, int32_t value, lv_style_sele
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_clip_corner(lv_obj_t * obj, bool value, lv_style_selector_t selector);
 
@@ -3172,10 +3172,10 @@ void lv_obj_set_style_clip_corner(lv_obj_t * obj, bool value, lv_style_selector_
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
 
@@ -3188,10 +3188,10 @@ void lv_obj_set_style_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t se
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_opa_layered(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
 
@@ -3201,10 +3201,10 @@ void lv_obj_set_style_opa_layered(lv_obj_t * obj, lv_opa_t value, lv_style_selec
  * @param  obj        Pointer to Widget
  * @param  value      Pointer to color-filter descriptor
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_color_filter_dsc(lv_obj_t * obj, const lv_color_filter_dsc_t * value, lv_style_selector_t selector);
 
@@ -3214,10 +3214,10 @@ void lv_obj_set_style_color_filter_dsc(lv_obj_t * obj, const lv_color_filter_dsc
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_color_filter_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
 
@@ -3227,10 +3227,10 @@ void lv_obj_set_style_color_filter_opa(lv_obj_t * obj, lv_opa_t value, lv_style_
  * @param  obj        Pointer to Widget
  * @param  value      Color to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_recolor(lv_obj_t * obj, lv_color_t value, lv_style_selector_t selector);
 
@@ -3243,10 +3243,10 @@ void lv_obj_set_style_recolor(lv_obj_t * obj, lv_color_t value, lv_style_selecto
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_recolor_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selector_t selector);
 
@@ -3259,10 +3259,10 @@ void lv_obj_set_style_recolor_opa(lv_obj_t * obj, lv_opa_t value, lv_style_selec
  * @param  obj        Pointer to Widget
  * @param  value      Pointer to animation descriptor
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_anim(lv_obj_t * obj, const lv_anim_t * value, lv_style_selector_t selector);
 
@@ -3274,10 +3274,10 @@ void lv_obj_set_style_anim(lv_obj_t * obj, const lv_anim_t * value, lv_style_sel
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_anim_duration(lv_obj_t * obj, uint32_t value, lv_style_selector_t selector);
 
@@ -3287,10 +3287,10 @@ void lv_obj_set_style_anim_duration(lv_obj_t * obj, uint32_t value, lv_style_sel
  * @param  obj        Pointer to Widget
  * @param  value      Pointer to transition descriptor
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_transition(lv_obj_t * obj, const lv_style_transition_dsc_t * value, lv_style_selector_t selector);
 
@@ -3301,10 +3301,10 @@ void lv_obj_set_style_transition(lv_obj_t * obj, const lv_style_transition_dsc_t
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_blend_mode(lv_obj_t * obj, lv_blend_mode_t value, lv_style_selector_t selector);
 
@@ -3315,10 +3315,10 @@ void lv_obj_set_style_blend_mode(lv_obj_t * obj, lv_blend_mode_t value, lv_style
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_layout(lv_obj_t * obj, uint16_t value, lv_style_selector_t selector);
 
@@ -3328,10 +3328,10 @@ void lv_obj_set_style_layout(lv_obj_t * obj, uint16_t value, lv_style_selector_t
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_base_dir(lv_obj_t * obj, lv_base_dir_t value, lv_style_selector_t selector);
 
@@ -3342,10 +3342,10 @@ void lv_obj_set_style_base_dir(lv_obj_t * obj, lv_base_dir_t value, lv_style_sel
  * @param  obj        Pointer to Widget
  * @param  value      Pointer to A8 bitmap mask
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_bitmap_mask_src(lv_obj_t * obj, const void * value, lv_style_selector_t selector);
 
@@ -3356,10 +3356,10 @@ void lv_obj_set_style_bitmap_mask_src(lv_obj_t * obj, const void * value, lv_sty
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_rotary_sensitivity(lv_obj_t * obj, uint32_t value, lv_style_selector_t selector);
 
@@ -3370,10 +3370,10 @@ void lv_obj_set_style_rotary_sensitivity(lv_obj_t * obj, uint32_t value, lv_styl
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_flex_flow(lv_obj_t * obj, lv_flex_flow_t value, lv_style_selector_t selector);
 
@@ -3383,10 +3383,10 @@ void lv_obj_set_style_flex_flow(lv_obj_t * obj, lv_flex_flow_t value, lv_style_s
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_flex_main_place(lv_obj_t * obj, lv_flex_align_t value, lv_style_selector_t selector);
 
@@ -3396,10 +3396,10 @@ void lv_obj_set_style_flex_main_place(lv_obj_t * obj, lv_flex_align_t value, lv_
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_flex_cross_place(lv_obj_t * obj, lv_flex_align_t value, lv_style_selector_t selector);
 
@@ -3409,10 +3409,10 @@ void lv_obj_set_style_flex_cross_place(lv_obj_t * obj, lv_flex_align_t value, lv
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_flex_track_place(lv_obj_t * obj, lv_flex_align_t value, lv_style_selector_t selector);
 
@@ -3422,10 +3422,10 @@ void lv_obj_set_style_flex_track_place(lv_obj_t * obj, lv_flex_align_t value, lv
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_flex_grow(lv_obj_t * obj, uint8_t value, lv_style_selector_t selector);
 
@@ -3438,10 +3438,10 @@ void lv_obj_set_style_flex_grow(lv_obj_t * obj, uint8_t value, lv_style_selector
  * @param  obj        Pointer to Widget
  * @param  value      Pointer to grid-column descriptor array
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_grid_column_dsc_array(lv_obj_t * obj, const int32_t * value, lv_style_selector_t selector);
 
@@ -3451,10 +3451,10 @@ void lv_obj_set_style_grid_column_dsc_array(lv_obj_t * obj, const int32_t * valu
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_grid_column_align(lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector);
 
@@ -3464,10 +3464,10 @@ void lv_obj_set_style_grid_column_align(lv_obj_t * obj, lv_grid_align_t value, l
  * @param  obj        Pointer to Widget
  * @param  value      Pointer to grid-row descriptor array
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_grid_row_dsc_array(lv_obj_t * obj, const int32_t * value, lv_style_selector_t selector);
 
@@ -3477,10 +3477,10 @@ void lv_obj_set_style_grid_row_dsc_array(lv_obj_t * obj, const int32_t * value, 
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_grid_row_align(lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector);
 
@@ -3490,10 +3490,10 @@ void lv_obj_set_style_grid_row_align(lv_obj_t * obj, lv_grid_align_t value, lv_s
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_grid_cell_column_pos(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -3503,10 +3503,10 @@ void lv_obj_set_style_grid_cell_column_pos(lv_obj_t * obj, int32_t value, lv_sty
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_grid_cell_x_align(lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector);
 
@@ -3516,10 +3516,10 @@ void lv_obj_set_style_grid_cell_x_align(lv_obj_t * obj, lv_grid_align_t value, l
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_grid_cell_column_span(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -3529,10 +3529,10 @@ void lv_obj_set_style_grid_cell_column_span(lv_obj_t * obj, int32_t value, lv_st
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_grid_cell_row_pos(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 
@@ -3542,10 +3542,10 @@ void lv_obj_set_style_grid_cell_row_pos(lv_obj_t * obj, int32_t value, lv_style_
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_grid_cell_y_align(lv_obj_t * obj, lv_grid_align_t value, lv_style_selector_t selector);
 
@@ -3555,10 +3555,10 @@ void lv_obj_set_style_grid_cell_y_align(lv_obj_t * obj, lv_grid_align_t value, l
  * @param  obj        Pointer to Widget
  * @param  value      Value to submit
  * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
-                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
-                          - `LV_STATE_PRESSED`
-                          - `LV_PART_KNOB`
-                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
+ *                        - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
+ *                        - `LV_STATE_PRESSED`
+ *                        - `LV_PART_KNOB`
+ *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
  */
 void lv_obj_set_style_grid_cell_row_span(lv_obj_t * obj, int32_t value, lv_style_selector_t selector);
 


### PR DESCRIPTION
Overlooked in PR #9637 were these 4 asterisks mid-comment for the lower half of the `lv_ojb_style_gen.h` file.

Before:
```c
/**
 * Sets width of Widget. Pixel, percentage and `LV_SIZE_CONTENT` values can be used.
 * Percentage values are relative to the width of the parent's content area.
 * Default: Widget dependent, inherited: No, layout: Yes, ext. draw: No.
 * @param  obj        Pointer to Widget
 * @param  value      Value to submit
 * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
                          - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
                          - `LV_STATE_PRESSED`
                          - `LV_PART_KNOB`
                          - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
 */
```

After:
```c
/**
 * Sets width of Widget. Pixel, percentage and `LV_SIZE_CONTENT` values can be used.
 * Percentage values are relative to the width of the parent's content area.
 * Default: Widget dependent, inherited: No, layout: Yes, ext. draw: No.
 * @param  obj        Pointer to Widget
 * @param  value      Value to submit
 * @param  selector   A joint type for `lv_part_t` and `lv_state_t`. Example values:
 *                       - `0`: means `LV_PART_MAIN | LV_STATE_DEFAULT`
 *                        - `LV_STATE_PRESSED`
 *                        - `LV_PART_KNOB`
 *                        - `LV_PART_KNOB | LV_STATE_PRESSED | LV_STATE_CHECKED`
 */
```

cc:  @kisvegabor 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
