### PR TITLE
fix(font): fix underflow in adv_w calculation

### DIFF
--- a/src/font/fmt_txt/lv_font_fmt_txt.c
+++ b/src/font/fmt_txt/lv_font_fmt_txt.c
@@ -247,7 +247,7 @@ bool lv_font_get_glyph_dsc_fmt_txt(const lv_font_t * font, lv_font_glyph_dsc_t *
     uint32_t adv_w = gdsc->adv_w;
     if(is_tab) adv_w *= 2;
 
-    if((kv < 0) && (adv_w < -kv)) {
+    if((kv < 0) && (adv_w < (uint32_t)-kv)) {
         adv_w = 0;
     }
     else {

--- a/src/font/fmt_txt/lv_font_fmt_txt.c
+++ b/src/font/fmt_txt/lv_font_fmt_txt.c
@@ -247,7 +247,7 @@ bool lv_font_get_glyph_dsc_fmt_txt(const lv_font_t * font, lv_font_glyph_dsc_t *
     uint32_t adv_w = gdsc->adv_w;
     if(is_tab) adv_w *= 2;
 
-    if((kv < 0) && (adv_w < (uint32_t)-kv)) {
+    if((kv < 0) && (adv_w < (uint32_t) - kv)) {
         adv_w = 0;
     }
     else {

--- a/src/font/fmt_txt/lv_font_fmt_txt.c
+++ b/src/font/fmt_txt/lv_font_fmt_txt.c
@@ -247,7 +247,12 @@ bool lv_font_get_glyph_dsc_fmt_txt(const lv_font_t * font, lv_font_glyph_dsc_t *
     uint32_t adv_w = gdsc->adv_w;
     if(is_tab) adv_w *= 2;
 
-    adv_w += kv;
+    if((kv < 0) && (adv_w < -kv)) {
+        adv_w = 0;
+    }
+    else {
+        adv_w += kv;
+    }
     adv_w  = (adv_w + (1 << 3)) >> 4;
 
     dsc_out->adv_w = adv_w;

--- a/src/font/fmt_txt/lv_font_fmt_txt.c
+++ b/src/font/fmt_txt/lv_font_fmt_txt.c
@@ -247,12 +247,7 @@ bool lv_font_get_glyph_dsc_fmt_txt(const lv_font_t * font, lv_font_glyph_dsc_t *
     uint32_t adv_w = gdsc->adv_w;
     if(is_tab) adv_w *= 2;
 
-    if((kv < 0) && (adv_w < (uint32_t) - kv)) {
-        adv_w = 0;
-    }
-    else {
-        adv_w += kv;
-    }
+    adv_w = (uint32_t)LV_CLAMP(0, (int32_t)adv_w + kv, INT32_MAX);
     adv_w  = (adv_w + (1 << 3)) >> 4;
 
     dsc_out->adv_w = adv_w;


### PR DESCRIPTION
There was code in the `lv_font_get_glyph_dsc_fmt_txt` function where it tried to take the `adv_w` of the glyph and add the kerning:
```
adv_w += kv; //Line 250
```

When I ran this on my project, I ended up with `adv_w` being 38 and `kv` being -60. So when they subtracted, instead of getting -22, it ended up being 4294967273 (or UINT32_MAX - 22).

So this code attempts to clamp the operation to 0 if it wanted to go below zero (seemed the most appropriate for assignment to an unsigned value).

I'm not too familiar with your code base, so there may be better options for this check than I have here.