### PR TITLE
fix(fbdev): stride-based bpp, BGR auto-detect, buffer alignment, skip-unblank

### DIFF
--- a/include/lvgl/drivers/display/lv_linux_fbdev.h
+++ b/include/lvgl/drivers/display/lv_linux_fbdev.h
@@ -34,10 +34,31 @@ lv_display_t * lv_linux_fbdev_create(void);
 lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file);
 
 /**
+ * Skip the FBIOBLANK unblank ioctl in lv_linux_fbdev_set_file().
+ * Use when another process (e.g. splash screen) already owns the framebuffer
+ * and calling FBIOBLANK would cause visible flicker.
+ * Must be called BEFORE lv_linux_fbdev_set_file().
+ */
+void lv_linux_fbdev_set_skip_unblank(lv_display_t * disp, bool skip);
+
+/**
  * Force the display to be refreshed on every change.
  * Expected to be used with LV_DISPLAY_RENDER_MODE_DIRECT or LV_DISPLAY_RENDER_MODE_FULL.
  */
 void lv_linux_fbdev_set_force_refresh(lv_display_t * disp, bool enabled);
+
+/**
+ * Enable red/blue channel swap in the flush callback.
+ * Use for framebuffers with BGR pixel order (e.g., some Allwinner SoCs).
+ * Auto-detected from fb_var_screeninfo if not called explicitly.
+ * Must be called AFTER lv_linux_fbdev_set_file().
+ */
+void lv_linux_fbdev_set_swap_rb(lv_display_t * disp, bool enabled);
+
+/**
+ * Query whether red/blue channel swap is active.
+ */
+bool lv_linux_fbdev_get_swap_rb(lv_display_t * disp);
 
 /**********************
  *      MACROS

--- a/include/lvgl/drivers/display/lv_linux_fbdev.h
+++ b/include/lvgl/drivers/display/lv_linux_fbdev.h
@@ -50,7 +50,8 @@ void lv_linux_fbdev_set_force_refresh(lv_display_t * disp, bool enabled);
 /**
  * Enable red/blue channel swap in the flush callback.
  * Use for framebuffers with BGR pixel order (e.g., some Allwinner SoCs).
- * Auto-detected from fb_var_screeninfo if not called explicitly.
+ * On Linux (non-BSD) builds, auto-detected from fb_var_screeninfo if not called explicitly.
+ * When LV_LINUX_FBDEV_BSD is enabled, auto-detection is disabled and this must be set manually.
  * Must be called AFTER lv_linux_fbdev_set_file().
  */
 void lv_linux_fbdev_set_swap_rb(lv_display_t * disp, bool enabled);

--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -214,8 +214,12 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
                     dsc->vinfo.bits_per_pixel, stride_bpp);
         dsc->vinfo.bits_per_pixel = stride_bpp;
     }
