### PR TITLE
fix(draw_sw_triangle): fixed bug that blend_dsc.src_stride is not init

### DIFF
--- a/src/draw/sw/lv_draw_sw_triangle.c
+++ b/src/draw/sw/lv_draw_sw_triangle.c
@@ -135,6 +135,7 @@ void lv_draw_sw_triangle(lv_draw_task_t * t, const lv_draw_triangle_dsc_t * dsc)
     blend_dsc.mask_area = &blend_area;
     blend_dsc.mask_stride = 0;
     blend_dsc.blend_mode = LV_BLEND_MODE_NORMAL;
+    blend_dsc.src_stride = 0;
     blend_dsc.src_buf = NULL;
 
     lv_grad_dir_t grad_dir = dsc->grad.dir;


### PR DESCRIPTION
in draw_sw_triangle,blend_dsc.src_stride is not inited，when it is used later, that error that runtime error: signed integer overflow will be occur.
