### PR TITLE
docs(draw_descriptors):  fix 2 examples missing code

### DIFF
--- a/docs/src/main-modules/draw/draw_descriptors.rst
+++ b/docs/src/main-modules/draw/draw_descriptors.rst
@@ -737,10 +737,10 @@ There are several options to mask parts of a layer, Widget, or drawing:
    By using the Canvas Widget with an :cpp:enumerator:`LV_COLOR_FORMAT_L8` buffer,
    bitmap masks can be rendered dynamically.
 
-.. lv_example:: widgets/canvas/lv_example_label_4
+.. lv_example:: widgets/label/lv_example_label_4
   :language: c
 
-.. lv_example:: widgets/canvas/lv_example_roller_3
+.. lv_example:: widgets/roller/lv_example_roller_3
   :language: c
 
 


### PR DESCRIPTION
At the end of [Draw Descriptors page, Masking Operation section](https://docs.lvgl.io/master/main-modules/draw/draw_descriptors.html#masking-operation) is currently 2 examples that are both not the intended examples, but they are also missing the C code and the [View on GitHub] button.

All that happened was that in the `.rst` file, the path to the example didn't exist.  This PR corrects that.

cc:  @kisvegabor 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
