### PR TITLE
fix(draw/nanovg): use core_area for box shadow gradient

### DIFF
--- a/src/draw/nanovg/lv_draw_nanovg_box_shadow.c
+++ b/src/draw/nanovg/lv_draw_nanovg_box_shadow.c
@@ -68,17 +68,19 @@ void lv_draw_nanovg_box_shadow(lv_draw_task_t * t, const lv_draw_box_shadow_dsc_
     const NVGcolor icol = lv_nanovg_color_convert(dsc->color, dsc->opa);
     const NVGcolor ocol = lv_nanovg_color_convert(lv_color_black(), 0);
 
-    const int32_t w = lv_area_get_width(&shadow_area);
-    const int32_t h = lv_area_get_height(&shadow_area);
+    const int32_t core_w = lv_area_get_width(&core_area);
+    const int32_t core_h = lv_area_get_height(&core_area);
+    const int32_t shadow_w = lv_area_get_width(&shadow_area);
+    const int32_t shadow_h = lv_area_get_height(&shadow_area);
 
     NVGpaint paint = nvgBoxGradient(
                          u->vg,
-                         shadow_area.x1, shadow_area.y1,
-                         w, h,
+                         core_area.x1, core_area.y1,
+                         core_w, core_h,
                          dsc->radius, dsc->width, icol, ocol);
 
     nvgBeginPath(u->vg);
-    lv_nanovg_path_append_rect(u->vg, shadow_area.x1, shadow_area.y1, w, h, dsc->radius);
+    lv_nanovg_path_append_rect(u->vg, shadow_area.x1, shadow_area.y1, shadow_w, shadow_h, dsc->radius);
     nvgFillPaint(u->vg, paint);
     nvgFill(u->vg);
 


### PR DESCRIPTION
This PR fixes a bug with the new NanoVG box shadow renderer.

The current implementation passes `shadow_area` to `nvgBoxGradient()`
for both the gradient rectangle and the fill path. This causes the gradient's
outer fade to be clipped by the fill path, producing a hard visible edge instead
of a smooth fade to transparent.

To fix this, we can pass the `core_area` dimensions instead, while keeping the fill path on the full `shadow_area`.

Screenshots from my Raspberry Pi 5 (standard PiOS install, labwc/Wayland).

[
<img width="680" height="200" alt="LVGL-NanoVG-DropShadow-Issue" src="https://github.com/user-attachments/assets/706485d8-6fb9-4210-8e6c-084ebac5f851" />
](url)

![NanoVG_Issue](https://github.com/user-attachments/assets/00c38f5d-e4b5-4dc0-9250-7b1bc4237533)

As you can see in the sample screenshots, this still yields a different result to what we get from the software renderer, which creates a more complex (and arguably, more pleasing) gradient. However, since mimicking that would require more in-depth changes to the shaders themselves, I'd suggest this simple fix first.