### PR TITLE
fix(gles): transpose lv_matrix_t before uploading to shader

### DIFF
--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -348,14 +348,14 @@ void lv_opengles_render(const lv_opengles_render_params_t * params)
         lv_matrix_scale(&matrix, hor_scale, ver_scale);
     }
 
-    float gl_matrix[9];
-    lv_matrix_get_gl_matrix(&matrix, gl_matrix);
+    lv_matrix_t gl_matrix;
+    lv_matrix_transpose(&matrix, &gl_matrix);
 
     lv_opengles_shader_bind();
     lv_opengles_enable_blending(params->blend_opt);
     lv_opengles_shader_set_uniform1f("u_ColorDepth", LV_COLOR_DEPTH);
     lv_opengles_shader_set_uniform1i("u_Texture", 0);
-    lv_opengles_shader_set_uniformmatrix3fv("u_VertexTransform", 1, gl_matrix);
+    lv_opengles_shader_set_uniformmatrix3fv("u_VertexTransform", 1, (float *)&gl_matrix);
     lv_opengles_shader_set_uniform1f("u_Opa", (float)params->opa / (float)LV_OPA_100);
     lv_opengles_shader_set_uniform1i("u_IsFill", params->texture == 0);
     lv_opengles_shader_set_uniform3f("u_FillColor", (float)params->fill_color.red / 255.0f,

--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -348,11 +348,14 @@ void lv_opengles_render(const lv_opengles_render_params_t * params)
         lv_matrix_scale(&matrix, hor_scale, ver_scale);
     }
 
+    float gl_matrix[9];
+    lv_matrix_get_gl_matrix(&matrix, gl_matrix);
+
     lv_opengles_shader_bind();
     lv_opengles_enable_blending(params->blend_opt);
     lv_opengles_shader_set_uniform1f("u_ColorDepth", LV_COLOR_DEPTH);
     lv_opengles_shader_set_uniform1i("u_Texture", 0);
-    lv_opengles_shader_set_uniformmatrix3fv("u_VertexTransform", 1, (const float *)&matrix);
+    lv_opengles_shader_set_uniformmatrix3fv("u_VertexTransform", 1, gl_matrix);
     lv_opengles_shader_set_uniform1f("u_Opa", (float)params->opa / (float)LV_OPA_100);
     lv_opengles_shader_set_uniform1i("u_IsFill", params->texture == 0);
     lv_opengles_shader_set_uniform3f("u_FillColor", (float)params->fill_color.red / 255.0f,

--- a/src/misc/lv_matrix.c
+++ b/src/misc/lv_matrix.c
@@ -243,6 +243,22 @@ bool lv_matrix_is_identity_or_translation(const lv_matrix_t * matrix)
             matrix->m[2][2] == 1.0f);
 }
 
