### PR TITLE
fix(color): Explicit casting to prevent warnings

### DIFF
--- a/src/misc/lv_color.h
+++ b/src/misc/lv_color.h
@@ -352,7 +352,7 @@ static inline bool lv_color_is_in_range(lv_color_t color, lv_color_t l_color, lv
  */
 static inline lv_color_t lv_color16_to_color(lv_color16_t c)
 {
-    return lv_color_make(c.red << 3, c.green << 2, c.blue << 3);
+    return lv_color_make((uint8_t)(c.red << 3), (uint8_t)(c.green << 2), (uint8_t)(c.blue << 3));
 }
 
 /**


### PR DESCRIPTION

misc/lv_color.h(355): warning C4244: 'function': conversion from 'int' to 'uint8_t', possible loss of data

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
