### PR TITLE
fix(wayland): read and flush compositor events on a timer

### DIFF
--- a/src/drivers/wayland/lv_wayland.c
+++ b/src/drivers/wayland/lv_wayland.c
@@ -52,6 +52,10 @@
  *  STATIC PROTOTYPES
  **********************/
 
+/* Timer callback to process Wayland compositor events without blocking the UI.
+ * We use an independent timer so that we always read and flush compositor events even if LVGL
+ * doesn't need to redraw anything.
+ */
 static void read_compositor_events_timer_cb(lv_timer_t * timer);
 
 static void handle_global(void * data, struct wl_registry * registry, uint32_t name, const char * interface,

--- a/src/drivers/wayland/lv_wayland.c
+++ b/src/drivers/wayland/lv_wayland.c
@@ -223,6 +223,16 @@ static void read_compositor_events_timer_cb(lv_timer_t * timer)
     while(wl_display_prepare_read(lv_wl_ctx.wl_display) != 0) {
         wl_display_dispatch_pending(lv_wl_ctx.wl_display);
     }
+
+    struct pollfd fds = {
+        .fd = wl_display_get_fd(lv_wl_ctx.wl_display),
+        .events = POLLIN,
+    };
+    const bool is_event_ready = poll(&fds, 1, 0) > 0;
+    if(!is_event_ready) {
+        wl_display_cancel_read(lv_wl_ctx.wl_display);
+        return;
+    }
     wl_display_read_events(lv_wl_ctx.wl_display);
     wl_display_dispatch_pending(lv_wl_ctx.wl_display);
 }

--- a/src/drivers/wayland/lv_wayland.c
+++ b/src/drivers/wayland/lv_wayland.c
@@ -185,8 +185,10 @@ void lv_wayland_deinit(void)
         lv_wl_ctx.wl_display = NULL;
     }
 
-    lv_timer_delete(lv_wl_ctx.read_compositor_events_timer);
-    lv_wl_ctx.read_compositor_events_timer = NULL;
+    if(lv_wl_ctx.read_compositor_events_timer) {
+        lv_timer_delete(lv_wl_ctx.read_compositor_events_timer);
+        lv_wl_ctx.read_compositor_events_timer = NULL;
+    }
 
     lv_ll_clear(&lv_wl_ctx.window_ll);
     is_wayland_initialized = false;

--- a/src/drivers/wayland/lv_wayland.c
+++ b/src/drivers/wayland/lv_wayland.c
@@ -29,6 +29,7 @@
 #include <fcntl.h>
 #include <string.h>
 #include <time.h>
+#include <errno.h>
 #include <poll.h>
 #include <sys/mman.h>
 #include <linux/input.h>
@@ -50,6 +51,8 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
+
+static void read_compositor_events_timer_cb(lv_timer_t * timer);
 
 static void handle_global(void * data, struct wl_registry * registry, uint32_t name, const char * interface,
                           uint32_t version);
@@ -139,6 +142,7 @@ lv_result_t lv_wayland_init(void)
     lv_ll_init(&lv_wl_ctx.window_ll, sizeof(lv_wl_window_t));
 
     lv_tick_set_cb(tick_get_cb);
+    lv_wl_ctx.read_compositor_events_timer = lv_timer_create(read_compositor_events_timer_cb, LV_DEF_REFR_PERIOD, NULL);
 
     is_wayland_initialized = true;
     return LV_RESULT_OK;
@@ -177,13 +181,45 @@ void lv_wayland_deinit(void)
         lv_wl_ctx.wl_display = NULL;
     }
 
+    lv_timer_delete(lv_wl_ctx.read_compositor_events_timer);
+    lv_wl_ctx.read_compositor_events_timer = NULL;
+
     lv_ll_clear(&lv_wl_ctx.window_ll);
     is_wayland_initialized = false;
 }
 
+void lv_wayland_flush(void)
+{
+    int ret;
+    while((ret = wl_display_flush(lv_wl_ctx.wl_display)) == -1 && errno == EAGAIN) {
+        struct pollfd pfd = {
+            .fd = wl_display_get_fd(lv_wl_ctx.wl_display),
+            .events = POLLOUT,
+        };
+
+        if(poll(&pfd, 1, -1) == -1) {
+            LV_LOG_ERROR("poll failed: %s", strerror(errno));
+            break;
+        }
+        /* Socket is writable now, loop back and try flush again */
+    }
+}
 /**********************
  *   STATIC FUNCTIONS
  **********************/