-    else {
+    else if(stride_bpp > 0 && stride_bpp == dsc->vinfo.bits_per_pixel) {
         LV_LOG_INFO("bits_per_pixel %d matches stride calculation", dsc->vinfo.bits_per_pixel);
+    }
+    else {
+        LV_LOG_INFO("bits_per_pixel %d retained; stride-derived bpp %u ignored (zero or non-standard)",
+                    dsc->vinfo.bits_per_pixel, stride_bpp);
     }
 
     /* Figure out the size of the screen in bytes*/
@@ -287,10 +291,22 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
     /* Over-allocate to guarantee LV_DRAW_BUF_ALIGN alignment.
      * Store raw pointers in dsc for lv_free(), pass aligned pointers to LVGL. */
     dsc->draw_buf_1 = lv_malloc(draw_buf_size + LV_DRAW_BUF_ALIGN - 1);
+    LV_ASSERT_MALLOC(dsc->draw_buf_1);
+    if(dsc->draw_buf_1 == NULL) {
+        LV_LOG_ERROR("Failed to allocate draw buffer 1 (%u bytes)", draw_buf_size + LV_DRAW_BUF_ALIGN - 1);
+        return LV_RESULT_INVALID;
+    }
     draw_buf = lv_draw_buf_align(dsc->draw_buf_1, cf);
 
     if(LV_LINUX_FBDEV_BUFFER_COUNT == 2) {
         dsc->draw_buf_2 = lv_malloc(draw_buf_size + LV_DRAW_BUF_ALIGN - 1);
+        LV_ASSERT_MALLOC(dsc->draw_buf_2);
+        if(dsc->draw_buf_2 == NULL) {
+            LV_LOG_ERROR("Failed to allocate draw buffer 2 (%u bytes)", draw_buf_size + LV_DRAW_BUF_ALIGN - 1);
+            lv_free(dsc->draw_buf_1);
+            dsc->draw_buf_1 = NULL;
+            return LV_RESULT_INVALID;
+        }
         draw_buf_2 = lv_draw_buf_align(dsc->draw_buf_2, cf);
     }
 

--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -71,6 +71,10 @@ typedef struct {
     bool force_refresh;
     uint8_t * draw_buf_1;
     uint8_t * draw_buf_2;
+    bool skip_unblank;
+    bool swap_rb;
+    uint8_t * swap_line_buf;
+    size_t swap_line_buf_size;
 } lv_linux_fb_t;
 
 /**********************
@@ -80,6 +84,9 @@ typedef struct {
 static void del_event_cb(lv_event_t * e);
 static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * color_p);
 static uint32_t tick_get_cb(void);
+static void swap_rb_line_16(uint8_t * dst, const uint8_t * src, int32_t pixel_count);
+static void swap_rb_line_24(uint8_t * dst, const uint8_t * src, int32_t pixel_count);
+static void swap_rb_line_32(uint8_t * dst, const uint8_t * src, int32_t pixel_count);
 
 /**********************
  *  STATIC VARIABLES
@@ -143,10 +150,12 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
     }
     LV_LOG_INFO("The framebuffer device was opened successfully");
 
-    /* Make sure that the display is on.*/
-    if(ioctl(dsc->fbfd, FBIOBLANK, FB_BLANK_UNBLANK) != 0) {
-        perror("ioctl(FBIOBLANK)");
-        /* Don't return. Some framebuffer drivers like efifb or simplefb don't implement FBIOBLANK.*/
+    /* Make sure that the display is on (unless another process already owns the framebuffer). */
+    if(!dsc->skip_unblank) {
+        if(ioctl(dsc->fbfd, FBIOBLANK, FB_BLANK_UNBLANK) != 0) {
+            perror("ioctl(FBIOBLANK)");
+            /* Don't return. Some framebuffer drivers like efifb or simplefb don't implement FBIOBLANK.*/
+        }
     }
 
 #if LV_LINUX_FBDEV_BSD
@@ -189,6 +198,26 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
 
     LV_LOG_INFO("%dx%d, %dbpp", dsc->vinfo.xres, dsc->vinfo.yres, dsc->vinfo.bits_per_pixel);
 
+    /* AD5M and some other devices report incorrect bits_per_pixel via VSCREENINFO.
+     * The stride (line_length) is always correct, so calculate true bpp from it.
+     * Example: AD5M reports 16bpp but stride=3200 for 800px width = 4 bytes/pixel = 32bpp */
+    uint32_t stride_bpp = 0;
+    if(dsc->vinfo.xres > 0) {
+        stride_bpp = (dsc->finfo.line_length * 8) / dsc->vinfo.xres;
+    }
+
+    /* Only override if stride_bpp is a standard depth (avoids false positives
+     * from alignment-padded strides or virtual-width framebuffers). */
+    if(stride_bpp > 0 && stride_bpp != dsc->vinfo.bits_per_pixel
+       && (stride_bpp == 8 || stride_bpp == 16 || stride_bpp == 24 || stride_bpp == 32)) {
+        LV_LOG_WARN("bits_per_pixel mismatch: vinfo says %d, stride indicates %d. Using stride value.",
+                    dsc->vinfo.bits_per_pixel, stride_bpp);
+        dsc->vinfo.bits_per_pixel = stride_bpp;
+    }
+    else {
+        LV_LOG_INFO("bits_per_pixel %d matches stride calculation", dsc->vinfo.bits_per_pixel);
+    }
+
     /* Figure out the size of the screen in bytes*/
     dsc->screensize =  dsc->finfo.smem_len;/*finfo.line_length * vinfo.yres;*/
 
@@ -221,6 +250,25 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
             return LV_RESULT_INVALID;
     }
 
+#if !LV_LINUX_FBDEV_BSD
+    /* Auto-detect BGR framebuffer layout from vinfo field offsets.
+     * Standard RGB: red.offset > blue.offset (e.g., red=16, blue=0 for 32bpp)
+     * BGR layout:   red.offset < blue.offset (e.g., red=0, blue=16 for 32bpp)
+     * When BGR is detected, R/B channels are swapped during flush. */
+    if(dsc->vinfo.red.length > 0 && dsc->vinfo.blue.length > 0) {
+        if(dsc->vinfo.red.offset < dsc->vinfo.blue.offset) {
+            dsc->swap_rb = true;
+            LV_LOG_INFO("BGR framebuffer detected (red.offset=%d, blue.offset=%d) — enabling R/B swap",
+                        dsc->vinfo.red.offset, dsc->vinfo.blue.offset);
+        }
+        else {
+            dsc->swap_rb = false;
+            LV_LOG_INFO("RGB framebuffer layout (red.offset=%d, blue.offset=%d)",
+                        dsc->vinfo.red.offset, dsc->vinfo.blue.offset);
+        }
+    }
+#endif
+
     int32_t hor_res = dsc->vinfo.xres;
     int32_t ver_res = dsc->vinfo.yres;
     int32_t width = dsc->vinfo.width;
@@ -232,16 +280,19 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
         draw_buf_size *= ver_res;
     }
 
+    lv_color_format_t cf = lv_display_get_color_format(disp);
     uint8_t * draw_buf = NULL;
     uint8_t * draw_buf_2 = NULL;
-    draw_buf = lv_malloc(draw_buf_size);
+
+    /* Over-allocate to guarantee LV_DRAW_BUF_ALIGN alignment.
+     * Store raw pointers in dsc for lv_free(), pass aligned pointers to LVGL. */
+    dsc->draw_buf_1 = lv_malloc(draw_buf_size + LV_DRAW_BUF_ALIGN - 1);
+    draw_buf = lv_draw_buf_align(dsc->draw_buf_1, cf);
 
     if(LV_LINUX_FBDEV_BUFFER_COUNT == 2) {
-        draw_buf_2 = lv_malloc(draw_buf_size);
+        dsc->draw_buf_2 = lv_malloc(draw_buf_size + LV_DRAW_BUF_ALIGN - 1);
+        draw_buf_2 = lv_draw_buf_align(dsc->draw_buf_2, cf);
     }
-
-    dsc->draw_buf_1 = draw_buf;
-    dsc->draw_buf_2 = draw_buf_2;
 
     lv_display_set_resolution(disp, hor_res, ver_res);
     lv_display_set_buffers(disp, draw_buf, draw_buf_2, draw_buf_size, LV_LINUX_FBDEV_RENDER_MODE);
@@ -256,10 +307,28 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
     return LV_RESULT_OK;
 }
 
