### PR TITLE
fix(nuttx): fix missing input devices in libuv integration

### DIFF
--- a/src/drivers/nuttx/lv_nuttx_entry.c
+++ b/src/drivers/nuttx/lv_nuttx_entry.c
@@ -262,6 +262,11 @@ void lv_nuttx_deinit(lv_nuttx_result_t * result)
             lv_indev_delete(result->utouch_indev);
             result->utouch_indev = NULL;
         }
+
+        if(result->mouse_indev) {
+            lv_indev_delete(result->mouse_indev);
+            result->mouse_indev = NULL;
+        }
     }
 #else
     lv_nuttx_deinit_custom(result);
@@ -317,11 +322,15 @@ static void lv_nuttx_uv_loop(lv_nuttx_result_t * result)
     uv_info.loop = &loop;
     uv_info.disp = result->disp;
     uv_info.indev = result->indev;
-#ifdef CONFIG_UINPUT_TOUCH
-    uv_info.uindev = result->utouch_indev;
-#endif
+    uv_info.utouch_indev = result->utouch_indev;
+    uv_info.mouse_indev = result->mouse_indev;
 
     data = lv_nuttx_uv_init(&uv_info);
+    if(data == NULL) {
+        LV_LOG_ERROR("lv_nuttx_uv_init failed");
+        uv_loop_close(&loop);
+        return;
+    }
     uv_run(&loop, UV_RUN_DEFAULT);
     lv_nuttx_uv_deinit(&data);
 }

--- a/src/drivers/nuttx/lv_nuttx_libuv.c
+++ b/src/drivers/nuttx/lv_nuttx_libuv.c
@@ -42,6 +42,8 @@ typedef struct {
     uv_timer_t uv_timer;
     lv_nuttx_uv_fb_ctx_t fb_ctx;
     lv_nuttx_uv_input_ctx_t input_ctx;
+    lv_nuttx_uv_input_ctx_t utouch_ctx;
+    lv_nuttx_uv_input_ctx_t mouse_ctx;
     int32_t ref_count;
 } lv_nuttx_uv_ctx_t;
 
@@ -60,6 +62,9 @@ static int  lv_nuttx_uv_fb_init(lv_nuttx_uv_t * uv_info, lv_nuttx_uv_ctx_t * uv_
 static void lv_nuttx_uv_fb_deinit(lv_nuttx_uv_ctx_t * uv_ctx);
 
 static void lv_nuttx_uv_input_poll_cb(uv_poll_t * handle, int status, int events);
+static int lv_nuttx_uv_input_init_one(uv_loop_t * loop, lv_indev_t * indev,
+                                      lv_nuttx_uv_input_ctx_t * input_ctx, lv_nuttx_uv_ctx_t * uv_ctx);
+static void lv_nuttx_uv_input_deinit_one(lv_nuttx_uv_input_ctx_t * input_ctx);
 static int lv_nuttx_uv_input_init(lv_nuttx_uv_t * uv_info, lv_nuttx_uv_ctx_t * uv_ctx);
 static void lv_nuttx_uv_input_deinit(lv_nuttx_uv_ctx_t * uv_ctx);
 
@@ -102,7 +107,14 @@ void * lv_nuttx_uv_init(lv_nuttx_uv_t * uv_info)
     return uv_ctx;
 
 err_out:
-    lv_free(uv_ctx);
+    if(uv_ctx->ref_count > 0) {
+        lv_nuttx_uv_timer_deinit(uv_ctx);
+        lv_nuttx_uv_fb_deinit(uv_ctx);
+        lv_nuttx_uv_input_deinit(uv_ctx);
+    }
+    else {
+        lv_free(uv_ctx);
+    }
     return NULL;
 }
 
