### PR TITLE
build(make): add missing src/draw/sw to COMPONENT_SRCDIRS

### DIFF
--- a/component.mk
+++ b/component.mk
@@ -4,6 +4,7 @@ COMPONENT_SRCDIRS := . \
                   src \
                   src/core \
                   src/draw \
+                  src/draw/sw \
                   src/extra \
                   src/font \
                   src/gpu \


### PR DESCRIPTION
### Description of the feature or fix

Fixes undefined reference to `lv_draw_sw_init_ctx` when compiling LVGL with ESP8266 RTOS SDK (make-based build system).

The software renderer source files in `src/draw/sw/` were not included in `COMPONENT_SRCDIRS`, causing linker errors on ESP8266 and other ESP-IDF make-based projects.

Fixes #XXXX (if there's an existing issue)

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder
- [x] Update the [documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable

### Notes
- This fix only affects make-based build systems (CMake already includes src/draw/sw)
- ESP8266 RTOS SDK uses the legacy make system, not CMake
- No functional changes, only build system fix