+void lv_linux_fbdev_set_skip_unblank(lv_display_t * disp, bool skip)
+{
+    lv_linux_fb_t * dsc = lv_display_get_driver_data(disp);
+    dsc->skip_unblank = skip;
+}
+
 void lv_linux_fbdev_set_force_refresh(lv_display_t * disp, bool enabled)
 {
     lv_linux_fb_t * dsc = lv_display_get_driver_data(disp);
     dsc->force_refresh = enabled;
+}
+
+void lv_linux_fbdev_set_swap_rb(lv_display_t * disp, bool enabled)
+{
+    lv_linux_fb_t * dsc = lv_display_get_driver_data(disp);
+    dsc->swap_rb = enabled;
+}
+
+bool lv_linux_fbdev_get_swap_rb(lv_display_t * disp)
+{
+    lv_linux_fb_t * dsc = lv_display_get_driver_data(disp);
+    return dsc->swap_rb;
 }
 
 /**********************
@@ -297,6 +366,7 @@ static void del_event_cb(lv_event_t * e)
         dsc->fbfd = -1;
     }
     if(dsc->rotated_buf) lv_free(dsc->rotated_buf);
+    if(dsc->swap_line_buf) lv_free(dsc->swap_line_buf);
     if(dsc->draw_buf_1) lv_free(dsc->draw_buf_1);
     if(dsc->draw_buf_2) lv_free(dsc->draw_buf_2);
     if(dsc->devname) lv_free((void *)dsc->devname);
@@ -395,12 +465,31 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * colo
         (clipped_area.y1 + dsc->vinfo.yoffset) * dsc->finfo.line_length;
     const int32_t w = lv_area_get_width(&clipped_area);
 
+    /* Prepare swap line buffer if R/B swap is active */
+    const size_t line_bytes = w * px_size;
+    uint8_t * swap_buf = NULL;
+    if(dsc->swap_rb) {
+        if(!dsc->swap_line_buf || dsc->swap_line_buf_size < line_bytes) {
+            dsc->swap_line_buf = lv_realloc(dsc->swap_line_buf, line_bytes);
+            LV_ASSERT_MALLOC(dsc->swap_line_buf);
+            dsc->swap_line_buf_size = line_bytes;
+        }
+        swap_buf = dsc->swap_line_buf;
+    }
+
     if(LV_LINUX_FBDEV_RENDER_MODE == LV_DISPLAY_RENDER_MODE_DIRECT && rotation == LV_DISPLAY_ROTATION_0) {
         uint32_t color_pos =
             (clipped_area.x1 - disp->offset_x) * px_size +
             (clipped_area.y1 - disp->offset_y) * disp->hor_res * px_size;
         for(int32_t y = clipped_area.y1; y <= clipped_area.y2; y++) {
-            write_to_fb(dsc, fb_pos, &color_p[color_pos], w * px_size);
+            const uint8_t * src = &color_p[color_pos];
+            if(swap_buf) {
+                if(px_size == 4)      swap_rb_line_32(swap_buf, src, w);
+                else if(px_size == 3) swap_rb_line_24(swap_buf, src, w);
+                else                  swap_rb_line_16(swap_buf, src, w);
+                src = swap_buf;
+            }
+            write_to_fb(dsc, fb_pos, src, line_bytes);
             fb_pos += dsc->finfo.line_length;
             color_pos += disp->hor_res * px_size;
         }
@@ -414,7 +503,14 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * colo
         color_p += y_offset * stride + x_offset * px_size;
 
         for(int32_t y = clipped_area.y1; y <= clipped_area.y2; y++) {
-            write_to_fb(dsc, fb_pos, color_p, w * px_size);
+            const uint8_t * src = color_p;
+            if(swap_buf) {
+                if(px_size == 4)      swap_rb_line_32(swap_buf, src, w);
+                else if(px_size == 3) swap_rb_line_24(swap_buf, src, w);
+                else                  swap_rb_line_16(swap_buf, src, w);
+                src = swap_buf;
+            }
+            write_to_fb(dsc, fb_pos, src, line_bytes);
             fb_pos += dsc->finfo.line_length;
             color_p += stride;
         }
@@ -436,6 +532,44 @@ static uint32_t tick_get_cb(void)
     clock_gettime(CLOCK_MONOTONIC, &t);
     uint64_t time_ms = t.tv_sec * 1000 + (t.tv_nsec / 1000000);
     return time_ms;
+}
+
+/* Swap red and blue channels for BGR framebuffers.
+ * LVGL renders as RGB; these convert to BGR during the line copy. */
+
+static void swap_rb_line_16(uint8_t * dst, const uint8_t * src, int32_t pixel_count)
+{
+    const uint16_t * s = (const uint16_t *)src;
+    uint16_t * d = (uint16_t *)dst;
+    for(int32_t i = 0; i < pixel_count; i++) {
+        uint16_t px = s[i];
+        /* RGB565: RRRRRGGG_GGGBBBBB -> BGR565: BBBBBGGG_GGGRRRRR */
+        uint16_t r = (px >> 11) & 0x1F;
+        uint16_t g = (px >> 5) & 0x3F;
+        uint16_t b = px & 0x1F;
+        d[i] = (b << 11) | (g << 5) | r;
+    }
+}
+
+static void swap_rb_line_24(uint8_t * dst, const uint8_t * src, int32_t pixel_count)
+{
+    for(int32_t i = 0; i < pixel_count; i++) {
+        int32_t off = i * 3;
+        dst[off + 0] = src[off + 2];
+        dst[off + 1] = src[off + 1];
+        dst[off + 2] = src[off + 0];
+    }
+}
+
+static void swap_rb_line_32(uint8_t * dst, const uint8_t * src, int32_t pixel_count)
+{
+    const uint32_t * s = (const uint32_t *)src;
+    uint32_t * d = (uint32_t *)dst;
+    for(int32_t i = 0; i < pixel_count; i++) {
+        uint32_t px = s[i];
+        /* xRGB -> xBGR: swap bits [23:16] (R) and bits [7:0] (B), keep G and x */
+        d[i] = (px & 0xFF00FF00u) | ((px >> 16) & 0xFFu) | ((px & 0xFFu) << 16);
+    }
 }
 
 #endif /*LV_USE_LINUX_FBDEV*/

--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -196,8 +196,6 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
     }
 #endif /* LV_LINUX_FBDEV_BSD */
 
