### PR TITLE
fix(image): in case of a simple scaled down image use smaller invalidation area

### DIFF
--- a/src/widgets/image/lv_image.c
+++ b/src/widgets/image/lv_image.c
@@ -742,10 +742,20 @@ static void lv_image_event(const lv_obj_class_t * class_p, lv_event_t * e)
             int32_t w = lv_obj_get_width(obj);
             int32_t h = lv_obj_get_height(obj);
             lv_image_buf_get_transformed_area(&a, w, h, img->rotation, img->scale_x, img->scale_y, &pivot_px);
-            *s = LV_MAX(*s, -a.x1);
-            *s = LV_MAX(*s, -a.y1);
-            *s = LV_MAX(*s, a.x2 - w);
-            *s = LV_MAX(*s, a.y2 - h);
+            int32_t ext_transform_size = LV_MAX4(-a.x1, -a.y1, a.x2 - w, a.y2 - h);
+
+            /*If there is a visible background don't use negative ext_draw_size*/
+            if(lv_obj_get_style_bg_opa(obj, 0) ||
+               (lv_obj_get_style_border_width(obj, 0) && lv_obj_get_style_border_opa(obj, 0)) ||
+               (lv_obj_get_style_outline_width(obj, 0) && lv_obj_get_style_outline_opa(obj, 0)) ||
+               (lv_obj_get_style_shadow_opa(obj, 0) && (lv_obj_get_style_shadow_spread(obj, 0) ||
+                                                        lv_obj_get_style_shadow_width(obj, 0))) ||
+               (lv_obj_get_style_bg_image_src(obj, 0) && lv_obj_get_style_bg_image_opa(obj, 0))) {
+                *s = LV_MAX(*s, ext_transform_size);
+            }
+            else {
+                *s = ext_transform_size;
+            }
         }
     }
     else if(code == LV_EVENT_SIZE_CHANGED) {

--- a/tests/src/test_cases/widgets/test_image.c
+++ b/tests/src/test_cases/widgets/test_image.c
@@ -1147,4 +1147,54 @@ void test_image_draw_main_unknown_src_type(void)
     lv_refr_now(NULL);
 }
 
+static void  check_inv_area(lv_obj_t * obj, int32_t x1, int32_t y1, int32_t x2, int32_t y2)
+{
+    lv_display_t * disp = lv_display_get_default();
+    lv_refr_now(disp);
+    lv_obj_invalidate(obj);
+
+    TEST_ASSERT_EQUAL(1, disp->inv_p);
+    TEST_ASSERT_EQUAL(x1, disp->inv_areas[0].x1);
+    TEST_ASSERT_EQUAL(y1, disp->inv_areas[0].y1);
+    TEST_ASSERT_EQUAL(x2, disp->inv_areas[0].x2);
+    TEST_ASSERT_EQUAL(y2, disp->inv_areas[0].y2);
+}
+
+void test_image_transformed_invaldiaton_area(void)
+{
+
+    LV_IMAGE_DECLARE(test_image_cogwheel_argb8888);
+    lv_obj_t * img1 = lv_image_create(lv_screen_active());
+    lv_image_set_src(img1, &test_image_cogwheel_argb8888);
+    lv_obj_set_pos(img1, 200, 200);
+    check_inv_area(img1, 200, 200, 299, 299);
+
+    lv_image_set_scale(img1, 64);
+    check_inv_area(img1, 237, 237, 262, 262);
+
+    lv_image_set_scale(img1, 512);
+    check_inv_area(img1, 150, 150, 349, 349);
+
+    lv_image_set_rotation(img1, 450);
+    lv_image_set_scale(img1, 256);
+    check_inv_area(img1, 179, 179, 320, 320);
+
+    lv_image_set_scale(img1, 64);
+    check_inv_area(img1, 232, 232, 267, 267);
+
+    /*With non centered pivot the area is too large as we
+     *store only single ext_draw_size data for all sides which
+     *store makes it too large in all directions.
+     *Having 4  extra_draw_size for the 4 sides would be better */
+    lv_image_set_scale(img1, 256);
+    lv_image_set_pivot(img1, 0, 0);
+    check_inv_area(img1, 129, 129, 370, 370);
+
+    lv_image_set_pivot(img1, -50, -100);
+    check_inv_area(img1, 43, 43, 456, 456);
+
+    lv_image_set_scale(img1, 64);
+    check_inv_area(img1, 123, 123, 376, 376);
+}
+
 #endif


### PR DESCRIPTION
Without this fix the original area of the image was invalidated even if it was scaled down. This optimization can be applied only if the image has no background, border, etc as in that case the whole image needs to be invalidated.


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
