### PR TITLE
feat(evdev): add full keyboard support for evdev keypads using xkb

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2150,6 +2150,11 @@ menu "LVGL configuration"
 		config LV_USE_EVDEV
 			bool "Use evdev input driver"
 			default n
+		
+		config LV_EVDEV_XKB
+			bool "Enable full keyboard support via XKB"
+			depends on LV_USE_EVDEV
+			default n
 
 		config LV_USE_LIBINPUT
 			bool "Use libinput input driver"

--- a/docs/src/integration/embedded_linux/drivers/evdev.rst
+++ b/docs/src/integration/embedded_linux/drivers/evdev.rst
@@ -100,3 +100,51 @@ function which will be called when a new device is added.
     }
 
 At the time of writing, this feature is not supported in BSD.
+
+Full Keyboard Support (XKB)
+---------------------------
+
+By default, the evdev driver only supports a limited set of navigation keys (arrows, Enter, Backspace, Tab, etc.).
+To enable full keyboard support including letters, numbers, and modifiers (Shift, Ctrl, Alt), you need to enable XKB.
+
+First, ensure you have the development version of libxkbcommon installed (usually ``libxkbcommon-dev``).
+
+Then enable XKB support in ``lv_conf.h``:
+
+.. code-block:: c
+
+    #define LV_USE_EVDEV       1
+    #define LV_EVDEV_XKB       1
+    #define LV_EVDEV_XKB_KEY_MAP    { .rules = NULL, .model = "pc105", .layout = "us", .variant = NULL, .options = NULL }
+
+The ``LV_EVDEV_XKB_KEY_MAP`` macro defines the default keyboard layout using the XKB rule names structure:
+
+- ``rules``: Rule set (typically ``NULL`` or ``"evdev"``)
+- ``model``: Physical keyboard model (e.g., ``"pc104"``, ``"pc105"``)
+- ``layout``: Language layout (e.g., ``"us"``, ``"gb"``, ``"de"``, ``"fr"``)
+- ``variant``: Layout variant (e.g., ``"dvorak"``, ``"colemak"``, or ``NULL`` for default)
+- ``options``: Extra options (e.g., ``"ctrl:nocaps"`` to make CapsLock act as Ctrl)
+
+To find the right values for your keyboard, you can use:
+
+.. code-block:: console
+
+    $ setxkbmap -query
+
+Changing Keyboard Layout at Runtime
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can change the keyboard layout at runtime using :cpp:func:`lv_evdev_set_keymap`:
+
+.. code-block:: c
+
+    struct xkb_rule_names names = {
+        .rules = NULL,
+        .model = "pc105",
+        .layout = "de",      /* German layout */
+        .variant = NULL,
+        .options = NULL
+    };
+    lv_evdev_set_keymap(keyboard_indev, names);
+
+This can be useful for implementing a keyboard layout selector in your application's settings.

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -1374,6 +1374,15 @@
 /** Driver for evdev input devices */
 #define LV_USE_EVDEV    0
 
+#if LV_USE_EVDEV
+    /** Full keyboard support via XKB */
+    #define LV_EVDEV_XKB             0
+    #if LV_EVDEV_XKB
+        /** "setxkbmap -query" can help find the right values for your keyboard */
+        #define LV_EVDEV_XKB_KEY_MAP { .rules = NULL, .model = "pc101", .layout = "us", .variant = NULL, .options = NULL }
+    #endif
+#endif
+
 /** Driver for libinput input devices */
 #define LV_USE_LIBINPUT    0
 

