### PR TITLE
refactor(wayland): adhere to lvgl file name convention

### DIFF
--- a/src/drivers/wayland/lv_wayland.h
+++ b/src/drivers/wayland/lv_wayland.h
@@ -17,11 +17,11 @@ extern "C" {
 
 #if LV_USE_WAYLAND
 
-#include "lv_wl_keyboard.h"
-#include "lv_wl_pointer.h"
-#include "lv_wl_touch.h"
-#include "lv_wl_window.h"
-#include "lv_wl_pointer_axis.h"
+#include "lv_wayland_keyboard.h"
+#include "lv_wayland_pointer.h"
+#include "lv_wayland_touch.h"
+#include "lv_wayland_window.h"
+#include "lv_wayland_pointer_axis.h"
 
 /*********************
  *      DEFINES

--- a/src/drivers/wayland/lv_wayland_backend_egl.c
+++ b/src/drivers/wayland/lv_wayland_backend_egl.c
@@ -1,4 +1,4 @@
-/** @file lv_wl_egl_backend.c
+/** @file lv_wayland_backend_egl.c
  *
  */
 

--- a/src/drivers/wayland/lv_wayland_backend_g2d.c
+++ b/src/drivers/wayland/lv_wayland_backend_g2d.c
@@ -1,6 +1,5 @@
-
 /**
- * @file lv_wl_g2d_backend.c
+ * @file lv_wayland_backend_g2d.c
  *
  */
 

--- a/src/drivers/wayland/lv_wayland_backend_private.h
+++ b/src/drivers/wayland/lv_wayland_backend_private.h
@@ -1,10 +1,10 @@
 /**
- * @file lv_wl_backend_private.h
+ * @file lv_wayland_backend_private.h
  *
  */
 
-#ifndef LV_WL_BACKEND_PRIVATE_H
-#define LV_WL_BACKEND_PRIVATE_H
+#ifndef LV_WAYLAND_BACKEND_PRIVATE_H
+#define LV_WAYLAND_BACKEND_PRIVATE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -214,4 +214,4 @@ struct wl_surface * lv_wayland_get_window_surface(lv_display_t * display);
 } /*extern "C"*/
 #endif
 
-#endif /*LV_WL_BACKEND_PRIVATE_H*/
+#endif /*LV_WAYLAND_BACKEND_PRIVATE_H*/

--- a/src/drivers/wayland/lv_wayland_backend_shm.c
+++ b/src/drivers/wayland/lv_wayland_backend_shm.c
@@ -1,5 +1,5 @@
 /**
- * @file lv_wl_shm_backend.c
+ * @file lv_wayland_backend_shm.c
  *
  */
 

--- a/src/drivers/wayland/lv_wayland_keyboard.c
+++ b/src/drivers/wayland/lv_wayland_keyboard.c
@@ -1,9 +1,9 @@
 /**
- * @file lv_wl_keyboard.c
+ * @file lv_wayland_keyboard.c
  *
  */
 
-#include "lv_wl_keyboard.h"
+#include "lv_wayland_keyboard.h"
 
 #if LV_USE_WAYLAND
 

--- a/src/drivers/wayland/lv_wayland_keyboard.h
+++ b/src/drivers/wayland/lv_wayland_keyboard.h
@@ -1,12 +1,10 @@
-
-
 /**
- * @file lv_wl_touch.h
+ * @file lv_wayland_keyboard.h
  *
  */
 
-#ifndef LV_WL_TOUCH_H
-#define LV_WL_TOUCH_H
+#ifndef LV_WAYLAND_KEYBOARD_H
+#define LV_WAYLAND_KEYBOARD_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,14 +30,14 @@ extern "C" {
  * GLOBAL PROTOTYPES
  **********************/
 
-lv_indev_t * lv_wayland_touch_create(void);
+lv_indev_t * lv_wayland_keyboard_create(void);
 
 /**
- * Get touchscreen input device for given LVGL display
+ * Get keyboard input device for given LVGL display
  * @param display LVGL display
- * @return input device connected to touchscreen, or NULL on error
+ * @return input device connected to keyboard, or NULL on error
  */
