### PR TITLE
feat(gltf): add model deletion and removal APIs

### DIFF
--- a/src/libs/gltf/gltf_data/lv_gltf_data.cpp
+++ b/src/libs/gltf/gltf_data/lv_gltf_data.cpp
@@ -111,6 +111,11 @@ void lv_gltf_data_delete(lv_gltf_model_t * data)
     lv_free(data);
 }
 
+void lv_gltf_model_delete(lv_gltf_model_t * data)
+{
+    lv_gltf_data_delete(data);
+}
+
 const char * lv_gltf_get_filename(const lv_gltf_model_t * data)
 {
     LV_ASSERT_NULL(data);

--- a/src/libs/gltf/gltf_data/lv_gltf_data_internal.hpp
+++ b/src/libs/gltf/gltf_data/lv_gltf_data_internal.hpp
@@ -363,6 +363,8 @@ lv_gltf_model_t * lv_gltf_data_create_internal(const char * gltf_path, fastgltf:
 lv_gltf_model_t * lv_gltf_data_load_internal(const void * data_source, size_t data_size,
                                              lv_opengl_shader_manager_t * shaders);
 
+void lv_gltf_data_delete(lv_gltf_model_t * data);
+
 fastgltf::math::fvec4 lv_gltf_get_primitive_centerpoint(lv_gltf_model_t * data, fastgltf::Mesh & mesh,
                                                         uint32_t prim_num);
 

--- a/src/libs/gltf/gltf_data/lv_gltf_model.h
+++ b/src/libs/gltf/gltf_data/lv_gltf_model.h
@@ -119,6 +119,13 @@ bool lv_gltf_model_is_animation_paused(lv_gltf_model_t * model);
  */
 size_t lv_gltf_model_get_animation(lv_gltf_model_t * model);
 
+/**
+ * @brief Delete a glTF model and free its resources.
+ * @note If the model is attached to a viewer, it's recommended to use `lv_gltf_remove_model` instead.
+ * @param model pointer to the model to delete
+ */
+void lv_gltf_model_delete(lv_gltf_model_t * model);
+
 #ifdef __cplusplus
 } /*extern "C"*/
 #endif

--- a/src/libs/gltf/gltf_view/lv_gltf.h
+++ b/src/libs/gltf/gltf_view/lv_gltf.h
@@ -115,6 +115,19 @@ lv_gltf_model_t * lv_gltf_get_model_by_index(lv_obj_t * obj, size_t id);
 lv_gltf_model_t * lv_gltf_get_primary_model(lv_obj_t * obj);
 
 /**
+ * Remove a specific model from the glTF viewer
+ * @param obj pointer to a glTF viewer object
+ * @param model pointer to the model to remove
+ */
+void lv_gltf_remove_model(lv_obj_t * obj, lv_gltf_model_t * model);
+
+/**
+ * Remove all models from the glTF viewer
+ * @param obj pointer to a glTF viewer object
+ */
+void lv_gltf_remove_all_models(lv_obj_t * obj);
+
+/**
  * Set the yaw (horizontal rotation) of the camera
  * @param obj pointer to a glTF viewer object
  * @param yaw yaw angle in degrees


### PR DESCRIPTION
- Implement `lv_gltf_remove_model` and `lv_gltf_remove_all_models` to manage viewer state.
- Add `lv_gltf_model_delete` for manual resource cleanup.
- Ensure proper map clearing and object invalidation after removal.
