### PR TITLE
revert(canvas): remove api to skip canvas invalidation when setting pixel

### DIFF
--- a/docs/src/widgets/canvas.rst
+++ b/docs/src/widgets/canvas.rst
@@ -71,6 +71,15 @@ To set an individual pixel's color on the Canvas, use
 (``LV_COLOR_FORMAT_I1/2/4/8``) pass the color index as the ``color`` argument by using
 the *blue* channel in the ``color`` value, e.g. :cpp:expr:`lv_color_make(0, 0, index)`.
 
+.. tip::
+
+    To prevent the canvas from being redundantly invalidated for every single pixel update in a loop:
+
+    1. Use :cpp:func:`lv_display_enable_invalidation` to disable intermediate object invalidation
+    2. After the loop is done, re-enable the display invalidation (via :cpp:func:`lv_display_enable_invalidation`)
+    3. With the invalidation re-enabled, call :cpp:func:`lv_obj_invalidate` once.
+
+
 :cpp:expr:`lv_canvas_fill_bg(canvas, lv_color_hex(0x00ff00), LV_OPA_50)` fills the whole
 Canvas to blue with 50% opacity. Note that if the current color format
 doesn't support colors (e.g. :cpp:enumerator:`LV_COLOR_FORMAT_A8`) the color will be

--- a/docs/src/widgets/canvas.rst
+++ b/docs/src/widgets/canvas.rst
@@ -71,15 +71,6 @@ To set an individual pixel's color on the Canvas, use
 (``LV_COLOR_FORMAT_I1/2/4/8``) pass the color index as the ``color`` argument by using
 the *blue* channel in the ``color`` value, e.g. :cpp:expr:`lv_color_make(0, 0, index)`.
 
-.. tip::
-
-    When updating multiple pixels in a loop, follow these steps to improve performance:
-
-    1. Use :cpp:func:`lv_canvas_set_px_skip_invalidate` to set pixel colors without triggering a redraw.
-    2. Call :cpp:func:`lv_obj_invalidate` once after the loop is finished.
-
-    This prevents the canvas from being redundantly invalidated for every single pixel update.
-
 :cpp:expr:`lv_canvas_fill_bg(canvas, lv_color_hex(0x00ff00), LV_OPA_50)` fills the whole
 Canvas to blue with 50% opacity. Note that if the current color format
 doesn't support colors (e.g. :cpp:enumerator:`LV_COLOR_FORMAT_A8`) the color will be

--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -36,7 +36,8 @@ static void layout_update_core(lv_obj_t * obj);
 static void transform_point_array(const lv_obj_t * obj, lv_point_t * p, size_t p_count, bool inv);
 static bool is_transformed(const lv_obj_t * obj);
 static lv_result_t invalidate_area_core(const lv_obj_t * obj, lv_area_t * area_tmp);
-
+static lv_result_t obj_invalidate_area_internal(const lv_display_t * disp, const lv_obj_t * obj,
+                                                const lv_area_t * area);
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -1087,29 +1088,16 @@ lv_result_t lv_obj_invalidate_area(const lv_obj_t * obj, const lv_area_t * area)
     lv_display_t * disp   = lv_obj_get_display(obj);
     if(!lv_display_is_invalidation_enabled(disp)) return LV_RESULT_INVALID;
 
-    lv_area_t area_tmp;
-    lv_area_copy(&area_tmp, area);
-
-    lv_result_t res = invalidate_area_core(obj, &area_tmp);
-    if(res == LV_RESULT_INVALID) return res;
-
-    /*If this area is on a blurred widget, invalidate that widget too*/
-    blur_walk_data_t blur_walk_data;
-    blur_walk_data.requester_obj = obj;
-    blur_walk_data.inv_area = &area_tmp;
-    lv_obj_tree_walk(disp->act_scr, blur_walk_cb, &blur_walk_data);
-    if(disp->prev_scr) lv_obj_tree_walk(disp->prev_scr, blur_walk_cb, &blur_walk_data);
-    lv_obj_tree_walk(disp->sys_layer, blur_walk_cb, &blur_walk_data);
-    lv_obj_tree_walk(disp->top_layer, blur_walk_cb, &blur_walk_data);
-    lv_obj_tree_walk(disp->bottom_layer, blur_walk_cb, &blur_walk_data);
-
-    return res;
+    return obj_invalidate_area_internal(disp, obj, area);
 }
 
 
 lv_result_t lv_obj_invalidate(const lv_obj_t * obj)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_display_t * disp = lv_obj_get_display(obj);
+    if(!lv_display_is_invalidation_enabled(disp)) return LV_RESULT_INVALID;
 
     /*Truncate the area to the object*/
     lv_area_t obj_coords;
@@ -1120,7 +1108,7 @@ lv_result_t lv_obj_invalidate(const lv_obj_t * obj)
     obj_coords.x2 += ext_size;
     obj_coords.y2 += ext_size;
 
-    lv_result_t res = lv_obj_invalidate_area(obj, &obj_coords);
+    lv_result_t res = obj_invalidate_area_internal(disp, obj, &obj_coords);
 
     return res;
 }
@@ -1326,6 +1314,32 @@ const lv_matrix_t * lv_obj_get_transform(const lv_obj_t * obj)
 /**********************
  *   STATIC FUNCTIONS
  **********************/
