### PR TITLE
fixed signed integer overflow in runtime

### DIFF
--- a/src/draw/sw/lv_draw_sw_triangle.c
+++ b/src/draw/sw/lv_draw_sw_triangle.c
@@ -135,6 +135,7 @@ void lv_draw_sw_triangle(lv_draw_task_t * t, const lv_draw_triangle_dsc_t * dsc)
     blend_dsc.mask_area = &blend_area;
     blend_dsc.mask_stride = 0;
     blend_dsc.blend_mode = LV_BLEND_MODE_NORMAL;
+    blend_dsc.src_stride = 0;
     blend_dsc.src_buf = NULL;
 
     lv_grad_dir_t grad_dir = dsc->grad.dir;

--- a/src/widgets/buttonmatrix/lv_buttonmatrix.c
+++ b/src/widgets/buttonmatrix/lv_buttonmatrix.c
@@ -1036,8 +1036,8 @@ static void update_map(lv_obj_t * obj)
     const char * const * map_row = btnm->map_p;
 
     /*Count the units and the buttons in a line*/
-    uint32_t row;
-    for(row = 0; row < btnm->row_cnt; row++) {
+    int32_t row_cnt;
+    for(int32_t row = 0; row < row_cnt; row++) {
         uint32_t unit_cnt = 0;           /*Number of units in a row*/
         uint32_t btn_cnt = 0;            /*Number of buttons in a row*/
         /*Count the buttons and units in this row*/
@@ -1052,8 +1052,8 @@ static void update_map(lv_obj_t * obj)
             continue;
         }
 
-        int32_t row_y1 = stop + (max_h_no_gap * row) / btnm->row_cnt + row * prow;
-        int32_t row_y2 = stop + (max_h_no_gap * (row + 1)) / btnm->row_cnt + row * prow - 1;
+        int32_t row_y1 = stop + (max_h_no_gap * row) / row_cnt + row * prow;
+        int32_t row_y2 = stop + (max_h_no_gap * (row + 1)) / row_cnt + row * prow - 1;
 
         /*Set the button size and positions*/
         int32_t max_w_no_gap = max_w - (pcol * (btn_cnt - 1));


### PR DESCRIPTION
fixed the overflow like this runtime error: signed integer overflow: 2147483641 + 13 cannot be represented in type 'int'.

1. in buttonmatrix,this error is caused by type promot:
      When max_h_no_gap is negative, the calculation of row_y1 and row_y2 promotes max_h_no_gap to uint32_t, resulting in     row_y2 being an unexpectedly large value.
2.in draw_sw_triangle, is caused by blend_dsc.src_stride is not inited，when it is used later, that error will be occur. 