### PR TITLE
fix(drm): fix incorrect CRTC selection logic in DRM connector initialization.

### DIFF
--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -1362,6 +1362,10 @@
      * The GBM library aims to provide a platform independent memory management system
      * it supports the major GPU vendors - This option requires linking with libgbm */
     #define LV_USE_LINUX_DRM_GBM_BUFFERS 0
+
+
+    #define LV_USE_LINUX_DRM_PRIMARY_PRIORITY 1
+    #define LV_USE_LINUX_DRM_OVERLAY_PRIORITY (!LV_USE_LINUX_DRM_PRIMARY_PRIORITY)
 #endif
 
 /** Interface for TFT_eSPI */

--- a/src/drivers/display/drm/lv_linux_drm.c
+++ b/src/drivers/display/drm/lv_linux_drm.c
@@ -549,11 +549,53 @@ out:
     return ret;
 }
 
+
+static uint32_t find_compatible_crtc(int fd, drmModeRes *resources, drmModeConnector *connector) {
+    drmModeEncoder *encoder = NULL;
+    uint32_t selected_crtc = 0;
+
+    if (!resources || !connector)
+        return 0;
+
+    if (connector->encoder_id) {
+        encoder = drmModeGetEncoder(fd, connector->encoder_id);
+    }
+
+    if (encoder) {
+        selected_crtc = encoder->crtc_id;
+        drmModeFreeEncoder(encoder);
+        encoder = NULL;
+
+        if (selected_crtc)
+            return selected_crtc;
+    }
+
+    for (int i = 0; i < connector->count_encoders; i++) {
+        encoder = drmModeGetEncoder(fd, connector->encoders[i]);
+        if (!encoder)
+            continue;
+
+        for (int j = 0; j < resources->count_crtcs; j++) {
+            if (encoder->possible_crtcs & (1u << j)) {
+                selected_crtc = resources->crtcs[j];
+                drmModeFreeEncoder(encoder);
+                encoder = NULL;
+                return selected_crtc;
+            }
+        }
+
+        drmModeFreeEncoder(encoder);
+        encoder = NULL;
+    }
+
+    return 0;
+}
+
 static int drm_find_connector(drm_dev_t * drm_dev, int64_t connector_id)
 {
     drmModeConnector * conn = NULL;
     drmModeEncoder * enc = NULL;
-    drmModeRes * res;
+    drmModeRes * res = NULL;
     int i;
     int ret = -1;
 
@@ -575,6 +617,7 @@ static int drm_find_connector(drm_dev_t * drm_dev, int64_t connector_id)
 
         if(connector_id >= 0 && conn->connector_id != connector_id) {
             drmModeFreeConnector(conn);
+            conn = NULL;
             continue;
         }
 
@@ -591,8 +634,16 @@ static int drm_find_connector(drm_dev_t * drm_dev, int64_t connector_id)
             LV_LOG_TRACE("drm: connector %d: unknown", conn->connector_id);
         }
 
-        if(conn->connection == DRM_MODE_CONNECTED && conn->count_modes > 0)
-            break;
+        if(conn->connection == DRM_MODE_CONNECTED && conn->count_modes > 0) {
+            uint32_t candidate_crtc = find_compatible_crtc(drm_dev->fd, res, conn);
+            if(candidate_crtc) {
+                drm_dev->crtc_id = candidate_crtc;
+                break;
+            }
+            else {
+                LV_LOG_TRACE("drm: connector %d has no compatible crtc", conn->connector_id);
+            }
+        }
 
         drmModeFreeConnector(conn);
         conn = NULL;
@@ -619,71 +670,6 @@ static int drm_find_connector(drm_dev_t * drm_dev, int64_t connector_id)
     drm_dev->width = conn->modes[0].hdisplay;
     drm_dev->height = conn->modes[0].vdisplay;
 