-    LV_LOG_INFO("%dx%d, %dbpp", dsc->vinfo.xres, dsc->vinfo.yres, dsc->vinfo.bits_per_pixel);
-
     /* AD5M and some other devices report incorrect bits_per_pixel via VSCREENINFO.
      * The stride (line_length) is always correct, so calculate true bpp from it.
      * Example: AD5M reports 16bpp but stride=3200 for 800px width = 4 bytes/pixel = 32bpp */
@@ -221,6 +219,9 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
         LV_LOG_INFO("bits_per_pixel %d retained; stride-derived bpp %u ignored (zero or non-standard)",
                     dsc->vinfo.bits_per_pixel, stride_bpp);
     }
+
+    /* Log the resolution after any bits_per_pixel correction so it reflects the value actually used */
+    LV_LOG_INFO("%dx%d, %dbpp", dsc->vinfo.xres, dsc->vinfo.yres, dsc->vinfo.bits_per_pixel);
 
     /* Figure out the size of the screen in bytes*/
     dsc->screensize =  dsc->finfo.smem_len;/*finfo.line_length * vinfo.yres;*/
@@ -325,24 +326,28 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
 
 void lv_linux_fbdev_set_skip_unblank(lv_display_t * disp, bool skip)
 {
+    LV_CHECK_ARG(disp != NULL, return);
     lv_linux_fb_t * dsc = lv_display_get_driver_data(disp);
     dsc->skip_unblank = skip;
 }
 
 void lv_linux_fbdev_set_force_refresh(lv_display_t * disp, bool enabled)
 {
+    LV_CHECK_ARG(disp != NULL, return);
     lv_linux_fb_t * dsc = lv_display_get_driver_data(disp);
     dsc->force_refresh = enabled;
 }
 
 void lv_linux_fbdev_set_swap_rb(lv_display_t * disp, bool enabled)
 {
+    LV_CHECK_ARG(disp != NULL, return);
     lv_linux_fb_t * dsc = lv_display_get_driver_data(disp);
     dsc->swap_rb = enabled;
 }
 
 bool lv_linux_fbdev_get_swap_rb(lv_display_t * disp)
 {
+    LV_CHECK_ARG(disp != NULL, return false);
     lv_linux_fb_t * dsc = lv_display_get_driver_data(disp);
     return dsc->swap_rb;
 }

--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -200,8 +200,16 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
      * The stride (line_length) is always correct, so calculate true bpp from it.
      * Example: AD5M reports 16bpp but stride=3200 for 800px width = 4 bytes/pixel = 32bpp */
     uint32_t stride_bpp = 0;
-    if(dsc->vinfo.xres > 0) {
-        stride_bpp = (dsc->finfo.line_length * 8) / dsc->vinfo.xres;
+    /* Use the virtual (padded) width when available; some framebuffers pad each
+     * line to xres_virtual, so xres alone yields an inflated bpp. The BSD
+     * fb_var_info shim has no xres_virtual field, so fall back to xres there. */
+#if LV_LINUX_FBDEV_BSD
+    uint32_t xres_for_stride = dsc->vinfo.xres;
+#else
+    uint32_t xres_for_stride = dsc->vinfo.xres_virtual > 0 ? dsc->vinfo.xres_virtual : dsc->vinfo.xres;
+#endif
+    if(xres_for_stride > 0) {
+        stride_bpp = (dsc->finfo.line_length * 8) / xres_for_stride;
     }
 
     /* Only override if stride_bpp is a standard depth (avoids false positives
@@ -491,11 +499,21 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * colo
     uint8_t * swap_buf = NULL;
     if(dsc->swap_rb) {
         if(!dsc->swap_line_buf || dsc->swap_line_buf_size < line_bytes) {
-            dsc->swap_line_buf = lv_realloc(dsc->swap_line_buf, line_bytes);
-            LV_ASSERT_MALLOC(dsc->swap_line_buf);
-            dsc->swap_line_buf_size = line_bytes;
+            /* Use a temp pointer so a NULL return doesn't leak the old buffer
+             * or wrongly update the cached size. */
+            uint8_t * tmp = lv_realloc(dsc->swap_line_buf, line_bytes);
+            if(tmp == NULL) {
+                LV_ASSERT_MALLOC(tmp);
+                /* Keep the old buffer; skip the R/B swap this frame rather than
+                 * crash. swap_buf stays NULL, so the unswapped data is written. */
+                LV_LOG_WARN("Failed to (re)allocate swap line buffer; skipping R/B swap this frame");
+            }
+            else {
+                dsc->swap_line_buf = tmp;
+                dsc->swap_line_buf_size = line_bytes;
+            }
         }
-        swap_buf = dsc->swap_line_buf;
+        swap_buf = dsc->swap_line_buf && dsc->swap_line_buf_size >= line_bytes ? dsc->swap_line_buf : NULL;
     }
 
     if(LV_LINUX_FBDEV_RENDER_MODE == LV_DISPLAY_RENDER_MODE_DIRECT && rotation == LV_DISPLAY_ROTATION_0) {

--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -159,11 +159,9 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
     }
     LV_LOG_INFO("The framebuffer device was opened successfully");
 
-    /* Make sure that the display is on (unless another process already owns the framebuffer). */
     if(!dsc->skip_unblank) {
         if(ioctl(dsc->fbfd, FBIOBLANK, FB_BLANK_UNBLANK) != 0) {
             perror("ioctl(FBIOBLANK)");
-            /* Don't return. Some framebuffer drivers like efifb or simplefb don't implement FBIOBLANK.*/
         }
     }
 
@@ -316,8 +314,6 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
     uint8_t * draw_buf = NULL;
     uint8_t * draw_buf_2 = NULL;
 
