### PR TITLE
 feat(svg): simplify node attributes inheritance introduce in #9424

### DIFF
--- a/src/libs/svg/lv_svg_render.c
+++ b/src/libs/svg/lv_svg_render.c
@@ -26,10 +26,6 @@
     #define M_PI 3.1415926f
 #endif
 
-#ifndef LV_SVG_MAX_DEPTH
-    #define LV_SVG_MAX_DEPTH (10)
-#endif /*LV_SVG_MAX_DEPTH*/
-
 #define MIN(a,b) (((a)<(b))?(a):(b))
 #define MAX(a,b) (((a)>(b))?(a):(b))
 #define ABS(a) fabsf(a)
@@ -67,12 +63,12 @@ enum {
 *      TYPEDEFS
 **********************/
 static void _set_attr(lv_svg_render_obj_t * obj, lv_vector_path_ctx_t * dsc, const lv_svg_attr_t * attr);
+static void _set_draw_attr(lv_svg_render_obj_t * obj, lv_vector_path_ctx_t * dsc, const lv_svg_attr_t * attr);
 static void _init_draw_dsc(lv_vector_path_ctx_t * dsc);
 static void _deinit_draw_dsc(lv_vector_path_ctx_t * dsc);
 static void _copy_draw_dsc(lv_vector_path_ctx_t * dst, const lv_vector_path_ctx_t * src);
 static void _prepare_render(const lv_svg_render_obj_t * obj, lv_draw_vector_dsc_t * dsc);
 static void _special_render(const lv_svg_render_obj_t * obj, lv_draw_vector_dsc_t * dsc);
-static bool is_attr_inheritable(lv_svg_attr_type_t t);
 #if LV_USE_FREETYPE
     static void _freetype_outline_cb(lv_event_t * e);
 #endif
@@ -228,68 +224,6 @@ void lv_svg_render_init(const lv_svg_render_hal_t * hal)
     }
 }
 
