### PR TITLE
fix(freertos): correctly include atomic.h on esp platforms

### DIFF
--- a/src/osal/lv_freertos.c
+++ b/src/osal/lv_freertos.c
@@ -15,7 +15,11 @@
 #include "lv_os_private.h"
 #if LV_USE_OS == LV_OS_FREERTOS
 
+#ifdef ESP_PLATFORM
+#include "freertos/atomic.h"
+#else
 #include "atomic.h"
+#endif
 
 #include "../tick/lv_tick.h"
 #include "../misc/lv_log.h"

--- a/src/osal/lv_freertos.c
+++ b/src/osal/lv_freertos.c
@@ -16,9 +16,9 @@
 #if LV_USE_OS == LV_OS_FREERTOS
 
 #ifdef ESP_PLATFORM
-#include "freertos/atomic.h"
+    #include "freertos/atomic.h"
 #else
-#include "atomic.h"
+    #include "atomic.h"
 #endif
 
 #include "../tick/lv_tick.h"


### PR DESCRIPTION
Fixes #9814