-    /* Over-allocate to guarantee LV_DRAW_BUF_ALIGN alignment.
-     * Store raw pointers in dsc for lv_free(), pass aligned pointers to LVGL. */
     dsc->draw_buf_1 = lv_malloc(draw_buf_size + LV_DRAW_BUF_ALIGN - 1);
     LV_ASSERT_MALLOC(dsc->draw_buf_1);
     if(dsc->draw_buf_1 == NULL) {
@@ -531,13 +527,9 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * colo
     uint8_t * swap_buf = NULL;
     if(dsc->swap_rb) {
         if(!dsc->swap_line_buf || dsc->swap_line_buf_size < line_bytes) {
-            /* Use a temp pointer so a NULL return doesn't leak the old buffer
-             * or wrongly update the cached size. */
             uint8_t * tmp = lv_realloc(dsc->swap_line_buf, line_bytes);
+            LV_ASSERT_MALLOC(tmp);
             if(tmp == NULL) {
-                LV_ASSERT_MALLOC(tmp);
-                /* Keep the old buffer; skip the R/B swap this frame rather than
-                 * crash. swap_buf stays NULL, so the unswapped data is written. */
                 LV_LOG_WARN("Failed to (re)allocate swap line buffer; skipping R/B swap this frame");
             }
             else {

--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -209,8 +209,16 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
      * The stride (line_length) is always correct, so calculate true bpp from it.
      * Example: AD5M reports 16bpp but stride=3200 for 800px width = 4 bytes/pixel = 32bpp */
     uint32_t stride_bpp = 0;
-    if(dsc->vinfo.xres > 0) {
-        stride_bpp = (dsc->finfo.line_length * 8) / dsc->vinfo.xres;
+    /* Use the virtual (padded) width when available; some framebuffers pad each
+     * line to xres_virtual, so xres alone yields an inflated bpp. The BSD
+     * fb_var_info shim has no xres_virtual field, so fall back to xres there. */
+#if LV_LINUX_FBDEV_BSD
+    uint32_t xres_for_stride = dsc->vinfo.xres;
+#else
+    uint32_t xres_for_stride = dsc->vinfo.xres_virtual > 0 ? dsc->vinfo.xres_virtual : dsc->vinfo.xres;
+#endif
+    if(xres_for_stride > 0) {
+        stride_bpp = (dsc->finfo.line_length * 8) / xres_for_stride;
     }
 
     /* Only override if stride_bpp is a standard depth (avoids false positives
@@ -523,11 +531,21 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * colo
     uint8_t * swap_buf = NULL;
     if(dsc->swap_rb) {
         if(!dsc->swap_line_buf || dsc->swap_line_buf_size < line_bytes) {
-            dsc->swap_line_buf = lv_realloc(dsc->swap_line_buf, line_bytes);
-            LV_ASSERT_MALLOC(dsc->swap_line_buf);
-            dsc->swap_line_buf_size = line_bytes;
+            /* Use a temp pointer so a NULL return doesn't leak the old buffer
+             * or wrongly update the cached size. */
+            uint8_t * tmp = lv_realloc(dsc->swap_line_buf, line_bytes);
+            if(tmp == NULL) {
+                LV_ASSERT_MALLOC(tmp);
+                /* Keep the old buffer; skip the R/B swap this frame rather than
+                 * crash. swap_buf stays NULL, so the unswapped data is written. */
+                LV_LOG_WARN("Failed to (re)allocate swap line buffer; skipping R/B swap this frame");
+            }
+            else {
+                dsc->swap_line_buf = tmp;
+                dsc->swap_line_buf_size = line_bytes;
+            }
         }
-        swap_buf = dsc->swap_line_buf;
+        swap_buf = dsc->swap_line_buf && dsc->swap_line_buf_size >= line_bytes ? dsc->swap_line_buf : NULL;
     }
 
     if(LV_LINUX_FBDEV_RENDER_MODE == LV_DISPLAY_RENDER_MODE_DIRECT && rotation == LV_DISPLAY_ROTATION_0) {

--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -64,9 +64,11 @@ typedef struct {
 #if LV_LINUX_FBDEV_MMAP
     char * fbp;
 #endif
+    uint8_t * swap_line_buf;
     uint8_t * rotated_buf;
     uint8_t * draw_buf_1;
     uint8_t * draw_buf_2;
+    size_t swap_line_buf_size;
     size_t rotated_buf_size;
     long int screensize;
     int fbfd;
@@ -74,6 +76,8 @@ typedef struct {
     bool force_refresh;
     bool wait_vsync_next;
     bool vsync_supported;
+    bool skip_unblank;
+    bool swap_rb;
 } lv_linux_fb_t;
 
 /**********************
@@ -83,6 +87,9 @@ typedef struct {
 static void del_event_cb(lv_event_t * e);
 static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * color_p);
 static uint32_t tick_get_cb(void);
+static void swap_rb_line_16(uint8_t * dst, const uint8_t * src, int32_t pixel_count);
+static void swap_rb_line_24(uint8_t * dst, const uint8_t * src, int32_t pixel_count);
+static void swap_rb_line_32(uint8_t * dst, const uint8_t * src, int32_t pixel_count);
 
 /**********************
  *  STATIC VARIABLES
@@ -152,10 +159,12 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
     }
     LV_LOG_INFO("The framebuffer device was opened successfully");
 
-    /* Make sure that the display is on.*/
-    if(ioctl(dsc->fbfd, FBIOBLANK, FB_BLANK_UNBLANK) != 0) {
-        perror("ioctl(FBIOBLANK)");
-        /* Don't return. Some framebuffer drivers like efifb or simplefb don't implement FBIOBLANK.*/
+    /* Make sure that the display is on (unless another process already owns the framebuffer). */
+    if(!dsc->skip_unblank) {
+        if(ioctl(dsc->fbfd, FBIOBLANK, FB_BLANK_UNBLANK) != 0) {
+            perror("ioctl(FBIOBLANK)");
+            /* Don't return. Some framebuffer drivers like efifb or simplefb don't implement FBIOBLANK.*/
+        }
     }
 
 #if LV_LINUX_FBDEV_BSD
@@ -197,6 +206,26 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
 #endif /* LV_LINUX_FBDEV_BSD */
 
     LV_LOG_INFO("%dx%d, %dbpp", dsc->vinfo.xres, dsc->vinfo.yres, dsc->vinfo.bits_per_pixel);
+
+    /* AD5M and some other devices report incorrect bits_per_pixel via VSCREENINFO.
+     * The stride (line_length) is always correct, so calculate true bpp from it.
+     * Example: AD5M reports 16bpp but stride=3200 for 800px width = 4 bytes/pixel = 32bpp */
+    uint32_t stride_bpp = 0;
+    if(dsc->vinfo.xres > 0) {
+        stride_bpp = (dsc->finfo.line_length * 8) / dsc->vinfo.xres;
+    }
+
+    /* Only override if stride_bpp is a standard depth (avoids false positives
+     * from alignment-padded strides or virtual-width framebuffers). */
+    if(stride_bpp > 0 && stride_bpp != dsc->vinfo.bits_per_pixel
+       && (stride_bpp == 8 || stride_bpp == 16 || stride_bpp == 24 || stride_bpp == 32)) {
+        LV_LOG_WARN("bits_per_pixel mismatch: vinfo says %d, stride indicates %d. Using stride value.",
+                    dsc->vinfo.bits_per_pixel, stride_bpp);
+        dsc->vinfo.bits_per_pixel = stride_bpp;
+    }
+    else {
+        LV_LOG_INFO("bits_per_pixel %d matches stride calculation", dsc->vinfo.bits_per_pixel);
+    }
 
     /* Figure out the size of the screen in bytes*/
     dsc->screensize =  dsc->finfo.smem_len;/*finfo.line_length * vinfo.yres;*/
@@ -240,6 +269,25 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
             return LV_RESULT_INVALID;
     }
 
+#if !LV_LINUX_FBDEV_BSD
+    /* Auto-detect BGR framebuffer layout from vinfo field offsets.
+     * Standard RGB: red.offset > blue.offset (e.g., red=16, blue=0 for 32bpp)
+     * BGR layout:   red.offset < blue.offset (e.g., red=0, blue=16 for 32bpp)
+     * When BGR is detected, R/B channels are swapped during flush. */
+    if(dsc->vinfo.red.length > 0 && dsc->vinfo.blue.length > 0) {
+        if(dsc->vinfo.red.offset < dsc->vinfo.blue.offset) {
+            dsc->swap_rb = true;
+            LV_LOG_INFO("BGR framebuffer detected (red.offset=%d, blue.offset=%d) — enabling R/B swap",
+                        dsc->vinfo.red.offset, dsc->vinfo.blue.offset);
+        }
+        else {
+            dsc->swap_rb = false;
+            LV_LOG_INFO("RGB framebuffer layout (red.offset=%d, blue.offset=%d)",
+                        dsc->vinfo.red.offset, dsc->vinfo.blue.offset);
+        }
+    }
+#endif
+
     int32_t hor_res = dsc->vinfo.xres;
     int32_t ver_res = dsc->vinfo.yres;
     int32_t width = dsc->vinfo.width;
@@ -251,16 +299,19 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
         draw_buf_size *= ver_res;
     }
 
+    lv_color_format_t cf = lv_display_get_color_format(disp);
     uint8_t * draw_buf = NULL;
     uint8_t * draw_buf_2 = NULL;
-    draw_buf = lv_malloc(draw_buf_size);
+
+    /* Over-allocate to guarantee LV_DRAW_BUF_ALIGN alignment.
+     * Store raw pointers in dsc for lv_free(), pass aligned pointers to LVGL. */
+    dsc->draw_buf_1 = lv_malloc(draw_buf_size + LV_DRAW_BUF_ALIGN - 1);
+    draw_buf = lv_draw_buf_align(dsc->draw_buf_1, cf);
 
     if(LV_LINUX_FBDEV_BUFFER_COUNT == 2) {
-        draw_buf_2 = lv_malloc(draw_buf_size);
+        dsc->draw_buf_2 = lv_malloc(draw_buf_size + LV_DRAW_BUF_ALIGN - 1);
+        draw_buf_2 = lv_draw_buf_align(dsc->draw_buf_2, cf);
     }
-
-    dsc->draw_buf_1 = draw_buf;
-    dsc->draw_buf_2 = draw_buf_2;
 
     lv_display_set_resolution(disp, hor_res, ver_res);
     lv_display_set_buffers(disp, draw_buf, draw_buf_2, draw_buf_size, LV_LINUX_FBDEV_RENDER_MODE);
@@ -275,11 +326,29 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
     return LV_RESULT_OK;
 }
 
+void lv_linux_fbdev_set_skip_unblank(lv_display_t * disp, bool skip)
+{
+    lv_linux_fb_t * dsc = lv_display_get_driver_data(disp);
+    dsc->skip_unblank = skip;
+}
+
 void lv_linux_fbdev_set_force_refresh(lv_display_t * disp, bool enabled)
 {
     LV_CHECK_ARG(disp != NULL, return);
     lv_linux_fb_t * dsc = lv_display_get_driver_data(disp);
     dsc->force_refresh = enabled;
+}
+
+void lv_linux_fbdev_set_swap_rb(lv_display_t * disp, bool enabled)
+{
+    lv_linux_fb_t * dsc = lv_display_get_driver_data(disp);
+    dsc->swap_rb = enabled;
+}
+
+bool lv_linux_fbdev_get_swap_rb(lv_display_t * disp)
+{
+    lv_linux_fb_t * dsc = lv_display_get_driver_data(disp);
+    return dsc->swap_rb;
 }
 
 /**********************
@@ -317,6 +386,7 @@ static void del_event_cb(lv_event_t * e)
         dsc->fbfd = -1;
     }
     if(dsc->rotated_buf) lv_free(dsc->rotated_buf);
+    if(dsc->swap_line_buf) lv_free(dsc->swap_line_buf);
     if(dsc->draw_buf_1) lv_free(dsc->draw_buf_1);
     if(dsc->draw_buf_2) lv_free(dsc->draw_buf_2);
     if(dsc->devname) lv_free((void *)dsc->devname);
@@ -428,12 +498,31 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * colo
         (clipped_area.y1 + dsc->vinfo.yoffset) * dsc->finfo.line_length;
     const int32_t w = lv_area_get_width(&clipped_area);
 
+    /* Prepare swap line buffer if R/B swap is active */
+    const size_t line_bytes = w * px_size;
+    uint8_t * swap_buf = NULL;
+    if(dsc->swap_rb) {
+        if(!dsc->swap_line_buf || dsc->swap_line_buf_size < line_bytes) {
+            dsc->swap_line_buf = lv_realloc(dsc->swap_line_buf, line_bytes);
+            LV_ASSERT_MALLOC(dsc->swap_line_buf);
+            dsc->swap_line_buf_size = line_bytes;
+        }
+        swap_buf = dsc->swap_line_buf;
+    }
+
     if(LV_LINUX_FBDEV_RENDER_MODE == LV_DISPLAY_RENDER_MODE_DIRECT && rotation == LV_DISPLAY_ROTATION_0) {
         uint32_t color_pos =
             (clipped_area.x1 - disp->offset_x) * px_size +
             (clipped_area.y1 - disp->offset_y) * disp->hor_res * px_size;
         for(int32_t y = clipped_area.y1; y <= clipped_area.y2; y++) {
-            write_to_fb(dsc, fb_pos, &color_p[color_pos], w * px_size);
+            const uint8_t * src = &color_p[color_pos];
+            if(swap_buf) {
+                if(px_size == 4)      swap_rb_line_32(swap_buf, src, w);
+                else if(px_size == 3) swap_rb_line_24(swap_buf, src, w);
+                else                  swap_rb_line_16(swap_buf, src, w);
+                src = swap_buf;
+            }
+            write_to_fb(dsc, fb_pos, src, line_bytes);
             fb_pos += dsc->finfo.line_length;
             color_pos += disp->hor_res * px_size;
         }
@@ -447,7 +536,14 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * colo
         color_p += y_offset * stride + x_offset * px_size;
 
         for(int32_t y = clipped_area.y1; y <= clipped_area.y2; y++) {
-            write_to_fb(dsc, fb_pos, color_p, w * px_size);
+            const uint8_t * src = color_p;
+            if(swap_buf) {
+                if(px_size == 4)      swap_rb_line_32(swap_buf, src, w);
+                else if(px_size == 3) swap_rb_line_24(swap_buf, src, w);
+                else                  swap_rb_line_16(swap_buf, src, w);
+                src = swap_buf;
+            }
+            write_to_fb(dsc, fb_pos, src, line_bytes);
             fb_pos += dsc->finfo.line_length;
             color_p += stride;
         }
@@ -469,6 +565,44 @@ static uint32_t tick_get_cb(void)
     clock_gettime(CLOCK_MONOTONIC, &t);
     uint64_t time_ms = t.tv_sec * 1000 + (t.tv_nsec / 1000000);
     return time_ms;
+}
+
+/* Swap red and blue channels for BGR framebuffers.
+ * LVGL renders as RGB; these convert to BGR during the line copy. */
+
+static void swap_rb_line_16(uint8_t * dst, const uint8_t * src, int32_t pixel_count)
+{
+    const uint16_t * s = (const uint16_t *)src;
+    uint16_t * d = (uint16_t *)dst;
+    for(int32_t i = 0; i < pixel_count; i++) {
+        uint16_t px = s[i];
+        /* RGB565: RRRRRGGG_GGGBBBBB -> BGR565: BBBBBGGG_GGGRRRRR */
+        uint16_t r = (px >> 11) & 0x1F;
+        uint16_t g = (px >> 5) & 0x3F;
+        uint16_t b = px & 0x1F;
+        d[i] = (b << 11) | (g << 5) | r;
+    }
+}
+
+static void swap_rb_line_24(uint8_t * dst, const uint8_t * src, int32_t pixel_count)
+{
+    for(int32_t i = 0; i < pixel_count; i++) {
+        int32_t off = i * 3;
+        dst[off + 0] = src[off + 2];
+        dst[off + 1] = src[off + 1];
+        dst[off + 2] = src[off + 0];
+    }
+}
+
+static void swap_rb_line_32(uint8_t * dst, const uint8_t * src, int32_t pixel_count)
+{
+    const uint32_t * s = (const uint32_t *)src;
+    uint32_t * d = (uint32_t *)dst;
+    for(int32_t i = 0; i < pixel_count; i++) {
+        uint32_t px = s[i];
+        /* xRGB -> xBGR: swap bits [23:16] (R) and bits [7:0] (B), keep G and x */
+        d[i] = (px & 0xFF00FF00u) | ((px >> 16) & 0xFFu) | ((px & 0xFFu) << 16);
+    }
 }
 
 #endif /*LV_USE_LINUX_FBDEV*/

--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -223,8 +223,12 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
                     dsc->vinfo.bits_per_pixel, stride_bpp);
         dsc->vinfo.bits_per_pixel = stride_bpp;
     }
-    else {
+    else if(stride_bpp > 0 && stride_bpp == dsc->vinfo.bits_per_pixel) {
         LV_LOG_INFO("bits_per_pixel %d matches stride calculation", dsc->vinfo.bits_per_pixel);
+    }
+    else {
+        LV_LOG_INFO("bits_per_pixel %d retained; stride-derived bpp %u ignored (zero or non-standard)",
+                    dsc->vinfo.bits_per_pixel, stride_bpp);
     }
 
     /* Figure out the size of the screen in bytes*/
@@ -306,10 +310,22 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
     /* Over-allocate to guarantee LV_DRAW_BUF_ALIGN alignment.
      * Store raw pointers in dsc for lv_free(), pass aligned pointers to LVGL. */
     dsc->draw_buf_1 = lv_malloc(draw_buf_size + LV_DRAW_BUF_ALIGN - 1);
+    LV_ASSERT_MALLOC(dsc->draw_buf_1);
+    if(dsc->draw_buf_1 == NULL) {
+        LV_LOG_ERROR("Failed to allocate draw buffer 1 (%u bytes)", draw_buf_size + LV_DRAW_BUF_ALIGN - 1);
+        return LV_RESULT_INVALID;
+    }
     draw_buf = lv_draw_buf_align(dsc->draw_buf_1, cf);
 
     if(LV_LINUX_FBDEV_BUFFER_COUNT == 2) {
         dsc->draw_buf_2 = lv_malloc(draw_buf_size + LV_DRAW_BUF_ALIGN - 1);
+        LV_ASSERT_MALLOC(dsc->draw_buf_2);
+        if(dsc->draw_buf_2 == NULL) {
+            LV_LOG_ERROR("Failed to allocate draw buffer 2 (%u bytes)", draw_buf_size + LV_DRAW_BUF_ALIGN - 1);
+            lv_free(dsc->draw_buf_1);
+            dsc->draw_buf_1 = NULL;
+            return LV_RESULT_INVALID;
+        }
         draw_buf_2 = lv_draw_buf_align(dsc->draw_buf_2, cf);
     }
 

--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -205,8 +205,6 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
     }
 #endif /* LV_LINUX_FBDEV_BSD */
 
-    LV_LOG_INFO("%dx%d, %dbpp", dsc->vinfo.xres, dsc->vinfo.yres, dsc->vinfo.bits_per_pixel);
-
     /* AD5M and some other devices report incorrect bits_per_pixel via VSCREENINFO.
      * The stride (line_length) is always correct, so calculate true bpp from it.
      * Example: AD5M reports 16bpp but stride=3200 for 800px width = 4 bytes/pixel = 32bpp */
@@ -230,6 +228,9 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
         LV_LOG_INFO("bits_per_pixel %d retained; stride-derived bpp %u ignored (zero or non-standard)",
                     dsc->vinfo.bits_per_pixel, stride_bpp);
     }
