### PR TITLE
build(esp): only add fatfs component if use_fs_fatfs is enabled

### DIFF
--- a/env_support/cmake/esp.cmake
+++ b/env_support/cmake/esp.cmake
@@ -55,11 +55,15 @@ else()
     set_source_files_properties(${DEMO_MUSIC_SOURCES} COMPILE_FLAGS "-Wno-format")
   endif()
 
-if(${target} STREQUAL "esp32p4")
-  set(IDF_COMPONENTS esp_driver_ppa esp_mm esp_timer fatfs log)
-else()
-  set(IDF_COMPONENTS esp_timer fatfs log)
-endif()
+  set(IDF_COMPONENTS esp_timer log)
+
+  if(${target} STREQUAL "esp32p4")
+    list(APPEND IDF_COMPONENTS esp_driver_ppa esp_mm)
+  endif()
+
+  if(CONFIG_LV_USE_FS_FATFS)
+    list(APPEND IDF_COMPONENTS fatfs)
+  endif()
 
   idf_component_register(SRCS ${SOURCES} ${EXAMPLE_SOURCES} ${DEMO_SOURCES}
       INCLUDE_DIRS ${LVGL_ROOT_DIR} ${LVGL_ROOT_DIR}/src ${LVGL_ROOT_DIR}/../


### PR DESCRIPTION
PR https://github.com/lvgl/lvgl/pull/9742 adds fatfs as a requirement even if it's not necessary.

In reality up until now we have decided that linking these should be handled by the user directly but we're moving forward with automatically linking external dependencies in the next release so we can just go with it properly

cc @FASTSHIFT 