### PR TITLE
docs(wayland): remove server side window decorations promise

### DIFF
--- a/src/drivers/wayland/lv_wayland.c
+++ b/src/drivers/wayland/lv_wayland.c
@@ -17,7 +17,7 @@
 #ifdef LV_WAYLAND_WINDOW_DECORATIONS
     #if LV_WAYLAND_WINDOW_DECORATIONS == 1
         #warning LV_WAYLAND_WINDOW_DECORATIONS has been removed for v9.5. \
-        It's now the user's responsability to generate their own window decorations. See `lv_win`
+        It's now the user's responsibility to generate their own window decorations. See `lv_win`
     #endif
 #endif
 

--- a/src/drivers/wayland/lv_wayland.c
+++ b/src/drivers/wayland/lv_wayland.c
@@ -17,8 +17,7 @@
 #ifdef LV_WAYLAND_WINDOW_DECORATIONS
     #if LV_WAYLAND_WINDOW_DECORATIONS == 1
         #warning LV_WAYLAND_WINDOW_DECORATIONS has been removed for v9.5. \
-        It's now the user's responsability to generate their own window decorations. Server side window decorations will be \
-        added before the v9.5 release.
+        It's now the user's responsability to generate their own window decorations. See `lv_win`
     #endif
 #endif
 


### PR DESCRIPTION
We've decided against this feature after seeing that weston doesn't support it. As it's the most used embedded linux wayland compositor used, we believe that this feature wouldn't be useful enough

https://wayland.app/protocols/xdg-decoration-unstable-v1#compositor-support