### PR TITLE
fix(cmake): declare `fatfs` as private dependencies

### DIFF
--- a/env_support/cmake/esp.cmake
+++ b/env_support/cmake/esp.cmake
@@ -56,9 +56,9 @@ else()
   endif()
 
 if(${target} STREQUAL "esp32p4")
-  set(IDF_COMPONENTS esp_driver_ppa esp_mm esp_timer log)
+  set(IDF_COMPONENTS esp_driver_ppa esp_mm esp_timer fatfs log)
 else()
-  set(IDF_COMPONENTS esp_timer log)
+  set(IDF_COMPONENTS esp_timer fatfs log)
 endif()
 
   idf_component_register(SRCS ${SOURCES} ${EXAMPLE_SOURCES} ${DEMO_SOURCES}


### PR DESCRIPTION
Declare `fatfs` as private dependencies in the ESP-IDF CMake configuration.

Fixes "ff.h" include errors in lv_fs_fatfs