+
+    /* Log the resolution after any bits_per_pixel correction so it reflects the value actually used */
+    LV_LOG_INFO("%dx%d, %dbpp", dsc->vinfo.xres, dsc->vinfo.yres, dsc->vinfo.bits_per_pixel);
 
     /* Figure out the size of the screen in bytes*/
     dsc->screensize =  dsc->finfo.smem_len;/*finfo.line_length * vinfo.yres;*/
@@ -344,6 +345,7 @@ lv_result_t lv_linux_fbdev_set_file(lv_display_t * disp, const char * file)
 
 void lv_linux_fbdev_set_skip_unblank(lv_display_t * disp, bool skip)
 {
+    LV_CHECK_ARG(disp != NULL, return);
     lv_linux_fb_t * dsc = lv_display_get_driver_data(disp);
     dsc->skip_unblank = skip;
 }
@@ -357,12 +359,14 @@ void lv_linux_fbdev_set_force_refresh(lv_display_t * disp, bool enabled)
 
 void lv_linux_fbdev_set_swap_rb(lv_display_t * disp, bool enabled)
 {
+    LV_CHECK_ARG(disp != NULL, return);
     lv_linux_fb_t * dsc = lv_display_get_driver_data(disp);
     dsc->swap_rb = enabled;
 }
 
 bool lv_linux_fbdev_get_swap_rb(lv_display_t * disp)
 {
+    LV_CHECK_ARG(disp != NULL, return false);
     lv_linux_fb_t * dsc = lv_display_get_driver_data(disp);
     return dsc->swap_rb;
 }


