### PR TITLE
fix(indev): dont reset encoder key every frame

### DIFF
--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -199,12 +199,8 @@ void indev_read_core(lv_indev_t * indev, lv_indev_data_t * data)
         data->point.y = indev->pointer.last_raw_point.y;
     }
     /*Similarly set at least the last key in case of the user doesn't set it on release*/
-    else if(indev->type == LV_INDEV_TYPE_KEYPAD) {
+    else if(indev->type == LV_INDEV_TYPE_KEYPAD || indev->type == LV_INDEV_TYPE_ENCODER) {
         data->key = indev->keypad.last_key;
-    }
-    /*For compatibility assume that used button was enter (encoder push)*/
-    else if(indev->type == LV_INDEV_TYPE_ENCODER) {
-        data->key = LV_KEY_ENTER;
     }
 
     if(indev->read_cb) {
@@ -1693,6 +1689,16 @@ static void indev_proc_reset_query_handler(lv_indev_t * indev)
         indev->pointer.gesture_sum.x     = 0;
         indev->pointer.gesture_sum.y     = 0;
         indev->reset_query                     = 0;
+        if(indev->type == LV_INDEV_TYPE_ENCODER) {
+            /* Before v9.6, LV_INDEV_TYPE_ENCODER set LV_KEY_ENTER as the last key on EVERY frame.
+             * This required users to store and re-feed the last key to LVGL each frame.
+             * From v9.6 onward, we no longer reset the key every frame to simplify the user's
+             * implementation. However, this can cause compatibility issues for users who never
+             * explicitly set the key, as it was previously always defaulting to LV_KEY_ENTER.
+             * To maintain compatibility, we initialize the key to LV_KEY_ENTER here.
+             */
+            indev->keypad.last_key = LV_KEY_ENTER;
+        }
         indev->stop_processing_query           = 0;
         indev_obj_act                               = NULL;
     }


### PR DESCRIPTION
Fixes #9506 <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