--- a/src/drivers/evdev/lv_evdev.c
+++ b/src/drivers/evdev/lv_evdev.c
@@ -258,6 +258,7 @@ static void _evdev_read(lv_indev_t * indev, lv_indev_data_t * data)
                      * breaking Shift/Ctrl/Alt tracking. */
                     if(in.value == 2) {
                         /* For repeat events, we do nothing. LVGL handles this already */
+                        data->continue_reading = true;
                         break;
                     }
                     else {
@@ -278,7 +279,6 @@ static void _evdev_read(lv_indev_t * indev, lv_indev_data_t * data)
                     }
                 }
                 else {
-                    LV_LOG_WARN("Key event code: %d, value: %d", in.code, in.value);
                     dsc->key = _evdev_process_key(in.code);
                     if(dsc->key) {
                         dsc->state = in.value ? LV_INDEV_STATE_PRESSED : LV_INDEV_STATE_RELEASED;

--- a/src/drivers/evdev/lv_evdev.c
+++ b/src/drivers/evdev/lv_evdev.c
@@ -35,6 +35,10 @@
 #include "../../widgets/image/lv_image.h"
 #include "../../indev/lv_indev_gesture.h"
 
+#if LV_EVDEV_XKB
+    #include "../libinput/lv_xkb_private.h"
+#endif
+
 /*********************
  *      DEFINES
  *********************/
@@ -68,11 +72,15 @@ typedef struct {
     int key;
     lv_indev_state_t state;
     bool deleting;
+#  if LV_EVDEV_XKB
+    lv_xkb_t xkb_dsc;
+    bool xkb_ready;
+#  endif
     /* Multi-touch support */
-#if LV_USE_GESTURE_RECOGNITION
+#  if LV_USE_GESTURE_RECOGNITION
     lv_indev_touch_data_t touch_data[MAX_TOUCH_POINTS]; /* Array of touch points for gesture recognition */
-    uint8_t touch_count; /* Number of valid touch points */
-    uint8_t current_slot; /* Current touch point slot */
+    uint8_t touch_count;                                /* Number of valid touch points */
+    uint8_t current_slot;                               /* Current touch point slot */
     bool touch_data_changed; /* Flag to indicate if touch data has changed since last SYN_REPORT */
 #endif
 } lv_evdev_t;
@@ -241,12 +249,51 @@ static void _evdev_read(lv_indev_t * indev, lv_indev_data_t * data)
                 else if(in.value == 1) dsc->state = LV_INDEV_STATE_PRESSED;
             }
             else {
+#  if LV_EVDEV_XKB
+                if(dsc->xkb_ready) {
+                    /* evdev key values: 0=release, 1=press, 2=repeat.
+                     * Only forward genuine press/release to xkb_state_update_key;
+                     * repeat events (value==2) must not update XKB modifier state
+                     * or the press count will diverge from the release count,
+                     * breaking Shift/Ctrl/Alt tracking. */
+                    if(in.value == 2) {
+                        /* For repeat events, we do nothing. LVGL handles this already */
+                        break;
+                    }
+                    else {
+                        bool key_down = (in.value == 1);
+                        uint32_t xkb_key = lv_xkb_process_key(&dsc->xkb_dsc, in.code, key_down);
+                        if(xkb_key) {
+                            dsc->key = xkb_key;
+                            dsc->state = in.value ? LV_INDEV_STATE_PRESSED : LV_INDEV_STATE_RELEASED;
+                            data->continue_reading = true;
+                            break;
+                        }
+                        else {
+                            /* Bare modifier (Shift, Ctrl, Alt, etc.) or unmapped key.
+                             * XKB state was already updated inside lv_xkb_process_key.
+                             * Release any currently held key so it doesn't keep repeating. */
+                            dsc->state = LV_INDEV_STATE_RELEASED;
+                        }
+                    }
+                }
+                else {
+                    LV_LOG_WARN("Key event code: %d, value: %d", in.code, in.value);
+                    dsc->key = _evdev_process_key(in.code);
+                    if(dsc->key) {
+                        dsc->state = in.value ? LV_INDEV_STATE_PRESSED : LV_INDEV_STATE_RELEASED;
+                        data->continue_reading = true;
+                        break;
+                    }
+                }
+#  else
                 dsc->key = _evdev_process_key(in.code);
                 if(dsc->key) {
                     dsc->state = in.value ? LV_INDEV_STATE_PRESSED : LV_INDEV_STATE_RELEASED;
                     data->continue_reading = true; /*Keep following events in buffer for now*/
                     break;
                 }
+#  endif
             }
         }
 #if LV_USE_GESTURE_RECOGNITION
@@ -350,6 +397,11 @@ static void _evdev_indev_delete_cb(lv_event_t * e)
     lv_evdev_t * dsc = lv_indev_get_driver_data(indev);
     LV_ASSERT_NULL(dsc);
     lv_async_call_cancel(_evdev_async_delete_cb, indev);
+#  if LV_EVDEV_XKB
+    if(dsc->xkb_ready) {
+        lv_xkb_deinit(&dsc->xkb_dsc);
+    }
+#  endif
     close(dsc->fd);
     lv_free(dsc);
 }
