### PR TITLE
feat(style): add lv_obj_remove_theme

### DIFF
--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -262,6 +262,17 @@ void lv_obj_remove_style(lv_obj_t * obj, const lv_style_t * style, lv_style_sele
     }
 }
 
+void lv_obj_remove_theme(lv_obj_t * obj)
+{
+    if(obj->style_cnt == 0) return;
+    for(int32_t i = obj->style_cnt - 1; i >= 0; i--) {
+        lv_obj_style_t * s = &obj->styles[i];
+
+        if(s->is_theme) lv_obj_remove_style(obj, s->style, s->selector);
+    }
+
+}
+
 void lv_obj_remove_style_all(lv_obj_t * obj)
 {
     lv_obj_remove_style(obj, NULL, LV_PART_ANY | LV_STATE_ANY);

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -73,6 +73,7 @@ static void fade_in_anim_completed(lv_anim_t * a);
 static bool style_has_flag(const lv_style_t * style, uint32_t flag);
 static lv_style_res_t get_selector_style_prop(const lv_obj_t * obj, lv_style_selector_t selector, lv_style_prop_t prop,
                                               lv_style_value_t * value_act);
+static void remove_style_core(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector, bool theme_only);
 #if LV_USE_OBSERVER
     static void bind_style_observer_cb(lv_observer_t * observer, lv_subject_t * subject);
     static void bind_style_prop_observer_cb(lv_observer_t * observer, lv_subject_t * subject);
@@ -211,66 +212,12 @@ bool lv_obj_replace_style(lv_obj_t * obj, const lv_style_t * old_style, const lv
 
 void lv_obj_remove_style(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector)
 {
-    lv_state_t state = lv_obj_style_get_selector_state(selector);
-    lv_part_t part = lv_obj_style_get_selector_part(selector);
-    lv_style_prop_t prop = LV_STYLE_PROP_ANY;
-    if(style && style->prop_cnt == 0) prop = LV_STYLE_PROP_INV;
-
-    if(style && part == LV_PART_MAIN && style_has_flag(style, LV_STYLE_PROP_FLAG_TRANSFORM)) {
-        lv_obj_invalidate(obj);
-    }
-
-    uint32_t i = 0;
-    bool deleted = false;
-    while(i <  obj->style_cnt) {
-        lv_state_t state_act = lv_obj_style_get_selector_state(obj->styles[i].selector);
-        lv_part_t part_act = lv_obj_style_get_selector_part(obj->styles[i].selector);
-        if((state != LV_STATE_ANY && state_act != state) ||
-           (part != LV_PART_ANY && part_act != part) ||
-           (style != NULL && style != obj->styles[i].style)) {
-            i++;
-            continue;
-        }
-
-        if(obj->styles[i].is_trans) {
-            trans_delete(obj, part, LV_STYLE_PROP_ANY, NULL);
-        }
-
-        if(obj->styles[i].is_local || obj->styles[i].is_trans) {
-            if(obj->styles[i].style) lv_style_reset((lv_style_t *)obj->styles[i].style);
-            lv_free((lv_style_t *)obj->styles[i].style);
-            obj->styles[i].style = NULL;
-        }
-
-        /*Shift the styles after `i` by one*/
-        uint32_t j;
-        for(j = i; j < (uint32_t)obj->style_cnt - 1 ; j++) {
-            obj->styles[j] = obj->styles[j + 1];
-        }
-
-        obj->style_cnt--;
-        obj->styles = lv_realloc(obj->styles, obj->style_cnt * sizeof(lv_obj_style_t));
-
-        deleted = true;
-        /*The style from the current `i` index is removed, so `i` points to the next style.
-         *Therefore it doesn't needs to be incremented*/
-    }
-
-    if(deleted && prop != LV_STYLE_PROP_INV) {
-        full_cache_refresh(obj, part);
-        lv_obj_refresh_style(obj, part, prop);
-    }
+    remove_style_core(obj, style, selector, false);
 }
 
-void lv_obj_remove_theme(lv_obj_t * obj)
+void lv_obj_remove_theme(lv_obj_t * obj, lv_style_selector_t selector)
 {
-    if(obj->style_cnt == 0) return;
-    for(int32_t i = obj->style_cnt - 1; i >= 0; i--) {
-        lv_obj_style_t * s = &obj->styles[i];
-
-        if(s->is_theme) lv_obj_remove_style(obj, s->style, s->selector);
-    }
-
+    remove_style_core(obj, NULL, selector, true);
 }
 
 void lv_obj_remove_style_all(lv_obj_t * obj)
@@ -1308,6 +1255,65 @@ static lv_style_res_t get_selector_style_prop(const lv_obj_t * obj, lv_style_sel
     return LV_STYLE_RES_NOT_FOUND;
 }
 
+static void remove_style_core(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector, bool theme_only)
+{
+    lv_state_t state = lv_obj_style_get_selector_state(selector);
+    lv_part_t part = lv_obj_style_get_selector_part(selector);
+    lv_style_prop_t prop = LV_STYLE_PROP_ANY;
+    if(style && style->prop_cnt == 0) prop = LV_STYLE_PROP_INV;
+
+    if(style && part == LV_PART_MAIN && style_has_flag(style, LV_STYLE_PROP_FLAG_TRANSFORM)) {
+        lv_obj_invalidate(obj);
+    }
+
+    uint32_t i = 0;
+    bool deleted = false;
+    while(i <  obj->style_cnt) {
+        lv_state_t state_act = lv_obj_style_get_selector_state(obj->styles[i].selector);
+        lv_part_t part_act = lv_obj_style_get_selector_part(obj->styles[i].selector);
+        if(theme_only && !obj->styles[i].is_theme) {
+            i++;
+            continue;
+        }
+        if((state != LV_STATE_ANY && state_act != state) ||
+           (part != LV_PART_ANY && part_act != part) ||
+           (style != NULL && style != obj->styles[i].style)) {
+            i++;
+            continue;
+        }
+
+        if(obj->styles[i].is_trans) {
+            trans_delete(obj, part, LV_STYLE_PROP_ANY, NULL);
+        }
+
+        if(obj->styles[i].is_local || obj->styles[i].is_trans) {
+            if(obj->styles[i].style) lv_style_reset((lv_style_t *)obj->styles[i].style);
+            lv_free((lv_style_t *)obj->styles[i].style);
+            obj->styles[i].style = NULL;
+        }
+
+        /*Shift the styles after `i` by one*/
+        uint32_t j;
+        for(j = i; j < (uint32_t)obj->style_cnt - 1 ; j++) {
+            obj->styles[j] = obj->styles[j + 1];
+        }
+
+        obj->style_cnt--;
+        obj->styles = lv_realloc(obj->styles, obj->style_cnt * sizeof(lv_obj_style_t));
+
+        deleted = true;
+        /*The style from the current `i` index is removed, so `i` points to the next style.
+         *Therefore it doesn't needs to be incremented*/
+    }
+
+    if(deleted && prop != LV_STYLE_PROP_INV) {
+        full_cache_refresh(obj, part);
+        lv_obj_refresh_style(obj, part, prop);
+    }
+}
+
+
+
 #if LV_USE_OBSERVER
 
 static void bind_style_observer_cb(lv_observer_t * observer, lv_subject_t * subject)
@@ -1334,5 +1340,6 @@ static void bind_style_prop_observer_cb(lv_observer_t * observer, lv_subject_t *
 
     lv_obj_set_local_style_prop(observer->target, p->prop, style_v, p->selector);
 }
+
 
 #endif /*LV_USE_OBSERVER*/

--- a/src/core/lv_obj_style.h
+++ b/src/core/lv_obj_style.h
@@ -140,9 +140,11 @@ void lv_obj_remove_style(lv_obj_t * obj, const lv_style_t * style, lv_style_sele
 
 /**
  * Remove all styles added by a theme from a widget
+ * @param selector  OR-ed values of states and a part to remove only styles with matching selectors.
+ *                  LV_STATE_ANY and LV_PART_ANY can be used
  * @param obj   pointer to a widget
  */
-void lv_obj_remove_theme(lv_obj_t * obj);
+void lv_obj_remove_theme(lv_obj_t * obj, lv_style_selector_t selector);
 
 /**
  * Remove all styles from an object

--- a/src/core/lv_obj_style.h
+++ b/src/core/lv_obj_style.h
@@ -137,6 +137,13 @@ bool lv_obj_replace_style(lv_obj_t * obj, const lv_style_t * old_style, const lv
  */
 void lv_obj_remove_style(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector);
 
+
+/**
+ * Remove all styles added by a theme from a widget
+ * @param obj   pointer to a widget
+ */
+void lv_obj_remove_theme(lv_obj_t * obj);
+
 /**
  * Remove all styles from an object
  * @param obj       pointer to an object

--- a/src/core/lv_obj_style_private.h
+++ b/src/core/lv_obj_style_private.h
@@ -30,6 +30,7 @@ struct _lv_obj_style_t {
     uint32_t is_local : 1;
     uint32_t is_trans : 1;
     uint32_t is_disabled : 1;
+    uint32_t is_theme : 1;  /**< The style is added by a theme */
 };
 
 struct _lv_obj_style_transition_dsc_t {

--- a/src/themes/lv_theme.c
+++ b/src/themes/lv_theme.c
@@ -8,6 +8,7 @@
  *********************/
 #include "lv_theme_private.h"
 #include "../core/lv_obj_private.h"
+#include "../core/lv_obj_style_private.h"
 #include "../core/lv_obj_class_private.h"
 #include "../../lvgl.h"
 
@@ -133,7 +134,12 @@ void lv_theme_set_external_data(lv_theme_t * theme, void * data, void (* free_cb
 static void apply_theme(lv_theme_t * th, lv_obj_t * obj)
 {
     if(th->parent) apply_theme(th->parent, obj);
-    if(th->apply_cb) th->apply_cb(th, obj);
+    if(th->apply_cb) {
+        th->apply_cb(th, obj);
+        for(uint32_t i = 0; i < obj->style_cnt; i++) {
+            obj->styles[i].is_theme = 1;
+        }
+    }
 }
 
 static void apply_theme_recursion(lv_theme_t * th, lv_obj_t * obj)

--- a/tests/src/test_cases/test_style.c
+++ b/tests/src/test_cases/test_style.c
@@ -232,6 +232,8 @@ void test_style_remove_theme(void)
     lv_obj_set_size(sw, 100, 50);
     lv_obj_set_style_bg_color(sw, lv_color_hex(0xff0000), LV_PART_KNOB);
 
+    TEST_ASSERT_NOT_EQUAL(0, lv_obj_get_style_bg_opa(sw, LV_PART_KNOB));
+
     lv_obj_remove_theme(sw, LV_PART_KNOB);
 
     lv_obj_update_layout(sw);

--- a/tests/src/test_cases/test_style.c
+++ b/tests/src/test_cases/test_style.c
@@ -226,4 +226,23 @@ void test_style_has_prop(void)
     lv_style_reset(&style);
 }
 
+void test_style_remove_theme(void)
+{
+    lv_obj_t * sw = lv_switch_create(lv_screen_active());
+    lv_obj_set_size(sw, 100, 50);
+    lv_obj_set_style_bg_color(sw, lv_color_hex(0xff0000), 0);
+
+    lv_obj_remove_theme(sw);
+
+    lv_obj_update_layout(sw);
+
+    /*Local style props are kept*/
+    TEST_ASSERT_EQUAL(100, lv_obj_get_width(sw));
+    TEST_ASSERT_EQUAL(50, lv_obj_get_height(sw));
+    TEST_ASSERT_EQUAL_COLOR(lv_color_hex(0xff0000), lv_obj_get_style_bg_color(sw, 0));
+
+    /*Bg. opa is back to the default 0*/
+    TEST_ASSERT_EQUAL(0, lv_obj_get_style_bg_opa(sw, 0));
+}
+
 #endif

--- a/tests/src/test_cases/test_style.c
+++ b/tests/src/test_cases/test_style.c
@@ -230,19 +230,21 @@ void test_style_remove_theme(void)
 {
     lv_obj_t * sw = lv_switch_create(lv_screen_active());
     lv_obj_set_size(sw, 100, 50);
-    lv_obj_set_style_bg_color(sw, lv_color_hex(0xff0000), 0);
+    lv_obj_set_style_bg_color(sw, lv_color_hex(0xff0000), LV_PART_KNOB);
 
-    lv_obj_remove_theme(sw);
+    lv_obj_remove_theme(sw, LV_PART_KNOB);
 
     lv_obj_update_layout(sw);
 
-    /*Local style props are kept*/
+    /*Local style props are kept on main*/
     TEST_ASSERT_EQUAL(100, lv_obj_get_width(sw));
     TEST_ASSERT_EQUAL(50, lv_obj_get_height(sw));
-    TEST_ASSERT_EQUAL_COLOR(lv_color_hex(0xff0000), lv_obj_get_style_bg_color(sw, 0));
+
+    /*Local style is kept on the knob*/
+    TEST_ASSERT_EQUAL_COLOR(lv_color_hex(0xff0000), lv_obj_get_style_bg_color(sw, LV_PART_KNOB));
 
     /*Bg. opa is back to the default 0*/
-    TEST_ASSERT_EQUAL(0, lv_obj_get_style_bg_opa(sw, 0));
+    TEST_ASSERT_EQUAL(0, lv_obj_get_style_bg_opa(sw, LV_PART_KNOB));
 }
 
 #endif


### PR DESCRIPTION
`lv_obj_remove_theme` removes all the theme styles only. It is useful if you already added some local styles (even implicitly with `lv_obj_set_width`) and want to start with a clean styling after that. 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
