### PR TITLE
feat(g2d): remove rotate config

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -423,11 +423,6 @@ menu "LVGL configuration"
 			depends on LV_USE_G2D
 			default y
 
-		config LV_USE_ROTATE_G2D
-			bool "Use G2D to rotate display."
-			depends on LV_USE_G2D
-			default n
-
 		config LV_G2D_HASH_TABLE_SIZE
 			bool "Maximum number of buffers that can be stored for G2D draw unit."
 			default 50

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -296,9 +296,6 @@
     /** Use G2D for drawing. **/
     #define LV_USE_DRAW_G2D 1
 
-    /** Use G2D to rotate display. **/
-    #define LV_USE_ROTATE_G2D 0
-
     /** Maximum number of buffers that can be stored for G2D draw unit.
      *  Includes the frame buffers and assets. */
     #define LV_G2D_HASH_TABLE_SIZE 50

--- a/src/draw/nxp/g2d/lv_draw_buf_g2d.c
+++ b/src/draw/nxp/g2d/lv_draw_buf_g2d.c
@@ -16,7 +16,7 @@
 #include "lv_draw_g2d.h"
 
 #if LV_USE_G2D
-#if LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D
+#if LV_USE_DRAW_G2D
 #include "../../lv_draw_buf_private.h"
 #include "g2d.h"
 #include "lv_g2d_buf_map.h"
@@ -90,5 +90,5 @@ static void _invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * 
     g2d_cache_op(buf, G2D_CACHE_FLUSH);
 }
 
-#endif /*LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D*/
+#endif /*LV_USE_DRAW_G2D*/
 #endif /*LV_USE_G2D*/

--- a/src/draw/nxp/g2d/lv_draw_g2d.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d.c
@@ -358,5 +358,5 @@ static void _g2d_render_thread_cb(void * ptr)
 }
 #endif
 
-#endif /*LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D*/
+#endif /*LV_USE_DRAW_G2D */
 #endif /*LV_USE_G2D*/

--- a/src/draw/nxp/g2d/lv_draw_g2d.h
+++ b/src/draw/nxp/g2d/lv_draw_g2d.h
@@ -23,7 +23,7 @@ extern "C" {
 #include "../../../lv_conf_internal.h"
 
 #if LV_USE_G2D
-#if LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D
+#if LV_USE_DRAW_G2D
 #include "../../sw/lv_draw_sw_private.h"
 
 /*********************
@@ -61,7 +61,7 @@ void lv_draw_g2d_img(lv_draw_task_t * t);
  *      MACROS
  **********************/
 
-#endif /*LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D*/
+#endif /*LV_USE_DRAW_G2D*/
 #endif /*LV_USE_G2D*/
 
 #ifdef __cplusplus

--- a/src/draw/nxp/g2d/lv_g2d_buf_map.c
+++ b/src/draw/nxp/g2d/lv_g2d_buf_map.c
@@ -12,7 +12,7 @@
 #include "lv_g2d_buf_map.h"
 
 #if LV_USE_G2D
-#if LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D
+#if LV_USE_DRAW_G2D
 #include <stdio.h>
 #include "lv_g2d_utils.h"
 #include "g2d.h"
@@ -278,5 +278,5 @@ static void _map_free_list(unsigned long index, lv_array_t * list)
     table->overflow_list[index] = NULL;
 }
 
-#endif /*LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D*/
+#endif /*LV_USE_DRAW_G2D*/
 #endif /*LV_USE_G2D*/

--- a/src/draw/nxp/g2d/lv_g2d_buf_map.h
+++ b/src/draw/nxp/g2d/lv_g2d_buf_map.h
@@ -24,7 +24,7 @@ extern "C" {
 #include "../../../lv_conf_internal.h"
 
 #if LV_USE_G2D
-#if LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D
+#if LV_USE_DRAW_G2D
 
 #include "../../../misc/lv_array.h"
 #include <string.h>
@@ -73,7 +73,7 @@ void g2d_print_table(void);
  *      MACROS
  **********************/
 
-#endif /*LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D*/
+#endif /*LV_USE_DRAW_G2D*/
 #endif /*LV_USE_G2D*/
 
 #ifdef __cplusplus

--- a/src/draw/nxp/g2d/lv_g2d_utils.c
+++ b/src/draw/nxp/g2d/lv_g2d_utils.c
@@ -16,7 +16,7 @@
 #include "lv_g2d_utils.h"
 
 #if LV_USE_G2D
-#if LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D
+#if LV_USE_DRAW_G2D
 #include "lv_g2d_buf_map.h"
 #include "lv_draw_g2d.h"
 
@@ -100,7 +100,6 @@ void * g2d_get_handle(void)
     return g2d_handle;
 }
 