@@ -571,6 +623,19 @@ lv_indev_t * lv_evdev_create_fd(lv_indev_type_t indev_type, int fd)
     lv_indev_set_driver_data(indev, dsc);
     lv_indev_add_event_cb(indev, _evdev_indev_delete_cb, LV_EVENT_DELETE, NULL);
 
+#  if LV_EVDEV_XKB
+    if(indev_type == LV_INDEV_TYPE_KEYPAD) {
+        struct xkb_rule_names names = LV_EVDEV_XKB_KEY_MAP;
+        if(lv_xkb_init(&dsc->xkb_dsc, names)) {
+            dsc->xkb_ready = true;
+            LV_LOG_INFO("XKB keyboard support initialised for evdev");
+        }
+        else {
+            LV_LOG_WARN("XKB init failed, falling back to basic key mapping");
+        }
+    }
+#  endif
+
     return indev;
 
 err_after_malloc:
@@ -667,6 +732,35 @@ void lv_evdev_set_calibration(lv_indev_t * indev, int min_x, int min_y, int max_
     dsc->max_x = max_x;
     dsc->max_y = max_y;
 }
+
+#  if LV_EVDEV_XKB
+bool lv_evdev_set_keymap(lv_indev_t * indev, struct xkb_rule_names names)
+{
+    LV_ASSERT_NULL(indev);
+
+    if(lv_indev_get_type(indev) != LV_INDEV_TYPE_KEYPAD) {
+        LV_LOG_ERROR("Cannot set keymap for non-keypad indev");
+        return false;
+    }
+
+    lv_evdev_t * dsc = lv_indev_get_driver_data(indev);
+    LV_ASSERT_NULL(dsc);
+
+    if(dsc->xkb_ready) {
+        lv_xkb_deinit(&dsc->xkb_dsc);
+        dsc->xkb_ready = false;
+    }
+
+    if(lv_xkb_init(&dsc->xkb_dsc, names)) {
+        dsc->xkb_ready = true;
+        LV_LOG_INFO("XKB keymap updated for evdev");
+        return true;
+    }
+
+    LV_LOG_ERROR("Failed to set XKB keymap for evdev");
+    return false;
+}
+#  endif
 
 void lv_evdev_delete(lv_indev_t * indev)
 {

--- a/src/drivers/evdev/lv_evdev.h
+++ b/src/drivers/evdev/lv_evdev.h
@@ -18,6 +18,10 @@ extern "C" {
 
 #if LV_USE_EVDEV
 
+#   if LV_EVDEV_XKB
+#     include <xkbcommon/xkbcommon.h>
+#endif
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -90,6 +94,18 @@ void lv_evdev_set_swap_axes(lv_indev_t * indev, bool swap_axes);
  * @param max_y pointer coordinate mapped to max y of display
  */
 void lv_evdev_set_calibration(lv_indev_t * indev, int min_x, int min_y, int max_x, int max_y);
+
+#if LV_EVDEV_XKB
+/**
+ * Set the XKB keymap for an evdev keyboard device at runtime.
+ * Can be called at any time to change the keyboard layout.
+ * @param indev evdev input device (must be LV_INDEV_TYPE_KEYPAD)
+ * @param names XKB rule names describing the desired layout
+ *              (use {0} or {.layout="us"} etc.; NULL fields use system defaults)
+ * @return true if the keymap was set successfully
+ */
+bool lv_evdev_set_keymap(lv_indev_t * indev, struct xkb_rule_names names);
+#endif
 
 /**
  * Remove evdev input device.

--- a/src/drivers/evdev/lv_evdev.h
+++ b/src/drivers/evdev/lv_evdev.h
@@ -18,8 +18,8 @@ extern "C" {
 
 #if LV_USE_EVDEV
 
-#   if LV_EVDEV_XKB
-#     include <xkbcommon/xkbcommon.h>
+#if LV_EVDEV_XKB
+#include <xkbcommon/xkbcommon.h>
 #endif
 
 /**********************

--- a/src/drivers/libinput/lv_xkb.c
+++ b/src/drivers/libinput/lv_xkb.c
@@ -9,7 +9,7 @@
 
 #include "lv_xkb_private.h"
 
-#if defined(LV_LIBINPUT_XKB) && LV_LIBINPUT_XKB
+#if (defined(LV_LIBINPUT_XKB) && LV_LIBINPUT_XKB) || (defined(LV_EVDEV_XKB) && LV_EVDEV_XKB)
 
 #include "../../core/lv_group.h"
 #include "../../misc/lv_log.h"
@@ -177,4 +177,4 @@ static bool _set_keymap(lv_xkb_t * dsc, struct xkb_rule_names names)
     return true;
 }
 
-#endif /* defined(LV_LIBINPUT_XKB) && LV_LIBINPUT_XKB */
+#endif /* (defined(LV_LIBINPUT_XKB) && LV_LIBINPUT_XKB) || (defined(LV_EVDEV_XKB) && LV_EVDEV_XKB) */

--- a/src/drivers/libinput/lv_xkb.h
+++ b/src/drivers/libinput/lv_xkb.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #include "../../lv_conf_internal.h"
 
-#if defined(LV_LIBINPUT_XKB) && LV_LIBINPUT_XKB
+#if (defined(LV_LIBINPUT_XKB) && LV_LIBINPUT_XKB) || (defined(LV_EVDEV_XKB) && LV_EVDEV_XKB)
 
 #include "../../misc/lv_types.h"
 #include <stdbool.h>
@@ -55,7 +55,7 @@ uint32_t lv_xkb_process_key(lv_xkb_t * dsc, uint32_t scancode, bool down);
  *      MACROS
  **********************/
 
-#endif /* defined(LV_LIBINPUT_XKB) && LV_LIBINPUT_XKB */
+#endif /* (defined(LV_LIBINPUT_XKB) && LV_LIBINPUT_XKB) || (defined(LV_EVDEV_XKB) && LV_EVDEV_XKB) */
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/drivers/libinput/lv_xkb_private.h
+++ b/src/drivers/libinput/lv_xkb_private.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #include "lv_xkb.h"
 
-#if defined(LV_LIBINPUT_XKB) && LV_LIBINPUT_XKB
+#if (defined(LV_LIBINPUT_XKB) && LV_LIBINPUT_XKB) || (defined(LV_EVDEV_XKB) && LV_EVDEV_XKB)
 
 /*********************
  *      DEFINES
@@ -44,7 +44,7 @@ struct _lv_xkb_t {
  *      MACROS
  **********************/
 
-#endif /* defined(LV_LIBINPUT_XKB) && LV_LIBINPUT_XKB */
+#endif /* (defined(LV_LIBINPUT_XKB) && LV_LIBINPUT_XKB) || (defined(LV_EVDEV_XKB) && LV_EVDEV_XKB) */
 
 #ifdef __cplusplus
 } /*extern "C"*/

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -4375,6 +4375,27 @@
     #endif
 #endif
 
+#if LV_USE_EVDEV
+    /** Full keyboard support via XKB */
+    #ifndef LV_EVDEV_XKB
+        #ifdef CONFIG_LV_EVDEV_XKB
+            #define LV_EVDEV_XKB CONFIG_LV_EVDEV_XKB
+        #else
+            #define LV_EVDEV_XKB             0
+        #endif
+    #endif
+    #if LV_EVDEV_XKB
+        /** "setxkbmap -query" can help find the right values for your keyboard */
+        #ifndef LV_EVDEV_XKB_KEY_MAP
+            #ifdef CONFIG_LV_EVDEV_XKB_KEY_MAP
+                #define LV_EVDEV_XKB_KEY_MAP CONFIG_LV_EVDEV_XKB_KEY_MAP
+            #else
+                #define LV_EVDEV_XKB_KEY_MAP { .rules = NULL, .model = "pc101", .layout = "us", .variant = NULL, .options = NULL }
+            #endif
+        #endif
+    #endif
+#endif
+
 /** Driver for libinput input devices */
 #ifndef LV_USE_LIBINPUT
     #ifdef CONFIG_LV_USE_LIBINPUT


### PR DESCRIPTION
Evdev keyboard inputs now support the full keyboard instead of just some navigation keys.

Updated docs detail the specific usage, it is disabled by default like `lv_libinput`.

Uses XKB (like `lv_libinput`) so it can easily support different keyboard layouts. The `lv_evdev_set_keymap()` function allows changing the keyboard layout at runtime