+
+static lv_result_t obj_invalidate_area_internal(const lv_display_t * disp, const lv_obj_t * obj,
+                                                const lv_area_t * area)
+{
+    LV_ASSERT_NULL(disp);
+    LV_ASSERT_NULL(obj);
+    LV_ASSERT_NULL(area);
+
+    lv_area_t area_tmp;
+    lv_area_copy(&area_tmp, area);
+
+    lv_result_t res = invalidate_area_core(obj, &area_tmp);
+    if(res == LV_RESULT_INVALID) return res;
+
+    /*If this area is on a blurred widget, invalidate that widget too*/
+    blur_walk_data_t blur_walk_data;
+    blur_walk_data.requester_obj = obj;
+    blur_walk_data.inv_area = &area_tmp;
+    lv_obj_tree_walk(disp->act_scr, blur_walk_cb, &blur_walk_data);
+    if(disp->prev_scr) lv_obj_tree_walk(disp->prev_scr, blur_walk_cb, &blur_walk_data);
+    lv_obj_tree_walk(disp->sys_layer, blur_walk_cb, &blur_walk_data);
+    lv_obj_tree_walk(disp->top_layer, blur_walk_cb, &blur_walk_data);
+    lv_obj_tree_walk(disp->bottom_layer, blur_walk_cb, &blur_walk_data);
+
+    return res;
+}
 
 static bool is_transformed(const lv_obj_t * obj)
 {

--- a/src/widgets/canvas/lv_canvas.c
+++ b/src/widgets/canvas/lv_canvas.c
@@ -108,7 +108,7 @@ void lv_canvas_set_draw_buf(lv_obj_t * obj, lv_draw_buf_t * draw_buf)
     lv_image_cache_drop(draw_buf);
 }
 
-void lv_canvas_set_px_skip_invalidate(lv_obj_t * obj, int32_t x, int32_t y, lv_color_t color, lv_opa_t opa)
+void lv_canvas_set_px(lv_obj_t * obj, int32_t x, int32_t y, lv_color_t color, lv_opa_t opa)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
@@ -182,11 +182,6 @@ void lv_canvas_set_px_skip_invalidate(lv_obj_t * obj, int32_t x, int32_t y, lv_c
         buf->lumi = lv_color_luminance(color);
         buf->alpha = 255;
     }
-}
-
-void lv_canvas_set_px(lv_obj_t * obj, int32_t x, int32_t y, lv_color_t color, lv_opa_t opa)
-{
-    lv_canvas_set_px_skip_invalidate(obj, x, y, color, opa);
     lv_obj_invalidate(obj);
 }
 

--- a/src/widgets/canvas/lv_canvas.h
+++ b/src/widgets/canvas/lv_canvas.h
@@ -81,6 +81,10 @@ void lv_canvas_set_draw_buf(lv_obj_t * obj, lv_draw_buf_t * draw_buf);
  *              LV_COLOR_FORMAT_I1/2/4/8, LV_COLOR_FORMAT_A8,
  *              LV_COLOR_FORMAT_RGB565, LV_COLOR_FORMAT_RGB888,
  *              LV_COLOR_FORMAT_XRGB8888, LV_COLOR_FORMAT_ARGB8888
+ * @note    this function invalidates the canvas object every time,
+ *      for best performance, if you're changing a lot of pixels in a loop,
+ *      call `lv_display_enable_invalidation` before the loop starts
+ *      so the invalidation isn't done on every call
  */
 void lv_canvas_set_px(lv_obj_t * obj, int32_t x, int32_t y, lv_color_t color, lv_opa_t opa);
 

--- a/src/widgets/canvas/lv_canvas.h
+++ b/src/widgets/canvas/lv_canvas.h
@@ -85,22 +85,6 @@ void lv_canvas_set_draw_buf(lv_obj_t * obj, lv_draw_buf_t * draw_buf);
 void lv_canvas_set_px(lv_obj_t * obj, int32_t x, int32_t y, lv_color_t color, lv_opa_t opa);
 
 /**
- * Set a pixel's color and opacity without invalidating the canvas object
- * In order for the canvas to be redrawn, the user is required to manually call `lv_obj_invalidate`
- *
- * @param obj   pointer to a canvas
- * @param x     X coordinate of the pixel
- * @param y     Y coordinate of the pixel
- * @param color the color
- * @param opa   the opacity
- * @note        The following color formats are supported
- *              LV_COLOR_FORMAT_I1/2/4/8, LV_COLOR_FORMAT_A8,
- *              LV_COLOR_FORMAT_RGB565, LV_COLOR_FORMAT_RGB888,
- *              LV_COLOR_FORMAT_XRGB8888, LV_COLOR_FORMAT_ARGB8888
- */
-void lv_canvas_set_px_skip_invalidate(lv_obj_t * obj, int32_t x, int32_t y, lv_color_t color, lv_opa_t opa);
-
-/**
  * Set the palette color of a canvas for index format. Valid only for `LV_COLOR_FORMAT_I1/2/4/8`
  * @param obj       pointer to canvas object
  * @param index     the palette color to set:

--- a/tests/src/test_cases/widgets/test_canvas.c
+++ b/tests/src/test_cases/widgets/test_canvas.c
@@ -69,10 +69,6 @@ void test_canvas_functions_invalidate(void)
     lv_refr_now(NULL);
     TEST_ASSERT(draw_counter == 2);
 
-    lv_canvas_set_px_skip_invalidate(canvas, 0, 0, lv_color_black(), LV_OPA_COVER);
-    lv_refr_now(NULL);
-    TEST_ASSERT(draw_counter == 2);
-
     lv_canvas_fill_bg(canvas, lv_color_black(), LV_OPA_COVER);
     lv_refr_now(NULL);
     TEST_ASSERT(draw_counter == 3);


### PR DESCRIPTION
Reverts #9592 as there's already an easy solution for https://github.com/lvgl/lvgl/issues/9581

cc @AndyEveritt 