### PR TITLE
fix(string): add NULL guard to lv_strdup

### DIFF
--- a/src/stdlib/builtin/lv_string_builtin.c
+++ b/src/stdlib/builtin/lv_string_builtin.c
@@ -258,6 +258,7 @@ int lv_strncmp(const char * s1, const char * s2, size_t len)
 
 char * lv_strdup(const char * src)
 {
+    if(src == NULL) return NULL;
     size_t len = lv_strlen(src) + 1;
     char * dst = lv_malloc(len);
     if(dst == NULL) return NULL;

--- a/src/stdlib/clib/lv_string_clib.c
+++ b/src/stdlib/clib/lv_string_clib.c
@@ -98,6 +98,7 @@ int lv_strncmp(const char * s1, const char * s2, size_t len)
 
 char * lv_strdup(const char * src)
 {
+    if(src == NULL) return NULL;
     /*strdup uses malloc, so use the lv_malloc when LV_USE_STDLIB_MALLOC is not LV_STDLIB_CLIB */
     size_t len = lv_strlen(src) + 1;
     char * dst = lv_malloc(len);


### PR DESCRIPTION
## Description

`lv_strdup()` crashes with a segfault when called with a `NULL` `src` pointer. While the C standard says `strdup(NULL)` is undefined behavior, a library wrapper should handle it gracefully — especially since NULL strings can easily propagate through the widget system from missing configuration data.

### Changes

Added `if(src == NULL) return NULL;` to both implementations:
- `src/stdlib/builtin/lv_string_builtin.c`
- `src/stdlib/clib/lv_string_clib.c`

This is consistent with how `lv_malloc(0)` and other LVGL allocation functions handle edge cases gracefully.

### How has this been tested?

- Running in production on embedded Linux (ARM64) touchscreen devices
- Prevents crash when widgets reference unset/missing string data