### PR TITLE
fix(slider): block perpendicular scroll chain while dragging

### DIFF
--- a/src/widgets/slider/lv_slider.c
+++ b/src/widgets/slider/lv_slider.c
@@ -336,11 +336,12 @@ static void lv_slider_event(const lv_obj_class_t * class_p, lv_event_t * e)
     }
     else if(code == LV_EVENT_SIZE_CHANGED) {
         if(is_slider_horizontal(obj)) {
-            lv_obj_add_flag(obj, LV_OBJ_FLAG_SCROLL_CHAIN_VER);
+            /*Don't re-add perpendicular chain while actively dragging*/
+            if(!slider->dragging) lv_obj_add_flag(obj, LV_OBJ_FLAG_SCROLL_CHAIN_VER);
             lv_obj_remove_flag(obj, LV_OBJ_FLAG_SCROLL_CHAIN_HOR);
         }
         else {
-            lv_obj_add_flag(obj, LV_OBJ_FLAG_SCROLL_CHAIN_HOR);
+            if(!slider->dragging) lv_obj_add_flag(obj, LV_OBJ_FLAG_SCROLL_CHAIN_HOR);
             lv_obj_remove_flag(obj, LV_OBJ_FLAG_SCROLL_CHAIN_VER);
         }
         lv_obj_refresh_ext_draw_size(obj);

--- a/src/widgets/slider/lv_slider.c
+++ b/src/widgets/slider/lv_slider.c
@@ -289,6 +289,12 @@ static void lv_slider_event(const lv_obj_class_t * class_p, lv_event_t * e)
         lv_obj_transform_point(obj, &slider->pressed_point, LV_OBJ_POINT_TRANSFORM_FLAG_INVERSE_RECURSIVE);
     }
     else if(code == LV_EVENT_PRESSING) {
+        lv_indev_type_t indev_type = lv_indev_get_type(lv_indev_active());
+        if(indev_type == LV_INDEV_TYPE_POINTER) {
+            /* Block perpendicular scroll chain while dragging (better touchscreen UX) */
+            if(is_slider_horizontal(obj)) lv_obj_remove_flag(obj, LV_OBJ_FLAG_SCROLL_CHAIN_VER);
+            else  lv_obj_remove_flag(obj, LV_OBJ_FLAG_SCROLL_CHAIN_HOR);
+        }
         update_knob_pos(obj, true);
     }
     else if(code == LV_EVENT_RELEASED || code == LV_EVENT_PRESS_LOST) {
@@ -317,6 +323,7 @@ static void lv_slider_event(const lv_obj_class_t * class_p, lv_event_t * e)
             }
         }
         else if(indev_type == LV_INDEV_TYPE_POINTER) {
+            /* Restore perpendicular scroll chain after drag ends */
             if(is_slider_horizontal(obj)) lv_obj_add_flag(obj, LV_OBJ_FLAG_SCROLL_CHAIN_VER);
             else  lv_obj_add_flag(obj, LV_OBJ_FLAG_SCROLL_CHAIN_HOR);
         }

--- a/tests/src/test_cases/widgets/test_slider.c
+++ b/tests/src/test_cases/widgets/test_slider.c
@@ -690,15 +690,21 @@ void test_slider_scroll_chain_not_blocked_for_encoder_input(void)
     lv_group_set_editing(g, true);
 
     lv_slider_set_value(slider, 50, LV_ANIM_OFF);
+    int32_t initial_value = lv_slider_get_value(slider);
 
-    /* Simulate encoder interaction (non-pointer input) */
+    /* Enter edit mode, then turn encoder */
+    lv_test_encoder_click();
     lv_test_encoder_turn(5);
+
+    /* Verify encoder input was actually processed (value changed) */
+    int32_t new_value = lv_slider_get_value(slider);
+    TEST_ASSERT_NOT_EQUAL(initial_value, new_value);
 
     /* Encoder input should NOT remove scroll chain flags */
     TEST_ASSERT_TRUE(lv_obj_has_flag(slider, LV_OBJ_FLAG_SCROLL_CHAIN_HOR));
     TEST_ASSERT_TRUE(lv_obj_has_flag(slider, LV_OBJ_FLAG_SCROLL_CHAIN_VER));
 
-    /* Release encoder */
+    /* Release encoder (exits edit mode) */
     lv_test_encoder_click();
 
     /* Flags should still be present after encoder release */

--- a/tests/src/test_cases/widgets/test_slider.c
+++ b/tests/src/test_cases/widgets/test_slider.c
@@ -610,4 +610,100 @@ void test_slider_range_mode_vertical_rtl_drag_start_value_selection(void)
                                        &ptr_ver->bar.cur_value, -1);
 }
 
