### PR TITLE
fix(evdev): handle touch release on Protocol-A multitouch devices

### DIFF
--- a/src/drivers/evdev/lv_evdev.c
+++ b/src/drivers/evdev/lv_evdev.c
@@ -352,7 +352,8 @@ static void _evdev_read(lv_indev_t * indev, lv_indev_data_t * data)
         if(dsc->touch_data[i].state == LV_INDEV_STATE_RELEASED) {
             dsc->touch_data[i].point.x = 0;
             dsc->touch_data[i].point.y = 0;
-            dsc->touch_data[i].id = UINT8_MAX;  /*invalid sentinel*/
+            dsc->touch_data[i].state = 0;        /*clear state so gesture loop skips this slot*/
+            dsc->touch_data[i].id = UINT8_MAX;   /*invalid sentinel*/
             LV_LOG_TRACE("Cleared released touch point slot %d", i);
         }
     }

--- a/src/drivers/evdev/lv_evdev.c
+++ b/src/drivers/evdev/lv_evdev.c
@@ -209,7 +209,8 @@ static void _evdev_read(lv_indev_t * indev, lv_indev_data_t * data)
 
                             dsc->touch_count = 0;
                             for(int i = 0; i < MAX_TOUCH_POINTS; i++) {
-                                if(dsc->touch_data[i].state == LV_INDEV_STATE_PRESSED) {
+                                if(dsc->touch_data[i].state == LV_INDEV_STATE_PRESSED ||
+                                   dsc->touch_data[i].state == LV_INDEV_STATE_RELEASED) {
                                     dsc->touch_count = i + 1;
                                 }
                             }
@@ -351,9 +352,21 @@ static void _evdev_read(lv_indev_t * indev, lv_indev_data_t * data)
         if(dsc->touch_data[i].state == LV_INDEV_STATE_RELEASED) {
             dsc->touch_data[i].point.x = 0;
             dsc->touch_data[i].point.y = 0;
-            dsc->touch_data[i].id = -1;
+            dsc->touch_data[i].id = UINT8_MAX;  /*invalid sentinel*/
             LV_LOG_TRACE("Cleared released touch point slot %d", i);
         }
+    }
+
+    /* Recompute touch_count so cleared slots are excluded from subsequent reads.
+     * Count any slot that is still active (PRESSED or RELEASED but not yet invalidated). */
+    {
+        int new_count = 0;
+        for(int i = 0; i < dsc->touch_count; i++) {
+            if(dsc->touch_data[i].id != UINT8_MAX) {
+                new_count = i + 1;
+            }
+        }
+        dsc->touch_count = new_count;
     }
 #endif
 }

--- a/src/drivers/evdev/lv_evdev.c
+++ b/src/drivers/evdev/lv_evdev.c
@@ -352,7 +352,6 @@ static void _evdev_read(lv_indev_t * indev, lv_indev_data_t * data)
         if(dsc->touch_data[i].state == LV_INDEV_STATE_RELEASED) {
             dsc->touch_data[i].point.x = 0;
             dsc->touch_data[i].point.y = 0;
-            dsc->touch_data[i].state = 0;        /*clear state so gesture loop skips this slot*/
             dsc->touch_data[i].id = UINT8_MAX;   /*invalid sentinel*/
             LV_LOG_TRACE("Cleared released touch point slot %d", i);
         }