-lv_indev_t * lv_wayland_get_touchscreen(lv_display_t * display);
+lv_indev_t * lv_wayland_get_keyboard(lv_display_t * display);
 
 /**********************
  *      MACROS
@@ -51,4 +49,4 @@ lv_indev_t * lv_wayland_get_touchscreen(lv_display_t * display);
 } /*extern "C"*/
 #endif
 
-#endif /*LV_WL_TOUCH_H*/
+#endif /*LV_WAYLAND_KEYBOARD_H*/

--- a/src/drivers/wayland/lv_wayland_pointer.c
+++ b/src/drivers/wayland/lv_wayland_pointer.c
@@ -1,9 +1,9 @@
 /**
- * @file lv_wl_pointer.c
+ * @file lv_wayland_pointer.c
  *
  */
 
-#include "lv_wl_pointer.h"
+#include "lv_wayland_pointer.h"
 
 #if LV_USE_WAYLAND
 

--- a/src/drivers/wayland/lv_wayland_pointer.h
+++ b/src/drivers/wayland/lv_wayland_pointer.h
@@ -1,10 +1,11 @@
+
 /**
- * @file lv_wl_keyboard.h
+ * @file lv_wayland_pointer.h
  *
  */
 
-#ifndef LV_WL_KEYBOARD_H
-#define LV_WL_KEYBOARD_H
+#ifndef LV_WAYLAND_POINTER_H
+#define LV_WAYLAND_POINTER_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,14 +31,15 @@ extern "C" {
  * GLOBAL PROTOTYPES
  **********************/
 
-lv_indev_t * lv_wayland_keyboard_create(void);
+lv_indev_t * lv_wayland_pointer_create(void);
 
 /**
- * Get keyboard input device for given LVGL display
- * @param display LVGL display
- * @return input device connected to keyboard, or NULL on error
+ * Obtains the input device of the mouse pointer
+ * @note It is used to create an input group on application start
+ * @param disp Reference to the LVGL display associated to the window
+ * @return The input device
  */
-lv_indev_t * lv_wayland_get_keyboard(lv_display_t * display);
+lv_indev_t * lv_wayland_get_pointer(lv_display_t * disp);
 
 /**********************
  *      MACROS
@@ -49,4 +51,4 @@ lv_indev_t * lv_wayland_get_keyboard(lv_display_t * display);
 } /*extern "C"*/
 #endif
 
-#endif /*LV_WL_KEYBOARD_H*/
+#endif /*LV_WAYLAND_POINTER_H*/

--- a/src/drivers/wayland/lv_wayland_pointer_axis.h
+++ b/src/drivers/wayland/lv_wayland_pointer_axis.h
@@ -1,10 +1,10 @@
 /**
- * @file lv_wl_pointer_axis.h
+ * @file lv_wayland_pointer_axis.h
  *
  */
 
-#ifndef LV_WL_POINTER_AXIS_H
-#define LV_WL_POINTER_AXIS_H
+#ifndef LV_WAYLAND_POINTER_AXIS_H
+#define LV_WAYLAND_POINTER_AXIS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -51,4 +51,4 @@ lv_indev_t * lv_wayland_get_pointeraxis(lv_display_t * display);
 } /*extern "C"*/
 #endif
 
-#endif /*LV_WL_POINTER_AXIS_H*/
+#endif /*LV_WAYLAND_POINTER_AXIS_H*/