-    for(i = 0 ; i < res->count_encoders; i++) {
-        enc = drmModeGetEncoder(drm_dev->fd, res->encoders[i]);
-        if(!enc)
-            continue;
-
-        LV_LOG_TRACE("enc%d enc_id %d conn enc_id %d", i, enc->encoder_id, conn->encoder_id);
-
-        if(enc->encoder_id == conn->encoder_id)
-            break;
-
-        drmModeFreeEncoder(enc);
-        enc = NULL;
-    }
-
-    if(enc) {
-        drm_dev->enc_id = enc->encoder_id;
-        LV_LOG_TRACE("enc_id: %d", drm_dev->enc_id);
-        drm_dev->crtc_id = enc->crtc_id;
-        LV_LOG_TRACE("crtc_id: %d", drm_dev->crtc_id);
-        drmModeFreeEncoder(enc);
-        enc = NULL;
-    }
-    else {
-        /* Encoder hasn't been associated yet, look it up */
-        bool found = false;
-        for(i = 0; i < conn->count_encoders; i++) {
-            int crtc, crtc_id = -1;
-
-            enc = drmModeGetEncoder(drm_dev->fd, conn->encoders[i]);
-            if(!enc)
-                continue;
-
-            for(crtc = 0 ; crtc < res->count_crtcs; crtc++) {
-                uint32_t crtc_mask = 1 << crtc;
-
-                crtc_id = res->crtcs[crtc];
-
-                LV_LOG_TRACE("enc_id %d crtc%d id %d mask %x possible %x", enc->encoder_id, crtc, crtc_id, crtc_mask,
-                             enc->possible_crtcs);
-
-                if(enc->possible_crtcs & crtc_mask)
-                    break;
-            }
-
-            if(crtc_id > 0) {
-                drm_dev->enc_id = enc->encoder_id;
-                LV_LOG_TRACE("enc_id: %d", drm_dev->enc_id);
-                drm_dev->crtc_id = crtc_id;
-                LV_LOG_TRACE("crtc_id: %d", drm_dev->crtc_id);
-                drmModeFreeEncoder(enc);
-                enc = NULL;
-                found = true;
-                break;
-            }
-
-            drmModeFreeEncoder(enc);
-            enc = NULL;
-        }
-
-        if(!found) {
-            LV_LOG_ERROR("suitable encoder not found");
-            goto free_res;
-        }
-    }
-
     drm_dev->crtc_idx = UINT32_MAX;
 
     for(i = 0; i < res->count_crtcs; ++i) {
@@ -698,7 +684,9 @@ static int drm_find_connector(drm_dev_t * drm_dev, int64_t connector_id)
         goto free_res;
     }
 
+    LV_LOG_TRACE("crtc_id: %d", drm_dev->crtc_id);
     LV_LOG_TRACE("crtc_idx: %d", drm_dev->crtc_idx);
+
     ret = 0;
 
 free_res:

--- a/src/drivers/display/drm/lv_linux_drm.c
+++ b/src/drivers/display/drm/lv_linux_drm.c
@@ -550,33 +550,34 @@ out:
 }
 
 
