### PR TITLE
fix(gltf): flip vertically by default

### DIFF
--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -687,7 +687,7 @@ static void lv_draw_opengles_3d(lv_draw_task_t * t, const lv_draw_3d_dsc_t * dsc
     params.disp_h = targ_tex_h;
     params.texture_clip_area = &clip_area;
     params.h_flip = dsc->h_flip;
-    params.v_flip = !dsc->v_flip;
+    params.v_flip = dsc->v_flip;
     params.blend_opt = true;
     lv_opengles_render(&params);
 

--- a/src/libs/gltf/gltf_view/lv_gltf_view.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view.cpp
@@ -634,7 +634,7 @@ static void lv_gltf_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
     view->view_projection_matrix = fastgltf::math::fmat4x4(1.0f);
     view->camera_pos = fastgltf::math::fvec3(0.0f);
     view->texture.h_flip = false;
-    view->texture.v_flip = false;
+    view->texture.v_flip = true;
     new(&view->ibm_by_skin_then_node) std::map<int32_t, std::map<fastgltf::Node *, fastgltf::math::fmat4x4>>;
 
     lv_opengl_shader_portions_t portions;


### PR DESCRIPTION
The model is correctly rendered using draw opengles because we negate `v_flip` but with nanovg the model would be flipped because we weren't negating `v_flip` there. Instead of also provide the same hacky fix in Nanovg, we should just set the glTF flip parameter to true by default and just use v_flip as is in `draw_dsc`