@@ -295,37 +307,45 @@ static void lv_nuttx_uv_fb_deinit(lv_nuttx_uv_ctx_t * uv_ctx)
 
 static void lv_nuttx_uv_input_poll_cb(uv_poll_t * handle, int status, int events)
 {
-    lv_indev_t * indev = ((lv_nuttx_uv_ctx_t *)(handle->data))->input_ctx.indev;
+    lv_nuttx_uv_ctx_t * uv_ctx = (lv_nuttx_uv_ctx_t *)handle->data;
+    lv_indev_t * indev = NULL;
+
+    if(handle == &uv_ctx->input_ctx.input_poll) {
+        indev = uv_ctx->input_ctx.indev;
+    }
+    else if(handle == &uv_ctx->utouch_ctx.input_poll) {
+        indev = uv_ctx->utouch_ctx.indev;
+    }
+    else if(handle == &uv_ctx->mouse_ctx.input_poll) {
+        indev = uv_ctx->mouse_ctx.indev;
+    }
 
     if(status < 0) {
         LV_LOG_WARN("input poll error: %s ", uv_strerror(status));
         return;
     }
 
-    if(events & UV_READABLE) {
+    if(events & UV_READABLE && indev) {
         lv_indev_read(indev);
     }
 }
 
-static int lv_nuttx_uv_input_init(lv_nuttx_uv_t * uv_info, lv_nuttx_uv_ctx_t * uv_ctx)
+static int lv_nuttx_uv_input_init_one(uv_loop_t * loop, lv_indev_t * indev,
+                                      lv_nuttx_uv_input_ctx_t * input_ctx, lv_nuttx_uv_ctx_t * uv_ctx)
 {
-    uv_loop_t * loop = uv_info->loop;
-    lv_indev_t * indev = uv_info->indev;
-
     if(indev == NULL) {
-        LV_LOG_USER("skip uv input init.");
         return 0;
     }
 
-    LV_ASSERT_NULL(uv_ctx);
     LV_ASSERT_NULL(loop);
+    LV_ASSERT_NULL(input_ctx);
+    LV_ASSERT_NULL(uv_ctx);
 
     if(lv_indev_get_mode(indev) == LV_INDEV_MODE_EVENT) {
         LV_LOG_ERROR("input device has been running in event-driven mode");
         return -EINVAL;
     }
 
-    lv_nuttx_uv_input_ctx_t * input_ctx = &uv_ctx->input_ctx;
     input_ctx->fd = *(int *)lv_indev_get_driver_data(indev);
     if(input_ctx->fd <= 0) {
         LV_LOG_ERROR("can't get valid input fd");
@@ -345,12 +365,44 @@ static int lv_nuttx_uv_input_init(lv_nuttx_uv_t * uv_info, lv_nuttx_uv_ctx_t * u
     return 0;
 }
 
-static void lv_nuttx_uv_input_deinit(lv_nuttx_uv_ctx_t * uv_ctx)
+static int lv_nuttx_uv_input_init(lv_nuttx_uv_t * uv_info, lv_nuttx_uv_ctx_t * uv_ctx)
 {
-    lv_nuttx_uv_input_ctx_t * input_ctx = &uv_ctx->input_ctx;
+    uv_loop_t * loop = uv_info->loop;
+    int ret;
+
+    LV_ASSERT_NULL(uv_ctx);
+    LV_ASSERT_NULL(loop);
+
+    ret = lv_nuttx_uv_input_init_one(loop, uv_info->indev, &uv_ctx->input_ctx, uv_ctx);
+    if(ret < 0) {
+        return ret;
+    }
+
+    ret = lv_nuttx_uv_input_init_one(loop, uv_info->utouch_indev, &uv_ctx->utouch_ctx, uv_ctx);
+    if(ret < 0) {
+        return ret;
+    }
+
+    ret = lv_nuttx_uv_input_init_one(loop, uv_info->mouse_indev, &uv_ctx->mouse_ctx, uv_ctx);
+    if(ret < 0) {
+        return ret;
+    }
+
+    return 0;
+}
+
+static void lv_nuttx_uv_input_deinit_one(lv_nuttx_uv_input_ctx_t * input_ctx)
+{
     if(input_ctx->fd > 0) {
         uv_close((uv_handle_t *)&input_ctx->input_poll, lv_nuttx_uv_deinit_cb);
     }
+}
+
+static void lv_nuttx_uv_input_deinit(lv_nuttx_uv_ctx_t * uv_ctx)
+{
+    lv_nuttx_uv_input_deinit_one(&uv_ctx->input_ctx);
+    lv_nuttx_uv_input_deinit_one(&uv_ctx->utouch_ctx);
+    lv_nuttx_uv_input_deinit_one(&uv_ctx->mouse_ctx);
     LV_LOG_USER("Done");
 }
 

--- a/src/drivers/nuttx/lv_nuttx_libuv.h
+++ b/src/drivers/nuttx/lv_nuttx_libuv.h
@@ -33,6 +33,8 @@ typedef struct {
     void * loop;
     lv_display_t * disp;
     lv_indev_t * indev;
+    lv_indev_t * utouch_indev;
+    lv_indev_t * mouse_indev;
 } lv_nuttx_uv_t;
 
 /**********************


### PR DESCRIPTION
A quick fix for nuttx compilation error with CONFIG_UINPUT_TOUCH. struct member `uindev` was undefined