-/* Reference: https://www.w3.org/TR/SVGTiny12/attributeTable.html */
-static bool is_attr_inheritable(lv_svg_attr_type_t t)
-{
-    switch(t) {
-        case LV_SVG_ATTR_ID:
-        case LV_SVG_ATTR_XML_ID:
-        case LV_SVG_ATTR_VERSION:
-        case LV_SVG_ATTR_BASE_PROFILE:
-        case LV_SVG_ATTR_VIEWBOX:
-        case LV_SVG_ATTR_PRESERVE_ASPECT_RATIO:
-        case LV_SVG_ATTR_DISPLAY:
-        case LV_SVG_ATTR_X:
-        case LV_SVG_ATTR_Y:
-        case LV_SVG_ATTR_WIDTH:
-        case LV_SVG_ATTR_HEIGHT:
-        case LV_SVG_ATTR_RX:
-        case LV_SVG_ATTR_RY:
-        case LV_SVG_ATTR_CX:
-        case LV_SVG_ATTR_CY:
-        case LV_SVG_ATTR_R:
-        case LV_SVG_ATTR_X1:
-        case LV_SVG_ATTR_Y1:
-        case LV_SVG_ATTR_X2:
-        case LV_SVG_ATTR_Y2:
-        case LV_SVG_ATTR_POINTS:
-        case LV_SVG_ATTR_D:
-        case LV_SVG_ATTR_PATH_LENGTH:
-        case LV_SVG_ATTR_XLINK_HREF:
-        case LV_SVG_ATTR_GRADIENT_UNITS:
-        case LV_SVG_ATTR_GRADIENT_STOP_OFFSET:
-        case LV_SVG_ATTR_TRANSFORM:
-#if LV_USE_SVG_ANIMATION
-        case LV_SVG_ATTR_ATTRIBUTE_NAME:
-        case LV_SVG_ATTR_ATTRIBUTE_TYPE:
-        case LV_SVG_ATTR_BEGIN:
-        case LV_SVG_ATTR_END:
-        case LV_SVG_ATTR_DUR:
-        case LV_SVG_ATTR_MIN:
-        case LV_SVG_ATTR_MAX:
-        case LV_SVG_ATTR_RESTART:
-        case LV_SVG_ATTR_REPEAT_COUNT:
-        case LV_SVG_ATTR_REPEAT_DUR:
-        case LV_SVG_ATTR_CALC_MODE:
-        case LV_SVG_ATTR_VALUES:
-        case LV_SVG_ATTR_KEY_TIMES:
-        case LV_SVG_ATTR_KEY_SPLINES:
-        case LV_SVG_ATTR_KEY_POINTS:
-        case LV_SVG_ATTR_FROM:
-        case LV_SVG_ATTR_TO:
-        case LV_SVG_ATTR_BY:
-        case LV_SVG_ATTR_ADDITIVE:
-        case LV_SVG_ATTR_ACCUMULATE:
-        case LV_SVG_ATTR_PATH:
-        case LV_SVG_ATTR_ROTATE:
-        case LV_SVG_ATTR_TRANSFORM_TYPE:
-#endif
-            return false;
-        default:
-            return true;
-    }
-}
-
 static struct _lv_svg_draw_dsc * _lv_svg_draw_dsc_create(void)
 {
     struct _lv_svg_draw_dsc * dsc = lv_zalloc(sizeof(struct _lv_svg_draw_dsc));
@@ -330,6 +264,7 @@ static struct _lv_svg_draw_dsc * _lv_svg_draw_dsc_pop(struct _lv_svg_draw_dsc * 
 
 static void _set_viewport_attr(lv_svg_render_obj_t * obj, lv_vector_path_ctx_t * dsc, const lv_svg_attr_t * attr)
 {
+    _set_draw_attr(obj, dsc, attr);
     lv_svg_render_viewport_t * view = (lv_svg_render_viewport_t *)obj;
     switch(attr->id) {
         case LV_SVG_ATTR_WIDTH:
@@ -783,7 +718,7 @@ static void _set_image_attr(lv_svg_render_obj_t * obj, lv_vector_path_ctx_t * ds
     }
 }
 
-static void _set_attr(lv_svg_render_obj_t * obj, lv_vector_path_ctx_t * dsc, const lv_svg_attr_t * attr)
+static void _set_draw_attr(lv_svg_render_obj_t * obj, lv_vector_path_ctx_t * dsc, const lv_svg_attr_t * attr)
 {
     LV_UNUSED(obj);
     switch(attr->id) {
@@ -946,16 +881,22 @@ static void _set_attr(lv_svg_render_obj_t * obj, lv_vector_path_ctx_t * dsc, con
                 }
             }
             break;
-        case LV_SVG_ATTR_TRANSFORM: {
-                if(attr->class_type == LV_SVG_ATTR_VALUE_NONE) {
-                    return;
-                }
-                lv_memcpy(&(obj->matrix), attr->value.val, sizeof(lv_matrix_t));
-            }
-            break;
         case LV_SVG_ATTR_STROKE_DASH_OFFSET:
             /* not support yet */
             break;
+    }
+}
+
+static void _set_attr(lv_svg_render_obj_t * obj, lv_vector_path_ctx_t * dsc, const lv_svg_attr_t * attr)
+{
+    if(attr->id == LV_SVG_ATTR_TRANSFORM) {
+        if(attr->class_type == LV_SVG_ATTR_VALUE_NONE) {
+            return;
+        }
+        lv_memcpy(&(obj->matrix), attr->value.val, sizeof(lv_matrix_t));
+    }
+    else {
+        _set_draw_attr(obj, dsc, attr);
     }
 }
 
@@ -1129,38 +1070,10 @@ static void _set_render_attrs(lv_svg_render_obj_t * obj, const lv_svg_node_t * n
         obj->stroke_ref = lv_strdup(state->draw_dsc->stroke_ref);
     }
 
-    if(obj->clz->set_attr) {
-        const lv_svg_node_t * parents[LV_SVG_MAX_DEPTH];
-        uint32_t depth = 0;
-        const lv_svg_node_t * cur = (lv_svg_node_t *)node->base.parent;
-
-        while(cur && depth < LV_SVG_MAX_DEPTH) {
-            parents[depth++] = cur;
-            cur = (lv_svg_node_t *)cur->base.parent;
-            if(depth == LV_SVG_MAX_DEPTH && cur) {
-                LV_LOG_WARN("Reached maximum svg depth but still couldn't find root node. "
-                            "Increase LV_SVG_MAX_DEPTH in order to have this SVG rendered properly. "
-                            "Current Depth is %d",
-                            LV_SVG_MAX_DEPTH);
-            }
-        }
-
-        for(int32_t i = depth - 1; i >= 0; i--) {
-            uint32_t len = lv_array_size(&parents[i]->attrs);
-            for(uint32_t j = 0; j < len; j++) {
-                lv_svg_attr_t * attr = lv_array_at(&parents[i]->attrs, j);
-                if(!is_attr_inheritable(attr->id)) {
-                    continue;
-                }
-                obj->clz->set_attr(obj, &(state->draw_dsc->dsc), attr);
-            }
-        }
-
-        uint32_t len = lv_array_size(&node->attrs);
-        for(uint32_t i = 0; i < len; i++) {
-            lv_svg_attr_t * attr = lv_array_at(&node->attrs, i);
-            obj->clz->set_attr(obj, &(state->draw_dsc->dsc), attr);
-        }
+    uint32_t len = lv_array_size(&node->attrs);
+    for(uint32_t i = 0; i < len; i++) {
+        lv_svg_attr_t * attr = lv_array_at(&node->attrs, i);
+        obj->clz->set_attr(obj, &(state->draw_dsc->dsc), attr);
     }
     if(node->type == LV_SVG_TAG_G) { /* only <g> need store it */
         state->draw_dsc->fill_ref = obj->fill_ref;

--- a/src/libs/svg/lv_svg_render.c
+++ b/src/libs/svg/lv_svg_render.c
@@ -26,10 +26,6 @@
     #define M_PI 3.1415926f
 #endif
 
-#ifndef LV_SVG_MAX_DEPTH
-    #define LV_SVG_MAX_DEPTH (10)
-#endif /*LV_SVG_MAX_DEPTH*/
-
 #define MIN(a,b) (((a)<(b))?(a):(b))
 #define MAX(a,b) (((a)>(b))?(a):(b))
 #define ABS(a) fabsf(a)
@@ -67,12 +63,12 @@ enum {
 *      TYPEDEFS
 **********************/
 static void _set_attr(lv_svg_render_obj_t * obj, lv_vector_path_ctx_t * dsc, const lv_svg_attr_t * attr);
+static void _set_draw_attr(lv_svg_render_obj_t * obj, lv_vector_draw_dsc_t * dsc, const lv_svg_attr_t * attr);
 static void _init_draw_dsc(lv_vector_path_ctx_t * dsc);
 static void _deinit_draw_dsc(lv_vector_path_ctx_t * dsc);
 static void _copy_draw_dsc(lv_vector_path_ctx_t * dst, const lv_vector_path_ctx_t * src);
 static void _prepare_render(const lv_svg_render_obj_t * obj, lv_draw_vector_dsc_t * dsc);
 static void _special_render(const lv_svg_render_obj_t * obj, lv_draw_vector_dsc_t * dsc);
-static bool is_attr_inheritable(lv_svg_attr_type_t t);
 #if LV_USE_FREETYPE
     static void _freetype_outline_cb(lv_event_t * e);
 #endif
@@ -228,68 +224,6 @@ void lv_svg_render_init(const lv_svg_render_hal_t * hal)
     }
 }
 
-/* Reference: https://www.w3.org/TR/SVGTiny12/attributeTable.html */
-static bool is_attr_inheritable(lv_svg_attr_type_t t)
-{
-    switch(t) {
-        case LV_SVG_ATTR_ID:
-        case LV_SVG_ATTR_XML_ID:
-        case LV_SVG_ATTR_VERSION:
-        case LV_SVG_ATTR_BASE_PROFILE:
-        case LV_SVG_ATTR_VIEWBOX:
-        case LV_SVG_ATTR_PRESERVE_ASPECT_RATIO:
-        case LV_SVG_ATTR_DISPLAY:
-        case LV_SVG_ATTR_X:
-        case LV_SVG_ATTR_Y:
-        case LV_SVG_ATTR_WIDTH:
-        case LV_SVG_ATTR_HEIGHT:
-        case LV_SVG_ATTR_RX:
-        case LV_SVG_ATTR_RY:
-        case LV_SVG_ATTR_CX:
-        case LV_SVG_ATTR_CY:
-        case LV_SVG_ATTR_R:
-        case LV_SVG_ATTR_X1:
-        case LV_SVG_ATTR_Y1:
-        case LV_SVG_ATTR_X2:
-        case LV_SVG_ATTR_Y2:
-        case LV_SVG_ATTR_POINTS:
-        case LV_SVG_ATTR_D:
-        case LV_SVG_ATTR_PATH_LENGTH:
-        case LV_SVG_ATTR_XLINK_HREF:
-        case LV_SVG_ATTR_GRADIENT_UNITS:
-        case LV_SVG_ATTR_GRADIENT_STOP_OFFSET:
-        case LV_SVG_ATTR_TRANSFORM:
-#if LV_USE_SVG_ANIMATION
-        case LV_SVG_ATTR_ATTRIBUTE_NAME:
-        case LV_SVG_ATTR_ATTRIBUTE_TYPE:
-        case LV_SVG_ATTR_BEGIN:
-        case LV_SVG_ATTR_END:
-        case LV_SVG_ATTR_DUR:
-        case LV_SVG_ATTR_MIN:
-        case LV_SVG_ATTR_MAX:
-        case LV_SVG_ATTR_RESTART:
-        case LV_SVG_ATTR_REPEAT_COUNT:
-        case LV_SVG_ATTR_REPEAT_DUR:
-        case LV_SVG_ATTR_CALC_MODE:
-        case LV_SVG_ATTR_VALUES:
-        case LV_SVG_ATTR_KEY_TIMES:
-        case LV_SVG_ATTR_KEY_SPLINES:
-        case LV_SVG_ATTR_KEY_POINTS:
-        case LV_SVG_ATTR_FROM:
-        case LV_SVG_ATTR_TO:
-        case LV_SVG_ATTR_BY:
-        case LV_SVG_ATTR_ADDITIVE:
-        case LV_SVG_ATTR_ACCUMULATE:
-        case LV_SVG_ATTR_PATH:
-        case LV_SVG_ATTR_ROTATE:
-        case LV_SVG_ATTR_TRANSFORM_TYPE:
-#endif
-            return false;
-        default:
-            return true;
-    }
-}
-
 static struct _lv_svg_draw_dsc * _lv_svg_draw_dsc_create(void)
 {
     struct _lv_svg_draw_dsc * dsc = lv_zalloc(sizeof(struct _lv_svg_draw_dsc));
@@ -330,6 +264,7 @@ static struct _lv_svg_draw_dsc * _lv_svg_draw_dsc_pop(struct _lv_svg_draw_dsc * 
 
 static void _set_viewport_attr(lv_svg_render_obj_t * obj, lv_vector_path_ctx_t * dsc, const lv_svg_attr_t * attr)
 {
+    _set_draw_attr(obj, dsc, attr);
     lv_svg_render_viewport_t * view = (lv_svg_render_viewport_t *)obj;
     switch(attr->id) {
         case LV_SVG_ATTR_WIDTH:
@@ -783,7 +718,7 @@ static void _set_image_attr(lv_svg_render_obj_t * obj, lv_vector_path_ctx_t * ds
     }
 }
 
-static void _set_attr(lv_svg_render_obj_t * obj, lv_vector_path_ctx_t * dsc, const lv_svg_attr_t * attr)
+static void _set_draw_attr(lv_svg_render_obj_t * obj, lv_vector_draw_dsc_t * dsc, const lv_svg_attr_t * attr)
 {
     LV_UNUSED(obj);
     switch(attr->id) {
@@ -946,16 +881,22 @@ static void _set_attr(lv_svg_render_obj_t * obj, lv_vector_path_ctx_t * dsc, con
                 }
             }
             break;
-        case LV_SVG_ATTR_TRANSFORM: {
-                if(attr->class_type == LV_SVG_ATTR_VALUE_NONE) {
-                    return;
-                }
-                lv_memcpy(&(obj->matrix), attr->value.val, sizeof(lv_matrix_t));
-            }
-            break;
         case LV_SVG_ATTR_STROKE_DASH_OFFSET:
             /* not support yet */
             break;
+    }
+}
+
+static void _set_attr(lv_svg_render_obj_t * obj, lv_vector_draw_dsc_t * dsc, const lv_svg_attr_t * attr)
+{
+    if(attr->id == LV_SVG_ATTR_TRANSFORM) {
+        if(attr->class_type == LV_SVG_ATTR_VALUE_NONE) {
+            return;
+        }
+        lv_memcpy(&(obj->matrix), attr->value.val, sizeof(lv_matrix_t));
+    }
+    else {
+        _set_draw_attr(obj, dsc, attr);
     }
 }
 
@@ -1129,38 +1070,10 @@ static void _set_render_attrs(lv_svg_render_obj_t * obj, const lv_svg_node_t * n
         obj->stroke_ref = lv_strdup(state->draw_dsc->stroke_ref);
     }
 
-    if(obj->clz->set_attr) {
-        const lv_svg_node_t * parents[LV_SVG_MAX_DEPTH];
-        uint32_t depth = 0;
-        const lv_svg_node_t * cur = (lv_svg_node_t *)node->base.parent;
-
-        while(cur && depth < LV_SVG_MAX_DEPTH) {
-            parents[depth++] = cur;
-            cur = (lv_svg_node_t *)cur->base.parent;
-            if(depth == LV_SVG_MAX_DEPTH && cur) {
-                LV_LOG_WARN("Reached maximum svg depth but still couldn't find root node. "
-                            "Increase LV_SVG_MAX_DEPTH in order to have this SVG rendered properly. "
-                            "Current Depth is %d",
-                            LV_SVG_MAX_DEPTH);
-            }
-        }
-
-        for(int32_t i = depth - 1; i >= 0; i--) {
-            uint32_t len = lv_array_size(&parents[i]->attrs);
-            for(uint32_t j = 0; j < len; j++) {
-                lv_svg_attr_t * attr = lv_array_at(&parents[i]->attrs, j);
-                if(!is_attr_inheritable(attr->id)) {
-                    continue;
-                }
-                obj->clz->set_attr(obj, &(state->draw_dsc->dsc), attr);
-            }
-        }
-
-        uint32_t len = lv_array_size(&node->attrs);
-        for(uint32_t i = 0; i < len; i++) {
-            lv_svg_attr_t * attr = lv_array_at(&node->attrs, i);
-            obj->clz->set_attr(obj, &(state->draw_dsc->dsc), attr);
-        }
+    uint32_t len = lv_array_size(&node->attrs);
+    for(uint32_t i = 0; i < len; i++) {
+        lv_svg_attr_t * attr = lv_array_at(&node->attrs, i);
+        obj->clz->set_attr(obj, &(state->draw_dsc->dsc), attr);
     }
     if(node->type == LV_SVG_TAG_G) { /* only <g> need store it */
         state->draw_dsc->fill_ref = obj->fill_ref;


### PR DESCRIPTION
This PR uses a simpler approach to handle inherited attributes. In the SVG Tiny 1.2 standard, only the `<g>` and `<svg>` tags can be parent nodes, and they can contain displayable child nodes. The `<g>` tag already supports the `fill` and `stroke` attributes, as well as inheritance. We only need to modify the code implementing the `<svg>` tag to enable this functionality.

This implementation does not impact performance and has no 10-level maximum backtracking limit.

cc @AndreCostaaa @FASTSHIFT 

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