-static uint32_t find_compatible_crtc(int fd, drmModeRes *resources, drmModeConnector *connector) {
-    drmModeEncoder *encoder = NULL;
+static uint32_t find_compatible_crtc(int fd, drmModeRes * resources, drmModeConnector * connector)
+{
+    drmModeEncoder * encoder = NULL;
     uint32_t selected_crtc = 0;
 
-    if (!resources || !connector)
+    if(!resources || !connector)
         return 0;
 
-    if (connector->encoder_id) {
+    if(connector->encoder_id) {
         encoder = drmModeGetEncoder(fd, connector->encoder_id);
     }
 
-    if (encoder) {
+    if(encoder) {
         selected_crtc = encoder->crtc_id;
         drmModeFreeEncoder(encoder);
         encoder = NULL;
 
-        if (selected_crtc)
+        if(selected_crtc)
             return selected_crtc;
     }
 
-    for (int i = 0; i < connector->count_encoders; i++) {
+    for(int i = 0; i < connector->count_encoders; i++) {
         encoder = drmModeGetEncoder(fd, connector->encoders[i]);
-        if (!encoder)
+        if(!encoder)
             continue;
 
-        for (int j = 0; j < resources->count_crtcs; j++) {
-            if (encoder->possible_crtcs & (1u << j)) {
+        for(int j = 0; j < resources->count_crtcs; j++) {
+            if(encoder->possible_crtcs & (1u << j)) {
                 selected_crtc = resources->crtcs[j];
                 drmModeFreeEncoder(encoder);
                 encoder = NULL;

--- a/src/drivers/display/drm/lv_linux_drm.c
+++ b/src/drivers/display/drm/lv_linux_drm.c
@@ -98,7 +98,7 @@ static int drm_add_plane_property(drm_dev_t * drm_dev, const char * name, uint64
 static int drm_add_crtc_property(drm_dev_t * drm_dev, const char * name, uint64_t value);
 static int drm_add_conn_property(drm_dev_t * drm_dev, const char * name, uint64_t value);
 static int find_plane(drm_dev_t * drm_dev, unsigned int fourcc, uint32_t * plane_id, uint32_t crtc_id,
-                      uint32_t crtc_idx);
+                      uint32_t crtc_idx,  uint64_t want_type);
 static int drm_find_connector(drm_dev_t * drm_dev, int64_t connector_id);
 static int drm_open(const char * path);
 static int drm_setup(drm_dev_t * drm_dev, const char * device_path, int64_t connector_id, unsigned int fourcc);
@@ -492,15 +492,41 @@ static int drm_dmabuf_set_plane(drm_dev_t * drm_dev, drm_buffer_t * buf)
     return 0;
 }
 
-static int find_plane(drm_dev_t * drm_dev, unsigned int fourcc, uint32_t * plane_id, uint32_t crtc_id,
-                      uint32_t crtc_idx)
+static uint64_t get_plane_type(int fd, uint32_t plane_id)
+{
+    drmModeObjectPropertiesPtr props;
+    uint64_t type = UINT64_MAX;
+
+    props = drmModeObjectGetProperties(fd, plane_id, DRM_MODE_OBJECT_PLANE);
+    if(!props)
+        return UINT64_MAX;
+
+    for(uint32_t i = 0; i < props->count_props; i++) {
+        drmModePropertyPtr prop = drmModeGetProperty(fd, props->props[i]);
+        if(!prop)
+            continue;
+
+        if(strcmp(prop->name, "type") == 0) {
+            type = props->prop_values[i];
+            drmModeFreeProperty(prop);
+            break;
+        }
+
+        drmModeFreeProperty(prop);
+    }
+
+    drmModeFreeObjectProperties(props);
+    return type;
+}
+
+static int find_plane(drm_dev_t * drm_dev, unsigned int fourcc, uint32_t * plane_id,
+                      uint32_t crtc_id, uint32_t crtc_idx, uint64_t want_type)
 {
     LV_UNUSED(crtc_id);
     drmModePlaneResPtr planes;
     drmModePlanePtr plane;
-    unsigned int i;
-    unsigned int j;
-    int ret = 0;
+    unsigned int i, j;
+    int ret = -1;
 
     planes = drmModeGetPlaneResources(drm_dev->fd);
     if(!planes) {
@@ -518,7 +544,14 @@ static int find_plane(drm_dev_t * drm_dev, unsigned int fourcc, uint32_t * plane
             break;
         }
 
-        if(!(plane->possible_crtcs & (1 << crtc_idx))) {
+        LV_LOG_TRACE("drm: plane %u possible crtcs %x", plane->plane_id, plane->possible_crtcs);
+
+        if(!(plane->possible_crtcs & (1u << crtc_idx))) {
+            drmModeFreePlane(plane);
+            continue;
+        }
+
+        if(get_plane_type(drm_dev->fd, plane->plane_id) != want_type) {
             drmModeFreePlane(plane);
             continue;
         }
@@ -535,40 +568,48 @@ static int find_plane(drm_dev_t * drm_dev, unsigned int fourcc, uint32_t * plane
 
         *plane_id = plane->plane_id;
         drmModeFreePlane(plane);
-
-        LV_LOG_TRACE("found plane %d", *plane_id);
-
-        /* Success */
-        goto out;
+        LV_LOG_TRACE("found plane %u", *plane_id);
+        ret = 0;
+        break;
     }
 
-    if(i == planes->count_planes)
-        ret = -1;
-out:
     drmModeFreePlaneResources(planes);
     return ret;
 }
 
 
-static uint32_t find_compatible_crtc(int fd, drmModeRes * resources, drmModeConnector * connector)
+static bool find_compatible_pipeline(int fd, drmModeRes * resources,
+                                     drmModeConnector * connector,
+                                     uint32_t * out_enc_id, uint32_t * out_crtc_id)
 {
     drmModeEncoder * encoder = NULL;
-    uint32_t selected_crtc = 0;
 
-    if(!resources || !connector)
-        return 0;
+    if(!resources || !connector || !out_enc_id || !out_crtc_id) {
+        LV_LOG_ERROR("Invalid argument in find_compatible_pipeline");
+        return false;
+    }
+
+    *out_enc_id = 0;
+    *out_crtc_id = 0;
 
     if(connector->encoder_id) {
         encoder = drmModeGetEncoder(fd, connector->encoder_id);
     }
 
     if(encoder) {
-        selected_crtc = encoder->crtc_id;
+        if(encoder->crtc_id) {
+            for(int j = 0; j < resources->count_crtcs; j++) {
+                if(resources->crtcs[j] == encoder->crtc_id) {
+                    *out_enc_id = encoder->encoder_id;
+                    *out_crtc_id = encoder->crtc_id;
+                    drmModeFreeEncoder(encoder);
+                    return true;
+                }
+            }
+        }
+
         drmModeFreeEncoder(encoder);
         encoder = NULL;
-
-        if(selected_crtc)
-            return selected_crtc;
     }
 
     for(int i = 0; i < connector->count_encoders; i++) {
@@ -578,10 +619,10 @@ static uint32_t find_compatible_crtc(int fd, drmModeRes * resources, drmModeConn
 
         for(int j = 0; j < resources->count_crtcs; j++) {
             if(encoder->possible_crtcs & (1u << j)) {
-                selected_crtc = resources->crtcs[j];
+                *out_enc_id = encoder->encoder_id;
+                *out_crtc_id = resources->crtcs[j];
                 drmModeFreeEncoder(encoder);
-                encoder = NULL;
-                return selected_crtc;
+                return true;
             }
         }
 
@@ -589,7 +630,7 @@ static uint32_t find_compatible_crtc(int fd, drmModeRes * resources, drmModeConn
         encoder = NULL;
     }
 
-    return 0;
+    return false;
 }
 
 static int drm_find_connector(drm_dev_t * drm_dev, int64_t connector_id)
@@ -636,9 +677,8 @@ static int drm_find_connector(drm_dev_t * drm_dev, int64_t connector_id)
         }
 
         if(conn->connection == DRM_MODE_CONNECTED && conn->count_modes > 0) {
-            uint32_t candidate_crtc = find_compatible_crtc(drm_dev->fd, res, conn);
-            if(candidate_crtc) {
-                drm_dev->crtc_id = candidate_crtc;
+            bool found = find_compatible_pipeline(drm_dev->fd, res, conn, &drm_dev->enc_id, &drm_dev->crtc_id);
+            if(found) {
                 break;
             }
             else {
@@ -759,11 +799,19 @@ static int drm_setup(drm_dev_t * drm_dev, const char * device_path, int64_t conn
         goto err;
     }
 
-    ret = find_plane(drm_dev, fourcc, &drm_dev->plane_id, drm_dev->crtc_id, drm_dev->crtc_idx);
+#if LV_USE_LINUX_DRM_PRIMARY_PRIORITY
+    LV_LOG_INFO("Trying to find a plane for primary usage");
+    ret = find_plane(drm_dev, fourcc, &drm_dev->plane_id, drm_dev->crtc_id, drm_dev->crtc_idx, DRM_PLANE_TYPE_PRIMARY);
     if(ret) {
-        LV_LOG_ERROR("Cannot find plane");
-        goto err;
+        LV_LOG_WARN("Cannot find primary plane, falling back to overlay");
     }
+#elif LV_USE_LINUX_DRM_OVERLAY_PRIORITY
+    LV_LOG_INFO("Trying to find a plane for overlay usage");
+    ret = find_plane(drm_dev, fourcc, &drm_dev->plane_id, drm_dev->crtc_id, drm_dev->crtc_idx, DRM_PLANE_TYPE_OVERLAY);
+    if(ret) {
+        LV_LOG_WARN("Cannot find overlay plane, falling back to primary");
+    }
+#endif
 
     drm_dev->plane = drmModeGetPlane(drm_dev->fd, drm_dev->plane_id);
     if(!drm_dev->plane) {

--- a/src/drivers/display/drm/lv_linux_drm.c
+++ b/src/drivers/display/drm/lv_linux_drm.c
@@ -491,10 +491,13 @@ static int drm_dmabuf_set_plane(drm_dev_t * drm_dev, drm_buffer_t * buf)
             if(ret) {
                 LV_LOG_ERROR("Atomic commit succeeded without non-block flag, retrying with non-block");
                 drmModeAtomicFree(drm_dev->req);
+                drm_dev->req = NULL;
                 commit_count ++;
                 return ret;
             }
         }
+        drmModeAtomicFree(drm_dev->req);
+        drm_dev->req = NULL;
         return ret;
     }
     return 0;

--- a/src/drivers/display/drm/lv_linux_drm.c
+++ b/src/drivers/display/drm/lv_linux_drm.c
@@ -812,12 +812,22 @@ static int drm_setup(drm_dev_t * drm_dev, const char * device_path, int64_t conn
     ret = find_plane(drm_dev, fourcc, &drm_dev->plane_id, drm_dev->crtc_id, drm_dev->crtc_idx, DRM_PLANE_TYPE_PRIMARY);
     if(ret) {
         LV_LOG_WARN("Cannot find primary plane, falling back to overlay");
+        ret = find_plane(drm_dev, fourcc, &drm_dev->plane_id, drm_dev->crtc_id, drm_dev->crtc_idx, DRM_PLANE_TYPE_OVERLAY);
+        if(ret) {
+            LV_LOG_ERROR("Cannot find a usable plane");
+            goto err;
+        }
     }
 #elif LV_USE_LINUX_DRM_OVERLAY_PRIORITY
     LV_LOG_INFO("Trying to find a plane for overlay usage");
     ret = find_plane(drm_dev, fourcc, &drm_dev->plane_id, drm_dev->crtc_id, drm_dev->crtc_idx, DRM_PLANE_TYPE_OVERLAY);
     if(ret) {
         LV_LOG_WARN("Cannot find overlay plane, falling back to primary");
+        ret = find_plane(drm_dev, fourcc, &drm_dev->plane_id, drm_dev->crtc_id, drm_dev->crtc_idx, DRM_PLANE_TYPE_PRIMARY);
+        if(ret) {
+            LV_LOG_ERROR("Cannot find a usable plane");
+            goto err;
+        }
     }
 #endif
 

--- a/src/drivers/display/drm/lv_linux_drm.c
+++ b/src/drivers/display/drm/lv_linux_drm.c
@@ -483,12 +483,20 @@ static int drm_dmabuf_set_plane(drm_dev_t * drm_dev, drm_buffer_t * buf)
     drm_add_plane_property(drm_dev, "CRTC_H", drm_dev->height);
 
     ret = drmModeAtomicCommit(drm_dev->fd, drm_dev->req, flags, drm_dev);
+    static int commit_count = 0;
     if(ret) {
-        LV_LOG_ERROR("drmModeAtomicCommit failed: %s (%d)", strerror(errno), errno);
-        drmModeAtomicFree(drm_dev->req);
+        if(commit_count == 0) {
+            flags &= ~DRM_MODE_ATOMIC_NONBLOCK;
+            ret = drmModeAtomicCommit(drm_dev->fd, drm_dev->req, flags, drm_dev);
+            if(ret) {
+                LV_LOG_ERROR("Atomic commit succeeded without non-block flag, retrying with non-block");
+                drmModeAtomicFree(drm_dev->req);
+                commit_count ++;
+                return ret;
+            }
+        }
         return ret;
     }
-
     return 0;
 }
 

--- a/src/drivers/display/drm/lv_linux_drm.c
+++ b/src/drivers/display/drm/lv_linux_drm.c
@@ -489,7 +489,7 @@ static int drm_dmabuf_set_plane(drm_dev_t * drm_dev, drm_buffer_t * buf)
             flags &= ~DRM_MODE_ATOMIC_NONBLOCK;
             ret = drmModeAtomicCommit(drm_dev->fd, drm_dev->req, flags, drm_dev);
             if(ret) {
-                LV_LOG_ERROR("Atomic commit succeeded without non-block flag, retrying with non-block");
+                LV_LOG_ERROR("Atomic commit failed with non-block flag and also failed after retry without non-block flag");
                 drmModeAtomicFree(drm_dev->req);
                 drm_dev->req = NULL;
                 commit_count ++;

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -4365,6 +4365,10 @@
             #define LV_USE_LINUX_DRM_OVERLAY_PRIORITY (!LV_USE_LINUX_DRM_PRIMARY_PRIORITY)
         #endif
     #endif
+
+    #if LV_USE_LINUX_DRM_PRIMARY_PRIORITY && LV_USE_LINUX_DRM_OVERLAY_PRIORITY
+        #error "LV_USE_LINUX_DRM_PRIMARY_PRIORITY and LV_USE_LINUX_DRM_OVERLAY_PRIORITY cannot both be enabled."
+    #endif
 #endif
 
 /** Interface for TFT_eSPI */

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -4352,7 +4352,7 @@
             #ifdef CONFIG_LV_USE_LINUX_DRM_PRIMARY_PRIORITY
                 #define LV_USE_LINUX_DRM_PRIMARY_PRIORITY CONFIG_LV_USE_LINUX_DRM_PRIMARY_PRIORITY
             #else
-                #define LV_USE_LINUX_DRM_PRIMARY_PRIORITY 0
+                #define LV_USE_LINUX_DRM_PRIMARY_PRIORITY 1
             #endif
         #else
             #define LV_USE_LINUX_DRM_PRIMARY_PRIORITY 1

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -4345,6 +4345,26 @@
             #define LV_USE_LINUX_DRM_GBM_BUFFERS 0
         #endif
     #endif
+
+
+    #ifndef LV_USE_LINUX_DRM_PRIMARY_PRIORITY
+        #ifdef LV_KCONFIG_PRESENT
+            #ifdef CONFIG_LV_USE_LINUX_DRM_PRIMARY_PRIORITY
+                #define LV_USE_LINUX_DRM_PRIMARY_PRIORITY CONFIG_LV_USE_LINUX_DRM_PRIMARY_PRIORITY
+            #else
+                #define LV_USE_LINUX_DRM_PRIMARY_PRIORITY 0
+            #endif
+        #else
+            #define LV_USE_LINUX_DRM_PRIMARY_PRIORITY 1
+        #endif
+    #endif
+    #ifndef LV_USE_LINUX_DRM_OVERLAY_PRIORITY
+        #ifdef CONFIG_LV_USE_LINUX_DRM_OVERLAY_PRIORITY
+            #define LV_USE_LINUX_DRM_OVERLAY_PRIORITY CONFIG_LV_USE_LINUX_DRM_OVERLAY_PRIORITY
+        #else
+            #define LV_USE_LINUX_DRM_OVERLAY_PRIORITY (!LV_USE_LINUX_DRM_PRIMARY_PRIORITY)
+        #endif
+    #endif
 #endif
 
 /** Interface for TFT_eSPI */

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -4352,7 +4352,7 @@
             #ifdef CONFIG_LV_USE_LINUX_DRM_PRIMARY_PRIORITY
                 #define LV_USE_LINUX_DRM_PRIMARY_PRIORITY CONFIG_LV_USE_LINUX_DRM_PRIMARY_PRIORITY
             #else
-                #define LV_USE_LINUX_DRM_PRIMARY_PRIORITY 1
+                #define LV_USE_LINUX_DRM_PRIMARY_PRIORITY 0
             #endif
         #else
             #define LV_USE_LINUX_DRM_PRIMARY_PRIORITY 1
@@ -4364,10 +4364,6 @@
         #else
             #define LV_USE_LINUX_DRM_OVERLAY_PRIORITY (!LV_USE_LINUX_DRM_PRIMARY_PRIORITY)
         #endif
-    #endif
-
-    #if LV_USE_LINUX_DRM_PRIMARY_PRIORITY && LV_USE_LINUX_DRM_OVERLAY_PRIORITY
-        #error "LV_USE_LINUX_DRM_PRIMARY_PRIORITY and LV_USE_LINUX_DRM_OVERLAY_PRIORITY cannot both be enabled."
     #endif
 #endif
 


### PR DESCRIPTION
Fix incorrect CRTC selection logic in DRM connector initialization.

In my board previous code cannot lighting the mipi-dsi screen,now it works 

- Fix compatible CRTC detection
- Add auxiliary function find_compatible_crtc
In previous code,function drm_find_connector use
```c
        if(conn->connection == DRM_MODE_CONNECTED && conn->count_modes > 0)
            break;
``` 
This code uses the first `conn` of `DRM_MODE_CONNECTED` by default.However, based on the path from conn to encoder and then to CRTC, the current conn may not be applicable, which may result in finding an unsuitable CRTC number. so I create new function drm_find_connector:
Prioritize using the current path: First, check `connector->encoder_id`. If the hardware has already pre-defined the path, using it directly is the safest approach, avoiding unnecessary rewiring.

Exhaustive search for compatible paths: If no path is currently bound, you iterate through `connector->encoders` (all encoders supported by this interface) and further compare `encoder->possible_crtcs` with the system's global CRTC list.

Bitmask matching: `encoder->possible_crtcs & (1u << j)` is the core logic, accurately checking the hardware's physical connectivity.
and fix logic in drm_find_connector
```c
        if(conn->connection == DRM_MODE_CONNECTED && conn->count_modes > 0) {
            uint32_t candidate_crtc = find_compatible_crtc(drm_dev->fd, res, conn);
            if(candidate_crtc) {
                drm_dev->crtc_id = candidate_crtc;
                break;
            }
            else {
                LV_LOG_TRACE("drm: connector %d has no compatible crtc", conn->connector_id);
            }
        }
``` 
In this place check all adapt "if" conn and select suitable crtc

and In find plane it use primary plane type by default
In some scene,such as it already run weston
use primary plane type cannot lighting the screen
so I change conf file add selection so you can open LV_USE_LINUX_DRM_PRIMARY_PRIORITY to use primary type and close LV_USE_LINUX_DRM_PRIMARY_PRIORITY to use OVERLAY type

```c
#if LV_USE_LINUX_DRM_PRIMARY_PRIORITY
    LV_LOG_INFO("Trying to find a plane for primary usage");
    ret = find_plane(drm_dev, fourcc, &drm_dev->plane_id, drm_dev->crtc_id, drm_dev->crtc_idx, DRM_PLANE_TYPE_PRIMARY);
    if(ret) {
        LV_LOG_WARN("Cannot find primary plane, falling back to overlay");
    }
#elif LV_USE_LINUX_DRM_OVERLAY_PRIORITY
    LV_LOG_INFO("Trying to find a plane for overlay usage");
    ret = find_plane(drm_dev, fourcc, &drm_dev->plane_id, drm_dev->crtc_id, drm_dev->crtc_idx, DRM_PLANE_TYPE_OVERLAY);
    if(ret) {
        LV_LOG_WARN("Cannot find overlay plane, falling back to primary");
    }
#endif
``` 
the option LV_USE_LINUX_DRM_OVERLAY_PRIORITY and LV_USE_LINUX_DRM_PRIMARY_PRIORITY is mutex if you config LV_USE_LINUX_DRM_PRIMARY_PRIORITY as 1 so LV_USE_LINUX_DRM_OVERLAY_PRIORITY is 0
 
add retry in function drm_dmabuf_set_plane,in scene such as occupyed by weston(not in lvgl),we must use overlay to lighting the screen but input event attack in nonblock scene so add cancel nonblock and retry