### PR TITLE
perf(indev): use union to store both keypad and pointer data structures

### DIFF
--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -696,14 +696,14 @@ static void obj_delete_core(lv_obj_t * obj)
     while(indev) {
         lv_indev_type_t indev_type = lv_indev_get_type(indev);
         if(indev_type == LV_INDEV_TYPE_POINTER || indev_type == LV_INDEV_TYPE_BUTTON) {
-            if(indev->pointer.act_obj == obj || indev->pointer.scroll_obj == obj) {
+            if(indev->d.pointer.act_obj == obj || indev->d.pointer.scroll_obj == obj) {
                 obj_indev_reset(indev, obj);
             }
-            if(indev->pointer.last_pressed == obj) {
-                indev->pointer.last_pressed = NULL;
+            if(indev->d.pointer.last_pressed == obj) {
+                indev->d.pointer.last_pressed = NULL;
             }
-            if(indev->pointer.last_hovered == obj) {
-                indev->pointer.last_hovered = NULL;
+            if(indev->d.pointer.last_hovered == obj) {
+                indev->d.pointer.last_hovered = NULL;
             }
         }
 

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -1,8 +1,3 @@
-#include "lv_indev_private.h"
-#include "../misc/lv_event_private.h"
-#include "../misc/lv_area_private.h"
-#include "../misc/lv_anim_private.h"
-#include "../core/lv_obj_draw_private.h"
 /**
  * @file lv_indev.c
  *
@@ -11,6 +6,11 @@
 /*********************
  *      INCLUDES
  ********************/
+#include "lv_indev_private.h"
+#include "../misc/lv_event_private.h"
+#include "../misc/lv_area_private.h"
+#include "../misc/lv_anim_private.h"
+#include "../core/lv_obj_draw_private.h"
 #include "lv_indev_scroll.h"
 #include "lv_indev_gesture.h"
 #include "../display/lv_display_private.h"
@@ -86,13 +86,13 @@ static lv_result_t send_event(lv_event_code_t code, void * param);
 static void indev_scroll_throw_anim_start(lv_indev_t * indev);
 static void indev_scroll_throw_anim_cb(void * var, int32_t v);
 static void indev_scroll_throw_anim_completed_cb(lv_anim_t * anim);
+
 static inline void indev_scroll_throw_anim_reset(lv_indev_t * indev)
 {
-    if(indev) {
-        indev->pointer.scroll_throw_vect.x = 0;
-        indev->pointer.scroll_throw_vect.y = 0;
-        indev->scroll_throw_anim = NULL;
-    }
+    if(!indev) return;
+    indev->d.pointer.scroll_throw_vect.x = 0;
+    indev->d.pointer.scroll_throw_vect.y = 0;
+    indev->scroll_throw_anim = NULL;
 }
 
 /**********************
@@ -195,12 +195,12 @@ void indev_read_core(lv_indev_t * indev, lv_indev_data_t * data)
     /* For touchpad sometimes users don't set the last pressed coordinate on release.
      * So be sure a coordinates are initialized to the last point */
     if(indev->type == LV_INDEV_TYPE_POINTER) {
-        data->point.x = indev->pointer.last_raw_point.x;
-        data->point.y = indev->pointer.last_raw_point.y;
+        data->point.x = indev->d.pointer.last_raw_point.x;
+        data->point.y = indev->d.pointer.last_raw_point.y;
     }
     /*Similarly set at least the last key in case of the user doesn't set it on release*/
     else if(indev->type == LV_INDEV_TYPE_KEYPAD || indev->type == LV_INDEV_TYPE_ENCODER) {
-        data->key = indev->keypad.last_key;
+        data->key = indev->d.keypad.last_key;
     }
 
     if(indev->read_cb) {
@@ -442,7 +442,11 @@ bool lv_indev_get_press_moved(const lv_indev_t * indev)
 {
     if(indev == NULL) return false;
 
-    return indev->pointer.press_moved;
+    if(indev->type != LV_INDEV_TYPE_POINTER) {
+        return false;
+    }
+
+    return indev->d.pointer.press_moved;
 }
 
 void lv_indev_reset(lv_indev_t * indev, lv_obj_t * obj)
@@ -478,7 +482,7 @@ void lv_indev_set_cursor(lv_indev_t * indev, lv_obj_t * cur_obj)
 
     indev->cursor = cur_obj;
     lv_obj_set_parent(indev->cursor, lv_display_get_layer_sys(indev->disp));
-    lv_obj_set_pos(indev->cursor, indev->pointer.act_point.x, indev->pointer.act_point.y);
+    lv_obj_set_pos(indev->cursor, indev->d.pointer.act_point.x, indev->d.pointer.act_point.y);
     lv_obj_remove_flag(indev->cursor, LV_OBJ_FLAG_CLICKABLE);
     lv_obj_add_flag(indev->cursor, LV_OBJ_FLAG_IGNORE_LAYOUT | LV_OBJ_FLAG_FLOATING);
 }
@@ -508,43 +512,46 @@ void lv_indev_get_point(const lv_indev_t * indev, lv_point_t * point)
         point->y = -1;
     }
     else {
-        point->x = indev->pointer.act_point.x;
-        point->y = indev->pointer.act_point.y;
+        point->x = indev->d.pointer.act_point.x;
+        point->y = indev->d.pointer.act_point.y;
     }
 }
 
 lv_dir_t lv_indev_get_gesture_dir(const lv_indev_t * indev)
 {
-    return indev->pointer.gesture_dir;
+    if(!indev) return LV_DIR_NONE;
+    if(indev->type != LV_INDEV_TYPE_POINTER) return LV_DIR_NONE;
+    return indev->d.pointer.gesture_dir;
 }
 
 uint32_t lv_indev_get_key(const lv_indev_t * indev)
 {
-    uint32_t key = 0;
+    if(!indev) return 0;
+    if(indev->type != LV_INDEV_TYPE_KEYPAD) return 0;
 
-    if(indev && indev->type == LV_INDEV_TYPE_KEYPAD)
-        key = indev->keypad.last_key;
-
-    return key;
+    return indev->d.keypad.last_key;
 }
 
 uint8_t lv_indev_get_short_click_streak(const lv_indev_t * indev)
 {
-    return indev->pointer.short_click_streak;
+    if(!indev) return 0;
+    if(indev->type != LV_INDEV_TYPE_POINTER && indev->type != LV_INDEV_TYPE_BUTTON) return 0;
+
+    return indev->d.pointer.short_click_streak;
 }
 
 lv_dir_t lv_indev_get_scroll_dir(const lv_indev_t * indev)
 {
-    if(indev == NULL) return false;
-    if(indev->type != LV_INDEV_TYPE_POINTER && indev->type != LV_INDEV_TYPE_BUTTON) return false;
-    return indev->pointer.scroll_dir;
+    if(indev == NULL) return LV_DIR_NONE;
+    if(indev->type != LV_INDEV_TYPE_POINTER && indev->type != LV_INDEV_TYPE_BUTTON) return LV_DIR_NONE;
+    return indev->d.pointer.scroll_dir;
 }
 
 lv_obj_t * lv_indev_get_scroll_obj(const lv_indev_t * indev)
 {
     if(indev == NULL) return NULL;
     if(indev->type != LV_INDEV_TYPE_POINTER && indev->type != LV_INDEV_TYPE_BUTTON) return NULL;
-    return indev->pointer.scroll_obj;
+    return indev->d.pointer.scroll_obj;
 }
 
 void lv_indev_get_vect(const lv_indev_t * indev, lv_point_t * point)
@@ -554,10 +561,12 @@ void lv_indev_get_vect(const lv_indev_t * indev, lv_point_t * point)
 
     if(indev == NULL) return;
 
-    if(indev->type == LV_INDEV_TYPE_POINTER || indev->type == LV_INDEV_TYPE_BUTTON) {
-        point->x = indev->pointer.vect.x;
-        point->y = indev->pointer.vect.y;
+    if(indev->type != LV_INDEV_TYPE_POINTER && indev->type != LV_INDEV_TYPE_BUTTON) {
+        return;
     }
+
+    point->x = indev->d.pointer.vect.x;
+    point->y = indev->d.pointer.vect.y;
 }
 
 lv_obj_t * lv_indev_get_cursor(lv_indev_t * indev)
@@ -733,8 +742,8 @@ void lv_indev_set_external_data(lv_indev_t * indev, void * data, void (* free_cb
 static void indev_pointer_proc(lv_indev_t * i, lv_indev_data_t * data)
 {
     /*Save the raw points so they can be used again in indev_read_core*/
-    i->pointer.last_raw_point.x = data->point.x;
-    i->pointer.last_raw_point.y = data->point.y;
+    i->d.pointer.last_raw_point.x = data->point.x;
+    i->d.pointer.last_raw_point.y = data->point.y;
 
     lv_display_rotate_point(i->disp, &data->point);
 
@@ -754,13 +763,13 @@ static void indev_pointer_proc(lv_indev_t * i, lv_indev_data_t * data)
 
     /*Move the cursor if set and moved*/
     if(i->cursor != NULL &&
-       (i->pointer.last_point.x != data->point.x || i->pointer.last_point.y != data->point.y)) {
+       (i->d.pointer.last_point.x != data->point.x || i->d.pointer.last_point.y != data->point.y)) {
         lv_obj_set_pos(i->cursor, data->point.x, data->point.y);
     }
 
-    i->pointer.act_point.x = data->point.x;
-    i->pointer.act_point.y = data->point.y;
-    i->pointer.diff = data->enc_diff;
+    i->d.pointer.act_point.x = data->point.x;
+    i->d.pointer.act_point.y = data->point.y;
+    i->d.pointer.diff = data->enc_diff;
 
 #if LV_USE_GESTURE_RECOGNITION
     for(int gest = 0; gest < LV_INDEV_GESTURE_CNT; gest++) {
@@ -780,8 +789,8 @@ static void indev_pointer_proc(lv_indev_t * i, lv_indev_data_t * data)
     }
 
     i->prev_state = i->state;
-    i->pointer.last_point.x = i->pointer.act_point.x;
-    i->pointer.last_point.y = i->pointer.act_point.y;
+    i->d.pointer.last_point.x = i->d.pointer.act_point.x;
+    i->d.pointer.last_point.y = i->d.pointer.act_point.y;
 }
 
 /**
@@ -797,7 +806,7 @@ static void indev_keypad_proc(lv_indev_t * i, lv_indev_data_t * data)
         i->wait_until_release      = 0;
         i->pr_timestamp            = 0;
         i->long_pr_sent            = 0;
-        i->keypad.last_state = LV_INDEV_STATE_RELEASED; /*To skip the processing of release*/
+        i->d.keypad.last_state = LV_INDEV_STATE_RELEASED; /*To skip the processing of release*/
     }
 
     /* Remap key using callback */
@@ -806,8 +815,8 @@ static void indev_keypad_proc(lv_indev_t * i, lv_indev_data_t * data)
     }
 
     /*Save the last key. *It must be done here else `lv_indev_get_key` will return the last key in events*/
-    uint32_t prev_key = i->keypad.last_key;
-    i->keypad.last_key = data->key;
+    uint32_t prev_key = i->d.keypad.last_key;
+    i->d.keypad.last_key = data->key;
 
     lv_indev_send_event(indev_act, LV_EVENT_KEY, NULL);
 
@@ -826,8 +835,8 @@ static void indev_keypad_proc(lv_indev_t * i, lv_indev_data_t * data)
     /*Save the previous state so we can detect state changes below and also set the last state now
      *so if any event handler on the way returns `LV_RESULT_INVALID` the last state is remembered
      *for the next time*/
-    uint32_t prev_state             = i->keypad.last_state;
-    i->keypad.last_state = data->state;
+    uint32_t prev_state             = i->d.keypad.last_state;
+    i->d.keypad.last_state = data->state;
 
     /*Key press happened*/
     if(data->state == LV_INDEV_STATE_PRESSED && prev_state == LV_INDEV_STATE_RELEASED) {
@@ -956,14 +965,14 @@ static void indev_encoder_proc(lv_indev_t * i, lv_indev_data_t * data)
         i->wait_until_release      = 0;
         i->pr_timestamp            = 0;
         i->long_pr_sent            = 0;
-        i->keypad.last_state = LV_INDEV_STATE_RELEASED; /*To skip the processing of release*/
+        i->d.keypad.last_state = LV_INDEV_STATE_RELEASED; /*To skip the processing of release*/
     }
 
     /*Save the last keys before anything else.
      *They need to be already saved if the function returns for any reason*/
-    lv_indev_state_t last_state     = i->keypad.last_state;
-    i->keypad.last_state = data->state;
-    i->keypad.last_key   = data->key;
+    lv_indev_state_t last_state     = i->d.keypad.last_state;
+    i->d.keypad.last_state = data->state;
+    i->d.keypad.last_key   = data->key;
 
     lv_group_t * g = i->group;
     if(g == NULL) return;
@@ -1199,8 +1208,8 @@ static void indev_button_proc(lv_indev_t * i, lv_indev_data_t * data)
 
     /*If a new point comes always make a release*/
     if(data->state == LV_INDEV_STATE_PRESSED) {
-        if(i->pointer.last_point.x != x ||
-           i->pointer.last_point.y != y) {
+        if(i->d.pointer.last_point.x != x ||
+           i->d.pointer.last_point.y != y) {
             indev_proc_release(i);
         }
     }
@@ -1208,8 +1217,8 @@ static void indev_button_proc(lv_indev_t * i, lv_indev_data_t * data)
     if(indev_reset_check(i)) return;
 
     /*Save the new points*/
-    i->pointer.act_point.x = x;
-    i->pointer.act_point.y = y;
+    i->d.pointer.act_point.x = x;
+    i->d.pointer.act_point.y = y;
 
     if(data->state == LV_INDEV_STATE_PRESSED) {
         indev_proc_press(i);
@@ -1222,8 +1231,8 @@ static void indev_button_proc(lv_indev_t * i, lv_indev_data_t * data)
 
     if(indev_reset_check(i)) return;
 
-    i->pointer.last_point.x = i->pointer.act_point.x;
-    i->pointer.last_point.y = i->pointer.act_point.y;
+    i->d.pointer.last_point.x = i->d.pointer.act_point.x;
+    i->d.pointer.last_point.y = i->d.pointer.act_point.y;
 }
 
 /**
@@ -1246,9 +1255,9 @@ static int32_t indev_scroll_throw_decay(int32_t x, int32_t t)
  */
 static void indev_proc_press(lv_indev_t * indev)
 {
-    LV_LOG_INFO("pressed at x:%d y:%d", (int)indev->pointer.act_point.x,
-                (int)indev->pointer.act_point.y);
-    indev_obj_act = indev->pointer.act_obj;
+    LV_LOG_INFO("pressed at x:%d y:%d", (int)indev->data.pointer.act_point.x,
+                (int)indev->data.pointer.act_point.y);
+    indev_obj_act = indev->d.pointer.act_obj;
 
     if(indev->wait_until_release != 0) return;
 
@@ -1257,18 +1266,18 @@ static void indev_proc_press(lv_indev_t * indev)
 
     /*If there is no last object then search*/
     if(indev_obj_act == NULL) {
-        indev_obj_act = pointer_search_obj(disp, &indev->pointer.act_point);
+        indev_obj_act = pointer_search_obj(disp, &indev->d.pointer.act_point);
         new_obj_searched = true;
     }
     /*If there is an active object it's not scrolled and not press locked also search*/
-    else if(indev->pointer.scroll_obj == NULL &&
+    else if(indev->d.pointer.scroll_obj == NULL &&
             lv_obj_has_flag(indev_obj_act, LV_OBJ_FLAG_PRESS_LOCK) == false) {
-        indev_obj_act = pointer_search_obj(disp, &indev->pointer.act_point);
+        indev_obj_act = pointer_search_obj(disp, &indev->d.pointer.act_point);
         new_obj_searched = true;
     }
 
     /*The scroll object might have scroll throw. Stop it manually*/
-    if(new_obj_searched && indev->pointer.scroll_obj) {
+    if(new_obj_searched && indev->d.pointer.scroll_obj) {
         /*Attempt to stop scroll throw animation firstly*/
         if(indev->scroll_throw_anim) {
             lv_anim_delete(indev, indev_scroll_throw_anim_cb);
@@ -1280,51 +1289,51 @@ static void indev_proc_press(lv_indev_t * indev)
     }
 
     /*If a new object was found reset some variables and send a pressed event handler*/
-    if(indev_obj_act != indev->pointer.act_obj) {
+    if(indev_obj_act != indev->d.pointer.act_obj) {
         /*If no previous object was lost, overwrite the last point.*/
-        if(indev->pointer.act_obj == NULL) {
-            indev->pointer.last_point.x = indev->pointer.act_point.x;
-            indev->pointer.last_point.y = indev->pointer.act_point.y;
+        if(indev->d.pointer.act_obj == NULL) {
+            indev->d.pointer.last_point.x = indev->d.pointer.act_point.x;
+            indev->d.pointer.last_point.y = indev->d.pointer.act_point.y;
         }
-        indev->pointer.pressed = indev->prev_state == LV_INDEV_STATE_RELEASED;
+        indev->d.pointer.pressed = indev->prev_state == LV_INDEV_STATE_RELEASED;
 
         /*Without `LV_OBJ_FLAG_PRESS_LOCK` new widget can be found while pressing.*/
-        if(indev->pointer.last_hovered && indev->pointer.last_hovered != indev_obj_act) {
-            lv_obj_send_event(indev->pointer.last_hovered, LV_EVENT_HOVER_LEAVE, indev);
+        if(indev->d.pointer.last_hovered && indev->d.pointer.last_hovered != indev_obj_act) {
+            lv_obj_send_event(indev->d.pointer.last_hovered, LV_EVENT_HOVER_LEAVE, indev);
             if(indev_reset_check(indev)) return;
 
-            lv_indev_send_event(indev, LV_EVENT_HOVER_LEAVE, indev->pointer.last_hovered);
+            lv_indev_send_event(indev, LV_EVENT_HOVER_LEAVE, indev->d.pointer.last_hovered);
             if(indev_reset_check(indev)) return;
 
-            indev->pointer.last_hovered = indev_obj_act;
+            indev->d.pointer.last_hovered = indev_obj_act;
         }
 
         /*If a new object found the previous was lost, so send a PRESS_LOST event*/
-        if(indev->pointer.act_obj != NULL) {
+        if(indev->d.pointer.act_obj != NULL) {
             /*Save the obj because in special cases `act_obj` can change in the event */
-            lv_obj_t * prev_act_obj = indev->pointer.act_obj;
+            lv_obj_t * prev_act_obj = indev->d.pointer.act_obj;
             lv_obj_send_event(prev_act_obj, LV_EVENT_PRESS_LOST, indev_act);
             if(indev_reset_check(indev)) return;
         }
 
-        indev->pointer.act_obj  = indev_obj_act; /*Save the pressed object*/
+        indev->d.pointer.act_obj  = indev_obj_act; /*Save the pressed object*/
 
         if(indev_obj_act != NULL) {
 
             /*Save the time when the obj pressed to count long press time.*/
             indev->pr_timestamp                 = indev->timestamp;
             indev->long_pr_sent                 = 0;
-            indev->pointer.scroll_sum.x     = 0;
-            indev->pointer.scroll_sum.y     = 0;
-            indev->pointer.scroll_dir = LV_DIR_NONE;
-            indev->pointer.scroll_obj = NULL;
-            indev->pointer.gesture_dir = LV_DIR_NONE;
-            indev->pointer.gesture_sent   = 0;
-            indev->pointer.gesture_sum.x  = 0;
-            indev->pointer.gesture_sum.y  = 0;
-            indev->pointer.press_moved    = 0;
-            indev->pointer.vect.x         = 0;
-            indev->pointer.vect.y         = 0;
+            indev->d.pointer.scroll_sum.x     = 0;
+            indev->d.pointer.scroll_sum.y     = 0;
+            indev->d.pointer.scroll_dir = LV_DIR_NONE;
+            indev->d.pointer.scroll_obj = NULL;
+            indev->d.pointer.gesture_dir = LV_DIR_NONE;
+            indev->d.pointer.gesture_sent   = 0;
+            indev->d.pointer.gesture_sum.x  = 0;
+            indev->d.pointer.gesture_sum.y  = 0;
+            indev->d.pointer.press_moved    = 0;
+            indev->d.pointer.vect.x         = 0;
+            indev->d.pointer.vect.y         = 0;
 
 
             /* If the indev was already in a pressed state it means that we got dragged here
@@ -1334,7 +1343,7 @@ static void indev_proc_press(lv_indev_t * indev)
             if(indev->prev_state != LV_INDEV_STATE_PRESSED) {
                 const bool is_enabled = !lv_obj_has_state(indev_obj_act, LV_STATE_DISABLED);
                 if(is_enabled) {
-                    if(indev->pointer.last_hovered != indev_obj_act) {
+                    if(indev->d.pointer.last_hovered != indev_obj_act) {
                         if(send_event(LV_EVENT_HOVER_OVER, indev_act) == LV_RESULT_INVALID) return;
                     }
                     if(send_event(LV_EVENT_PRESSED, indev_act) == LV_RESULT_INVALID) return;
@@ -1351,25 +1360,26 @@ static void indev_proc_press(lv_indev_t * indev)
     }
 
     /*Update vector and scroll throw vector*/
-    indev->pointer.vect.x = indev->pointer.act_point.x - indev->pointer.last_point.x;
-    indev->pointer.vect.y = indev->pointer.act_point.y - indev->pointer.last_point.y;
+    indev->d.pointer.vect.x = indev->d.pointer.act_point.x - indev->d.pointer.last_point.x;
+    indev->d.pointer.vect.y = indev->d.pointer.act_point.y - indev->d.pointer.last_point.y;
 
-    indev->pointer.vect_hist[indev->pointer.vect_hist_index] = indev->pointer.vect;
-    indev->pointer.vect_hist_timestamp[indev->pointer.vect_hist_index] = indev->timestamp;
-    indev->pointer.vect_hist_index = (indev->pointer.vect_hist_index + 1) % LV_INDEV_VECT_HIST_SIZE;
+    indev->d.pointer.vect_hist[indev->d.pointer.vect_hist_index] = indev->d.pointer.vect;
+    indev->d.pointer.vect_hist_timestamp[indev->d.pointer.vect_hist_index] = indev->timestamp;
+    indev->d.pointer.vect_hist_index = (indev->d.pointer.vect_hist_index + 1) % LV_INDEV_VECT_HIST_SIZE;
 
-    indev->pointer.scroll_throw_vect.x = 0;
-    indev->pointer.scroll_throw_vect.y = 0;
+    indev->d.pointer.scroll_throw_vect.x = 0;
+    indev->d.pointer.scroll_throw_vect.y = 0;
     for(int i = 0; i < LV_INDEV_VECT_HIST_SIZE; i++) {
-        int32_t t = lv_tick_diff(indev->timestamp, indev->pointer.vect_hist_timestamp[i]);
-        indev->pointer.scroll_throw_vect.x += indev_scroll_throw_decay(indev->pointer.vect_hist[i].x, t);
-        indev->pointer.scroll_throw_vect.y += indev_scroll_throw_decay(indev->pointer.vect_hist[i].y, t);
+        int32_t t = lv_tick_diff(indev->timestamp, indev->d.pointer.vect_hist_timestamp[i]);
+        indev->d.pointer.scroll_throw_vect.x += indev_scroll_throw_decay(indev->d.pointer.vect_hist[i].x, t);
+        indev->d.pointer.scroll_throw_vect.y += indev_scroll_throw_decay(indev->d.pointer.vect_hist[i].y, t);
     }
 
-    indev->pointer.scroll_throw_vect_ori = indev->pointer.scroll_throw_vect;
+    indev->d.pointer.scroll_throw_vect_ori = indev->d.pointer.scroll_throw_vect;
 
-    if(LV_ABS(indev->pointer.vect.x) > indev->scroll_limit || LV_ABS(indev->pointer.vect.y) > indev->scroll_limit) {
-        indev->pointer.press_moved = 1;
+    if(LV_ABS(indev->d.pointer.vect.x) > indev->scroll_limit ||
+       LV_ABS(indev->d.pointer.vect.y) > indev->scroll_limit) {
+        indev->d.pointer.press_moved = 1;
     }
 
 #if LV_USE_GESTURE_RECOGNITION
@@ -1403,8 +1413,8 @@ static void indev_proc_press(lv_indev_t * indev)
 
         if(indev_act->wait_until_release) return;
 
-        if(indev->pointer.scroll_obj) {
-            lv_obj_stop_scroll_anim(indev->pointer.scroll_obj);
+        if(indev->d.pointer.scroll_obj) {
+            lv_obj_stop_scroll_anim(indev->d.pointer.scroll_obj);
         }
 
         lv_indev_scroll_handler(indev);
@@ -1419,7 +1429,7 @@ static void indev_proc_press(lv_indev_t * indev)
         }
 
         /*If there is no scrolling then check for long press time*/
-        if(indev->pointer.scroll_obj == NULL && indev->long_pr_sent == 0) {
+        if(indev->d.pointer.scroll_obj == NULL && indev->long_pr_sent == 0) {
             /*Send a long press event if enough time elapsed*/
             if(lv_tick_diff(indev->timestamp, indev->pr_timestamp) >= indev_act->long_press_time) {
                 if(is_enabled) {
@@ -1433,7 +1443,7 @@ static void indev_proc_press(lv_indev_t * indev)
             }
         }
 
-        if(indev->pointer.scroll_obj == NULL && indev->long_pr_sent == 1) {
+        if(indev->d.pointer.scroll_obj == NULL && indev->long_pr_sent == 1) {
             if(lv_tick_diff(indev->timestamp, indev->longpr_rep_timestamp) >= indev_act->long_press_repeat_time) {
                 if(is_enabled) {
                     if(send_event(LV_EVENT_LONG_PRESSED_REPEAT, indev_act) == LV_RESULT_INVALID) return;
@@ -1451,10 +1461,10 @@ static void indev_proc_press(lv_indev_t * indev)
 static void indev_proc_release(lv_indev_t * indev)
 {
     if(indev->wait_until_release || /*Hover the new widget even if the coordinates didn't changed*/
-       (indev->pointer.last_point.x != indev->pointer.act_point.x ||
-        indev->pointer.last_point.y != indev->pointer.act_point.y)) {
-        lv_obj_t ** last = &indev->pointer.last_hovered;
-        lv_obj_t * hovered = pointer_search_obj(lv_display_get_default(), &indev->pointer.act_point);
+       (indev->d.pointer.last_point.x != indev->d.pointer.act_point.x ||
+        indev->d.pointer.last_point.y != indev->d.pointer.act_point.y)) {
+        lv_obj_t ** last = &indev->d.pointer.last_hovered;
+        lv_obj_t * hovered = pointer_search_obj(lv_display_get_default(), &indev->d.pointer.act_point);
         if(*last != hovered) {
             lv_obj_send_event(hovered, LV_EVENT_HOVER_OVER, indev);
             if(indev_reset_check(indev)) return;
@@ -1470,19 +1480,19 @@ static void indev_proc_release(lv_indev_t * indev)
     }
 
     if(indev->wait_until_release) {
-        lv_obj_send_event(indev->pointer.act_obj, LV_EVENT_PRESS_LOST, indev_act);
+        lv_obj_send_event(indev->d.pointer.act_obj, LV_EVENT_PRESS_LOST, indev_act);
         if(indev_reset_check(indev)) {
             indev->wait_until_release = 0;
             return;
         }
 
-        indev->pointer.act_obj  = NULL;
+        indev->d.pointer.act_obj  = NULL;
         indev->pr_timestamp           = 0;
         indev->longpr_rep_timestamp   = 0;
         indev->wait_until_release     = 0;
     }
-    indev_obj_act = indev->pointer.act_obj;
-    lv_obj_t * scroll_obj = indev->pointer.scroll_obj;
+    indev_obj_act = indev->d.pointer.act_obj;
+    lv_obj_t * scroll_obj = indev->d.pointer.scroll_obj;
 
     if(indev->mode == LV_INDEV_MODE_EVENT && indev->read_timer && !lv_timer_get_paused(indev->read_timer)) {
         lv_timer_pause(indev->read_timer);
@@ -1520,7 +1530,7 @@ static void indev_proc_release(lv_indev_t * indev)
 
         if(is_enabled) {
             if(scroll_obj == NULL) {
-                if(indev->pointer.pressed) {
+                if(indev->d.pointer.pressed) {
                     if(indev->long_pr_sent == 0) {
                         if(indev_proc_short_click(indev) == LV_RESULT_INVALID) return;
                     }
@@ -1532,7 +1542,7 @@ static void indev_proc_release(lv_indev_t * indev)
                 if(indev_reset_check(indev)) return;
             }
         }
-        indev->pointer.act_obj = NULL;
+        indev->d.pointer.act_obj = NULL;
         indev->pr_timestamp          = 0;
         indev->longpr_rep_timestamp  = 0;
 
@@ -1564,8 +1574,8 @@ static void indev_proc_release(lv_indev_t * indev)
                 angle = -angle;
                 scale_x = (256 * 256) / scale_x;
                 scale_y = (256 * 256) / scale_y;
-                lv_point_transform(&indev->pointer.scroll_throw_vect, angle, scale_x, scale_y, &pivot, false);
-                lv_point_transform(&indev->pointer.scroll_throw_vect_ori, angle, scale_x, scale_y, &pivot, false);
+                lv_point_transform(&indev->d.pointer.scroll_throw_vect, angle, scale_x, scale_y, &pivot, false);
+                lv_point_transform(&indev->d.pointer.scroll_throw_vect_ori, angle, scale_x, scale_y, &pivot, false);
             }
         }
     }
@@ -1582,18 +1592,18 @@ static void indev_proc_release(lv_indev_t * indev)
 static lv_result_t indev_proc_short_click(lv_indev_t * indev)
 {
     /*Update streak for clicks within small distance and short time*/
-    indev->pointer.short_click_streak++;
-    if(lv_tick_diff(indev->timestamp, indev->pointer.last_short_click_timestamp) > indev->long_press_time) {
-        indev->pointer.short_click_streak = 1;
+    indev->d.pointer.short_click_streak++;
+    if(lv_tick_diff(indev->timestamp, indev->d.pointer.last_short_click_timestamp) > indev->long_press_time) {
+        indev->d.pointer.short_click_streak = 1;
     }
     else if(indev->type == LV_INDEV_TYPE_POINTER || indev->type == LV_INDEV_TYPE_BUTTON) {
-        int32_t dx = indev->pointer.last_short_click_point.x - indev->pointer.act_point.x;
-        int32_t dy = indev->pointer.last_short_click_point.y - indev->pointer.act_point.y;
-        if(dx * dx + dy * dy > indev->scroll_limit * indev->scroll_limit) indev->pointer.short_click_streak = 1;
+        int32_t dx = indev->d.pointer.last_short_click_point.x - indev->d.pointer.act_point.x;
+        int32_t dy = indev->d.pointer.last_short_click_point.y - indev->d.pointer.act_point.y;
+        if(dx * dx + dy * dy > indev->scroll_limit * indev->scroll_limit) indev->d.pointer.short_click_streak = 1;
     }
 
-    indev->pointer.last_short_click_timestamp = indev->timestamp;
-    lv_indev_get_point(indev, &indev->pointer.last_short_click_point);
+    indev->d.pointer.last_short_click_timestamp = indev->timestamp;
+    lv_indev_get_point(indev, &indev->d.pointer.last_short_click_point);
 
     /*Simple short click*/
     lv_result_t res = send_event(LV_EVENT_SHORT_CLICKED, indev_act);
@@ -1602,7 +1612,7 @@ static lv_result_t indev_proc_short_click(lv_indev_t * indev)
     }
 
     /*Cycle through single/double/triple click*/
-    switch((indev->pointer.short_click_streak - 1) % 3) {
+    switch((indev->d.pointer.short_click_streak - 1) % 3) {
         case 0:
             return send_event(LV_EVENT_SINGLE_CLICKED, indev_act);
         case 1:
@@ -1615,9 +1625,9 @@ static lv_result_t indev_proc_short_click(lv_indev_t * indev)
 
 static void indev_proc_pointer_diff(lv_indev_t * indev)
 {
-    lv_obj_t * obj = indev->pointer.last_pressed;
+    lv_obj_t * obj = indev->d.pointer.last_pressed;
     if(obj == NULL) return;
-    if(indev->pointer.diff == 0) return;
+    if(indev->d.pointer.diff == 0) return;
 
     indev_obj_act = obj;
 
@@ -1626,22 +1636,22 @@ static void indev_proc_pointer_diff(lv_indev_t * indev)
     if(editable) {
         uint32_t indev_sensitivity = indev->rotary_sensitivity;
         uint32_t obj_sensitivity = lv_obj_get_style_rotary_sensitivity(indev_obj_act, LV_PART_MAIN);
-        int32_t diff = (int32_t)((int32_t)indev->pointer.diff * indev_sensitivity * obj_sensitivity + 32768) >> 16;
+        int32_t diff = (int32_t)((int32_t)indev->d.pointer.diff * indev_sensitivity * obj_sensitivity + 32768) >> 16;
         send_event(LV_EVENT_ROTARY, &diff);
     }
     else {
 
-        int32_t vect = indev->pointer.diff > 0 ? indev->scroll_limit : -indev->scroll_limit;
-        indev->pointer.vect.y = vect;
-        indev->pointer.act_obj = obj;
+        int32_t vect = indev->d.pointer.diff > 0 ? indev->scroll_limit : -indev->scroll_limit;
+        indev->d.pointer.vect.y = vect;
+        indev->d.pointer.act_obj = obj;
         lv_obj_t * scroll_obj = lv_indev_find_scroll_obj(indev);
         if(scroll_obj == NULL) return;
         uint32_t indev_sensitivity = indev->rotary_sensitivity;
         uint32_t obj_sensitivity = lv_obj_get_style_rotary_sensitivity(scroll_obj, LV_PART_MAIN);
-        int32_t diff = (int32_t)((int32_t)indev->pointer.diff * indev_sensitivity * obj_sensitivity + 32768) >> 16;
+        int32_t diff = (int32_t)((int32_t)indev->d.pointer.diff * indev_sensitivity * obj_sensitivity + 32768) >> 16;
 
-        indev->pointer.scroll_throw_vect.y = diff;
-        indev->pointer.scroll_throw_vect_ori.y = diff;
+        indev->d.pointer.scroll_throw_vect.y = diff;
+        indev->d.pointer.scroll_throw_vect_ori.y = diff;
         lv_indev_scroll_handler(indev);
     }
 
@@ -1673,21 +1683,21 @@ static lv_obj_t * pointer_search_obj(lv_display_t * disp, lv_point_t * p)
 static void indev_proc_reset_query_handler(lv_indev_t * indev)
 {
     if(indev->reset_query) {
-        indev->pointer.act_obj           = NULL;
-        indev->pointer.scroll_obj        = NULL;
-        indev->pointer.last_hovered      = NULL;
+        indev->d.pointer.act_obj           = NULL;
+        indev->d.pointer.scroll_obj        = NULL;
+        indev->d.pointer.last_hovered      = NULL;
         indev->timestamp = lv_tick_get();
         indev->long_pr_sent                    = 0;
         indev->pr_timestamp                    = 0;
         indev->longpr_rep_timestamp            = 0;
-        indev->pointer.scroll_sum.x        = 0;
-        indev->pointer.scroll_sum.y        = 0;
-        indev->pointer.scroll_dir = LV_DIR_NONE;
-        indev->pointer.scroll_obj = NULL;
-        indev->pointer.scroll_throw_vect.x = 0;
-        indev->pointer.scroll_throw_vect.y = 0;
-        indev->pointer.gesture_sum.x     = 0;
-        indev->pointer.gesture_sum.y     = 0;
+        indev->d.pointer.scroll_sum.x        = 0;
+        indev->d.pointer.scroll_sum.y        = 0;
+        indev->d.pointer.scroll_dir = LV_DIR_NONE;
+        indev->d.pointer.scroll_obj = NULL;
+        indev->d.pointer.scroll_throw_vect.x = 0;
+        indev->d.pointer.scroll_throw_vect.y = 0;
+        indev->d.pointer.gesture_sum.x     = 0;
+        indev->d.pointer.gesture_sum.y     = 0;
         indev->reset_query                     = 0;
         if(indev->type == LV_INDEV_TYPE_ENCODER) {
             /* Before v9.5, LV_INDEV_TYPE_ENCODER set LV_KEY_ENTER as the last key on EVERY frame.
@@ -1697,7 +1707,7 @@ static void indev_proc_reset_query_handler(lv_indev_t * indev)
              * explicitly set the key, as it was previously always defaulting to LV_KEY_ENTER.
              * To maintain compatibility, we initialize the key to LV_KEY_ENTER here.
              */
-            indev->keypad.last_key = LV_KEY_ENTER;
+            indev->d.keypad.last_key = LV_KEY_ENTER;
         }
         indev->stop_processing_query           = 0;
         indev_obj_act                               = NULL;
@@ -1716,7 +1726,7 @@ static void indev_click_focus(lv_indev_t * indev)
     }
 
     lv_group_t * g_act = lv_obj_get_group(indev_obj_act);
-    lv_group_t * g_prev = indev->pointer.last_pressed ? lv_obj_get_group(indev->pointer.last_pressed) : NULL;
+    lv_group_t * g_prev = indev->d.pointer.last_pressed ? lv_obj_get_group(indev->d.pointer.last_pressed) : NULL;
 
     /*If both the last and act. obj. are in the same group (or have no group)*/
     if(g_act == g_prev) {
@@ -1727,8 +1737,8 @@ static void indev_click_focus(lv_indev_t * indev)
         }
         /*The object are not in group*/
         else {
-            if(indev->pointer.last_pressed != indev_obj_act) {
-                lv_obj_send_event(indev->pointer.last_pressed, LV_EVENT_DEFOCUSED, indev_act);
+            if(indev->d.pointer.last_pressed != indev_obj_act) {
+                lv_obj_send_event(indev->d.pointer.last_pressed, LV_EVENT_DEFOCUSED, indev_act);
                 if(indev_reset_check(indev)) return;
 
                 lv_obj_send_event(indev_obj_act, LV_EVENT_FOCUSED, indev_act);
@@ -1739,21 +1749,21 @@ static void indev_click_focus(lv_indev_t * indev)
     /*The object are not in the same group (in different groups or one has no group)*/
     else {
         /*If the prev. obj. is not in a group then defocus it.*/
-        if(g_prev == NULL && indev->pointer.last_pressed) {
-            lv_obj_send_event(indev->pointer.last_pressed, LV_EVENT_DEFOCUSED, indev_act);
+        if(g_prev == NULL && indev->d.pointer.last_pressed) {
+            lv_obj_send_event(indev->d.pointer.last_pressed, LV_EVENT_DEFOCUSED, indev_act);
             if(indev_reset_check(indev)) return;
         }
         /*Focus on a non-group object*/
         else {
-            if(indev->pointer.last_pressed) {
+            if(indev->d.pointer.last_pressed) {
                 /*If the prev. object also wasn't in a group defocus it*/
                 if(g_prev == NULL) {
-                    lv_obj_send_event(indev->pointer.last_pressed, LV_EVENT_DEFOCUSED, indev_act);
+                    lv_obj_send_event(indev->d.pointer.last_pressed, LV_EVENT_DEFOCUSED, indev_act);
                     if(indev_reset_check(indev)) return;
                 }
                 /*If the prev. object also was in a group at least "LEAVE" it instead of defocus*/
                 else {
-                    lv_obj_send_event(indev->pointer.last_pressed, LV_EVENT_LEAVE, indev_act);
+                    lv_obj_send_event(indev->d.pointer.last_pressed, LV_EVENT_LEAVE, indev_act);
                     if(indev_reset_check(indev)) return;
                 }
             }
@@ -1769,7 +1779,7 @@ static void indev_click_focus(lv_indev_t * indev)
             if(indev_reset_check(indev)) return;
         }
     }
-    indev->pointer.last_pressed = indev_obj_act;
+    indev->d.pointer.last_pressed = indev_obj_act;
 }
 
 /**
@@ -1778,10 +1788,10 @@ static void indev_click_focus(lv_indev_t * indev)
 */
 void indev_gesture(lv_indev_t * indev)
 {
-    if(indev->pointer.scroll_obj) return;
-    if(indev->pointer.gesture_sent) return;
+    if(indev->d.pointer.scroll_obj) return;
+    if(indev->d.pointer.gesture_sent) return;
 
-    lv_obj_t * gesture_obj = indev->pointer.act_obj;
+    lv_obj_t * gesture_obj = indev->d.pointer.act_obj;
 
     /*If gesture parent is active check recursively the gesture attribute*/
     while(gesture_obj && lv_obj_has_flag(gesture_obj, LV_OBJ_FLAG_GESTURE_BUBBLE)) {
@@ -1790,32 +1800,32 @@ void indev_gesture(lv_indev_t * indev)
 
     if(gesture_obj == NULL) return;
 
-    if((LV_ABS(indev->pointer.vect.x) < indev_act->gesture_min_velocity) &&
-       (LV_ABS(indev->pointer.vect.y) < indev_act->gesture_min_velocity)) {
-        indev->pointer.gesture_sum.x = 0;
-        indev->pointer.gesture_sum.y = 0;
+    if((LV_ABS(indev->d.pointer.vect.x) < indev_act->gesture_min_velocity) &&
+       (LV_ABS(indev->d.pointer.vect.y) < indev_act->gesture_min_velocity)) {
+        indev->d.pointer.gesture_sum.x = 0;
+        indev->d.pointer.gesture_sum.y = 0;
     }
 
     /*Count the movement by gesture*/
-    indev->pointer.gesture_sum.x += indev->pointer.vect.x;
-    indev->pointer.gesture_sum.y += indev->pointer.vect.y;
+    indev->d.pointer.gesture_sum.x += indev->d.pointer.vect.x;
+    indev->d.pointer.gesture_sum.y += indev->d.pointer.vect.y;
 
-    if((LV_ABS(indev->pointer.gesture_sum.x) > indev_act->gesture_min_distance) ||
-       (LV_ABS(indev->pointer.gesture_sum.y) > indev_act->gesture_min_distance)) {
+    if((LV_ABS(indev->d.pointer.gesture_sum.x) > indev_act->gesture_min_distance) ||
+       (LV_ABS(indev->d.pointer.gesture_sum.y) > indev_act->gesture_min_distance)) {
 
-        indev->pointer.gesture_sent = 1;
+        indev->d.pointer.gesture_sent = 1;
 
-        if(LV_ABS(indev->pointer.gesture_sum.x) > LV_ABS(indev->pointer.gesture_sum.y)) {
-            if(indev->pointer.gesture_sum.x > 0)
-                indev->pointer.gesture_dir = LV_DIR_RIGHT;
+        if(LV_ABS(indev->d.pointer.gesture_sum.x) > LV_ABS(indev->d.pointer.gesture_sum.y)) {
+            if(indev->d.pointer.gesture_sum.x > 0)
+                indev->d.pointer.gesture_dir = LV_DIR_RIGHT;
             else
-                indev->pointer.gesture_dir = LV_DIR_LEFT;
+                indev->d.pointer.gesture_dir = LV_DIR_LEFT;
         }
         else {
-            if(indev->pointer.gesture_sum.y > 0)
-                indev->pointer.gesture_dir = LV_DIR_BOTTOM;
+            if(indev->d.pointer.gesture_sum.y > 0)
+                indev->d.pointer.gesture_dir = LV_DIR_BOTTOM;
             else
-                indev->pointer.gesture_dir = LV_DIR_TOP;
+                indev->d.pointer.gesture_dir = LV_DIR_TOP;
         }
 
         lv_obj_send_event(gesture_obj, LV_EVENT_GESTURE, indev_act);
@@ -1863,30 +1873,30 @@ static void indev_reset_core(lv_indev_t * indev, lv_obj_t * obj)
     indev->reset_query = 1;
     if(indev_act == indev) indev_obj_act = NULL;
     if(indev->type == LV_INDEV_TYPE_POINTER || indev->type == LV_INDEV_TYPE_KEYPAD) {
-        if(obj == NULL || indev->pointer.last_pressed == obj) {
-            indev->pointer.last_pressed = NULL;
+        if(obj == NULL || indev->d.pointer.last_pressed == obj) {
+            indev->d.pointer.last_pressed = NULL;
         }
 
-        if(indev->pointer.act_obj) {
+        if(indev->d.pointer.act_obj) {
             /* Avoid recursive calls */
-            act_obj = indev->pointer.act_obj;
-            indev->pointer.act_obj = NULL;
+            act_obj = indev->d.pointer.act_obj;
+            indev->d.pointer.act_obj = NULL;
             lv_obj_send_event(act_obj, LV_EVENT_INDEV_RESET, indev);
             lv_indev_send_event(indev, LV_EVENT_INDEV_RESET, act_obj);
             act_obj = NULL;
         }
 
-        if(indev->pointer.scroll_obj) {
+        if(indev->d.pointer.scroll_obj) {
             /* Avoid recursive calls */
-            scroll_obj = indev->pointer.scroll_obj;
-            indev->pointer.scroll_obj = NULL;
+            scroll_obj = indev->d.pointer.scroll_obj;
+            indev->d.pointer.scroll_obj = NULL;
             lv_obj_send_event(scroll_obj, LV_EVENT_INDEV_RESET, indev);
             lv_indev_send_event(indev, LV_EVENT_INDEV_RESET, scroll_obj);
             scroll_obj = NULL;
         }
 
-        if(obj == NULL || indev->pointer.last_hovered == obj) {
-            indev->pointer.last_hovered = NULL;
+        if(obj == NULL || indev->d.pointer.last_hovered == obj) {
+            indev->d.pointer.last_hovered = NULL;
         }
     }
 }
@@ -1927,7 +1937,7 @@ static void indev_scroll_throw_anim_cb(void * var, int32_t v)
 
     lv_indev_scroll_throw_handler(indev);
 
-    if(indev->pointer.scroll_dir == LV_DIR_NONE || indev->pointer.scroll_obj == NULL) {
+    if(indev->d.pointer.scroll_dir == LV_DIR_NONE || indev->d.pointer.scroll_obj == NULL) {
         if(indev->scroll_throw_anim) {
             LV_LOG_INFO("stop animation");
             lv_anim_delete(indev, indev_scroll_throw_anim_cb);

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -199,12 +199,8 @@ void indev_read_core(lv_indev_t * indev, lv_indev_data_t * data)
         data->point.y = indev->pointer.last_raw_point.y;
     }
     /*Similarly set at least the last key in case of the user doesn't set it on release*/
-    else if(indev->type == LV_INDEV_TYPE_KEYPAD) {
+    else if(indev->type == LV_INDEV_TYPE_KEYPAD || indev->type == LV_INDEV_TYPE_ENCODER) {
         data->key = indev->keypad.last_key;
-    }
-    /*For compatibility assume that used button was enter (encoder push)*/
-    else if(indev->type == LV_INDEV_TYPE_ENCODER) {
-        data->key = LV_KEY_ENTER;
     }
 
     if(indev->read_cb) {
@@ -1693,6 +1689,16 @@ static void indev_proc_reset_query_handler(lv_indev_t * indev)
         indev->pointer.gesture_sum.x     = 0;
         indev->pointer.gesture_sum.y     = 0;
         indev->reset_query                     = 0;
+        if(indev->type == LV_INDEV_TYPE_ENCODER) {
+            /* Before v9.5, LV_INDEV_TYPE_ENCODER set LV_KEY_ENTER as the last key on EVERY frame.
+             * This required users to store and re-feed the last key to LVGL each frame.
+             * From v9.5 onward, we no longer reset the key every frame to simplify the user's
+             * implementation. However, this can cause compatibility issues for users who never
+             * explicitly set the key, as it was previously always defaulting to LV_KEY_ENTER.
+             * To maintain compatibility, we initialize the key to LV_KEY_ENTER here.
+             */
+            indev->keypad.last_key = LV_KEY_ENTER;
+        }
         indev->stop_processing_query           = 0;
         indev_obj_act                               = NULL;
     }

--- a/src/indev/lv_indev_private.h
+++ b/src/indev/lv_indev_private.h
@@ -83,42 +83,44 @@ struct _lv_indev_t {
     /**< Rotary diff count will be multiplied by this value and divided by 256*/
     int32_t rotary_sensitivity;
 
-    struct {
-        /*Pointer and button data*/
-        lv_point_t act_point; /**< Current point of input device.*/
-        lv_point_t last_point; /**< Last point of input device.*/
-        lv_point_t last_raw_point; /**< Last point read from read_cb. */
-        lv_point_t vect; /**< Difference between `act_point` and `last_point`.*/
-        lv_point_t vect_hist[LV_INDEV_VECT_HIST_SIZE];
-        uint32_t   vect_hist_timestamp[LV_INDEV_VECT_HIST_SIZE];
-        uint8_t    vect_hist_index;
-        lv_point_t scroll_sum; /*Count the dragged pixels to check LV_INDEV_DEF_SCROLL_LIMIT*/
-        lv_point_t scroll_throw_vect;
-        lv_point_t scroll_throw_vect_ori;
-        lv_obj_t * act_obj;      /*The object being pressed*/
-        lv_obj_t * scroll_obj;   /*The object being scrolled*/
-        lv_obj_t * last_pressed; /*The lastly pressed object*/
-        lv_obj_t * last_hovered; /*The lastly hovered object*/
-        lv_area_t scroll_area;
-        lv_point_t gesture_sum; /*Count the gesture pixels to check LV_INDEV_DEF_GESTURE_LIMIT*/
-        int32_t diff;
-        /*Short click streaks*/
-        uint8_t short_click_streak;
-        lv_point_t last_short_click_point;
-        uint32_t last_short_click_timestamp;
-        /*Flags*/
-        uint8_t scroll_dir : 4;
-        uint8_t gesture_dir : 4;
-        uint8_t gesture_sent : 1;
-        uint8_t press_moved : 1;
-        uint8_t pressed : 1;
-    } pointer;
-    struct {
-        /*Keypad data*/
-        lv_indev_state_t last_state;
-        uint32_t last_key;
-    } keypad;
+    union {
+        struct {
+            /*Pointer and button data*/
+            lv_point_t act_point; /**< Current point of input device.*/
+            lv_point_t last_point; /**< Last point of input device.*/
+            lv_point_t last_raw_point; /**< Last point read from read_cb. */
+            lv_point_t vect; /**< Difference between `act_point` and `last_point`.*/
+            lv_point_t vect_hist[LV_INDEV_VECT_HIST_SIZE];
+            uint32_t   vect_hist_timestamp[LV_INDEV_VECT_HIST_SIZE];
+            uint8_t    vect_hist_index;
+            lv_point_t scroll_sum; /*Count the dragged pixels to check LV_INDEV_DEF_SCROLL_LIMIT*/
+            lv_point_t scroll_throw_vect;
+            lv_point_t scroll_throw_vect_ori;
+            lv_obj_t * act_obj;      /*The object being pressed*/
+            lv_obj_t * scroll_obj;   /*The object being scrolled*/
+            lv_obj_t * last_pressed; /*The lastly pressed object*/
+            lv_obj_t * last_hovered; /*The lastly hovered object*/
+            lv_area_t scroll_area;
+            lv_point_t gesture_sum; /*Count the gesture pixels to check LV_INDEV_DEF_GESTURE_LIMIT*/
+            int32_t diff;
+            /*Short click streaks*/
+            uint8_t short_click_streak;
+            lv_point_t last_short_click_point;
+            uint32_t last_short_click_timestamp;
+            /*Flags*/
+            uint8_t scroll_dir : 4;
+            uint8_t gesture_dir : 4;
+            uint8_t gesture_sent : 1;
+            uint8_t press_moved : 1;
+            uint8_t pressed : 1;
+        } pointer;
 
+        struct {
+            /*Keypad data*/
+            lv_indev_state_t last_state;
+            uint32_t last_key;
+        } keypad;
+    } d;
     lv_obj_t * cursor;     /**< Cursor for LV_INPUT_TYPE_POINTER*/
     lv_group_t * group;   /**< Keypad destination group*/
     const lv_point_t * btn_points; /**< Array points assigned to the button ()screen will be pressed

--- a/src/indev/lv_indev_scroll.c
+++ b/src/indev/lv_indev_scroll.c
@@ -46,11 +46,11 @@ static void has_more_snap_points(lv_obj_t * scroll_obj, lv_dir_t dir, bool * has
 
 void lv_indev_scroll_handler(lv_indev_t * indev)
 {
-    if(indev->pointer.vect.x == 0 && indev->pointer.vect.y == 0) {
+    if(indev->d.pointer.vect.x == 0 && indev->d.pointer.vect.y == 0) {
         return;
     }
 
-    lv_obj_t * scroll_obj = indev->pointer.scroll_obj;
+    lv_obj_t * scroll_obj = indev->d.pointer.scroll_obj;
     /*If there is no scroll object yet try to find one*/
     if(scroll_obj == NULL) {
         scroll_obj = lv_indev_find_scroll_obj(indev);
@@ -58,7 +58,7 @@ void lv_indev_scroll_handler(lv_indev_t * indev)
 
         init_scroll_limits(indev);
 
-        lv_obj_remove_state(indev->pointer.act_obj, LV_STATE_PRESSED);
+        lv_obj_remove_state(indev->d.pointer.act_obj, LV_STATE_PRESSED);
         lv_obj_send_event(scroll_obj, LV_EVENT_SCROLL_BEGIN, NULL);
         if(indev->reset_query) return;
     }
@@ -90,20 +90,20 @@ void lv_indev_scroll_handler(lv_indev_t * indev)
         scale_x = (256 * 256) / scale_x;
         scale_y = (256 * 256) / scale_y;
         lv_point_t pivot = { 0, 0 };
-        lv_point_transform(&indev->pointer.vect, angle, scale_x, scale_y, &pivot, false);
+        lv_point_transform(&indev->d.pointer.vect, angle, scale_x, scale_y, &pivot, false);
     }
 
     int32_t diff_x = 0;
     int32_t diff_y = 0;
-    if(indev->pointer.scroll_dir == LV_DIR_HOR) {
+    if(indev->d.pointer.scroll_dir == LV_DIR_HOR) {
         int32_t sr = lv_obj_get_scroll_right(scroll_obj);
         int32_t sl = lv_obj_get_scroll_left(scroll_obj);
-        diff_x = elastic_diff(scroll_obj, indev->pointer.vect.x, sl, sr, LV_DIR_HOR);
+        diff_x = elastic_diff(scroll_obj, indev->d.pointer.vect.x, sl, sr, LV_DIR_HOR);
     }
     else {
         int32_t st = lv_obj_get_scroll_top(scroll_obj);
         int32_t sb = lv_obj_get_scroll_bottom(scroll_obj);
-        diff_y = elastic_diff(scroll_obj, indev->pointer.vect.y, st, sb, LV_DIR_VER);
+        diff_y = elastic_diff(scroll_obj, indev->d.pointer.vect.y, st, sb, LV_DIR_VER);
     }
 
     lv_dir_t scroll_dir = lv_obj_get_scroll_dir(scroll_obj);
@@ -117,72 +117,72 @@ void lv_indev_scroll_handler(lv_indev_t * indev)
 
     lv_obj_scroll_by_raw(scroll_obj, diff_x, diff_y);
     if(indev->reset_query) return;
-    indev->pointer.scroll_sum.x += diff_x;
-    indev->pointer.scroll_sum.y += diff_y;
+    indev->d.pointer.scroll_sum.x += diff_x;
+    indev->d.pointer.scroll_sum.y += diff_y;
 }
 
 void lv_indev_scroll_throw_handler(lv_indev_t * indev)
 {
-    lv_obj_t * scroll_obj = indev->pointer.scroll_obj;
+    lv_obj_t * scroll_obj = indev->d.pointer.scroll_obj;
     if(scroll_obj == NULL) return;
-    if(indev->pointer.scroll_dir == LV_DIR_NONE) return;
+    if(indev->d.pointer.scroll_dir == LV_DIR_NONE) return;
 
     int32_t scroll_throw = indev->scroll_throw;
 
     if(lv_obj_has_flag(scroll_obj, LV_OBJ_FLAG_SCROLL_MOMENTUM) == false) {
-        indev->pointer.scroll_throw_vect.y = 0;
-        indev->pointer.scroll_throw_vect.x = 0;
+        indev->d.pointer.scroll_throw_vect.y = 0;
+        indev->d.pointer.scroll_throw_vect.x = 0;
     }
 
     lv_scroll_snap_t align_x = lv_obj_get_scroll_snap_x(scroll_obj);
     lv_scroll_snap_t align_y = lv_obj_get_scroll_snap_y(scroll_obj);
 
-    if(indev->pointer.scroll_dir == LV_DIR_VER) {
-        indev->pointer.scroll_throw_vect.x = 0;
+    if(indev->d.pointer.scroll_dir == LV_DIR_VER) {
+        indev->d.pointer.scroll_throw_vect.x = 0;
         /*If no snapping "throw"*/
         if(align_y == LV_SCROLL_SNAP_NONE) {
-            indev->pointer.scroll_throw_vect.y =
-                indev->pointer.scroll_throw_vect.y * (100 - scroll_throw) / 100;
+            indev->d.pointer.scroll_throw_vect.y =
+                indev->d.pointer.scroll_throw_vect.y * (100 - scroll_throw) / 100;
 
             int32_t sb = lv_obj_get_scroll_bottom(scroll_obj);
             int32_t st = lv_obj_get_scroll_top(scroll_obj);
 
-            indev->pointer.scroll_throw_vect.y = elastic_diff(scroll_obj, indev->pointer.scroll_throw_vect.y, st, sb,
-                                                              LV_DIR_VER);
+            indev->d.pointer.scroll_throw_vect.y = elastic_diff(scroll_obj, indev->d.pointer.scroll_throw_vect.y, st, sb,
+                                                                LV_DIR_VER);
 
-            lv_obj_scroll_by_raw(scroll_obj, 0,  indev->pointer.scroll_throw_vect.y);
+            lv_obj_scroll_by_raw(scroll_obj, 0,  indev->d.pointer.scroll_throw_vect.y);
             if(indev->reset_query) return;
         }
         /*With snapping find the nearest snap point and scroll there*/
         else {
             int32_t diff_y = lv_indev_scroll_throw_predict(indev, LV_DIR_VER);
-            indev->pointer.scroll_throw_vect.y = 0;
+            indev->d.pointer.scroll_throw_vect.y = 0;
             scroll_limit_diff(indev, NULL, &diff_y);
             int32_t y = find_snap_point_y(scroll_obj, LV_COORD_MIN, LV_COORD_MAX, diff_y);
             lv_obj_scroll_by(scroll_obj, 0, diff_y + y, LV_ANIM_ON);
             if(indev->reset_query) return;
         }
     }
-    else if(indev->pointer.scroll_dir == LV_DIR_HOR) {
-        indev->pointer.scroll_throw_vect.y = 0;
+    else if(indev->d.pointer.scroll_dir == LV_DIR_HOR) {
+        indev->d.pointer.scroll_throw_vect.y = 0;
         /*If no snapping "throw"*/
         if(align_x == LV_SCROLL_SNAP_NONE) {
-            indev->pointer.scroll_throw_vect.x =
-                indev->pointer.scroll_throw_vect.x * (100 - scroll_throw) / 100;
+            indev->d.pointer.scroll_throw_vect.x =
+                indev->d.pointer.scroll_throw_vect.x * (100 - scroll_throw) / 100;
 
             int32_t sl = lv_obj_get_scroll_left(scroll_obj);
             int32_t sr = lv_obj_get_scroll_right(scroll_obj);
 
-            indev->pointer.scroll_throw_vect.x = elastic_diff(scroll_obj, indev->pointer.scroll_throw_vect.x, sl, sr,
-                                                              LV_DIR_HOR);
+            indev->d.pointer.scroll_throw_vect.x = elastic_diff(scroll_obj, indev->d.pointer.scroll_throw_vect.x, sl, sr,
+                                                                LV_DIR_HOR);
 
-            lv_obj_scroll_by_raw(scroll_obj, indev->pointer.scroll_throw_vect.x, 0);
+            lv_obj_scroll_by_raw(scroll_obj, indev->d.pointer.scroll_throw_vect.x, 0);
             if(indev->reset_query) return;
         }
         /*With snapping find the nearest snap point and scroll there*/
         else {
             int32_t diff_x = lv_indev_scroll_throw_predict(indev, LV_DIR_HOR);
-            indev->pointer.scroll_throw_vect.x = 0;
+            indev->d.pointer.scroll_throw_vect.x = 0;
             scroll_limit_diff(indev, &diff_x, NULL);
             int32_t x = find_snap_point_x(scroll_obj, LV_COORD_MIN, LV_COORD_MAX, diff_x);
             lv_obj_scroll_by(scroll_obj, x + diff_x, 0, LV_ANIM_ON);
@@ -191,7 +191,7 @@ void lv_indev_scroll_throw_handler(lv_indev_t * indev)
     }
 
     /*Check if the scroll has finished*/
-    if(indev->pointer.scroll_throw_vect.x == 0 && indev->pointer.scroll_throw_vect.y == 0) {
+    if(indev->d.pointer.scroll_throw_vect.x == 0 && indev->d.pointer.scroll_throw_vect.y == 0) {
         /*Revert if scrolled in*/
         /*If vertically scrollable and not controlled by snap*/
         if(align_y == LV_SCROLL_SNAP_NONE) {
@@ -228,8 +228,8 @@ void lv_indev_scroll_throw_handler(lv_indev_t * indev)
         lv_obj_send_event(scroll_obj, LV_EVENT_SCROLL_END, indev);
         if(indev->reset_query) return;
 
-        indev->pointer.scroll_dir = LV_DIR_NONE;
-        indev->pointer.scroll_obj = NULL;
+        indev->d.pointer.scroll_dir = LV_DIR_NONE;
+        indev->d.pointer.scroll_obj = NULL;
     }
 }
 
@@ -239,10 +239,10 @@ int32_t lv_indev_scroll_throw_predict(lv_indev_t * indev, lv_dir_t dir)
     int32_t v;
     switch(dir) {
         case LV_DIR_VER:
-            v = indev->pointer.scroll_throw_vect_ori.y;
+            v = indev->d.pointer.scroll_throw_vect_ori.y;
             break;
         case LV_DIR_HOR:
-            v = indev->pointer.scroll_throw_vect_ori.x;
+            v = indev->d.pointer.scroll_throw_vect_ori.x;
             break;
         default:
             return 0;
@@ -277,13 +277,13 @@ lv_obj_t * lv_indev_find_scroll_obj(lv_indev_t * indev)
      * 3. If an object can be scrolled into the current direction then use it ("real match"")
      * 4. If can be scrolled on the current axis (hor/ver) save it as candidate (at least show an elastic scroll effect)
      * 5. Use the last candidate. Always the "deepest" parent or the object from point 3*/
-    lv_obj_t * obj_act = indev->pointer.act_obj;
+    lv_obj_t * obj_act = indev->d.pointer.act_obj;
 
     /*Decide if it's a horizontal or vertical scroll*/
     bool hor_en = false;
     bool ver_en = false;
-    indev->pointer.scroll_sum.x += indev->pointer.vect.x;
-    indev->pointer.scroll_sum.y += indev->pointer.vect.y;
+    indev->d.pointer.scroll_sum.x += indev->d.pointer.vect.x;
+    indev->d.pointer.scroll_sum.y += indev->d.pointer.vect.y;
 
     while(obj_act) {
         /*Get the transformed scroll_sum with this object*/
@@ -309,7 +309,7 @@ lv_obj_t * lv_indev_find_scroll_obj(lv_indev_t * indev)
             scale_y = 1;
         }
 
-        lv_point_t obj_scroll_sum = indev->pointer.scroll_sum;
+        lv_point_t obj_scroll_sum = indev->d.pointer.scroll_sum;
         if(angle != 0 || scale_x != LV_SCALE_NONE || scale_y != LV_SCALE_NONE) {
             angle = -angle;
             scale_x = (256 * 256) / scale_x;
@@ -412,7 +412,7 @@ lv_obj_t * lv_indev_find_scroll_obj(lv_indev_t * indev)
            (right_en && obj_scroll_sum.x <= - scroll_limit) ||
            (up_en    && obj_scroll_sum.y >=   scroll_limit) ||
            (down_en  && obj_scroll_sum.y <= - scroll_limit)) {
-            indev->pointer.scroll_dir = hor_en ? LV_DIR_HOR : LV_DIR_VER;
+            indev->d.pointer.scroll_dir = hor_en ? LV_DIR_HOR : LV_DIR_VER;
             break;
         }
 
@@ -426,10 +426,10 @@ lv_obj_t * lv_indev_find_scroll_obj(lv_indev_t * indev)
 
     /*Use the last candidate*/
     if(obj_candidate) {
-        indev->pointer.scroll_dir = dir_candidate;
-        indev->pointer.scroll_obj = obj_candidate;
-        indev->pointer.scroll_sum.x = 0;
-        indev->pointer.scroll_sum.y = 0;
+        indev->d.pointer.scroll_dir = dir_candidate;
+        indev->d.pointer.scroll_obj = obj_candidate;
+        indev->d.pointer.scroll_sum.x = 0;
+        indev->d.pointer.scroll_sum.y = 0;
     }
 
     return obj_candidate;
@@ -441,66 +441,66 @@ lv_obj_t * lv_indev_find_scroll_obj(lv_indev_t * indev)
 
 static void init_scroll_limits(lv_indev_t * indev)
 {
-    lv_obj_t * obj = indev->pointer.scroll_obj;
+    lv_obj_t * obj = indev->d.pointer.scroll_obj;
     /*If there no STOP allow scrolling anywhere*/
     if(lv_obj_has_flag(obj, LV_OBJ_FLAG_SCROLL_ONE) == false) {
-        lv_area_set(&indev->pointer.scroll_area, LV_COORD_MIN, LV_COORD_MIN, LV_COORD_MAX, LV_COORD_MAX);
+        lv_area_set(&indev->d.pointer.scroll_area, LV_COORD_MIN, LV_COORD_MIN, LV_COORD_MAX, LV_COORD_MAX);
     }
     /*With STOP limit the scrolling to the perv and next snap point*/
     else {
         switch(lv_obj_get_scroll_snap_y(obj)) {
             case LV_SCROLL_SNAP_START:
-                indev->pointer.scroll_area.y1 = find_snap_point_y(obj, obj->coords.y1 + 1, LV_COORD_MAX, 0);
-                indev->pointer.scroll_area.y2 = find_snap_point_y(obj, LV_COORD_MIN, obj->coords.y1 - 1, 0);
+                indev->d.pointer.scroll_area.y1 = find_snap_point_y(obj, obj->coords.y1 + 1, LV_COORD_MAX, 0);
+                indev->d.pointer.scroll_area.y2 = find_snap_point_y(obj, LV_COORD_MIN, obj->coords.y1 - 1, 0);
                 break;
             case LV_SCROLL_SNAP_END:
-                indev->pointer.scroll_area.y1 = find_snap_point_y(obj, obj->coords.y2, LV_COORD_MAX, 0);
-                indev->pointer.scroll_area.y2 = find_snap_point_y(obj, LV_COORD_MIN, obj->coords.y2, 0);
+                indev->d.pointer.scroll_area.y1 = find_snap_point_y(obj, obj->coords.y2, LV_COORD_MAX, 0);
+                indev->d.pointer.scroll_area.y2 = find_snap_point_y(obj, LV_COORD_MIN, obj->coords.y2, 0);
                 break;
             case LV_SCROLL_SNAP_CENTER: {
                     int32_t y_mid = obj->coords.y1 + lv_area_get_height(&obj->coords) / 2;
-                    indev->pointer.scroll_area.y1 = find_snap_point_y(obj, y_mid + 1, LV_COORD_MAX, 0);
-                    indev->pointer.scroll_area.y2 = find_snap_point_y(obj, LV_COORD_MIN, y_mid - 1, 0);
+                    indev->d.pointer.scroll_area.y1 = find_snap_point_y(obj, y_mid + 1, LV_COORD_MAX, 0);
+                    indev->d.pointer.scroll_area.y2 = find_snap_point_y(obj, LV_COORD_MIN, y_mid - 1, 0);
                     break;
                 }
             default:
-                indev->pointer.scroll_area.y1 = LV_COORD_MIN;
-                indev->pointer.scroll_area.y2 = LV_COORD_MAX;
+                indev->d.pointer.scroll_area.y1 = LV_COORD_MIN;
+                indev->d.pointer.scroll_area.y2 = LV_COORD_MAX;
                 break;
         }
 
         switch(lv_obj_get_scroll_snap_x(obj)) {
             case LV_SCROLL_SNAP_START:
-                indev->pointer.scroll_area.x1 = find_snap_point_x(obj, obj->coords.x1, LV_COORD_MAX, 0);
-                indev->pointer.scroll_area.x2 = find_snap_point_x(obj, LV_COORD_MIN, obj->coords.x1, 0);
+                indev->d.pointer.scroll_area.x1 = find_snap_point_x(obj, obj->coords.x1, LV_COORD_MAX, 0);
+                indev->d.pointer.scroll_area.x2 = find_snap_point_x(obj, LV_COORD_MIN, obj->coords.x1, 0);
                 break;
             case LV_SCROLL_SNAP_END:
-                indev->pointer.scroll_area.x1 = find_snap_point_x(obj, obj->coords.x2, LV_COORD_MAX, 0);
-                indev->pointer.scroll_area.x2 = find_snap_point_x(obj, LV_COORD_MIN, obj->coords.x2, 0);
+                indev->d.pointer.scroll_area.x1 = find_snap_point_x(obj, obj->coords.x2, LV_COORD_MAX, 0);
+                indev->d.pointer.scroll_area.x2 = find_snap_point_x(obj, LV_COORD_MIN, obj->coords.x2, 0);
                 break;
             case LV_SCROLL_SNAP_CENTER: {
                     int32_t x_mid = obj->coords.x1 + lv_area_get_width(&obj->coords) / 2;
-                    indev->pointer.scroll_area.x1 = find_snap_point_x(obj, x_mid + 1, LV_COORD_MAX, 0);
-                    indev->pointer.scroll_area.x2 = find_snap_point_x(obj, LV_COORD_MIN, x_mid - 1, 0);
+                    indev->d.pointer.scroll_area.x1 = find_snap_point_x(obj, x_mid + 1, LV_COORD_MAX, 0);
+                    indev->d.pointer.scroll_area.x2 = find_snap_point_x(obj, LV_COORD_MIN, x_mid - 1, 0);
                     break;
                 }
             default:
-                indev->pointer.scroll_area.x1 = LV_COORD_MIN;
-                indev->pointer.scroll_area.x2 = LV_COORD_MAX;
+                indev->d.pointer.scroll_area.x1 = LV_COORD_MIN;
+                indev->d.pointer.scroll_area.x2 = LV_COORD_MAX;
                 break;
         }
     }
 
     /*`find_snap_point_x/y()` return LV_COORD_MAX is not snap point was found,
      *but x1/y1 should be small. */
-    if(indev->pointer.scroll_area.x1 == LV_COORD_MAX) indev->pointer.scroll_area.x1 = LV_COORD_MIN;
-    if(indev->pointer.scroll_area.y1 == LV_COORD_MAX) indev->pointer.scroll_area.y1 = LV_COORD_MIN;
+    if(indev->d.pointer.scroll_area.x1 == LV_COORD_MAX) indev->d.pointer.scroll_area.x1 = LV_COORD_MIN;
+    if(indev->d.pointer.scroll_area.y1 == LV_COORD_MAX) indev->d.pointer.scroll_area.y1 = LV_COORD_MIN;
 
     /*Allow scrolling on the edges. It will be reverted to the edge due to snapping anyway*/
-    if(indev->pointer.scroll_area.x1 == 0) indev->pointer.scroll_area.x1 = LV_COORD_MIN;
-    if(indev->pointer.scroll_area.x2 == 0) indev->pointer.scroll_area.x2 = LV_COORD_MAX;
-    if(indev->pointer.scroll_area.y1 == 0) indev->pointer.scroll_area.y1 = LV_COORD_MIN;
-    if(indev->pointer.scroll_area.y2 == 0) indev->pointer.scroll_area.y2 = LV_COORD_MAX;
+    if(indev->d.pointer.scroll_area.x1 == 0) indev->d.pointer.scroll_area.x1 = LV_COORD_MIN;
+    if(indev->d.pointer.scroll_area.x2 == 0) indev->d.pointer.scroll_area.x2 = LV_COORD_MAX;
+    if(indev->d.pointer.scroll_area.y1 == 0) indev->d.pointer.scroll_area.y1 = LV_COORD_MIN;
+    if(indev->d.pointer.scroll_area.y2 == 0) indev->d.pointer.scroll_area.y2 = LV_COORD_MAX;
 }
 
 /**
@@ -618,22 +618,22 @@ static int32_t find_snap_point_y(const lv_obj_t * obj, int32_t min, int32_t max,
 static void scroll_limit_diff(lv_indev_t * indev, int32_t * diff_x, int32_t * diff_y)
 {
     if(diff_y) {
-        if(indev->pointer.scroll_sum.y + *diff_y < indev->pointer.scroll_area.y1) {
-            *diff_y = indev->pointer.scroll_area.y1 - indev->pointer.scroll_sum.y;
+        if(indev->d.pointer.scroll_sum.y + *diff_y < indev->d.pointer.scroll_area.y1) {
+            *diff_y = indev->d.pointer.scroll_area.y1 - indev->d.pointer.scroll_sum.y;
         }
 
-        if(indev->pointer.scroll_sum.y + *diff_y > indev->pointer.scroll_area.y2) {
-            *diff_y = indev->pointer.scroll_area.y2 - indev->pointer.scroll_sum.y;
+        if(indev->d.pointer.scroll_sum.y + *diff_y > indev->d.pointer.scroll_area.y2) {
+            *diff_y = indev->d.pointer.scroll_area.y2 - indev->d.pointer.scroll_sum.y;
         }
     }
 
     if(diff_x) {
-        if(indev->pointer.scroll_sum.x + *diff_x < indev->pointer.scroll_area.x1) {
-            *diff_x = indev->pointer.scroll_area.x1 - indev->pointer.scroll_sum.x;
+        if(indev->d.pointer.scroll_sum.x + *diff_x < indev->d.pointer.scroll_area.x1) {
+            *diff_x = indev->d.pointer.scroll_area.x1 - indev->d.pointer.scroll_sum.x;
         }
 
-        if(indev->pointer.scroll_sum.x + *diff_x > indev->pointer.scroll_area.x2) {
-            *diff_x = indev->pointer.scroll_area.x2 - indev->pointer.scroll_sum.x;
+        if(indev->d.pointer.scroll_sum.x + *diff_x > indev->d.pointer.scroll_area.x2) {
+            *diff_x = indev->d.pointer.scroll_area.x2 - indev->d.pointer.scroll_sum.x;
         }
     }
 }

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -7,13 +7,13 @@
  *      INCLUDES
  *********************/
 #include "lv_roller_private.h"
+#if LV_USE_ROLLER != 0
+
 #include "../label/lv_label_private.h"
 #include "../../misc/lv_area_private.h"
 #include "../../misc/lv_anim_private.h"
 #include "../../core/lv_obj_private.h"
 #include "../../core/lv_obj_class_private.h"
-#if LV_USE_ROLLER != 0
-
 #include "../../misc/lv_assert.h"
 #include "../../misc/lv_text_private.h"
 #include "../../draw/lv_draw_private.h"
@@ -820,7 +820,7 @@ static lv_result_t release_handler(lv_obj_t * obj)
             int32_t label_unit = font_h + line_space;
             int32_t mid        = obj->coords.y1 + (obj->coords.y2 - obj->coords.y1) / 2;
 
-            lv_point_t p = indev->pointer.scroll_throw_vect_ori;
+            lv_point_t p = indev->d.pointer.scroll_throw_vect_ori;
             transform_vect_recursive(obj, &p);
 
             int32_t scroll_throw = indev->scroll_throw;


### PR DESCRIPTION
Saves a couple of bytes per indev as these two structures are not used at the same time