### PR TITLE
fix(thorvg): ensure height is always positive

### DIFF
--- a/src/libs/thorvg/tvgSwRasterTexmap.h
+++ b/src/libs/thorvg/tvgSwRasterTexmap.h
@@ -837,7 +837,7 @@ static AASpans* _AASpans(float ymin, float ymax, const SwImage* image, const SwB
     aaSpans->yEnd = yEnd;
 
     //Initialize X range
-    auto height = yEnd - yStart;
+    auto height = std::abs(yEnd - yStart);
 
     aaSpans->lines = static_cast<AALine*>(lv_malloc(height * sizeof(AALine)));
     LV_ASSERT_MALLOC(aaSpans->lines);


### PR DESCRIPTION
Fixes #9662 

yend - ystart ended up being negative which would underflow and try to allocate a huge amount of memory