### PR TITLE
fix(draw/g2d): disable image rendering

### DIFF
--- a/src/draw/nxp/g2d/lv_draw_g2d.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d.c
@@ -201,6 +201,9 @@ static int32_t _g2d_evaluate(lv_draw_unit_t * u, lv_draw_task_t * t)
                 return 1;
             }
         case LV_DRAW_TASK_TYPE_IMAGE: {
+                /* TODO: Fix issue where images rendered to a different layer don't render in the final layer.*/
+                return 0;
+#if 0
                 const lv_draw_image_dsc_t * draw_dsc = (lv_draw_image_dsc_t *) t->draw_dsc;
 
                 if(!_g2d_src_cf_supported(draw_dsc->header.cf))
@@ -214,6 +217,7 @@ static int32_t _g2d_evaluate(lv_draw_unit_t * u, lv_draw_task_t * t)
                     t->preferred_draw_unit_id = DRAW_UNIT_ID_G2D;
                 }
                 return 1;
+#endif
             }
         default:
             return 0;


### PR DESCRIPTION
Images do not show if they're rendered using G2D to a different layer, eg in the case of opa layer

This can be seen in the demo benchmark in the opa layered scene. I tried fixing it but couldn't, as the release is very close this PR disables this feature to make sure it works at least

Related issue: https://github.com/lvgl/lv_port_linux/issues/122

cc @cosmindanielradu19 if you have any idea on how to fix it let me know