### PR TITLE
fix(gstreamer): prevent memory leak when updating video frames

### DIFF
--- a/src/libs/gstreamer/lv_gstreamer.c
+++ b/src/libs/gstreamer/lv_gstreamer.c
@@ -389,13 +389,15 @@ static void lv_gstreamer_constructor(const lv_obj_class_t * class_p, lv_obj_t * 
     LV_TRACE_OBJ_CREATE("begin");
     lv_gstreamer_t * streamer = (lv_gstreamer_t *)obj;
     lv_memzero(&streamer->frame, sizeof(streamer->frame));
+    streamer->pixel_buffer = NULL;
+    streamer->pixel_buffer_size = 0;
+    streamer->image_src_set = false;
 
     streamer->gstreamer_timer = lv_timer_create(gstreamer_timer_cb, LV_DEF_REFR_PERIOD / 5, streamer);
     LV_ASSERT_NULL(streamer->gstreamer_timer);
 
     streamer->frame_queue = g_async_queue_new();
     LV_ASSERT_NULL(streamer->frame_queue);
-    streamer->last_sample = NULL;
 
     LV_TRACE_OBJ_CREATE("finished");
 }
@@ -461,37 +463,57 @@ static void gstreamer_update_frame(lv_gstreamer_t * streamer)
         streamer->is_video_info_valid = true;
     }
 
-
     GstBuffer * buffer = gst_sample_get_buffer(sample);
     GstMapInfo map;
-    if(buffer && gst_buffer_map(buffer, &map, GST_MAP_READ)) {
-        if(streamer->last_buffer) {
-            gst_buffer_unmap(streamer->last_buffer, &streamer->last_map_info);
-        }
-        if(streamer->last_sample) {
-            gst_sample_unref(streamer->last_sample);
-        }
-        streamer->last_buffer = buffer;
-        streamer->last_map_info = map;
 
-        streamer->last_sample = sample;
-
-        streamer->frame = (lv_image_dsc_t) {
-            .data = map.data,
-            .data_size = map.size,
-            .header = {
-                .magic = LV_IMAGE_HEADER_MAGIC,
-                .cf = IMAGE_FORMAT,
-                .flags = LV_IMAGE_FLAGS_MODIFIABLE,
-                .h = GST_VIDEO_INFO_HEIGHT(&streamer->video_info),
-                .w = GST_VIDEO_INFO_WIDTH(&streamer->video_info),
-                .stride = GST_VIDEO_INFO_PLANE_STRIDE(&streamer->video_info, 0),
-            }
-        };
-        lv_image_set_src((lv_obj_t *)streamer, &streamer->frame);
+    if(!buffer || !gst_buffer_map(buffer, &map, GST_MAP_READ)) {
+        gst_sample_unref(sample);
+        return;
     }
-    /* We send the event AFTER setting the image source so that users can query the
-     * resolution on this specific event callback */
+
+    uint32_t width  = GST_VIDEO_INFO_WIDTH(&streamer->video_info);
+    uint32_t height = GST_VIDEO_INFO_HEIGHT(&streamer->video_info);
+    uint32_t stride = GST_VIDEO_INFO_PLANE_STRIDE(&streamer->video_info, 0);
+    size_t required_size = map.size;
+
+    // Update pixel buffer once and on resolution change
+    if(streamer->pixel_buffer == NULL || streamer->pixel_buffer_size != required_size) {
+
+        if(streamer->pixel_buffer) {
+            free(streamer->pixel_buffer);
+            streamer->pixel_buffer = NULL;
+        }
+
+        streamer->pixel_buffer = malloc(required_size);
+        if(!streamer->pixel_buffer) {
+            gst_buffer_unmap(buffer, &map);
+            gst_sample_unref(sample);
+            return;
+        }
+
+        streamer->pixel_buffer_size = required_size;
+        streamer->frame.header.magic  = LV_IMAGE_HEADER_MAGIC;
+        streamer->frame.header.cf     = IMAGE_FORMAT;
+        streamer->frame.header.flags  = LV_IMAGE_FLAGS_MODIFIABLE;
+        streamer->frame.header.w      = width;
+        streamer->frame.header.h      = height;
+        streamer->frame.header.stride = stride;
+        streamer->frame.data_size = required_size;
+        streamer->frame.data      = streamer->pixel_buffer;
+        streamer->image_src_set = false;  // force rebind
+    }
+
+    /* Copy new pixels */
+    memcpy(streamer->pixel_buffer, map.data, required_size);
+    if(!streamer->image_src_set) {
+        lv_image_set_src((lv_obj_t *)streamer, &streamer->frame);
+        streamer->image_src_set = true;
+    }
+
+    lv_obj_invalidate((lv_obj_t *)streamer);
+    gst_buffer_unmap(buffer, &map);
+    gst_sample_unref(sample);
+
     if(first_frame) {
         if(gstreamer_send_state_changed(streamer, LV_GSTREAMER_STREAM_STATE_START) == LV_RESULT_INVALID) {
             /* Object deleted inside event handler */
@@ -525,12 +547,6 @@ static void lv_gstreamer_destructor(const lv_obj_class_t * class_p, lv_obj_t * o
         gst_element_set_state(streamer->pipeline, GST_STATE_NULL);
         gst_object_unref(streamer->pipeline);
     }
-    if(streamer->last_buffer) {
-        gst_buffer_unmap(streamer->last_buffer, &streamer->last_map_info);
-    }
-    if(streamer->last_sample) {
-        gst_sample_unref(streamer->last_sample);
-    }
     if(streamer->frame_queue) {
         GstSample * sample;
         while((sample = g_async_queue_try_pop(streamer->frame_queue)) != NULL) {
@@ -538,6 +554,10 @@ static void lv_gstreamer_destructor(const lv_obj_class_t * class_p, lv_obj_t * o
         }
         g_async_queue_unref(streamer->frame_queue);
         streamer->frame_queue = NULL;
+    }
+    if(streamer->pixel_buffer) {
+        free(streamer->pixel_buffer);
+        streamer->pixel_buffer = NULL;
     }
     lv_timer_delete(streamer->gstreamer_timer);
 }
@@ -674,6 +694,10 @@ static GstFlowReturn on_new_sample(GstElement * sink, gpointer user_data)
         return GST_FLOW_OK;
     }
 
+    while(g_async_queue_length(streamer->frame_queue) > 0) {
+        GstSample * old = g_async_queue_try_pop(streamer->frame_queue);
+        if(old) gst_sample_unref(old);
+    }
     g_async_queue_push(streamer->frame_queue, sample);
     return GST_FLOW_OK;
 }

--- a/src/libs/gstreamer/lv_gstreamer_internal.h
+++ b/src/libs/gstreamer/lv_gstreamer_internal.h
@@ -37,15 +37,15 @@ struct _lv_gstreamer_t {
     lv_image_t image;
     lv_image_dsc_t frame;
     GstVideoInfo video_info;
-    GstMapInfo last_map_info;
-    GstBuffer * last_buffer;
-    GstSample * last_sample;
     GstElement * pipeline;
     GstElement * audio_convert;
     GstElement * video_convert;
     GstElement * audio_volume;
     lv_timer_t * gstreamer_timer;
     GAsyncQueue * frame_queue;
+    uint8_t * pixel_buffer;
+    size_t pixel_buffer_size;
+    bool image_src_set;
     bool is_video_info_valid;
 };
 


### PR DESCRIPTION
Reuse a persistent image descriptor and pixel buffer instead of creating a new image source each frame. This prevents repeated texture allocations (notably on OpenGL).
