### PR TITLE
feat(gltf): upgrade fastgltf with latest fixes

### DIFF
--- a/docs/src/libs/gltf.rst
+++ b/docs/src/libs/gltf.rst
@@ -141,7 +141,7 @@ The recommended way to integrate the required libraries is using CMake's FetchCo
     FetchContent_Declare(
       fastgltf
       GIT_REPOSITORY https://github.com/spnda/fastgltf
-      GIT_TAG 4e2261350888bae7c35a1f39991f6233d57795f5)
+      GIT_TAG f04052ebd8d157c7b6e8fc3dd9f1ed83df99f3e5)
     set(FASTGLTF_ENABLE_DEPRECATED_EXT
         ON
         CACHE BOOL "" FORCE)

--- a/src/libs/gltf/fastgltf/lv_fastgltf.hpp
+++ b/src/libs/gltf/fastgltf/lv_fastgltf.hpp
@@ -22,75 +22,59 @@
 
 namespace fastgltf
 {
-/**
- * Computes the transform matrix for a given node
- */
-FASTGLTF_EXPORT inline auto getLocalTransformMatrix(const Node& node) {
-	return visit_exhaustive(visitor {
-		[&](const math::fmat4x4& matrix) {
-				return matrix;
-		},
-		[&](const TRS& trs) {
-			/* This may appear backwards, like it is applying the scale last, but it should 
-			 * be first.  However, these operations alter the matrix *in place*, they are *not* 
-			 * matrix multiplications and they should *not* be applied in the standard 
-			 * post-multiplicative order, so this is correct as shown.  This method is used for
-			 * performance reasons, since it uses less multiplications and gets the same results.
-			 * This function is being added to fastgltf and will be removed from this file soon.
-			 */
-			return scale(rotate(translate(math::fmat4x4(), trs.translation), trs.rotation), trs.scale);
-		}
-	}, node.transform);
-}
 
 /**
  * Computes the transform matrix for a given node a different way with less total operations
  */
-FASTGLTF_EXPORT inline auto getFastLocalTransformMatrix(const Node& node) {
-	return visit_exhaustive(visitor {
-		[&](const math::fmat4x4& matrix) {
-				return matrix;
-		},
-		[&](const TRS& trs) {
-			math::fmat4x4 matrix = math::fmat4x4();
-			float sx = trs.scale[0], sy = trs.scale[1], sz = trs.scale[2];
-			float qx = trs.rotation[0], qy = trs.rotation[1], qz = trs.rotation[2], qw = trs.rotation[3];
-			float x2 = qx + qx, y2 = qy + qy, z2 = qz + qz;
-			float xx = qx * x2, xy = qx * y2, xz = qx * z2;
-			float yy = qy * y2, yz = qy * z2, zz = qz * z2;
-			float wx = qw * x2, wy = qw * y2, wz = qw * z2;
-			matrix[0][0] = (1 - (yy + zz)) * sx;
-			matrix[0][1] = (xy + wz) * sx;
-			matrix[0][2] = (xz - wy) * sx;
-			matrix[1][0] = (xy - wz) * sy;
-			matrix[1][1] = (1 - (xx + zz)) * sy;
-			matrix[1][2] = (yz + wx) * sy;
-			matrix[2][0] = (xz + wy) * sz;
-			matrix[2][1] = (yz - wx) * sz;
-			matrix[2][2] = (1 - (xx + yy)) * sz;
-			matrix[3][0] = trs.translation[0];
-			matrix[3][1] = trs.translation[1];
-			matrix[3][2] = trs.translation[2];
-			matrix[0][3] = 0.f;
-			matrix[1][3] = 0.f;
-			matrix[2][3] = 0.f;
-			matrix[3][3] = 1.f;
-			return matrix;
-		}
-	}, node.transform);
+FASTGLTF_EXPORT inline auto getFastLocalTransformMatrix(const Node & node)
+{
+    return visit_exhaustive(visitor {
+        [&](const math::fmat4x4 & matrix)
+        {
+            return matrix;
+        },
+        [&](const TRS & trs)
+        {
+            math::fmat4x4 matrix = math::fmat4x4();
+            float sx = trs.scale[0], sy = trs.scale[1], sz = trs.scale[2];
+            float qx = trs.rotation[0], qy = trs.rotation[1], qz = trs.rotation[2], qw = trs.rotation[3];
+            float x2 = qx + qx, y2 = qy + qy, z2 = qz + qz;
+            float xx = qx * x2, xy = qx * y2, xz = qx * z2;
+            float yy = qy * y2, yz = qy * z2, zz = qz * z2;
+            float wx = qw * x2, wy = qw * y2, wz = qw * z2;
+            matrix[0][0] = (1 - (yy + zz)) * sx;
+            matrix[0][1] = (xy + wz) * sx;
+            matrix[0][2] = (xz - wy) * sx;
+            matrix[1][0] = (xy - wz) * sy;
+            matrix[1][1] = (1 - (xx + zz)) * sy;
+            matrix[1][2] = (yz + wx) * sy;
+            matrix[2][0] = (xz + wy) * sz;
+            matrix[2][1] = (yz - wx) * sz;
+            matrix[2][2] = (1 - (xx + yy)) * sz;
+            matrix[3][0] = trs.translation[0];
+            matrix[3][1] = trs.translation[1];
+            matrix[3][2] = trs.translation[2];
+            matrix[0][3] = 0.f;
+            matrix[1][3] = 0.f;
+            matrix[2][3] = 0.f;
+            matrix[3][3] = 1.f;
+            return matrix;
+        }
+    }, node.transform);
 }
 
 /**
- * Attempts to remove the scale component of a 4x4 matrix transform.  Will silently fail if 
+ * Attempts to remove the scale component of a 4x4 matrix transform.  Will silently fail if
  * any of the component scales is 0 or near zero (which they should never be).
  */
-FASTGLTF_EXPORT inline void removeScale(fastgltf::math::fmat4x4& matrix) {
-	auto scale = math::fvec3( length(matrix.col(0)), length(matrix.col(1)), length(matrix.col(2)) );
-	if ( ( fabs(scale.x()) > 0.00001f) && (fabs(scale.y()) > 0.00001f) && (fabs(scale.z()) > 0.00001f) ) {
-		matrix.col(0) /= scale.x();
-		matrix.col(1) /= scale.y();
-		matrix.col(2) /= scale.z();
-	}
+FASTGLTF_EXPORT inline void removeScale(fastgltf::math::fmat4x4 & matrix)
+{
+    auto scale = math::fvec3(length(matrix.col(0)), length(matrix.col(1)), length(matrix.col(2)));
+    if((fabs(scale.x()) > 0.00001f) && (fabs(scale.y()) > 0.00001f) && (fabs(scale.z()) > 0.00001f)) {
+        matrix.col(0) /= scale.x();
+        matrix.col(1) /= scale.y();
+        matrix.col(2) /= scale.z();
+    }
 }
 
 FASTGLTF_EXPORT template <typename AssetType, typename Callback>

--- a/src/libs/gltf/gltf_view/lv_gltf_view.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view.cpp
@@ -494,7 +494,7 @@ lv_3dray_t lv_gltf_get_ray_from_2d_coordinate(lv_obj_t * obj, const lv_point_t *
 
     lv_3dray_t outray  {{0, 0, 0}, {0, 0, 0}};
 
-    fastgltf::math::fmat4x4 proj_mat = fastgltf::math::invert(fastgltf::math::fmat4x4(viewer->projection_matrix));
+    fastgltf::math::fmat4x4 proj_mat = fastgltf::math::inverse(fastgltf::math::fmat4x4(viewer->projection_matrix));
 
     /* Convert mouse coordinates to NDC */
     float x = norm_mouse_x * 2.0f - 1.0f;
@@ -507,7 +507,7 @@ lv_3dray_t lv_gltf_get_ray_from_2d_coordinate(lv_obj_t * obj, const lv_point_t *
     ray_eye[3] = 0.0f;
 
     /* Calculate ray world direction */
-    fastgltf::math::fvec4 ray_world = fastgltf::math::invert(viewer->view_matrix) * ray_eye;
+    fastgltf::math::fvec4 ray_world = fastgltf::math::inverse(viewer->view_matrix) * ray_eye;
     auto ray_direction = fastgltf::math::normalize(fastgltf::math::fvec3(ray_world[0], ray_world[1], ray_world[2]));
 
     outray.direction = {ray_direction[0], ray_direction[1], ray_direction[2]};

--- a/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_render.cpp
@@ -507,7 +507,7 @@ static void render_skins(lv_gltf_t * viewer, lv_gltf_model_t * model)
 
             lv_memcpy(&texture_data[texture_data_index], final_joint_matrix.data(), sizeof(float) * 16);
             lv_memcpy(&texture_data[texture_data_index + 16],
-                      fastgltf::math::transpose(fastgltf::math::invert(final_joint_matrix)).data(),
+                      fastgltf::math::transpose(fastgltf::math::inverse(final_joint_matrix)).data(),
                       sizeof(float) * 16);
 
             texture_data_index += 32;
@@ -1422,8 +1422,7 @@ static void lv_gltf_view_recache_all_transforms(lv_gltf_model_t * model)
                 fastgltf::math::fmat4x4 cammat = worldmatrix_was_inlined ? inlined_worldmatrix : (parentworldmatrix * localmatrix);
                 fastgltf::removeScale(cammat);
                 model->view_pos = cammat.col(3);  /* Implicit conversion from 4 element column to 3 element vector */
-                model->view_mat = fastgltf::math::invert(cammat);
-
+                model->view_mat = fastgltf::math::inverse(cammat);
             }
         }
     });


### PR DESCRIPTION
The latest version of fastgltf contain some updates to better support older toolchains

While upgrading some breaking changes were made

- `invert` became `inverse`

We also had applied our own version of `getLocalTransformationMatrix` which is now part of upstream so we can get rid of it from our codebase

Docs were updated with new change and I'll also update `lv_port_linux` CMakeLists once this is merged