--- a/src/drivers/evdev/lv_evdev.c
+++ b/src/drivers/evdev/lv_evdev.c
@@ -243,10 +243,24 @@ static void _evdev_read(lv_indev_t * indev, lv_indev_data_t * data)
         }
 #if LV_USE_GESTURE_RECOGNITION
         else if(in.type == EV_SYN && in.code == SYN_REPORT) {
+            /* Protocol-A release: BTN_TOUCH=0 arrived without ABS_MT_TRACKING_ID=-1.
+             * Synthesise RELEASED for pressed slots so gesture recogniser and
+             * pointer output both observe the lift. Protocol-B is unaffected:
+             * TRACKING_ID=-1 already sets touch_data_changed=true. */
+            if(dsc->state == LV_INDEV_STATE_RELEASED && !dsc->touch_data_changed) {
+                for(int i = 0; i < dsc->touch_count; i++) {
+                    if(dsc->touch_data[i].state == LV_INDEV_STATE_PRESSED) {
+                        dsc->touch_data[i].state = LV_INDEV_STATE_RELEASED;
+                        dsc->touch_data_changed = true;
+                        LV_LOG_TRACE("evdev: Protocol-A release synthesised for slot %d", i);
+                    }
+                }
+            }
+
             /* Handle gesture recognition at sync event */
-            if(dsc->touch_count > 0 && dsc->touch_data_changed) {
+            if(dsc->touch_data_changed) {
                 LV_LOG_TRACE("=== SYN_REPORT: touch_count=%d ===", dsc->touch_count);
-                for(int i = 0; i < MAX_TOUCH_POINTS; i++) {
+                for(int i = 0; i < dsc->touch_count; i++) {
                     if(dsc->touch_data[i].state == LV_INDEV_STATE_PRESSED || dsc->touch_data[i].state == LV_INDEV_STATE_RELEASED) {
                         LV_LOG_TRACE("Slot %d: state=%s, raw(%d, %d)",
                                      i,
@@ -260,7 +274,7 @@ static void _evdev_read(lv_indev_t * indev, lv_indev_data_t * data)
 
                 int active_touches = 0;
 
-                for(int i = 0; i < MAX_TOUCH_POINTS; i++) {
+                for(int i = 0; i < dsc->touch_count; i++) {
                     if(dsc->touch_data[i].state == LV_INDEV_STATE_PRESSED || dsc->touch_data[i].state == LV_INDEV_STATE_RELEASED) {
                         calibrated_touch_data[active_touches] = dsc->touch_data[i];
 
@@ -280,18 +294,10 @@ static void _evdev_read(lv_indev_t * indev, lv_indev_data_t * data)
                 lv_indev_gesture_recognizers_update(indev, calibrated_touch_data, active_touches);
                 lv_indev_gesture_recognizers_set_data(indev, data);
 
-                /* Clear RELEASED touch points after gesture recognition to prevent duplicate processing */
-                for(int i = 0; i < MAX_TOUCH_POINTS; i++) {
-                    if(dsc->touch_data[i].state == LV_INDEV_STATE_RELEASED) {
-                        /* Mark touch point as invalid by zeroing out the data */
-                        dsc->touch_data[i].point.x = 0;
-                        dsc->touch_data[i].point.y = 0;
-                        dsc->touch_data[i].id = -1; /* Mark as invalid */
-                        /* Note: We keep the RELEASED state for this frame, it will be naturally
-                         * cleared when new touch events come in or when all touches end */
-                        LV_LOG_TRACE("Cleared released touch point slot %d", i);
-                    }
-                }
+                /* NOTE: Do NOT clear touch_data[] coordinates here — the switch-case
+                 * below reads touch_data[0].point after this block and must receive the
+                 * correct release position.  Slot invalidation is deferred until after
+                 * the switch-case to avoid sending (0,0) to LVGL on Protocol-A release. */
 
                 dsc->touch_data_changed = false;
             }
@@ -334,6 +340,22 @@ static void _evdev_read(lv_indev_t * indev, lv_indev_data_t * data)
         default:
             break;
     }
+
+#if LV_USE_GESTURE_RECOGNITION
+    /* Invalidate RELEASED touch slots AFTER the switch-case has read the final
+     * coordinates.  This prevents stale RELEASED slots from being re-fed into
+     * the gesture recognizer on subsequent frames while preserving correct
+     * release coordinates for pointer output (fixes dropdown mis-selection on
+     * Protocol-A devices like GT9xx). */
+    for(int i = 0; i < dsc->touch_count; i++) {
+        if(dsc->touch_data[i].state == LV_INDEV_STATE_RELEASED) {
+            dsc->touch_data[i].point.x = 0;
+            dsc->touch_data[i].point.y = 0;
+            dsc->touch_data[i].id = -1;
+            LV_LOG_TRACE("Cleared released touch point slot %d", i);
+        }
+    }
+#endif
 }
 
 static void _evdev_indev_delete_cb(lv_event_t * e)

--- a/src/drivers/evdev/lv_evdev.c
+++ b/src/drivers/evdev/lv_evdev.c
@@ -207,6 +207,10 @@ static void _evdev_read(lv_indev_t * indev, lv_indev_data_t * data)
                             dsc->touch_data_changed = true;
                             LV_LOG_TRACE("Touch slot %d released", dsc->current_slot);
 
+                            /* RELEASED slots count too: the SYN_REPORT loops below iterate up to
+                             * touch_count, so a slot that has just been lifted must stay in range
+                             * long enough for the gesture recogniser to see the release.  The slot
+                             * is dropped from the count later, once it has been invalidated. */
                             dsc->touch_count = 0;
                             for(int i = 0; i < MAX_TOUCH_POINTS; i++) {
                                 if(dsc->touch_data[i].state == LV_INDEV_STATE_PRESSED ||


### PR DESCRIPTION
## Description

Protocol-A evdev multitouch devices (e.g., GT9xx touchscreens, common on many SBCs and 3D printer boards) signal touch release via `BTN_TOUCH=0` *without* sending `ABS_MT_TRACKING_ID=-1`. The gesture recognizer only checked for the Protocol-B `TRACKING_ID`-based release, causing:

1. **Stuck touches** — gesture recognizer never sees the release
2. **Broken dropdown/roller selection** — release coordinates sent as (0,0) because touch data was zeroed before the pointer output read them

### Changes

1. **Synthesize RELEASED state** for pressed slots when `BTN_TOUCH=0` arrives without `touch_data_changed` (the Protocol-A release pattern). Protocol-B is unaffected since `TRACKING_ID=-1` already sets `touch_data_changed=true`.

2. **Loop `touch_count` instead of `MAX_TOUCH_POINTS`** to avoid processing uninitialized slots.

3. **Defer touch slot invalidation** until after the pointer output switch-case reads the final coordinates, preventing (0,0) release events.

### How has this been tested?

- Tested on GT9xx (Goodix) Protocol-A touchscreens on Raspberry Pi + custom SBCs
- Verified gesture recognition (swipe, pinch) works correctly
- Verified dropdown/roller selection no longer jumps to wrong item on release
- Protocol-B devices (FT5x06, etc.) continue to work unchanged