### PR TITLE
fix(theme): add missing focus outline to arc and calendar widgets

### DIFF
--- a/src/themes/default/lv_theme_default.c
+++ b/src/themes/default/lv_theme_default.c
@@ -1004,6 +1004,8 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj)
         lv_obj_add_style(obj, &theme->styles.arc_indic, LV_PART_INDICATOR);
         lv_obj_add_style(obj, &theme->styles.arc_indic_primary, LV_PART_INDICATOR);
         lv_obj_add_style(obj, &theme->styles.knob, LV_PART_KNOB);
+        lv_obj_add_style(obj, &theme->styles.outline_primary, LV_STATE_FOCUS_KEY);
+        lv_obj_add_style(obj, &theme->styles.outline_secondary, LV_STATE_EDITED);
     }
 #endif
 
@@ -1033,6 +1035,8 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj)
     else if(lv_obj_check_type(obj, &lv_calendar_class)) {
         lv_obj_add_style(obj, &theme->styles.card, 0);
         lv_obj_add_style(obj, &theme->styles.pad_zero, 0);
+        lv_obj_add_style(obj, &theme->styles.outline_primary, LV_STATE_FOCUS_KEY);
+        lv_obj_add_style(obj, &theme->styles.outline_secondary, LV_STATE_EDITED);
     }
 
 #if LV_USE_CALENDAR_HEADER_ARROW


### PR DESCRIPTION
## Summary

The default theme applies `outline_primary` for `LV_STATE_FOCUS_KEY` to most interactive widgets (buttons, sliders, checkboxes, dropdowns, tables, textareas, etc.) but omits it for `lv_arc` and `lv_calendar`. This makes these widgets invisible to keyboard/encoder navigation — they receive focus but show no visual indicator.

This PR adds `outline_primary` (FOCUS_KEY) and `outline_secondary` (EDITED) styles to both widget classes, matching the pattern used by all other focusable widgets in the theme.

## Changes

- **`lv_arc_class`**: Added `outline_primary` for `LV_STATE_FOCUS_KEY` and `outline_secondary` for `LV_STATE_EDITED`
- **`lv_calendar_class`**: Same addition

The calendar's inner `lv_buttonmatrix` already has its own focus outline (line 849), but the outer `lv_calendar` container — which is what receives group focus when navigating with keyboard/encoder — had none.

## How to reproduce

1. Add a calendar or arc widget to a group
2. Navigate to it with keyboard (Tab / arrow keys)
3. **Before this fix**: No visual focus indicator appears
4. **After this fix**: Primary-color outline ring appears, matching other widgets