+
+static void read_compositor_events_timer_cb(lv_timer_t * timer)
+{
+    LV_UNUSED(timer);
+
+    lv_wayland_flush();
+
+    while(wl_display_prepare_read(lv_wl_ctx.wl_display) != 0) {
+        wl_display_dispatch_pending(lv_wl_ctx.wl_display);
+    }
+    wl_display_read_events(lv_wl_ctx.wl_display);
+    wl_display_dispatch_pending(lv_wl_ctx.wl_display);
+}
 
 static void output_geometry(void * data, struct wl_output * output, int32_t x, int32_t y, int32_t physical_width,
                             int32_t physical_height,

--- a/src/drivers/wayland/lv_wayland.c
+++ b/src/drivers/wayland/lv_wayland.c
@@ -150,6 +150,10 @@ lv_result_t lv_wayland_init(void)
 
 void lv_wayland_deinit(void)
 {
+    if(!is_wayland_initialized) {
+        return;
+    }
+
     lv_wl_window_t * window = NULL;
 
     LV_LL_READ(&lv_wl_ctx.window_ll, window) {

--- a/src/drivers/wayland/lv_wayland_private.h
+++ b/src/drivers/wayland/lv_wayland_private.h
@@ -106,7 +106,7 @@ typedef struct {
     struct xdg_wm_base * xdg_wm;
 
     lv_ll_t window_ll;
-    lv_timer_t * cycle_timer;
+    lv_timer_t * read_compositor_events_timer;
 } lv_wl_ctx_t;
 
 typedef struct {
@@ -165,6 +165,8 @@ extern lv_wl_ctx_t lv_wl_ctx;
 
 lv_result_t lv_wayland_init(void);
 void lv_wayland_deinit(void);
+
+void lv_wayland_flush(void);
 
 /**********************
  *      Window

--- a/src/drivers/wayland/lv_wl_pointer.c
+++ b/src/drivers/wayland/lv_wl_pointer.c
@@ -205,7 +205,6 @@ static void pointer_handle_enter(void * data, struct wl_pointer * pointer, uint3
 
 static void pointer_handle_leave(void * data, struct wl_pointer * pointer, uint32_t serial, struct wl_surface * surface)
 {
-
     LV_UNUSED(data);
     LV_UNUSED(serial);
     LV_UNUSED(surface);
@@ -245,8 +244,6 @@ static void pointer_handle_button(void * data, struct wl_pointer * pointer, uint
     else if(button == BTN_MIDDLE) {
         seat_pointer->wheel_btn_state = lv_state;
     }
-
-
 }
 
 static void pointer_handle_axis(void * data, struct wl_pointer * pointer, uint32_t time, uint32_t axis,

--- a/src/drivers/wayland/lv_wl_window.c
+++ b/src/drivers/wayland/lv_wl_window.c
@@ -323,14 +323,6 @@ static void refr_start_event(lv_event_t * e)
     lv_display_t * display = lv_event_get_target(e);
     lv_wl_window_t * window = lv_display_get_driver_data(display);
 
-    while(wl_display_prepare_read(lv_wl_ctx.wl_display) != 0) {
-        wl_display_dispatch_pending(lv_wl_ctx.wl_display);
-    }
-
-    wl_display_read_events(lv_wl_ctx.wl_display);
-    wl_display_dispatch_pending(lv_wl_ctx.wl_display);
-
-
     if(lv_wayland_xdg_is_resize_pending(window)) {
         lv_wayland_xdg_resize(window);
     }
@@ -339,20 +331,9 @@ static void refr_start_event(lv_event_t * e)
 static void refr_end_event(lv_event_t * e)
 {
     LV_UNUSED(e);
-    int ret;
-    while((ret = wl_display_flush(lv_wl_ctx.wl_display)) == -1 && errno == EAGAIN) {
-        struct pollfd pfd = {
-            .fd = wl_display_get_fd(lv_wl_ctx.wl_display),
-            .events = POLLOUT,
-        };
-
-        if(poll(&pfd, 1, -1) == -1) {
-            LV_LOG_ERROR("poll failed: %s", strerror(errno));
-            break;
-        }
-        /* Socket is writable now, loop back and try flush again */
-    }
+    lv_wayland_flush();
 }
+
 static void res_changed_event(lv_event_t * e)
 {
     lv_display_t * display = (lv_display_t *) lv_event_get_target(e);


### PR DESCRIPTION
The window would stop responding if the UI didn't have to update as REFR_START and REFR_END events wouldn't be sent

This happens on UIs that don't update often