### PR TITLE
feat(fbdev): enable L8 support

### DIFF
--- a/docs/src/integration/embedded_linux/drivers/fbdev.rst
+++ b/docs/src/integration/embedded_linux/drivers/fbdev.rst
@@ -13,6 +13,7 @@ Prerequisites
 -------------
 
 Your system has a framebuffer device configured (usually under ``/dev/fb0``).
+Your display uses the following color formats: I1, L8, RGB565, RGB888, XRGB8888.
 
 Configuring the driver
 ----------------------

--- a/docs/src/integration/embedded_linux/drivers/fbdev.rst
+++ b/docs/src/integration/embedded_linux/drivers/fbdev.rst
@@ -13,7 +13,7 @@ Prerequisites
 -------------
 
 Your system has a framebuffer device configured (usually under ``/dev/fb0``).
-Your display uses the following color formats: I1, L8, RGB565, RGB888, XRGB8888.
+Your framebuffer uses one of the following pixel formats: 8-bit grayscale (L8), 16-bit RGB565, 24-bit RGB888, or 32-bit XRGB8888.
 
 Configuring the driver
 ----------------------

--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -207,6 +207,12 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
     LV_LOG_INFO("The framebuffer device was mapped to memory successfully");
 
     switch(dsc->vinfo.bits_per_pixel) {
+        case 1:
+            lv_display_set_color_format(disp, LV_COLOR_FORMAT_I1);
+            break;
+        case 8:
+            lv_display_set_color_format(disp, LV_COLOR_FORMAT_L8);
+            break;
         case 16:
             lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB565);
             break;

--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -207,9 +207,6 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
     LV_LOG_INFO("The framebuffer device was mapped to memory successfully");
 
     switch(dsc->vinfo.bits_per_pixel) {
-        case 1:
-            lv_display_set_color_format(disp, LV_COLOR_FORMAT_I1);
-            break;
         case 8:
             lv_display_set_color_format(disp, LV_COLOR_FORMAT_L8);
             break;

--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -208,6 +208,17 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
 
     switch(dsc->vinfo.bits_per_pixel) {
         case 8:
+#if !LV_LINUX_FBDEV_BSD
+            /* In 8bpp modes, many Linux framebuffers are pseudocolor (palette indexed).
+             * LV_COLOR_FORMAT_L8 assumes a linear grayscale buffer, so reject
+             * pseudocolor visuals unless the colormap is explicitly managed. */
+            if(dsc->finfo.visual == FB_VISUAL_PSEUDOCOLOR ||
+               dsc->finfo.visual == FB_VISUAL_STATIC_PSEUDOCOLOR) {
+                LV_LOG_WARN("8bpp pseudocolor framebuffer visual (%d) is not supported with "
+                            "LV_COLOR_FORMAT_L8", dsc->finfo.visual);
+                return LV_RESULT_INVALID;
+            }
+#endif
             lv_display_set_color_format(disp, LV_COLOR_FORMAT_L8);
             break;
         case 16:


### PR DESCRIPTION
Use the default palettes formats for a given bit depth as defined in lv_config.h to add support for ~~1bpp~~ and 8bpp.

I have tested and am using the 8bpp support.

This does use opinionated format the palate but so does `lv_config.h`, but I understand if you wouldn't want to add it until its fully exposed in the config but at least the docs should be updated.

Note: I have removed support for 1bpp as the bot brought up some points that I don't know enough about lvgl to address without potentially compromising performance.
