### PR TITLE
fix(arc): guard against negative inner radius in arc area calculation

### DIFF
--- a/src/draw/lv_draw_arc.c
+++ b/src/draw/lv_draw_arc.c
@@ -89,6 +89,16 @@ void lv_draw_arc_get_area(int32_t x, int32_t y, uint16_t radius,  lv_value_preci
     int32_t start_angle_int = (int32_t) start_angle;
     int32_t end_angle_int = (int32_t) end_angle;
 
+    /*Guard: radius too small for stroke width — return full bounding box
+     *to avoid negative rin causing inverted trig calculations*/
+    if(radius <= w) {
+        area->x1 = x - rout - w;
+        area->y1 = y - rout - w;
+        area->x2 = x + rout + w;
+        area->y2 = y + rout + w;
+        return;
+    }
+
     /*Special case: full arc invalidation */
     if(end_angle_int == start_angle_int + 360) {
         area->x1 = x - rout;

--- a/src/draw/lv_draw_arc.c
+++ b/src/draw/lv_draw_arc.c
@@ -89,13 +89,14 @@ void lv_draw_arc_get_area(int32_t x, int32_t y, uint16_t radius,  lv_value_preci
     int32_t start_angle_int = (int32_t) start_angle;
     int32_t end_angle_int = (int32_t) end_angle;
 
-    /*Guard: radius too small for stroke width — return full bounding box
-     *to avoid negative rin causing inverted trig calculations*/
+    /*Guard: radius too small for stroke width — return outer-radius bounding box
+     *to avoid negative rin causing inverted trig calculations.
+     *The arc never draws outside its outer radius regardless of stroke width. */
     if(radius <= w) {
-        area->x1 = x - rout - w;
-        area->y1 = y - rout - w;
-        area->x2 = x + rout + w;
-        area->y2 = y + rout + w;
+        area->x1 = x - rout;
+        area->y1 = y - rout;
+        area->x2 = x + rout;
+        area->y2 = y + rout;
         return;
     }
 

--- a/src/draw/lv_draw_arc.c
+++ b/src/draw/lv_draw_arc.c
@@ -86,6 +86,16 @@ void lv_draw_arc_get_area(int32_t x, int32_t y, uint16_t radius,  lv_value_preci
     int32_t start_angle_int = (int32_t) start_angle;
     int32_t end_angle_int = (int32_t) end_angle;
 
+    /*Guard: radius too small for stroke width — return full bounding box
+     *to avoid negative rin causing inverted trig calculations*/
+    if(radius <= w) {
+        area->x1 = x - rout - w;
+        area->y1 = y - rout - w;
+        area->x2 = x + rout + w;
+        area->y2 = y + rout + w;
+        return;
+    }
+
     /*Special case: full arc invalidation */
     if(end_angle_int == start_angle_int + 360) {
         area->x1 = x - rout;

--- a/src/draw/lv_draw_arc.c
+++ b/src/draw/lv_draw_arc.c
@@ -86,13 +86,14 @@ void lv_draw_arc_get_area(int32_t x, int32_t y, uint16_t radius,  lv_value_preci
     int32_t start_angle_int = (int32_t) start_angle;
     int32_t end_angle_int = (int32_t) end_angle;
 
-    /*Guard: radius too small for stroke width — return full bounding box
-     *to avoid negative rin causing inverted trig calculations*/
+    /*Guard: radius too small for stroke width — return outer-radius bounding box
+     *to avoid negative rin causing inverted trig calculations.
+     *The arc never draws outside its outer radius regardless of stroke width. */
     if(radius <= w) {
-        area->x1 = x - rout - w;
-        area->y1 = y - rout - w;
-        area->x2 = x + rout + w;
-        area->y2 = y + rout + w;
+        area->x1 = x - rout;
+        area->y1 = y - rout;
+        area->x2 = x + rout;
+        area->y2 = y + rout;
         return;
     }
 

--- a/src/widgets/arc/lv_arc.c
+++ b/src/widgets/arc/lv_arc.c
@@ -894,6 +894,12 @@ static void inv_arc_area(lv_obj_t * obj, lv_value_precise_t start_angle, lv_valu
     int32_t w = lv_obj_get_style_arc_width(obj, part);
     bool rounded = lv_obj_get_style_arc_rounded(obj, part);
 
+    /*Guard: if radius is zero or negative after padding, invalidate full object (incl. ext-draw area)*/
+    if(r <= 0) {
+        lv_obj_invalidate(obj);
+        return;
+    }
+
     lv_area_t inv_area;
     lv_draw_arc_get_area(c.x, c.y, r, start_angle, end_angle, w, rounded, &inv_area);
 

--- a/src/widgets/arc/lv_arc.c
+++ b/src/widgets/arc/lv_arc.c
@@ -905,6 +905,12 @@ static void inv_arc_area(lv_obj_t * obj, lv_value_precise_t start_angle, lv_valu
     int32_t w = lv_obj_get_style_arc_width(obj, part);
     bool rounded = lv_obj_get_style_arc_rounded(obj, part);
 
+    /*Guard: if radius is zero or negative after padding, invalidate full object (incl. ext-draw area)*/
+    if(r <= 0) {
+        lv_obj_invalidate(obj);
+        return;
+    }
+
     lv_area_t inv_area;
     lv_draw_arc_get_area(c.x, c.y, r, start_angle, end_angle, w, rounded, &inv_area);
 

--- a/tests/src/test_cases/widgets/test_arc.c
+++ b/tests/src/test_cases/widgets/test_arc.c
@@ -793,4 +793,60 @@ void test_arc_angle_within_bg_bounds_edge_cases(void)
     run_arc_drag_test(300, 60, 80, 60, 75);
 }
 
+/* Regression: negative inner radius in inv_arc_area() when padding
+ * exceeds the arc radius. Previously passed a negative value to
+ * lv_draw_arc_get_area(), causing undefined trig results. */
+void test_arc_negative_radius_no_crash(void)
+{
+    arc = lv_arc_create(active_screen);
+    lv_obj_set_size(arc, 10, 10);
+    lv_obj_set_style_arc_width(arc, 50, LV_PART_INDICATOR);
+    lv_obj_set_style_arc_width(arc, 50, LV_PART_MAIN);
+    lv_obj_set_style_pad_all(arc, 30, LV_PART_MAIN);
+
+    lv_arc_set_value(arc, 50);
+    lv_obj_invalidate(arc);
+    lv_refr_now(NULL);
+
+    TEST_ASSERT_NOT_NULL(arc);
+}
+
+/* Regression: stroke width wider than radius in lv_draw_arc_get_area()
+ * produced a negative inner radius, leading to bad trig calculations. */
+void test_arc_stroke_wider_than_radius_no_crash(void)
+{
+    arc = lv_arc_create(active_screen);
+    lv_obj_set_size(arc, 30, 30);
+    lv_obj_set_style_arc_width(arc, 40, LV_PART_INDICATOR);
+    lv_obj_set_style_arc_width(arc, 40, LV_PART_MAIN);
+
+    lv_arc_set_value(arc, 70);
+    lv_obj_invalidate(arc);
+    lv_refr_now(NULL);
+
+    TEST_ASSERT_NOT_NULL(arc);
+}
+
+/* Edge case: zero-size arc should not crash during invalidation
+ * or redraw. */
+void test_arc_zero_size_no_crash(void)
+{
+    arc = lv_arc_create(active_screen);
+    lv_obj_set_size(arc, 1, 1);
+
+    lv_arc_set_value(arc, 50);
+    lv_obj_invalidate(arc);
+    lv_refr_now(NULL);
+
+    TEST_ASSERT_NOT_NULL(arc);
+
+    /* Also try true zero size */
+    lv_obj_set_size(arc, 0, 0);
+    lv_arc_set_value(arc, 80);
+    lv_obj_invalidate(arc);
+    lv_refr_now(NULL);
+
+    TEST_ASSERT_NOT_NULL(arc);
+}
+
 #endif


### PR DESCRIPTION
## Description

When an arc widget's radius is smaller than its stroke width, the inner radius (`rin`) becomes negative. This causes:

- Inverted trigonometric calculations in `lv_draw_arc_get_area()` producing garbage invalidation coordinates
- Potential rendering artifacts or crashes from invalid area values

Similarly, when `radius <= 0` after padding in `inv_arc_area()`, negative values propagate into the area calculation.

### Changes

1. **`lv_draw_arc_get_area()`**: When `radius <= w` (stroke width), return a full bounding box instead of attempting trig calculations with a negative inner radius.

2. **`inv_arc_area()`**: When `r <= 0` after padding, invalidate the full object area instead of passing bad values to `lv_draw_arc_get_area()`.

### How has this been tested?

- Tested on embedded Linux with arc widgets at various small radii and large stroke widths
- Verified no rendering artifacts or crashes with edge-case arc configurations