+void lv_matrix_get_gl_matrix(const lv_matrix_t * matrix, float * out_ptr)
+{
+    /* Unrolled transposition: Row-Major to Column-Major */
+    out_ptr[0] = matrix->m[0][0];
+    out_ptr[1] = matrix->m[1][0];
+    out_ptr[2] = matrix->m[2][0];
+
+    out_ptr[3] = matrix->m[0][1];
+    out_ptr[4] = matrix->m[1][1];
+    out_ptr[5] = matrix->m[2][1];
+
+    out_ptr[6] = matrix->m[0][2];
+    out_ptr[7] = matrix->m[1][2];
+    out_ptr[8] = matrix->m[2][2];
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/misc/lv_matrix.c
+++ b/src/misc/lv_matrix.c
@@ -245,21 +245,37 @@ bool lv_matrix_is_identity_or_translation(const lv_matrix_t * matrix)
 
 void lv_matrix_transpose(const lv_matrix_t * src, lv_matrix_t * dst)
 {
-    lv_matrix_t res;
+    if(src == NULL || dst == NULL) return;
 
-    res.m[0][0] = src->m[0][0];
-    res.m[0][1] = src->m[1][0];
-    res.m[0][2] = src->m[2][0];
+    if(src == dst) {
+        /* In-place transposition: 3 swaps, minimal stack usage */
+        float tmp;
 
-    res.m[1][0] = src->m[0][1];
-    res.m[1][1] = src->m[1][1];
-    res.m[1][2] = src->m[2][1];
+        tmp = dst->m[0][1];
+        dst->m[0][1] = dst->m[1][0];
+        dst->m[1][0] = tmp;
 
-    res.m[2][0] = src->m[0][2];
-    res.m[2][1] = src->m[1][2];
-    res.m[2][2] = src->m[2][2];
+        tmp = dst->m[0][2];
+        dst->m[0][2] = dst->m[2][0];
+        dst->m[2][0] = tmp;
 
-    lv_memcpy(dst, &res, sizeof(lv_matrix_t));
+        tmp = dst->m[1][2];
+        dst->m[1][2] = dst->m[2][1];
+        dst->m[2][1] = tmp;
+    }
+    else {
+        dst->m[0][0] = src->m[0][0];
+        dst->m[0][1] = src->m[1][0];
+        dst->m[0][2] = src->m[2][0];
+
+        dst->m[1][0] = src->m[0][1];
+        dst->m[1][1] = src->m[1][1];
+        dst->m[1][2] = src->m[2][1];
+
+        dst->m[2][0] = src->m[0][2];
+        dst->m[2][1] = src->m[1][2];
+        dst->m[2][2] = src->m[2][2];
+    }
 }
 
 /**********************

--- a/src/misc/lv_matrix.c
+++ b/src/misc/lv_matrix.c
@@ -243,20 +243,23 @@ bool lv_matrix_is_identity_or_translation(const lv_matrix_t * matrix)
             matrix->m[2][2] == 1.0f);
 }
 
-void lv_matrix_get_gl_matrix(const lv_matrix_t * matrix, float * out_ptr)
+void lv_matrix_transpose(const lv_matrix_t * src, lv_matrix_t * dst)
 {
-    /* Unrolled transposition: Row-Major to Column-Major */
-    out_ptr[0] = matrix->m[0][0];
-    out_ptr[1] = matrix->m[1][0];
-    out_ptr[2] = matrix->m[2][0];
+    lv_matrix_t res;
 
-    out_ptr[3] = matrix->m[0][1];
-    out_ptr[4] = matrix->m[1][1];
-    out_ptr[5] = matrix->m[2][1];
+    res.m[0][0] = src->m[0][0];
+    res.m[0][1] = src->m[1][0];
+    res.m[0][2] = src->m[2][0];
 
-    out_ptr[6] = matrix->m[0][2];
-    out_ptr[7] = matrix->m[1][2];
-    out_ptr[8] = matrix->m[2][2];
+    res.m[1][0] = src->m[0][1];
+    res.m[1][1] = src->m[1][1];
+    res.m[1][2] = src->m[2][1];
+
+    res.m[2][0] = src->m[0][2];
+    res.m[2][1] = src->m[1][2];
+    res.m[2][2] = src->m[2][2];
+
+    lv_memcpy(dst, &res, sizeof(lv_matrix_t));
 }
 
 /**********************

--- a/src/misc/lv_matrix.h
+++ b/src/misc/lv_matrix.h
@@ -125,8 +125,9 @@ bool lv_matrix_is_identity_or_translation(const lv_matrix_t * matrix);
 
 /**
  * Transpose a matrix.
- * @param src   pointer to the source matrix
- * @param dst   pointer to the destination matrix to store the result
+ * @param src   pointer to the source matrix. If NULL, the function returns.
+ * @param dst   pointer to the destination matrix. If NULL, the function returns.
+ * Note: src and dst may point to the same matrix for in-place transposition.
  */
 void lv_matrix_transpose(const lv_matrix_t * src, lv_matrix_t * dst);
 

--- a/src/misc/lv_matrix.h
+++ b/src/misc/lv_matrix.h
@@ -123,6 +123,14 @@ bool lv_matrix_is_identity(const lv_matrix_t * matrix);
  */
 bool lv_matrix_is_identity_or_translation(const lv_matrix_t * matrix);
 
+/**
+ * Convert the internal row-major matrix to a column-major flat array.
+ * Required for OpenGLES which expects translation components in the last column of the matrix memory.
+ * @param matrix    pointer to the source lv_matrix_t (row-major)
+ * @param out_ptr   pointer to a float[9] array where the result will be stored
+ */
+void lv_matrix_get_gl_matrix(const lv_matrix_t * matrix, float * out_ptr);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/misc/lv_matrix.h
+++ b/src/misc/lv_matrix.h
@@ -124,12 +124,11 @@ bool lv_matrix_is_identity(const lv_matrix_t * matrix);
 bool lv_matrix_is_identity_or_translation(const lv_matrix_t * matrix);
 
 /**
- * Convert the internal row-major matrix to a column-major flat array.
- * Required for OpenGLES which expects translation components in the last column of the matrix memory.
- * @param matrix    pointer to the source lv_matrix_t (row-major)
- * @param out_ptr   pointer to a float[9] array where the result will be stored
+ * Transpose a matrix.
+ * @param src   pointer to the source matrix
+ * @param dst   pointer to the destination matrix to store the result
  */
-void lv_matrix_get_gl_matrix(const lv_matrix_t * matrix, float * out_ptr);
+void lv_matrix_transpose(const lv_matrix_t * src, lv_matrix_t * dst);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
- revert back to  transposition matrix to ensure column-major array for GLES mat3.

Fixes issue starting from commit 1f46178 of objects being centered when using opengl backend with egl as seen below (tabview example)
<img width="936" height="1013" alt="master" src="https://github.com/user-attachments/assets/58629007-297f-4d0e-ac91-0110d8e3cc8c" />
