### PR TITLE
fix(vg_lite): automatically select filters based on the matrix

### DIFF
--- a/src/draw/vg_lite/lv_draw_vg_lite_arc.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_arc.c
@@ -188,7 +188,7 @@ void lv_draw_vg_lite_arc(lv_draw_task_t * t, const lv_draw_arc_dsc_t * dsc,
                 VG_LITE_PATTERN_COLOR,
                 0,
                 img_color,
-                VG_LITE_FILTER_BI_LINEAR);
+                lv_vg_lite_matrix_get_filter(&matrix));
 
             lv_vg_lite_pending_add(u->image_dsc_pending, &decoder_dsc);
         }

--- a/src/draw/vg_lite/lv_draw_vg_lite_img.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_img.c
@@ -31,8 +31,6 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static inline bool matrix_has_transform(const vg_lite_matrix_t * matrix);
-
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -83,7 +81,7 @@ void lv_draw_vg_lite_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
     vg_lite_matrix_t matrix = u->global_matrix;
     lv_vg_lite_matrix_multiply(&matrix, &image_matrix);
 
-    const bool has_transform = matrix_has_transform(&matrix);
+    const bool has_transform = lv_vg_lite_matrix_has_transform(&matrix);
     const vg_lite_filter_t filter = has_transform ?  VG_LITE_FILTER_BI_LINEAR : VG_LITE_FILTER_POINT;
 
     /* Use coords as the fallback image width and height */
@@ -240,20 +238,5 @@ void lv_draw_vg_lite_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
 /**********************
  *   STATIC FUNCTIONS
  **********************/
-
-static inline bool matrix_has_transform(const vg_lite_matrix_t * matrix)
-{
-    /**
-     * When the rotation angle is 0 or 180 degrees,
-     * it is considered that there is no transformation.
-     */
-    return !((matrix->m[0][0] == 1.0f || matrix->m[0][0] == -1.0f) &&
-             matrix->m[0][1] == 0.0f &&
-             matrix->m[1][0] == 0.0f &&
-             (matrix->m[1][1] == 1.0f || matrix->m[1][1] == -1.0f) &&
-             matrix->m[2][0] == 0.0f &&
-             matrix->m[2][1] == 0.0f &&
-             matrix->m[2][2] == 1.0f);
-}
 
 #endif /*LV_USE_DRAW_VG_LITE*/

--- a/src/draw/vg_lite/lv_draw_vg_lite_label.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_label.c
@@ -353,7 +353,7 @@ static void draw_letter_bitmap(lv_draw_task_t * t, const lv_draw_glyph_dsc_t * d
             &matrix,
             VG_LITE_BLEND_SRC_OVER,
             color,
-            VG_LITE_FILTER_LINEAR);
+            lv_vg_lite_matrix_get_filter(&matrix));
     }
     else {
         lv_vg_lite_path_t * path = lv_vg_lite_path_get(u, VG_LITE_S16);
@@ -378,7 +378,7 @@ static void draw_letter_bitmap(lv_draw_task_t * t, const lv_draw_glyph_dsc_t * d
             VG_LITE_PATTERN_COLOR,
             0,
             color,
-            VG_LITE_FILTER_LINEAR);
+            lv_vg_lite_matrix_get_filter(&matrix));
 
         lv_vg_lite_path_drop(u, path);
     }

--- a/src/draw/vg_lite/lv_draw_vg_lite_vector.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite_vector.c
@@ -160,7 +160,7 @@ static void draw_fill(lv_draw_vg_lite_unit_t * u,
                         VG_LITE_PATTERN_COLOR,
                         0,
                         recolor,
-                        VG_LITE_FILTER_BI_LINEAR);
+                        lv_vg_lite_matrix_get_filter(&pattern_matrix));
 
                     if(ctx->fill_dsc.img_dsc.colorkey) {
                         lv_vg_lite_set_color_key(NULL);

--- a/src/draw/vg_lite/lv_vg_lite_utils.h
+++ b/src/draw/vg_lite/lv_vg_lite_utils.h
@@ -177,6 +177,26 @@ bool lv_vg_lite_matrix_inverse(vg_lite_matrix_t * result, const vg_lite_matrix_t
 
 lv_point_precise_t lv_vg_lite_matrix_transform_point(const vg_lite_matrix_t * matrix, const lv_point_precise_t * point);
 
+static inline bool lv_vg_lite_matrix_has_transform(const vg_lite_matrix_t * matrix)
+{
+    /**
+     * When the rotation angle is 0 or 180 degrees,
+     * it is considered that there is no transformation.
+     */
+    return !((matrix->m[0][0] == 1.0f || matrix->m[0][0] == -1.0f) &&
+             matrix->m[0][1] == 0.0f &&
+             matrix->m[1][0] == 0.0f &&
+             (matrix->m[1][1] == 1.0f || matrix->m[1][1] == -1.0f) &&
+             matrix->m[2][0] == 0.0f &&
+             matrix->m[2][1] == 0.0f &&
+             matrix->m[2][2] == 1.0f);
+}
+
+static inline vg_lite_filter_t lv_vg_lite_matrix_get_filter(const vg_lite_matrix_t * matrix)
+{
+    return lv_vg_lite_matrix_has_transform(matrix) ? VG_LITE_FILTER_BI_LINEAR : VG_LITE_FILTER_POINT;
+}
+
 void lv_vg_lite_set_scissor_area(struct _lv_draw_vg_lite_unit_t * u, const lv_area_t * area);
 
 void lv_vg_lite_disable_scissor(void);


### PR DESCRIPTION
Use `VG_LITE_FILTER_POINT` to improve accuracy and performance when the matrix is ​​not rotated or scaled.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