--- a/src/drivers/wayland/lv_wayland_private.h
+++ b/src/drivers/wayland/lv_wayland_private.h
@@ -23,7 +23,7 @@ extern "C" {
 #include <wayland-client-protocol.h>
 #include <wayland_xdg_shell.h>
 #include "../../misc/lv_types.h"
-#include "lv_wl_backend_private.h"
+#include "lv_wayland_backend_private.h"
 
 /*********************
  *      DEFINES

--- a/src/drivers/wayland/lv_wayland_seat.c
+++ b/src/drivers/wayland/lv_wayland_seat.c
@@ -1,5 +1,5 @@
 /**
- * @file lv_wl_seat.c
+ * @file lv_wayland_seat.c
  *
  */
 

--- a/src/drivers/wayland/lv_wayland_touch.c
+++ b/src/drivers/wayland/lv_wayland_touch.c
@@ -1,9 +1,9 @@
 /**
- * @file lv_wl_touch.c
+ * @file lv_wayland_touch.c
  *
  */
 
-#include "lv_wl_touch.h"
+#include "lv_wayland_touch.h"
 
 #if LV_USE_WAYLAND
 

--- a/src/drivers/wayland/lv_wayland_touch.h
+++ b/src/drivers/wayland/lv_wayland_touch.h
@@ -1,11 +1,10 @@
-
 /**
- * @file lv_wl_pointer.h
+ * @file lv_wayland_touch.h
  *
  */
 
-#ifndef LV_WL_POINTER_H
-#define LV_WL_POINTER_H
+#ifndef LV_WAYLAND_TOUCH_H
+#define LV_WAYLAND_TOUCH_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,15 +30,14 @@ extern "C" {
  * GLOBAL PROTOTYPES
  **********************/
 
-lv_indev_t * lv_wayland_pointer_create(void);
+lv_indev_t * lv_wayland_touch_create(void);
 
 /**
- * Obtains the input device of the mouse pointer
- * @note It is used to create an input group on application start
- * @param disp Reference to the LVGL display associated to the window
- * @return The input device
+ * Get touchscreen input device for given LVGL display
+ * @param display LVGL display
+ * @return input device connected to touchscreen, or NULL on error
  */
-lv_indev_t * lv_wayland_get_pointer(lv_display_t * disp);
+lv_indev_t * lv_wayland_get_touchscreen(lv_display_t * display);
 
 /**********************
  *      MACROS
@@ -51,4 +49,4 @@ lv_indev_t * lv_wayland_get_pointer(lv_display_t * disp);
 } /*extern "C"*/
 #endif
 
-#endif /*LV_WL_POINTER_H*/
+#endif /*LV_WAYLAND_TOUCH_H*/

--- a/src/drivers/wayland/lv_wayland_window.c
+++ b/src/drivers/wayland/lv_wayland_window.c
@@ -1,12 +1,12 @@
 /**
- * @file lv_wl_window.c
+ * @file lv_wayland_window.c
  *
  */
 
 /*********************
  *      INCLUDES
  *********************/
-#include "lv_wl_window.h"
+#include "lv_wayland_window.h"
 
 #if LV_USE_WAYLAND
 
@@ -16,10 +16,10 @@
 #include <string.h>
 #include "lv_wayland_private.h"
 #include "lv_wayland_private.h"
-#include "lv_wl_pointer.h"
-#include "lv_wl_pointer_axis.h"
-#include "lv_wl_touch.h"
-#include "lv_wl_keyboard.h"
+#include "lv_wayland_pointer.h"
+#include "lv_wayland_pointer_axis.h"
+#include "lv_wayland_touch.h"
+#include "lv_wayland_keyboard.h"
 
 /*********************
  *      DEFINES

--- a/src/drivers/wayland/lv_wayland_window.h
+++ b/src/drivers/wayland/lv_wayland_window.h
@@ -1,11 +1,11 @@
 
 /**
- * @file lv_wl_window.h
+ * @file lv_wayland_window.h
  *
  */
 
-#ifndef LV_WL_WINDOW_H
-#define LV_WL_WINDOW_H
+#ifndef LV_WAYLAND_WINDOW_H
+#define LV_WAYLAND_WINDOW_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -101,4 +101,4 @@ void lv_wayland_window_set_minimized(lv_display_t * disp);
 } /*extern "C"*/
 #endif
 
-#endif /*LV_WL_WINDOW_H*/
+#endif /*LV_WAYLAND_WINDOW_H*/

--- a/src/drivers/wayland/lv_wayland_xdg_shell.c
+++ b/src/drivers/wayland/lv_wayland_xdg_shell.c
@@ -1,5 +1,5 @@
 /**
- * @file lv_wl_xdg_shell.c
+ * @file lv_wayland_xdg_shell.c
  *
  */
 


### PR DESCRIPTION
No changes inside these files, the only thing that was changed were the file names

`wl` -> `wayland` 

`XXX_backend.c` -> `backend_XXX.c`