### PR TITLE
fix(blur): render non-backdrop blur when the main rendering is done

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -695,6 +695,11 @@ static void lv_obj_draw(lv_event_t * e)
         lv_draw_rect_dsc_init(&draw_dsc);
         draw_dsc.base.layer = layer;
 
+        int32_t w = lv_obj_get_style_transform_width(obj, LV_PART_MAIN);
+        int32_t h = lv_obj_get_style_transform_height(obj, LV_PART_MAIN);
+        lv_area_t coords;
+        lv_area_copy(&coords, &obj->coords);
+        lv_area_increase(&coords, w, h);
 
         bool backdrop_blur = lv_obj_get_style_blur_backdrop(obj, LV_PART_MAIN);
         if(backdrop_blur) {
@@ -703,7 +708,7 @@ static void lv_obj_draw(lv_event_t * e)
             lv_obj_init_draw_blur_dsc(obj, LV_PART_MAIN, &blur_dsc);
             blur_dsc.corner_radius = draw_dsc.radius;
             blur_dsc.base.layer = layer;
-            lv_draw_blur(layer, &blur_dsc, &obj->coords);
+            lv_draw_blur(layer, &blur_dsc, &coords);
         }
 
         lv_obj_init_draw_rect_dsc(obj, LV_PART_MAIN, &draw_dsc);
@@ -712,11 +717,6 @@ static void lv_obj_draw(lv_event_t * e)
             draw_dsc.border_post = 1;
         }
 
-        int32_t w = lv_obj_get_style_transform_width(obj, LV_PART_MAIN);
-        int32_t h = lv_obj_get_style_transform_height(obj, LV_PART_MAIN);
-        lv_area_t coords;
-        lv_area_copy(&coords, &obj->coords);
-        lv_area_increase(&coords, w, h);
 
         lv_draw_rect(layer, &draw_dsc, &coords);
     }
@@ -725,12 +725,18 @@ static void lv_obj_draw(lv_event_t * e)
         lv_layer_t * layer = lv_event_get_layer(e);
         bool backdrop_blur = lv_obj_get_style_blur_backdrop(obj, LV_PART_MAIN);
         if(!backdrop_blur) {
+            int32_t w = lv_obj_get_style_transform_width(obj, LV_PART_MAIN);
+            int32_t h = lv_obj_get_style_transform_height(obj, LV_PART_MAIN);
+            lv_area_t coords;
+            lv_area_copy(&coords, &obj->coords);
+            lv_area_increase(&coords, w, h);
+
             lv_draw_blur_dsc_t blur_dsc;
             lv_draw_blur_dsc_init(&blur_dsc);
             lv_obj_init_draw_blur_dsc(obj, LV_PART_MAIN, &blur_dsc);
             blur_dsc.corner_radius = lv_obj_get_style_radius(obj, LV_PART_MAIN);
             blur_dsc.base.layer = layer;
-            lv_draw_blur(layer, &blur_dsc, &obj->coords);
+            lv_draw_blur(layer, &blur_dsc, &coords);
         }
     }
     else if(code == LV_EVENT_DRAW_POST) {

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -695,14 +695,16 @@ static void lv_obj_draw(lv_event_t * e)
         lv_draw_rect_dsc_init(&draw_dsc);
         draw_dsc.base.layer = layer;
 
-        lv_draw_blur_dsc_t blur_dsc;
-        lv_draw_blur_dsc_init(&blur_dsc);
-        blur_dsc.corner_radius = draw_dsc.radius;
 
-        bool backdrop_blur = lv_obj_get_style_blur_backdrop(obj, LV_PART_INDICATOR);
-        lv_obj_init_draw_blur_dsc(obj, LV_PART_MAIN, &blur_dsc);
-        blur_dsc.base.layer = layer;
-        if(backdrop_blur) lv_draw_blur(layer, &blur_dsc, &obj->coords);
+        bool backdrop_blur = lv_obj_get_style_blur_backdrop(obj, LV_PART_MAIN);
+        if(backdrop_blur) {
+            lv_draw_blur_dsc_t blur_dsc;
+            lv_draw_blur_dsc_init(&blur_dsc);
+            lv_obj_init_draw_blur_dsc(obj, LV_PART_MAIN, &blur_dsc);
+            blur_dsc.corner_radius = draw_dsc.radius;
+            blur_dsc.base.layer = layer;
+            lv_draw_blur(layer, &blur_dsc, &obj->coords);
+        }
 
         lv_obj_init_draw_rect_dsc(obj, LV_PART_MAIN, &draw_dsc);
         /*If the border is drawn later disable loading its properties*/
@@ -717,9 +719,19 @@ static void lv_obj_draw(lv_event_t * e)
         lv_area_increase(&coords, w, h);
 
         lv_draw_rect(layer, &draw_dsc, &coords);
-
-        blur_dsc.blur_radius = lv_obj_get_style_blur_radius(obj, LV_PART_MAIN);
-        if(!backdrop_blur) lv_draw_blur(layer, &blur_dsc, &coords);
+    }
+    else if(code == LV_EVENT_DRAW_MAIN_END) {
+        /*Draw the non backdrop blur when the main content is rendered the the children are not yet */
+        lv_layer_t * layer = lv_event_get_layer(e);
+        bool backdrop_blur = lv_obj_get_style_blur_backdrop(obj, LV_PART_MAIN);
+        if(!backdrop_blur) {
+            lv_draw_blur_dsc_t blur_dsc;
+            lv_draw_blur_dsc_init(&blur_dsc);
+            lv_obj_init_draw_blur_dsc(obj, LV_PART_MAIN, &blur_dsc);
+            blur_dsc.corner_radius = lv_obj_get_style_radius(obj, LV_PART_MAIN);
+            blur_dsc.base.layer = layer;
+            lv_draw_blur(layer, &blur_dsc, &obj->coords);
+        }
     }
     else if(code == LV_EVENT_DRAW_POST) {
         lv_layer_t * layer = lv_event_get_layer(e);
@@ -1021,7 +1033,8 @@ static void lv_obj_event(const lv_obj_class_t * class_p, lv_event_t * e)
         int32_t d = lv_obj_calculate_ext_draw_size(obj, LV_PART_MAIN);
         lv_event_set_ext_draw_size(e, d);
     }
-    else if(code == LV_EVENT_DRAW_MAIN || code == LV_EVENT_DRAW_POST || code == LV_EVENT_COVER_CHECK) {
+    else if(code == LV_EVENT_DRAW_MAIN || code == LV_EVENT_DRAW_POST || code == LV_EVENT_DRAW_MAIN_END ||
+            code == LV_EVENT_COVER_CHECK) {
         lv_obj_draw(e);
     }
     else if(code == LV_EVENT_INDEV_RESET) {


### PR DESCRIPTION

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
