### PR TITLE
feat(draw): support dynamic video textures in OpenGLES

### DIFF
--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -530,6 +530,14 @@ static void draw_from_cached_texture(lv_draw_task_t * t)
 
     lv_cache_release(u->texture_cache, entry_cached, u);
 
+    /*Do not cache modifiable images as they might change in the next frame
+     *resulting in stale textures in the cache. */
+    if(t->type == LV_DRAW_TASK_TYPE_IMAGE) {
+        lv_draw_image_dsc_t * img_dsc = (lv_draw_image_dsc_t *)t->draw_dsc;
+        if(img_dsc->header.flags & LV_IMAGE_FLAGS_MODIFIABLE) {
+            lv_cache_drop(u->texture_cache, &data_to_find, u);
+        }
+    }
     /*Do not cache non static (const) texts as the text's pointer can be freed/reallocated
      *at any time resulting in a wild pointer in the cached draw dsc. */
     if(t->type == LV_DRAW_TASK_TYPE_LABEL) {

--- a/src/libs/ffmpeg/lv_ffmpeg.c
+++ b/src/libs/ffmpeg/lv_ffmpeg.c
@@ -208,6 +208,7 @@ lv_result_t lv_ffmpeg_player_set_src(lv_obj_t * obj, const char * path)
     player->imgdsc.data_size = data_size;
     player->imgdsc.header.cf = cf;
     player->imgdsc.header.stride = stride;
+    player->imgdsc.header.flags = LV_IMAGE_FLAGS_MODIFIABLE;
     player->imgdsc.data = data;
 
     lv_image_set_src(&player->img.obj, &(player->imgdsc));
@@ -673,6 +674,7 @@ static int ffmpeg_get_image_header(lv_image_decoder_dsc_t * dsc,
         header->h = video_dec_ctx->height;
         header->cf = has_alpha ? LV_COLOR_FORMAT_ARGB8888 : LV_COLOR_FORMAT_NATIVE;
         header->stride = header->w * lv_color_format_get_size(header->cf);
+        header->flags = LV_IMAGE_FLAGS_MODIFIABLE;
 
         ret = 0;
     }

--- a/src/libs/gstreamer/lv_gstreamer.c
+++ b/src/libs/gstreamer/lv_gstreamer.c
@@ -459,6 +459,7 @@ static void gstreamer_update_frame(lv_gstreamer_t * streamer)
             .header = {
                 .magic = LV_IMAGE_HEADER_MAGIC,
                 .cf = IMAGE_FORMAT,
+                .flags = LV_IMAGE_FLAGS_MODIFIABLE,
                 .h = GST_VIDEO_INFO_HEIGHT(&streamer->video_info),
                 .w = GST_VIDEO_INFO_WIDTH(&streamer->video_info),
                 .stride = GST_VIDEO_INFO_PLANE_STRIDE(&streamer->video_info, 0),


### PR DESCRIPTION
- Mark ffmpeg and gstreamer image headers as LV_IMAGE_FLAGS_MODIFIABLE.
- Force texture cache invalidation in GLES draw task for modifiable images.
- Ensure gstreamer player invalidates the object on frame updates.

Fixes video playback showing only the first frame/cached texture.
<img width="936" height="1013" alt="pr-video" src="https://github.com/user-attachments/assets/9aa27fcd-3b38-4489-bd1c-da8591453cf0" />
