### PR TITLE
fix(refr): flag when all tasks are added to screen layers

### DIFF
--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -863,6 +863,7 @@ static void refr_area(const lv_area_t * area_p, int32_t y_offset)
     layer->_clip_area = *area_p;
     layer->phy_clip_area = *area_p;
     layer->partial_y_offset = y_offset;
+	layer->all_tasks_added = false;
 
     if(disp_refr->render_mode == LV_DISPLAY_RENDER_MODE_PARTIAL) {
         /*In partial mode render this area to the buffer*/
@@ -904,6 +905,7 @@ static void refr_area(const lv_area_t * area_p, int32_t y_offset)
 
     if(tile_cnt == 1) {
         refr_configured_layer(layer);
+        layer->all_tasks_added = true;
     }
     else {
         /* Don't draw to the layers buffer of the display but create smaller dummy layers which are using the
@@ -931,6 +933,7 @@ static void refr_area(const lv_area_t * area_p, int32_t y_offset)
             tile_layer->buf_area = layer->buf_area; /*the buffer is still large*/
             tile_layer->draw_buf = layer->draw_buf;
             refr_configured_layer(tile_layer);
+            tile_layer->all_tasks_added = true;
         }
 
 
@@ -955,6 +958,8 @@ static void refr_area(const lv_area_t * area_p, int32_t y_offset)
             if(disp_refr->layer_deinit) disp_refr->layer_deinit(disp_refr, tile_layer);
         }
         lv_free(tile_layers);
+
+        layer->all_tasks_added = true;
     }
 
     disp_refr->refreshed_area = *area_p;

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -863,7 +863,7 @@ static void refr_area(const lv_area_t * area_p, int32_t y_offset)
     layer->_clip_area = *area_p;
     layer->phy_clip_area = *area_p;
     layer->partial_y_offset = y_offset;
-	layer->all_tasks_added = false;
+    layer->all_tasks_added = false;
 
     if(disp_refr->render_mode == LV_DISPLAY_RENDER_MODE_PARTIAL) {
         /*In partial mode render this area to the buffer*/

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -424,6 +424,7 @@ void lv_layer_reset(lv_layer_t * layer)
 #endif
     layer->opa = LV_OPA_COVER;
     layer->recolor = lv_color32_make(0, 0, 0, 0);
+    layer->all_tasks_added = false;
 }
 
 lv_layer_t * lv_draw_layer_create(lv_layer_t * parent_layer, lv_color_format_t color_format, const lv_area_t * area)

--- a/src/draw/snapshot/lv_snapshot.c
+++ b/src/draw/snapshot/lv_snapshot.c
@@ -172,6 +172,8 @@ lv_result_t lv_snapshot_take_to_draw_buf(lv_obj_t * obj, lv_color_format_t cf, l
         }
     }
 
+    layer.all_tasks_added = true;
+
     while(layer.draw_task_head) {
         lv_draw_dispatch_wait_for_request();
         lv_draw_dispatch();

--- a/src/widgets/canvas/lv_canvas.c
+++ b/src/widgets/canvas/lv_canvas.c
@@ -411,6 +411,8 @@ void lv_canvas_finish_layer(lv_obj_t * canvas, lv_layer_t * layer)
         return;
     }
 
+    layer->all_tasks_added = true;
+
     bool task_dispatched;
 
     while(layer->draw_task_head) {


### PR DESCRIPTION
We're preparing a new backend for the new EVE5/BT820 embedded GPU, which supports render targets. The implementation is fully pipelined, so display lists are constructed and dispatched to the GPU while the GPU is still processing previous rendering commands. (Another PR will be opened once that backend is ready, this PR is to address some requirements.)

In the task dispatcher, we flag all tasks as `LV_DRAW_TASK_STATE_QUEUED` (which doesn't seem to be used by any other implementations but appears to work correctly), and then when the last task has been added and all tasks are marked as queued (meaning, all sub-layers have already been rendered to a bitmap, or at least are pipelined to render), the whole list of draw tasks is processed in one shot by the render engine (building display list, and then render) and marked as `FINISHED`.

**One issue that was found is that not all code paths were flagging `layer->all_tasks_added` consistently. This patch fixes that requirement.**

Works well with that fixed. :)

![photo_2026-02-13_06-34-01](https://github.com/user-attachments/assets/a5df3701-f80d-40fa-a9fb-3166b671c6fd)

![photo_2026-02-13_06-33-11](https://github.com/user-attachments/assets/34ef4f5a-4349-48d7-9fe9-79eefbe2a618)