### PR TITLE
chore(gdb): support str input and auto-infer target_type in Value.normalize

### DIFF
--- a/scripts/gdb/lvglgdb/value.py
+++ b/scripts/gdb/lvglgdb/value.py
@@ -12,7 +12,8 @@ class Value(gdb.Value):
         """Normalize input to a typed Value pointer.
 
         Args:
-            val: Input value - int (address), gdb.Value, or Value instance
+            val: Input value - str (GDB expression), int (address),
+                 gdb.Value, or Value instance
             target_type: C type name (e.g. "lv_obj_t"). If provided,
                          result is cast to target_type*
 
@@ -22,11 +23,22 @@ class Value(gdb.Value):
         Raises:
             ValueError: If target_type lookup fails or cast fails
         """
+        if isinstance(val, str):
+            val = gdb.parse_and_eval(val)
+
         if isinstance(val, int):
             val = gdb.Value(val)
 
         if not isinstance(val, Value):
             val = Value(val)
+
+        # Auto-infer target_type from pointer type when not specified
+        if target_type is None:
+            typ = val.type.strip_typedefs()
+            if typ.code == gdb.TYPE_CODE_PTR:
+                target = typ.target().strip_typedefs()
+                if target.code in (gdb.TYPE_CODE_STRUCT, gdb.TYPE_CODE_UNION):
+                    target_type = str(target)
 
         if target_type is not None:
             try:
@@ -105,4 +117,4 @@ class Value(gdb.Value):
 
 
 # Type alias for all wrapper class __init__ parameters
-ValueInput = Union[int, gdb.Value, Value]
+ValueInput = Union[str, int, gdb.Value, Value]


### PR DESCRIPTION
equals:

```python
Value(gdb.parse_and_eval("obj"))
Value.normalize("obj", target_type)
Value.normalize("obj")
```


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