-#if LV_USE_ROTATE_G2D
 void g2d_rotate(lv_draw_buf_t * buf1, lv_draw_buf_t * buf2, int32_t width, int32_t height, uint32_t rotation,
                 lv_color_format_t cf)
 {
@@ -168,11 +167,10 @@ void g2d_rotate(lv_draw_buf_t * buf1, lv_draw_buf_t * buf2, int32_t width, int32
     g2d_blit(handle, &src_surf, &dst_surf);
     g2d_finish(handle);
 }
-#endif
 
 /**********************
 *   STATIC FUNCTIONS
 **********************/
 
-#endif /*LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D*/
+#endif /*LV_USE_DRAW_G2D*/
 #endif /*LV_USE_G2D*/

--- a/src/draw/nxp/g2d/lv_g2d_utils.h
+++ b/src/draw/nxp/g2d/lv_g2d_utils.h
@@ -22,7 +22,7 @@ extern "C" {
 #include "../../../lv_conf_internal.h"
 
 #if LV_USE_G2D
-#if LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D
+#if LV_USE_DRAW_G2D
 #include "../../sw/lv_draw_sw_private.h"
 #include "g2d.h"
 #include "g2dExt.h"
@@ -65,15 +65,13 @@ void g2d_set_handle(void * handle);
 
 void * g2d_get_handle(void);
 
-#if LV_USE_ROTATE_G2D
 void g2d_rotate(lv_draw_buf_t * buf1, lv_draw_buf_t * buf2, int32_t width, int32_t height, uint32_t rotation,
                 lv_color_format_t cf);
-#endif
 /**********************
  *      MACROS
  **********************/
 
-#endif /*LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D*/
+#endif /*LV_USE_DRAW_G2D */
 #endif /*LV_USE_G2D*/
 
 #ifdef __cplusplus

--- a/src/drivers/wayland/lv_wayland_backend_g2d.c
+++ b/src/drivers/wayland/lv_wayland_backend_g2d.c
@@ -46,9 +46,10 @@ typedef struct {
 
 typedef struct {
     lv_wl_buffer_t buffers[LV_WL_G2D_BUF_COUNT];
-#if LV_USE_ROTATE_G2D
+    /* Use a separate buffer if rotation is enabled
+     * Let LVGL render to this buffer and then copy it
+     * and rotate it to one off the two main buffers*/
     lv_wl_buffer_t rotate_buffer;
-#endif
     uint32_t drm_cf;
     uint8_t last_used;
     bool flushing;
@@ -265,7 +266,6 @@ static lv_wl_g2d_display_data_t * wl_g2d_create_display_data(lv_wl_g2d_ctx_t * c
         return NULL;
     }
 
-    lv_display_rotation_t rotation = lv_display_get_rotation(display);
     lv_color_format_t cf = lv_display_get_color_format(display);
     if(cf == LV_COLOR_FORMAT_RGB565 && !ctx->supports_rgb565) {
         LV_LOG_WARN("RGB565 is not supported by the wayland compositor. Falling back to XRGB8888");
@@ -278,14 +278,13 @@ static lv_wl_g2d_display_data_t * wl_g2d_create_display_data(lv_wl_g2d_ctx_t * c
         init_buffer(ctx, &ddata->buffers[i], width, height, cf);
     }
 
-#if LV_USE_ROTATE_G2D
+    lv_display_rotation_t rotation = lv_display_get_rotation(display);
     if(rotation == LV_DISPLAY_ROTATION_90 || rotation == LV_DISPLAY_ROTATION_270) {
         init_buffer(ctx, &ddata->rotate_buffer, height, width, cf);
     }
-    else {
+    else if(rotation == LV_DISPLAY_ROTATION_180) {
         init_buffer(ctx, &ddata->rotate_buffer, width, height, cf);
     }
-#endif
 
     wl_display_flush(lv_wl_ctx.wl_display);
     wl_display_roundtrip(lv_wl_ctx.wl_display);
@@ -297,16 +296,18 @@ static lv_wl_g2d_display_data_t * wl_g2d_create_display_data(lv_wl_g2d_ctx_t * c
         }
     }
 
-#if LV_USE_ROTATE_G2D
+    if(rotation == LV_DISPLAY_ROTATION_0) {
+        lv_display_set_draw_buffers(display, ddata->buffers[0].lv_draw_buf, ddata->buffers[1].lv_draw_buf);
+        return ddata;
+    }
+
+    /*rotation != 0 so use a separate buffer for rendering and two other for flushing*/
     if(!ddata->rotate_buffer.wl_buffer) {
         wl_g2d_delete_display_data(ddata);
         LV_LOG_ERROR("DMABUF creation failed");
         return NULL;
     }
     lv_display_set_draw_buffers(display, ddata->rotate_buffer.lv_draw_buf, NULL);
-#else
-    lv_display_set_draw_buffers(display, ddata->buffers[0].lv_draw_buf, ddata->buffers[1].lv_draw_buf);
-#endif
 
     return ddata;
 }
@@ -317,9 +318,7 @@ static void wl_g2d_delete_display_data(lv_wl_g2d_display_data_t * ddata)
         delete_buffer(ddata->buffers + i);
     }
 
-#if LV_USE_ROTATE_G2D
     delete_buffer(&ddata->rotate_buffer);
-#endif
 
     lv_free(ddata);
 }
@@ -597,10 +596,7 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, unsigned char 
     lv_wl_g2d_display_data_t * ddata = lv_wayland_get_backend_display_data(disp);
     int32_t src_width = lv_area_get_width(area);
     int32_t src_height = lv_area_get_height(area);
-    uint32_t rotation = lv_display_get_rotation(disp);
-#if LV_USE_ROTATE_G2D
-    lv_draw_buf_invalidate_cache(ddata->rotate_buffer.lv_draw_buf, NULL);
-#endif
+    lv_display_rotation_t rotation = lv_display_get_rotation(disp);
 
     struct wl_surface * surface = lv_wayland_get_window_surface(disp);
     /* Mark surface damage */
@@ -619,20 +615,22 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, unsigned char 
     }
 
     lv_draw_buf_invalidate_cache(buf->lv_draw_buf, NULL);
+
     /*Rerender the whole surface if we're using rotation*/
     if(rotation != LV_DISPLAY_ROTATION_0) {
         wl_surface_damage(surface, 0, 0,
                           lv_display_get_original_horizontal_resolution(disp),
                           lv_display_get_original_vertical_resolution(disp));
+
+        lv_draw_buf_invalidate_cache(ddata->rotate_buffer.lv_draw_buf, NULL);
+        g2d_rotate(ddata->rotate_buffer.lv_draw_buf, buf->lv_draw_buf,
+                   lv_display_get_original_horizontal_resolution(disp),
+                   lv_display_get_original_vertical_resolution(disp),
+                   lv_display_get_rotation(disp),
+                   lv_display_get_color_format(disp));
+
     }
 
-#if LV_USE_ROTATE_G2D
-    g2d_rotate(ddata->rotate_buffer.lv_draw_buf, buf->lv_draw_buf,
-               lv_display_get_original_horizontal_resolution(disp),
-               lv_display_get_original_vertical_resolution(disp),
-               lv_display_get_rotation(disp),
-               lv_display_get_color_format(disp));
-#endif
     /* Finally, attach buffer and commit to surface */
     struct wl_callback * cb = wl_surface_frame(surface);
     wl_callback_add_listener(cb, &frame_listener, disp);

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -831,15 +831,6 @@
         #endif
     #endif
 
-    /** Use G2D to rotate display. **/
-    #ifndef LV_USE_ROTATE_G2D
-        #ifdef CONFIG_LV_USE_ROTATE_G2D
-            #define LV_USE_ROTATE_G2D CONFIG_LV_USE_ROTATE_G2D
-        #else
-            #define LV_USE_ROTATE_G2D 0
-        #endif
-    #endif
-
     /** Maximum number of buffers that can be stored for G2D draw unit.
      *  Includes the frame buffers and assets. */
     #ifndef LV_G2D_HASH_TABLE_SIZE

--- a/src/lv_init.c
+++ b/src/lv_init.c
@@ -56,7 +56,7 @@
     #endif
 #endif
 #if LV_USE_G2D
-    #if LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D
+    #if LV_USE_DRAW_G2D
         #include "draw/nxp/g2d/lv_draw_g2d.h"
     #endif
 #endif
@@ -248,7 +248,7 @@ void lv_init(void)
 #endif
 
 #if LV_USE_G2D
-#if LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D
+#if LV_USE_DRAW_G2D
     lv_draw_g2d_init();
 #endif
 #endif
@@ -484,7 +484,7 @@ void lv_deinit(void)
     lv_wayland_deinit();
 #endif
 #if LV_USE_G2D
-#if LV_USE_DRAW_G2D || LV_USE_ROTATE_G2D
+#if LV_USE_DRAW_G2D
     lv_draw_g2d_deinit();
 #endif
 #endif


### PR DESCRIPTION
Simplifies `lv_conf` by removing this config. instead we should just detect at runtime that we require rotation and enable it

Contains changes from #9730 