### PR TITLE
feat(env): always use the C library when building for QNX

### DIFF
--- a/env_support/qnx/common.mk
+++ b/env_support/qnx/common.mk
@@ -34,6 +34,7 @@ $(SRC_ROOT)/libs/rle \
 $(SRC_ROOT)/libs/gif \
 $(SRC_ROOT)/libs/freetype \
 $(SRC_ROOT)/draw \
+$(SRC_ROOT)/draw/convert \
 $(SRC_ROOT)/draw/vg_lite \
 $(SRC_ROOT)/draw/sw \
 $(SRC_ROOT)/draw/sw/arm2d \
@@ -43,7 +44,10 @@ $(SRC_ROOT)/draw/sw/blend/arm2d \
 $(SRC_ROOT)/draw/sw/blend/neon \
 $(SRC_ROOT)/misc \
 $(SRC_ROOT)/misc/cache \
+$(SRC_ROOT)/misc/cache/class \
+$(SRC_ROOT)/misc/cache/instance \
 $(SRC_ROOT)/font \
+$(SRC_ROOT)/font/fmt_txt \
 $(SRC_ROOT)/stdlib \
 $(SRC_ROOT)/stdlib/builtin \
 $(SRC_ROOT)/stdlib/rtthread \

--- a/env_support/qnx/common.mk
+++ b/env_support/qnx/common.mk
@@ -125,3 +125,6 @@ $(PROJECT_ROOT)/lv_conf.h: $(PROJECT_ROOT)/../../lv_conf_template.h
 	sed -i -e "s/#define LV_COLOR_DEPTH 16/#define LV_COLOR_DEPTH 32/" $@
 	sed -i -e "s/#define LV_USE_QNX.*/#define LV_USE_QNX 1/" $@
 	sed -i -e "s/#define LV_QNX_BUF_COUNT.*/#define LV_QNX_BUF_COUNT 2/" $@
+	sed -i -e "s/#define LV_USE_STDLIB_MALLOC.*/#define LV_USE_STDLIB_MALLOC LV_STDLIB_CLIB/" $@
+	sed -i -e "s/#define LV_USE_STDLIB_STRING.*/#define LV_USE_STDLIB_STRING LV_STDLIB_CLIB/" $@
+	sed -i -e "s/#define LV_USE_STDLIB_SPRINTF.*/#define LV_USE_STDLIB_SPRINTF LV_STDLIB_CLIB/" $@


### PR DESCRIPTION
Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

The default build for QNX currently uses the internal LVGL implementation for various C library functions. These are inadequate for the types of systems QNX runs on, and in any case are not needed. Set the generated `lv_conf.h` file always to use the C library for these functions.

Another commit within this pull request also adds some missing directories to the list of sources. These were added since the last time I made changes to the `common.mk` file. Clearly we need a better solution than manually adding directories.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
