### PR TITLE
fix(wayland): remove extraneous timer_handler declaration

### DIFF
--- a/src/drivers/wayland/lv_wayland.h
+++ b/src/drivers/wayland/lv_wayland.h
@@ -36,14 +36,6 @@ extern "C" {
  **********************/
 
 /**
- * Wrapper around lv_timer_handler
- * @note Must be called in the application run loop instead of the
- * regular lv_timer_handler provided by LVGL
- * @return time till it needs to be run next (in ms)
- */
-uint32_t lv_wayland_timer_handler(void);
-
-/**
  * Retrieves the file descriptor of the wayland socket
  */
 int lv_wayland_get_fd(void);


### PR DESCRIPTION
This function doesn't exist anymore (there's a macro in the api map)