### PR DESCRIPTION
## Description

Four improvements to the Linux framebuffer driver addressing real-world issues on embedded hardware.

### 1. Stride-based bpp detection

Some devices report incorrect `bits_per_pixel` via `FBIOGET_VSCREENINFO` while the stride (`line_length` from `FBIOGET_FSCREENINFO`) is always correct. For example, the Creality AD5M reports 16bpp but has stride=3200 for 800px width = 4 bytes/pixel = 32bpp.

Without this fix, the display is garbled or crashes on affected hardware. The stride-calculated value is used when it disagrees with `vinfo.bits_per_pixel`.

### 2. BGR framebuffer auto-detection

Many SoCs (especially Allwinner, common on 3D printer boards and SBCs) use BGR pixel ordering in the framebuffer. LVGL renders RGB, causing red/blue color inversion.

Auto-detects BGR layout by comparing `red.offset` vs `blue.offset` in `fb_var_screeninfo` and swaps R/B channels during flush. Implements per-line swap for 16, 24, and 32bpp formats.

New public API:
- `lv_linux_fbdev_set_swap_rb(disp, enabled)` — manual override
- `lv_linux_fbdev_get_swap_rb(disp)` — query current state

### 3. Draw buffer alignment

`lv_malloc()` may not return memory aligned to `LV_DRAW_BUF_ALIGN`, causing alignment faults on platforms with strict alignment requirements (some ARM SoCs with NEON). Over-allocates by `LV_DRAW_BUF_ALIGN - 1` bytes and uses `lv_draw_buf_align()` to ensure proper alignment. Stores raw pointers for `lv_free()` while passing aligned pointers to LVGL.

### 4. Skip-unblank API

Adds `lv_linux_fbdev_set_skip_unblank()` to skip the `FBIOBLANK` ioctl during initialization. Useful when another process (e.g., a boot splash screen) already owns the framebuffer and calling `FBIOBLANK` would cause visible flicker during handoff.

### How has this been tested?

- Stride bpp: Tested on Creality AD5M (Allwinner, reports 16bpp, actually 32bpp)
- BGR swap: Tested on Allwinner H616 boards with BGR framebuffers
- Buffer alignment: Tested on Raspberry Pi 4/5 (ARM64 with NEON)
- Skip-unblank: Tested with Plymouth splash screen handoff on Raspberry Pi