### PR TITLE
fix(uefi): add missing trailing newline to driver headers

### DIFF
--- a/src/drivers/uefi/lv_uefi_context.h
+++ b/src/drivers/uefi/lv_uefi_context.h
@@ -69,3 +69,4 @@ void lv_uefi_platform_deinit(void);
 #endif
 
 #endif //__LV_UEFI_CONTEXT_H__
+

--- a/src/drivers/uefi/lv_uefi_display.h
+++ b/src/drivers/uefi/lv_uefi_display.h
@@ -63,3 +63,4 @@ void * lv_uefi_display_get_any(void);
 #endif
 
 #endif //__LV_UEFI_DISPLAY_H__
+

--- a/src/drivers/uefi/lv_uefi_indev.h
+++ b/src/drivers/uefi/lv_uefi_indev.h
@@ -106,3 +106,4 @@ void lv_uefi_simple_text_input_indev_add_all(lv_indev_t * indev);
 #endif
 
 #endif //__LV_UEFI_INDEV_H__
+


### PR DESCRIPTION
Add missing trailing newline at end of file in three UEFI driver headers.

POSIX standard requires text files to end with a newline character. Without it, some compilers and tools emit "No newline at end of file" warnings, and diff tools may show unnecessary noise in future changes.

Changed files:
- src/drivers/uefi/lv_uefi_context.h
- src/drivers/uefi/lv_uefi_indev.h
- src/drivers/uefi/lv_uefi_display.h

No functional changes, formatting only.
No documentation, examples, tests, or config updates needed.