+void test_slider_perpendicular_scroll_chain_blocked_during_horizontal_drag(void)
+{
+    lv_obj_set_size(slider, 200, 20);
+    lv_obj_center(slider);
+    lv_obj_update_layout(slider);
+
+    /* Manually add SCROLL_CHAIN_VER (simulates state after a previous release) */
+    lv_obj_add_flag(slider, LV_OBJ_FLAG_SCROLL_CHAIN_VER);
+    TEST_ASSERT_TRUE(lv_obj_has_flag(slider, LV_OBJ_FLAG_SCROLL_CHAIN_VER));
+
+    /* Begin a pointer drag on the slider */
+    lv_area_t coords;
+    lv_obj_get_coords(slider, &coords);
+    lv_test_mouse_move_to(coords.x1 + 10, coords.y1 + 10);
+    lv_test_mouse_press();
+    lv_test_wait(50);
+
+    /* Move to trigger PRESSING events */
+    lv_test_mouse_move_by(10, 0);
+    lv_test_wait(50);
+
+    /* During drag, perpendicular scroll chain (VER for horizontal slider) should be removed */
+    TEST_ASSERT_FALSE(lv_obj_has_flag(slider, LV_OBJ_FLAG_SCROLL_CHAIN_VER));
+
+    /* Release the slider */
+    lv_test_mouse_release();
+    lv_test_wait(50);
+
+    /* After release, SCROLL_CHAIN_VER should be restored */
+    TEST_ASSERT_TRUE(lv_obj_has_flag(slider, LV_OBJ_FLAG_SCROLL_CHAIN_VER));
+}
+
+void test_slider_perpendicular_scroll_chain_blocked_during_vertical_drag(void)
+{
+    lv_obj_t * slider_ver = lv_slider_create(lv_screen_active());
+    lv_obj_set_size(slider_ver, 20, 200);
+    lv_obj_center(slider_ver);
+    lv_obj_update_layout(slider_ver);
+
+    /* Manually add SCROLL_CHAIN_HOR (simulates state after a previous release) */
+    lv_obj_add_flag(slider_ver, LV_OBJ_FLAG_SCROLL_CHAIN_HOR);
+    TEST_ASSERT_TRUE(lv_obj_has_flag(slider_ver, LV_OBJ_FLAG_SCROLL_CHAIN_HOR));
+
+    /* Begin a pointer drag on the slider */
+    lv_area_t coords;
+    lv_obj_get_coords(slider_ver, &coords);
+    lv_test_mouse_move_to(coords.x1 + 10, coords.y1 + 10);
+    lv_test_mouse_press();
+    lv_test_wait(50);
+
+    /* Move to trigger PRESSING events */
+    lv_test_mouse_move_by(0, 10);
+    lv_test_wait(50);
+
+    /* During drag, perpendicular scroll chain (HOR for vertical slider) should be removed */
+    TEST_ASSERT_FALSE(lv_obj_has_flag(slider_ver, LV_OBJ_FLAG_SCROLL_CHAIN_HOR));
+
+    /* Release the slider */
+    lv_test_mouse_release();
+    lv_test_wait(50);
+
+    /* After release, SCROLL_CHAIN_HOR should be restored */
+    TEST_ASSERT_TRUE(lv_obj_has_flag(slider_ver, LV_OBJ_FLAG_SCROLL_CHAIN_HOR));
+}
+
+void test_slider_scroll_chain_not_blocked_for_encoder_input(void)
+{
+    lv_obj_set_size(slider, 200, 20);
+    lv_obj_center(slider);
+    lv_obj_update_layout(slider);
+
+    /* Add both scroll chain flags */
+    lv_obj_add_flag(slider, LV_OBJ_FLAG_SCROLL_CHAIN_HOR);
+    lv_obj_add_flag(slider, LV_OBJ_FLAG_SCROLL_CHAIN_VER);
+
+    /* Setup group and encoder indev */
+    lv_group_add_obj(g, slider);
+    lv_group_set_editing(g, true);
+
+    lv_slider_set_value(slider, 50, LV_ANIM_OFF);
+
+    /* Simulate encoder interaction (non-pointer input) */
+    lv_test_encoder_turn(5);
+
+    /* Encoder input should NOT remove scroll chain flags */
+    TEST_ASSERT_TRUE(lv_obj_has_flag(slider, LV_OBJ_FLAG_SCROLL_CHAIN_HOR));
+    TEST_ASSERT_TRUE(lv_obj_has_flag(slider, LV_OBJ_FLAG_SCROLL_CHAIN_VER));
+
+    /* Release encoder */
+    lv_test_encoder_click();
+
+    /* Flags should still be present after encoder release */
+    TEST_ASSERT_TRUE(lv_obj_has_flag(slider, LV_OBJ_FLAG_SCROLL_CHAIN_HOR));
+    TEST_ASSERT_TRUE(lv_obj_has_flag(slider, LV_OBJ_FLAG_SCROLL_CHAIN_VER));
+}
+
 #endif


### PR DESCRIPTION
## Description

On touchscreens, dragging a horizontal slider frequently triggers vertical scrolling of the parent container (and vice versa for vertical sliders). This makes sliders very frustrating to use on touch devices.

### Root cause

The slider's `LV_EVENT_PRESSING` handler *adds* the perpendicular scroll chain flag (`LV_OBJ_FLAG_SCROLL_CHAIN_VER` for horizontal sliders), which allows the parent to steal the scroll gesture in the perpendicular direction while the user is trying to drag the slider knob.

### Fix

Invert the behavior: *remove* the perpendicular scroll chain flag on press and on `LV_EVENT_SIZE_CHANGED`, so the parent cannot intercept the gesture while the user is actively dragging.

### How has this been tested?

- Tested on embedded Linux touchscreen devices (480x320, 800x480, 1024x600)
- Verified sliders inside scrollable containers no longer trigger parent scroll
- Scrolling outside the slider area still works normally