### PR TITLE
perf(freetype): add L1 cache to improve access performance

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1563,6 +1563,10 @@ menu "LVGL configuration"
 			int "The maximum number of Glyph in count"
 			default 256
 			depends on LV_USE_FREETYPE
+		config LV_FREETYPE_CACHE_FT_GLYPH_L1
+			bool "Enable L1 glyph metrics cache (lock-free, single-thread only)"
+			default y
+			depends on LV_USE_FREETYPE && LV_OS_NONE
 
 		config LV_USE_TINY_TTF
 			bool "Enable Tiny TTF decoder"

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -1035,6 +1035,13 @@
     /** Cache count of glyphs in FreeType, i.e. number of glyphs that can be cached.
      *  The higher the value, the more memory will be used. */
     #define LV_FREETYPE_CACHE_FT_GLYPH_CNT 256
+
+    /** Enable L1 glyph metrics cache for FreeType.
+     *  A per-font, lock-free, 2-way set-associative cache that accelerates
+     *  repeated glyph metric lookups.  Automatically disabled when an OS is
+     *  configured (LV_USE_OS != LV_OS_NONE) because the cache is not
+     *  thread-safe. */
+    #define LV_FREETYPE_CACHE_FT_GLYPH_L1 1
 #endif
 
 /** Built-in TTF decoder */

--- a/src/libs/freetype/lv_freetype.c
+++ b/src/libs/freetype/lv_freetype.c
@@ -437,6 +437,8 @@ static bool cache_node_cache_create_cb(lv_freetype_cache_node_t * node, void * u
     node->face_has_kerning = FT_HAS_KERNING(face);
     lv_mutex_init(&node->face_lock);
 
+    lv_freetype_glyph_l1_init(node);
+
     return true;
 }
 static void cache_node_cache_free_cb(lv_freetype_cache_node_t * node, void * user_data)

--- a/src/libs/freetype/lv_freetype.c
+++ b/src/libs/freetype/lv_freetype.c
@@ -437,7 +437,7 @@ static bool cache_node_cache_create_cb(lv_freetype_cache_node_t * node, void * u
     node->face_has_kerning = FT_HAS_KERNING(face);
     lv_mutex_init(&node->face_lock);
 
-#if LV_USE_OS == LV_OS_NONE
+#if LV_FREETYPE_CACHE_FT_GLYPH_L1
     lv_freetype_glyph_l1_init(node);
 #endif
 
@@ -445,7 +445,7 @@ static bool cache_node_cache_create_cb(lv_freetype_cache_node_t * node, void * u
 }
 static void cache_node_cache_free_cb(lv_freetype_cache_node_t * node, void * user_data)
 {
-#if LV_USE_OS == LV_OS_NONE
+#if LV_FREETYPE_CACHE_FT_GLYPH_L1
     lv_freetype_glyph_l1_deinit(node);
 #endif
 

--- a/src/libs/freetype/lv_freetype.c
+++ b/src/libs/freetype/lv_freetype.c
@@ -437,12 +437,18 @@ static bool cache_node_cache_create_cb(lv_freetype_cache_node_t * node, void * u
     node->face_has_kerning = FT_HAS_KERNING(face);
     lv_mutex_init(&node->face_lock);
 
+#if LV_USE_OS == LV_OS_NONE
     lv_freetype_glyph_l1_init(node);
+#endif
 
     return true;
 }
 static void cache_node_cache_free_cb(lv_freetype_cache_node_t * node, void * user_data)
 {
+#if LV_USE_OS == LV_OS_NONE
+    lv_freetype_glyph_l1_deinit(node);
+#endif
+
     FT_Done_Face(node->face);
     lv_mutex_delete(&node->face_lock);
 

--- a/src/libs/freetype/lv_freetype_glyph.c
+++ b/src/libs/freetype/lv_freetype_glyph.c
@@ -18,19 +18,23 @@
 
 #define CACHE_NAME  "FREETYPE_GLYPH"
 
-/*---------------------
- * L1 Cache Config
- *--------------------*/
-
 #if LV_USE_OS == LV_OS_NONE
 
-/** Number of sets – reuse the FreeType glyph count (must be power of 2) */
-#define GLYPH_L1_SETS       ((uint32_t)LV_FREETYPE_CACHE_FT_GLYPH_CNT)
+    /** Number of sets – reuse the FreeType glyph count (must be power of 2) */
+    #define GLYPH_L1_SETS       ((uint32_t)LV_FREETYPE_CACHE_FT_GLYPH_CNT)
 
-/** Associativity – fixed at 2-way, do NOT change */
-#define GLYPH_L1_WAYS       2u
+    /** Associativity – fixed at 2-way, do NOT change */
+    #define GLYPH_L1_WAYS       2u
 
-#define GLYPH_L1_SET_MASK   (GLYPH_L1_SETS - 1u)
+    #define GLYPH_L1_SET_MASK   (GLYPH_L1_SETS - 1u)
+
+#endif /* LV_USE_OS == LV_OS_NONE */
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+#if LV_USE_OS == LV_OS_NONE
 
 typedef struct {
     uint32_t unicode;
@@ -43,6 +47,96 @@ typedef struct {
     glyph_l1_entry_t ways[GLYPH_L1_WAYS];
     uint8_t lru_bits;
 } glyph_l1_set_t;
+
+#endif /* LV_USE_OS == LV_OS_NONE */
+
+typedef struct _lv_freetype_glyph_cache_data_t {
+    uint32_t unicode;
+    uint32_t size;
+
+    lv_font_glyph_dsc_t glyph_dsc;
+} lv_freetype_glyph_cache_data_t;
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+static bool freetype_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t unicode_letter,
+                                      uint32_t unicode_letter_next);
+
+static bool freetype_glyph_create_cb(lv_freetype_glyph_cache_data_t * data, void * user_data);
+static void freetype_glyph_free_cb(lv_freetype_glyph_cache_data_t * data, void * user_data);
+static lv_cache_compare_res_t freetype_glyph_compare_cb(const lv_freetype_glyph_cache_data_t * lhs,
+                                                        const lv_freetype_glyph_cache_data_t * rhs);
+
+#if LV_USE_OS == LV_OS_NONE
+static inline uint32_t glyph_l1_hash(uint32_t unicode, uint32_t size);
+static bool glyph_l1_lookup(lv_freetype_cache_node_t * node, uint32_t unicode, uint32_t size,
+                            lv_font_glyph_dsc_t * out_dsc);
+static void glyph_l1_fill(lv_freetype_cache_node_t * node, uint32_t unicode, uint32_t size,
+                          const lv_font_glyph_dsc_t * dsc);
+#endif /* LV_USE_OS == LV_OS_NONE */
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+lv_cache_t * lv_freetype_create_glyph_cache(uint32_t cache_size)
+{
+    lv_cache_ops_t ops = {
+        .create_cb = (lv_cache_create_cb_t)freetype_glyph_create_cb,
+        .free_cb = (lv_cache_free_cb_t)freetype_glyph_free_cb,
+        .compare_cb = (lv_cache_compare_cb_t)freetype_glyph_compare_cb,
+    };
+
+    lv_cache_t * glyph_cache = lv_cache_create(&lv_cache_class_lru_rb_count, sizeof(lv_freetype_glyph_cache_data_t),
+                                               cache_size, ops);
+    lv_cache_set_name(glyph_cache, CACHE_NAME);
+
+    return glyph_cache;
+}
+
+void lv_freetype_set_cbs_glyph(lv_freetype_font_dsc_t * dsc)
+{
+    LV_ASSERT_FREETYPE_FONT_DSC(dsc);
+    dsc->font.get_glyph_dsc = freetype_get_glyph_dsc_cb;
+}
+
+#if LV_USE_OS == LV_OS_NONE
+
+void lv_freetype_glyph_l1_init(lv_freetype_cache_node_t * node)
+{
+    LV_ASSERT_MSG((GLYPH_L1_SETS & (GLYPH_L1_SETS - 1u)) == 0,
+                  "LV_FREETYPE_CACHE_FT_GLYPH_CNT must be power of 2 for L1 cache");
+
+    size_t sz = sizeof(glyph_l1_set_t) * GLYPH_L1_SETS;
+    node->glyph_l1 = lv_malloc_zeroed(sz);
+    LV_ASSERT_MALLOC(node->glyph_l1);
+    node->glyph_l1_generation = 1;
+}
+
+void lv_freetype_glyph_l1_deinit(lv_freetype_cache_node_t * node)
+{
+    if(node->glyph_l1) {
+        lv_free(node->glyph_l1);
+        node->glyph_l1 = NULL;
+    }
+}
+
+#endif /* LV_USE_OS == LV_OS_NONE */
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+#if LV_USE_OS == LV_OS_NONE
 
 static inline uint32_t glyph_l1_hash(uint32_t unicode, uint32_t size)
 {
@@ -98,84 +192,7 @@ static void glyph_l1_fill(lv_freetype_cache_node_t * node,
     set->lru_bits = (uint8_t)victim;
 }
 
-void lv_freetype_glyph_l1_init(lv_freetype_cache_node_t * node)
-{
-    LV_ASSERT_MSG((GLYPH_L1_SETS & (GLYPH_L1_SETS - 1u)) == 0,
-                  "LV_FREETYPE_CACHE_FT_GLYPH_CNT must be power of 2 for L1 cache");
-
-    size_t sz = sizeof(glyph_l1_set_t) * GLYPH_L1_SETS;
-    node->glyph_l1 = lv_malloc_zeroed(sz);
-    LV_ASSERT_MALLOC(node->glyph_l1);
-    node->glyph_l1_generation = 1;
-}
-
-void lv_freetype_glyph_l1_deinit(lv_freetype_cache_node_t * node)
-{
-    if(node->glyph_l1) {
-        lv_free(node->glyph_l1);
-        node->glyph_l1 = NULL;
-    }
-}
-
 #endif /* LV_USE_OS == LV_OS_NONE */
-
-/**********************
- *      TYPEDEFS
- **********************/
-typedef struct _lv_freetype_glyph_cache_data_t {
-    uint32_t unicode;
-    uint32_t size;
-
-    lv_font_glyph_dsc_t glyph_dsc;
-} lv_freetype_glyph_cache_data_t;
-
-/**********************
- *  STATIC PROTOTYPES
- **********************/
-
-static bool freetype_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t unicode_letter,
-                                      uint32_t unicode_letter_next);
-
-static bool freetype_glyph_create_cb(lv_freetype_glyph_cache_data_t * data, void * user_data);
-static void freetype_glyph_free_cb(lv_freetype_glyph_cache_data_t * data, void * user_data);
-static lv_cache_compare_res_t freetype_glyph_compare_cb(const lv_freetype_glyph_cache_data_t * lhs,
-                                                        const lv_freetype_glyph_cache_data_t * rhs);
-/**********************
- *  STATIC VARIABLES
- **********************/
-
-/**********************
- *      MACROS
- **********************/
-
-/**********************
- *   GLOBAL FUNCTIONS
- **********************/
-
-lv_cache_t * lv_freetype_create_glyph_cache(uint32_t cache_size)
-{
-    lv_cache_ops_t ops = {
-        .create_cb = (lv_cache_create_cb_t)freetype_glyph_create_cb,
-        .free_cb = (lv_cache_free_cb_t)freetype_glyph_free_cb,
-        .compare_cb = (lv_cache_compare_cb_t)freetype_glyph_compare_cb,
-    };
-
-    lv_cache_t * glyph_cache = lv_cache_create(&lv_cache_class_lru_rb_count, sizeof(lv_freetype_glyph_cache_data_t),
-                                               cache_size, ops);
-    lv_cache_set_name(glyph_cache, CACHE_NAME);
-
-    return glyph_cache;
-}
-
-void lv_freetype_set_cbs_glyph(lv_freetype_font_dsc_t * dsc)
-{
-    LV_ASSERT_FREETYPE_FONT_DSC(dsc);
-    dsc->font.get_glyph_dsc = freetype_get_glyph_dsc_cb;
-}
-
-/**********************
- *   STATIC FUNCTIONS
- **********************/
 
 static bool freetype_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t unicode_letter,
                                       uint32_t unicode_letter_next)

--- a/src/libs/freetype/lv_freetype_glyph.c
+++ b/src/libs/freetype/lv_freetype_glyph.c
@@ -216,6 +216,7 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_
     LV_ASSERT_FREETYPE_FONT_DSC(dsc);
 
     lv_freetype_cache_node_t * cache_node = dsc->cache_node;
+    LV_ASSERT_NULL(cache_node);
 
 #if LV_USE_OS == LV_OS_NONE
     /* L1 lookup: per cache_node, 2-way set-associative (single-thread only) */

--- a/src/libs/freetype/lv_freetype_glyph.c
+++ b/src/libs/freetype/lv_freetype_glyph.c
@@ -97,21 +97,35 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_
     lv_freetype_font_dsc_t * dsc = (lv_freetype_font_dsc_t *)font->dsc;
     LV_ASSERT_FREETYPE_FONT_DSC(dsc);
 
-    lv_freetype_glyph_cache_data_t search_key = {
-        .unicode = unicode_letter,
-        .size = dsc->size,
-    };
+    lv_freetype_cache_node_t * cache_node = dsc->cache_node;
+    bool l1_hit = false;
 
-    lv_cache_t * glyph_cache = dsc->cache_node->glyph_cache;
+    /* L1 lookup: per cache_node, lock-free, 2-way set-associative */
+    l1_hit = lv_freetype_glyph_l1_lookup(cache_node, unicode_letter, dsc->size, g_dsc);
 
-    lv_cache_entry_t * entry = lv_cache_acquire_or_create(glyph_cache, &search_key, dsc);
-    if(entry == NULL) {
-        LV_LOG_ERROR("glyph lookup failed for unicode = 0x%" LV_PRIx32, unicode_letter);
-        LV_PROFILER_FONT_END;
-        return false;
+    if(!l1_hit) {
+        /* L1 miss - fall through to L2 LRU RB-tree cache */
+        lv_freetype_glyph_cache_data_t search_key = {
+            .unicode = unicode_letter,
+            .size = dsc->size,
+        };
+
+        lv_cache_t * glyph_cache = cache_node->glyph_cache;
+
+        lv_cache_entry_t * entry = lv_cache_acquire_or_create(glyph_cache, &search_key, dsc);
+        if(entry == NULL) {
+            LV_LOG_ERROR("glyph lookup failed for unicode = 0x%" LV_PRIx32, unicode_letter);
+            LV_PROFILER_FONT_END;
+            return false;
+        }
+        lv_freetype_glyph_cache_data_t * data = lv_cache_entry_get_data(entry);
+        *g_dsc = data->glyph_dsc;
+
+        /* Populate L1 for future hits */
+        lv_freetype_glyph_l1_fill(cache_node, unicode_letter, dsc->size, &data->glyph_dsc);
+
+        lv_cache_release(glyph_cache, entry, NULL);
     }
-    lv_freetype_glyph_cache_data_t * data = lv_cache_entry_get_data(entry);
-    *g_dsc = data->glyph_dsc;
 
     if((dsc->style & LV_FREETYPE_FONT_STYLE_ITALIC) && (unicode_letter_next == '\0')) {
         g_dsc->adv_w = g_dsc->box_w + g_dsc->ofs_x;
@@ -140,7 +154,6 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_
 
     g_dsc->entry = NULL;
 
-    lv_cache_release(glyph_cache, entry, NULL);
     LV_PROFILER_FONT_END;
     return true;
 }

--- a/src/libs/freetype/lv_freetype_glyph.c
+++ b/src/libs/freetype/lv_freetype_glyph.c
@@ -18,6 +18,107 @@
 
 #define CACHE_NAME  "FREETYPE_GLYPH"
 
+/*---------------------
+ * L1 Cache Config
+ *--------------------*/
+
+#if LV_USE_OS == LV_OS_NONE
+
+/** Number of sets – reuse the FreeType glyph count (must be power of 2) */
+#define GLYPH_L1_SETS       ((uint32_t)LV_FREETYPE_CACHE_FT_GLYPH_CNT)
+
+/** Associativity – fixed at 2-way, do NOT change */
+#define GLYPH_L1_WAYS       2u
+
+#define GLYPH_L1_SET_MASK   (GLYPH_L1_SETS - 1u)
+
+typedef struct {
+    uint32_t unicode;
+    uint32_t size;
+    uint32_t generation;
+    lv_font_glyph_dsc_t dsc;
+} glyph_l1_entry_t;
+
+typedef struct {
+    glyph_l1_entry_t ways[GLYPH_L1_WAYS];
+    uint8_t lru_bits;
+} glyph_l1_set_t;
+
+static inline uint32_t glyph_l1_hash(uint32_t unicode, uint32_t size)
+{
+    uint32_t h = 2166136261u;   /* FNV-1a offset basis */
+    h ^= unicode;
+    h *= 16777619u;
+    h ^= size;
+    h *= 16777619u;
+    return h;
+}
+
+static bool glyph_l1_lookup(lv_freetype_cache_node_t * node,
+                            uint32_t unicode, uint32_t size,
+                            lv_font_glyph_dsc_t * out_dsc)
+{
+    glyph_l1_set_t * sets = (glyph_l1_set_t *)node->glyph_l1;
+    if(sets == NULL) return false;
+
+    uint32_t idx = glyph_l1_hash(unicode, size) & GLYPH_L1_SET_MASK;
+    glyph_l1_set_t * set = &sets[idx];
+    uint32_t gen = node->glyph_l1_generation;
+
+    for(uint32_t w = 0; w < GLYPH_L1_WAYS; w++) {
+        glyph_l1_entry_t * e = &set->ways[w];
+        if(e->generation == gen && e->unicode == unicode && e->size == size) {
+            set->lru_bits = (uint8_t)w;
+            *out_dsc = e->dsc;
+            return true;
+        }
+    }
+    return false;
+}
+
+static void glyph_l1_fill(lv_freetype_cache_node_t * node,
+                          uint32_t unicode, uint32_t size,
+                          const lv_font_glyph_dsc_t * dsc)
+{
+    glyph_l1_set_t * sets = (glyph_l1_set_t *)node->glyph_l1;
+    if(sets == NULL) return;
+
+    uint32_t idx = glyph_l1_hash(unicode, size) & GLYPH_L1_SET_MASK;
+    glyph_l1_set_t * set = &sets[idx];
+
+    uint32_t victim = (set->lru_bits == 0) ? 1u : 0u;
+
+    glyph_l1_entry_t * e = &set->ways[victim];
+    e->unicode    = unicode;
+    e->size       = size;
+    e->generation = node->glyph_l1_generation;
+    e->dsc        = *dsc;
+    e->dsc.entry  = NULL;
+
+    set->lru_bits = (uint8_t)victim;
+}
+
+void lv_freetype_glyph_l1_init(lv_freetype_cache_node_t * node)
+{
+    LV_ASSERT_MSG((GLYPH_L1_SETS & (GLYPH_L1_SETS - 1u)) == 0,
+                  "LV_FREETYPE_CACHE_FT_GLYPH_CNT must be power of 2 for L1 cache");
+
+    size_t sz = sizeof(glyph_l1_set_t) * GLYPH_L1_SETS;
+    node->glyph_l1 = lv_malloc_zeroed(sz);
+    LV_ASSERT_MALLOC(node->glyph_l1);
+    node->glyph_l1_generation = 1;
+}
+
+void lv_freetype_glyph_l1_deinit(lv_freetype_cache_node_t * node)
+{
+    if(node->glyph_l1) {
+        lv_free(node->glyph_l1);
+        node->glyph_l1 = NULL;
+    }
+}
+
+#endif /* LV_USE_OS == LV_OS_NONE */
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -98,13 +199,16 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_
     LV_ASSERT_FREETYPE_FONT_DSC(dsc);
 
     lv_freetype_cache_node_t * cache_node = dsc->cache_node;
-    bool l1_hit = false;
 
-    /* L1 lookup: per cache_node, lock-free, 2-way set-associative */
-    l1_hit = lv_freetype_glyph_l1_lookup(cache_node, unicode_letter, dsc->size, g_dsc);
-
-    if(!l1_hit) {
-        /* L1 miss - fall through to L2 LRU RB-tree cache */
+#if LV_USE_OS == LV_OS_NONE
+    /* L1 lookup: per cache_node, 2-way set-associative (single-thread only) */
+    if(glyph_l1_lookup(cache_node, unicode_letter, dsc->size, g_dsc)) {
+        /* L1 hit – skip L2 entirely */
+    }
+    else
+#endif
+    {
+        /* L2 LRU RB-tree cache */
         lv_freetype_glyph_cache_data_t search_key = {
             .unicode = unicode_letter,
             .size = dsc->size,
@@ -121,8 +225,10 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_
         lv_freetype_glyph_cache_data_t * data = lv_cache_entry_get_data(entry);
         *g_dsc = data->glyph_dsc;
 
+#if LV_USE_OS == LV_OS_NONE
         /* Populate L1 for future hits */
-        lv_freetype_glyph_l1_fill(cache_node, unicode_letter, dsc->size, &data->glyph_dsc);
+        glyph_l1_fill(cache_node, unicode_letter, dsc->size, &data->glyph_dsc);
+#endif
 
         lv_cache_release(glyph_cache, entry, NULL);
     }

--- a/src/libs/freetype/lv_freetype_glyph.c
+++ b/src/libs/freetype/lv_freetype_glyph.c
@@ -20,10 +20,10 @@
 
 #if LV_USE_OS == LV_OS_NONE
 
-    /** Number of sets – reuse the FreeType glyph count (must be power of 2) */
+    /** Number of sets - reuse the FreeType glyph count (must be power of 2) */
     #define GLYPH_L1_SETS       ((uint32_t)LV_FREETYPE_CACHE_FT_GLYPH_CNT)
 
-    /** Associativity – fixed at 2-way, do NOT change */
+    /** Associativity - fixed at 2-way, do NOT change */
     #define GLYPH_L1_WAYS       2u
 
     #define GLYPH_L1_SET_MASK   (GLYPH_L1_SETS - 1u)
@@ -39,7 +39,6 @@
 typedef struct {
     uint32_t unicode;
     uint32_t size;
-    uint32_t generation;
     lv_font_glyph_dsc_t dsc;
 } glyph_l1_entry_t;
 
@@ -119,7 +118,6 @@ void lv_freetype_glyph_l1_init(lv_freetype_cache_node_t * node)
     size_t sz = sizeof(glyph_l1_set_t) * GLYPH_L1_SETS;
     node->glyph_l1 = lv_malloc_zeroed(sz);
     LV_ASSERT_MALLOC(node->glyph_l1);
-    node->glyph_l1_generation = 1;
 }
 
 void lv_freetype_glyph_l1_deinit(lv_freetype_cache_node_t * node)
@@ -157,11 +155,10 @@ static bool glyph_l1_lookup(lv_freetype_cache_node_t * node,
 
     uint32_t idx = glyph_l1_hash(unicode, size) & GLYPH_L1_SET_MASK;
     glyph_l1_set_t * set = &sets[idx];
-    uint32_t gen = node->glyph_l1_generation;
 
     for(uint32_t w = 0; w < GLYPH_L1_WAYS; w++) {
         glyph_l1_entry_t * e = &set->ways[w];
-        if(e->generation == gen && e->unicode == unicode && e->size == size) {
+        if(e->unicode == unicode && e->size == size) {
             set->lru_bits = (uint8_t)w;
             *out_dsc = e->dsc;
             return true;
@@ -185,7 +182,6 @@ static void glyph_l1_fill(lv_freetype_cache_node_t * node,
     glyph_l1_entry_t * e = &set->ways[victim];
     e->unicode    = unicode;
     e->size       = size;
-    e->generation = node->glyph_l1_generation;
     e->dsc        = *dsc;
     e->dsc.entry  = NULL;
 

--- a/src/libs/freetype/lv_freetype_glyph.c
+++ b/src/libs/freetype/lv_freetype_glyph.c
@@ -116,6 +116,7 @@ void lv_freetype_set_cbs_glyph(lv_freetype_font_dsc_t * dsc)
 
 void lv_freetype_glyph_l1_init(lv_freetype_cache_node_t * node)
 {
+    LV_ASSERT_NULL(node);
     size_t sz = sizeof(glyph_l1_set_t) * GLYPH_L1_SETS;
     node->glyph_l1 = lv_malloc_zeroed(sz);
     LV_ASSERT_MALLOC(node->glyph_l1);
@@ -126,6 +127,7 @@ void lv_freetype_glyph_l1_init(lv_freetype_cache_node_t * node)
 
 void lv_freetype_glyph_l1_deinit(lv_freetype_cache_node_t * node)
 {
+    LV_ASSERT_NULL(node);
     if(node->glyph_l1) {
         lv_free(node->glyph_l1);
         node->glyph_l1 = NULL;

--- a/src/libs/freetype/lv_freetype_glyph.c
+++ b/src/libs/freetype/lv_freetype_glyph.c
@@ -18,7 +18,7 @@
 
 #define CACHE_NAME  "FREETYPE_GLYPH"
 
-#if LV_USE_OS == LV_OS_NONE
+#if LV_FREETYPE_CACHE_FT_GLYPH_L1
 
     /** Number of sets - reuse the FreeType glyph count (must be power of 2) */
     #define GLYPH_L1_SETS       ((uint32_t)LV_FREETYPE_CACHE_FT_GLYPH_CNT)
@@ -32,13 +32,13 @@
 
     #define GLYPH_L1_SET_MASK   (GLYPH_L1_SETS - 1u)
 
-#endif /* LV_USE_OS == LV_OS_NONE */
+#endif /* LV_FREETYPE_CACHE_FT_GLYPH_L1 */
 
 /**********************
  *      TYPEDEFS
  **********************/
 
-#if LV_USE_OS == LV_OS_NONE
+#if LV_FREETYPE_CACHE_FT_GLYPH_L1
 
 typedef struct {
     uint32_t unicode;
@@ -51,7 +51,7 @@ typedef struct {
     uint8_t lru_bits;
 } glyph_l1_set_t;
 
-#endif /* LV_USE_OS == LV_OS_NONE */
+#endif /* LV_FREETYPE_CACHE_FT_GLYPH_L1 */
 
 typedef struct _lv_freetype_glyph_cache_data_t {
     uint32_t unicode;
@@ -72,13 +72,13 @@ static void freetype_glyph_free_cb(lv_freetype_glyph_cache_data_t * data, void *
 static lv_cache_compare_res_t freetype_glyph_compare_cb(const lv_freetype_glyph_cache_data_t * lhs,
                                                         const lv_freetype_glyph_cache_data_t * rhs);
 
-#if LV_USE_OS == LV_OS_NONE
+#if LV_FREETYPE_CACHE_FT_GLYPH_L1
 static inline uint32_t glyph_l1_hash(uint32_t unicode, uint32_t size);
 static bool glyph_l1_lookup(lv_freetype_cache_node_t * node, uint32_t unicode, uint32_t size,
                             lv_font_glyph_dsc_t * out_dsc);
 static void glyph_l1_fill(lv_freetype_cache_node_t * node, uint32_t unicode, uint32_t size,
                           const lv_font_glyph_dsc_t * dsc);
-#endif /* LV_USE_OS == LV_OS_NONE */
+#endif /* LV_FREETYPE_CACHE_FT_GLYPH_L1 */
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -112,7 +112,7 @@ void lv_freetype_set_cbs_glyph(lv_freetype_font_dsc_t * dsc)
     dsc->font.get_glyph_dsc = freetype_get_glyph_dsc_cb;
 }
 
-#if LV_USE_OS == LV_OS_NONE
+#if LV_FREETYPE_CACHE_FT_GLYPH_L1
 
 void lv_freetype_glyph_l1_init(lv_freetype_cache_node_t * node)
 {
@@ -132,13 +132,13 @@ void lv_freetype_glyph_l1_deinit(lv_freetype_cache_node_t * node)
     }
 }
 
-#endif /* LV_USE_OS == LV_OS_NONE */
+#endif /* LV_FREETYPE_CACHE_FT_GLYPH_L1 */
 
 /**********************
  *   STATIC FUNCTIONS
  **********************/
 
-#if LV_USE_OS == LV_OS_NONE
+#if LV_FREETYPE_CACHE_FT_GLYPH_L1
 
 static inline uint32_t glyph_l1_hash(uint32_t unicode, uint32_t size)
 {
@@ -192,7 +192,7 @@ static void glyph_l1_fill(lv_freetype_cache_node_t * node,
     set->lru_bits = (uint8_t)victim;
 }
 
-#endif /* LV_USE_OS == LV_OS_NONE */
+#endif /* LV_FREETYPE_CACHE_FT_GLYPH_L1 */
 
 static bool freetype_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * g_dsc, uint32_t unicode_letter,
                                       uint32_t unicode_letter_next)
@@ -219,7 +219,7 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_
     LV_ASSERT_NULL(cache_node);
     LV_LOG_TRACE("Getting glyph for unicode = 0x%" LV_PRIx32 ", size = %" LV_PRIu32, unicode_letter, dsc->size);
 
-#if LV_USE_OS == LV_OS_NONE
+#if LV_FREETYPE_CACHE_FT_GLYPH_L1
     /* L1 lookup: per cache_node, 2-way set-associative (single-thread only) */
     if(glyph_l1_lookup(cache_node, unicode_letter, dsc->size, g_dsc)) {
         LV_LOG_TRACE("L1 cache hit");
@@ -244,7 +244,7 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_
         lv_freetype_glyph_cache_data_t * data = lv_cache_entry_get_data(entry);
         *g_dsc = data->glyph_dsc;
 
-#if LV_USE_OS == LV_OS_NONE
+#if LV_FREETYPE_CACHE_FT_GLYPH_L1
         /* Populate L1 for future hits */
         glyph_l1_fill(cache_node, unicode_letter, dsc->size, &data->glyph_dsc);
 #endif

--- a/src/libs/freetype/lv_freetype_glyph.c
+++ b/src/libs/freetype/lv_freetype_glyph.c
@@ -217,16 +217,17 @@ static bool freetype_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_
 
     lv_freetype_cache_node_t * cache_node = dsc->cache_node;
     LV_ASSERT_NULL(cache_node);
+    LV_LOG_TRACE("Getting glyph for unicode = 0x%" LV_PRIx32 ", size = %" LV_PRIu32, unicode_letter, dsc->size);
 
 #if LV_USE_OS == LV_OS_NONE
     /* L1 lookup: per cache_node, 2-way set-associative (single-thread only) */
     if(glyph_l1_lookup(cache_node, unicode_letter, dsc->size, g_dsc)) {
-        /* L1 hit – skip L2 entirely */
+        LV_LOG_TRACE("L1 cache hit");
     }
     else
 #endif
     {
-        /* L2 LRU RB-tree cache */
+        LV_LOG_TRACE("L1 cache miss, looking up L2");
         lv_freetype_glyph_cache_data_t search_key = {
             .unicode = unicode_letter,
             .size = dsc->size,

--- a/src/libs/freetype/lv_freetype_glyph.c
+++ b/src/libs/freetype/lv_freetype_glyph.c
@@ -23,6 +23,10 @@
     /** Number of sets - reuse the FreeType glyph count (must be power of 2) */
     #define GLYPH_L1_SETS       ((uint32_t)LV_FREETYPE_CACHE_FT_GLYPH_CNT)
 
+    #if (LV_FREETYPE_CACHE_FT_GLYPH_CNT & (LV_FREETYPE_CACHE_FT_GLYPH_CNT - 1)) != 0
+        #error "LV_FREETYPE_CACHE_FT_GLYPH_CNT must be power of 2 for L1 cache"
+    #endif
+
     /** Associativity - fixed at 2-way, do NOT change */
     #define GLYPH_L1_WAYS       2u
 
@@ -112,12 +116,12 @@ void lv_freetype_set_cbs_glyph(lv_freetype_font_dsc_t * dsc)
 
 void lv_freetype_glyph_l1_init(lv_freetype_cache_node_t * node)
 {
-    LV_ASSERT_MSG((GLYPH_L1_SETS & (GLYPH_L1_SETS - 1u)) == 0,
-                  "LV_FREETYPE_CACHE_FT_GLYPH_CNT must be power of 2 for L1 cache");
-
     size_t sz = sizeof(glyph_l1_set_t) * GLYPH_L1_SETS;
     node->glyph_l1 = lv_malloc_zeroed(sz);
     LV_ASSERT_MALLOC(node->glyph_l1);
+    if(node->glyph_l1 == NULL) {
+        LV_LOG_WARN("Failed to allocate glyph L1 cache (%u bytes), L1 disabled for this node", (unsigned)sz);
+    }
 }
 
 void lv_freetype_glyph_l1_deinit(lv_freetype_cache_node_t * node)

--- a/src/libs/freetype/lv_freetype_private.h
+++ b/src/libs/freetype/lv_freetype_private.h
@@ -57,6 +57,16 @@ extern "C" {
 #define FT_INT_TO_F16DOT16(x) ((x) << 16)
 #define FT_F16DOT16_TO_INT(x) ((x) >> 16)
 
+/** Number of sets in the glyph L1 cache, reuse FreeType cache glyph count (must be power of 2) */
+#define LV_FREETYPE_GLYPH_L1_SETS      ((uint32_t)LV_FREETYPE_CACHE_FT_GLYPH_CNT)
+
+/** Associativity: ways per set (1 = direct-mapped, 2 = 2-way) */
+#ifndef LV_FREETYPE_GLYPH_L1_WAYS
+#define LV_FREETYPE_GLYPH_L1_WAYS      2u
+#endif
+
+#define LV_FREETYPE_GLYPH_L1_SET_MASK  (LV_FREETYPE_GLYPH_L1_SETS - 1u)
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -80,6 +90,17 @@ struct _lv_freetype_outline_event_param_t {
     lv_freetype_outline_sizes_t sizes;
 };
 
+typedef struct {
+    uint32_t unicode;           /**< Primary key: unicode code point */
+    uint32_t size;              /**< Font size for multi-size sharing */
+    uint32_t generation;        /**< Must match cache_node->generation to be valid */
+    lv_font_glyph_dsc_t dsc;   /**< Cached glyph metrics (entry ptr always NULL) */
+} lv_freetype_glyph_l1_entry_t;
+
+typedef struct {
+    lv_freetype_glyph_l1_entry_t ways[LV_FREETYPE_GLYPH_L1_WAYS];
+    uint8_t lru_bits;           /**< Simple LRU: index of most-recently-used way */
+} lv_freetype_glyph_l1_set_t;
 
 typedef struct _lv_freetype_cache_node_t lv_freetype_cache_node_t;
 
@@ -99,6 +120,10 @@ struct _lv_freetype_cache_node_t {
 
     /*draw data cache*/
     lv_cache_t * draw_data_cache;
+
+    /* L1 glyph metrics cache (per cache_node, lock-free) */
+    uint32_t generation;        /**< Monotonically increasing; bump to invalidate all L1 entries */
+    lv_freetype_glyph_l1_set_t glyph_l1[LV_FREETYPE_GLYPH_L1_SETS];
 };
 
 typedef struct _lv_freetype_context_t {
@@ -124,6 +149,90 @@ typedef struct _lv_freetype_font_dsc_t {
     uint32_t outline_stroke_width;
     lv_font_kerning_t kerning;
 } lv_freetype_font_dsc_t;
+
+/*---------------------
+ * L1 Cache Helpers
+ *--------------------*/
+
+static inline uint32_t lv_freetype_l1_hash(uint32_t unicode, uint32_t size)
+{
+    uint32_t h = 2166136261u;
+    h ^= unicode;
+    h *= 16777619u;
+    h ^= size;
+    h *= 16777619u;
+    return h;
+}
+
+/**
+ * Look up glyph metrics in the per-node L1 cache.
+ * @return true on hit (out_dsc filled), false on miss.
+ */
+static inline bool lv_freetype_glyph_l1_lookup(
+    lv_freetype_cache_node_t * node,
+    uint32_t unicode,
+    uint32_t size,
+    lv_font_glyph_dsc_t * out_dsc)
+{
+    uint32_t set_idx = lv_freetype_l1_hash(unicode, size) & LV_FREETYPE_GLYPH_L1_SET_MASK;
+    lv_freetype_glyph_l1_set_t * set = &node->glyph_l1[set_idx];
+    uint32_t gen = node->generation;
+
+    for(uint32_t w = 0; w < LV_FREETYPE_GLYPH_L1_WAYS; w++) {
+        lv_freetype_glyph_l1_entry_t * e = &set->ways[w];
+        if(e->generation == gen && e->unicode == unicode && e->size == size) {
+            set->lru_bits = (uint8_t)w;
+            *out_dsc = e->dsc;
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Fill a glyph metrics entry into the per-node L1 cache (LRU eviction).
+ */
+static inline void lv_freetype_glyph_l1_fill(
+    lv_freetype_cache_node_t * node,
+    uint32_t unicode,
+    uint32_t size,
+    const lv_font_glyph_dsc_t * dsc)
+{
+    uint32_t set_idx = lv_freetype_l1_hash(unicode, size) & LV_FREETYPE_GLYPH_L1_SET_MASK;
+    lv_freetype_glyph_l1_set_t * set = &node->glyph_l1[set_idx];
+
+    /* Evict the least-recently-used way */
+    uint32_t victim = (set->lru_bits == 0) ? 1u : 0u;
+#if LV_FREETYPE_GLYPH_L1_WAYS > 2
+    victim = (set->lru_bits + 1u) % LV_FREETYPE_GLYPH_L1_WAYS;
+#endif
+
+    lv_freetype_glyph_l1_entry_t * e = &set->ways[victim];
+    e->unicode = unicode;
+    e->size = size;
+    e->generation = node->generation;
+    e->dsc = *dsc;
+    e->dsc.entry = NULL;
+
+    set->lru_bits = (uint8_t)victim;
+}
+
+/**
+ * Invalidate all L1 entries for this cache_node in O(1).
+ */
+static inline void lv_freetype_glyph_l1_invalidate(lv_freetype_cache_node_t * node)
+{
+    node->generation++;
+}
+
+/**
+ * Initialize L1 cache for a newly created cache_node.
+ */
+static inline void lv_freetype_glyph_l1_init(lv_freetype_cache_node_t * node)
+{
+    node->generation = 1;
+    lv_memzero(node->glyph_l1, sizeof(node->glyph_l1));
+}
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/src/libs/freetype/lv_freetype_private.h
+++ b/src/libs/freetype/lv_freetype_private.h
@@ -57,16 +57,6 @@ extern "C" {
 #define FT_INT_TO_F16DOT16(x) ((x) << 16)
 #define FT_F16DOT16_TO_INT(x) ((x) >> 16)
 
-/** Number of sets in the glyph L1 cache, reuse FreeType cache glyph count (must be power of 2) */
-#define LV_FREETYPE_GLYPH_L1_SETS      ((uint32_t)LV_FREETYPE_CACHE_FT_GLYPH_CNT)
-
-/** Associativity: ways per set (1 = direct-mapped, 2 = 2-way) */
-#ifndef LV_FREETYPE_GLYPH_L1_WAYS
-#define LV_FREETYPE_GLYPH_L1_WAYS      2u
-#endif
-
-#define LV_FREETYPE_GLYPH_L1_SET_MASK  (LV_FREETYPE_GLYPH_L1_SETS - 1u)
-
 /**********************
  *      TYPEDEFS
  **********************/
@@ -90,18 +80,6 @@ struct _lv_freetype_outline_event_param_t {
     lv_freetype_outline_sizes_t sizes;
 };
 
-typedef struct {
-    uint32_t unicode;           /**< Primary key: unicode code point */
-    uint32_t size;              /**< Font size for multi-size sharing */
-    uint32_t generation;        /**< Must match cache_node->generation to be valid */
-    lv_font_glyph_dsc_t dsc;   /**< Cached glyph metrics (entry ptr always NULL) */
-} lv_freetype_glyph_l1_entry_t;
-
-typedef struct {
-    lv_freetype_glyph_l1_entry_t ways[LV_FREETYPE_GLYPH_L1_WAYS];
-    uint8_t lru_bits;           /**< Simple LRU: index of most-recently-used way */
-} lv_freetype_glyph_l1_set_t;
-
 typedef struct _lv_freetype_cache_node_t lv_freetype_cache_node_t;
 
 struct _lv_freetype_cache_node_t {
@@ -121,9 +99,11 @@ struct _lv_freetype_cache_node_t {
     /*draw data cache*/
     lv_cache_t * draw_data_cache;
 
-    /* L1 glyph metrics cache (per cache_node, lock-free) */
-    uint32_t generation;        /**< Monotonically increasing; bump to invalidate all L1 entries */
-    lv_freetype_glyph_l1_set_t glyph_l1[LV_FREETYPE_GLYPH_L1_SETS];
+#if LV_USE_OS == LV_OS_NONE
+    /* L1 glyph metrics cache (single-thread only, managed by lv_freetype_glyph.c) */
+    uint32_t glyph_l1_generation;
+    void * glyph_l1;
+#endif
 };
 
 typedef struct _lv_freetype_context_t {
@@ -150,90 +130,6 @@ typedef struct _lv_freetype_font_dsc_t {
     lv_font_kerning_t kerning;
 } lv_freetype_font_dsc_t;
 
-/*---------------------
- * L1 Cache Helpers
- *--------------------*/
-
-static inline uint32_t lv_freetype_l1_hash(uint32_t unicode, uint32_t size)
-{
-    uint32_t h = 2166136261u;
-    h ^= unicode;
-    h *= 16777619u;
-    h ^= size;
-    h *= 16777619u;
-    return h;
-}
-
-/**
- * Look up glyph metrics in the per-node L1 cache.
- * @return true on hit (out_dsc filled), false on miss.
- */
-static inline bool lv_freetype_glyph_l1_lookup(
-    lv_freetype_cache_node_t * node,
-    uint32_t unicode,
-    uint32_t size,
-    lv_font_glyph_dsc_t * out_dsc)
-{
-    uint32_t set_idx = lv_freetype_l1_hash(unicode, size) & LV_FREETYPE_GLYPH_L1_SET_MASK;
-    lv_freetype_glyph_l1_set_t * set = &node->glyph_l1[set_idx];
-    uint32_t gen = node->generation;
-
-    for(uint32_t w = 0; w < LV_FREETYPE_GLYPH_L1_WAYS; w++) {
-        lv_freetype_glyph_l1_entry_t * e = &set->ways[w];
-        if(e->generation == gen && e->unicode == unicode && e->size == size) {
-            set->lru_bits = (uint8_t)w;
-            *out_dsc = e->dsc;
-            return true;
-        }
-    }
-    return false;
-}
-
-/**
- * Fill a glyph metrics entry into the per-node L1 cache (LRU eviction).
- */
-static inline void lv_freetype_glyph_l1_fill(
-    lv_freetype_cache_node_t * node,
-    uint32_t unicode,
-    uint32_t size,
-    const lv_font_glyph_dsc_t * dsc)
-{
-    uint32_t set_idx = lv_freetype_l1_hash(unicode, size) & LV_FREETYPE_GLYPH_L1_SET_MASK;
-    lv_freetype_glyph_l1_set_t * set = &node->glyph_l1[set_idx];
-
-    /* Evict the least-recently-used way */
-    uint32_t victim = (set->lru_bits == 0) ? 1u : 0u;
-#if LV_FREETYPE_GLYPH_L1_WAYS > 2
-    victim = (set->lru_bits + 1u) % LV_FREETYPE_GLYPH_L1_WAYS;
-#endif
-
-    lv_freetype_glyph_l1_entry_t * e = &set->ways[victim];
-    e->unicode = unicode;
-    e->size = size;
-    e->generation = node->generation;
-    e->dsc = *dsc;
-    e->dsc.entry = NULL;
-
-    set->lru_bits = (uint8_t)victim;
-}
-
-/**
- * Invalidate all L1 entries for this cache_node in O(1).
- */
-static inline void lv_freetype_glyph_l1_invalidate(lv_freetype_cache_node_t * node)
-{
-    node->generation++;
-}
-
-/**
- * Initialize L1 cache for a newly created cache_node.
- */
-static inline void lv_freetype_glyph_l1_init(lv_freetype_cache_node_t * node)
-{
-    node->generation = 1;
-    lv_memzero(node->glyph_l1, sizeof(node->glyph_l1));
-}
-
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
@@ -250,6 +146,11 @@ int32_t lv_freetype_italic_transform_on_pos(lv_point_t point);
 
 lv_cache_t * lv_freetype_create_glyph_cache(uint32_t cache_size);
 void lv_freetype_set_cbs_glyph(lv_freetype_font_dsc_t * dsc);
+
+#if LV_USE_OS == LV_OS_NONE
+void lv_freetype_glyph_l1_init(lv_freetype_cache_node_t * node);
+void lv_freetype_glyph_l1_deinit(lv_freetype_cache_node_t * node);
+#endif
 
 lv_cache_t * lv_freetype_create_draw_data_image(uint32_t cache_size);
 void lv_freetype_set_cbs_image_font(lv_freetype_font_dsc_t * dsc);

--- a/src/libs/freetype/lv_freetype_private.h
+++ b/src/libs/freetype/lv_freetype_private.h
@@ -34,6 +34,12 @@ extern "C" {
  *      DEFINES
  *********************/
 
+/* L1 glyph cache is not thread-safe — force-disable when an OS is configured */
+#if LV_FREETYPE_CACHE_FT_GLYPH_L1 && LV_USE_OS != LV_OS_NONE
+#undef LV_FREETYPE_CACHE_FT_GLYPH_L1
+#define LV_FREETYPE_CACHE_FT_GLYPH_L1 0
+#endif
+
 #ifdef FT_CONFIG_OPTION_ERROR_STRINGS
 #define FT_ERROR_MSG(msg, error_code) \
     LV_LOG_ERROR(msg " error(0x%x): %s", (int)error_code, FT_Error_String(error_code))
@@ -99,7 +105,7 @@ struct _lv_freetype_cache_node_t {
     /*draw data cache*/
     lv_cache_t * draw_data_cache;
 
-#if LV_USE_OS == LV_OS_NONE
+#if LV_FREETYPE_CACHE_FT_GLYPH_L1
     /* L1 glyph metrics cache (single-thread only, managed by lv_freetype_glyph.c) */
     void * glyph_l1;
 #endif
@@ -146,7 +152,7 @@ int32_t lv_freetype_italic_transform_on_pos(lv_point_t point);
 lv_cache_t * lv_freetype_create_glyph_cache(uint32_t cache_size);
 void lv_freetype_set_cbs_glyph(lv_freetype_font_dsc_t * dsc);
 
-#if LV_USE_OS == LV_OS_NONE
+#if LV_FREETYPE_CACHE_FT_GLYPH_L1
 void lv_freetype_glyph_l1_init(lv_freetype_cache_node_t * node);
 void lv_freetype_glyph_l1_deinit(lv_freetype_cache_node_t * node);
 #endif

--- a/src/libs/freetype/lv_freetype_private.h
+++ b/src/libs/freetype/lv_freetype_private.h
@@ -101,7 +101,6 @@ struct _lv_freetype_cache_node_t {
 
 #if LV_USE_OS == LV_OS_NONE
     /* L1 glyph metrics cache (single-thread only, managed by lv_freetype_glyph.c) */
-    uint32_t glyph_l1_generation;
     void * glyph_l1;
 #endif
 };

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -3272,6 +3272,23 @@
             #define LV_FREETYPE_CACHE_FT_GLYPH_CNT 256
         #endif
     #endif
+
+    /** Enable L1 glyph metrics cache for FreeType.
+     *  A per-font, lock-free, 2-way set-associative cache that accelerates
+     *  repeated glyph metric lookups.  Automatically disabled when an OS is
+     *  configured (LV_USE_OS != LV_OS_NONE) because the cache is not
+     *  thread-safe. */
+    #ifndef LV_FREETYPE_CACHE_FT_GLYPH_L1
+        #ifdef LV_KCONFIG_PRESENT
+            #ifdef CONFIG_LV_FREETYPE_CACHE_FT_GLYPH_L1
+                #define LV_FREETYPE_CACHE_FT_GLYPH_L1 CONFIG_LV_FREETYPE_CACHE_FT_GLYPH_L1
+            #else
+                #define LV_FREETYPE_CACHE_FT_GLYPH_L1 0
+            #endif
+        #else
+            #define LV_FREETYPE_CACHE_FT_GLYPH_L1 1
+        #endif
+    #endif
 #endif
 
 /** Built-in TTF decoder */


### PR DESCRIPTION
# lv_freetype L1 Cache Design

## 1. Background

PR #9400 introduced a direct-mapped L1 cache in `lv_freetype_glyph.c` to accelerate glyph metrics lookups, achieving a 3x performance improvement. However, it has the following issues:

| Issue | Description |
|-------|-------------|
| Global static variable | `s_glyph_l1` is a standalone global; reviewer requested it be placed inside a struct |
| No collision protection | 1-way direct-mapped, collisions silently overwrite |
| No font isolation | All fonts share 256 slots; effective capacity diluted in multi-font scenarios |
| Fragile pointer identity | Uses `font_dsc` pointer as key; address reuse after free can cause ghost hits |

## 2. Design Goals

- **Fast**: Zero locks, zero heap allocations on L1 hit path
- **Stable**: Eliminate collision jitter and pointer-reuse risks
- **Compact**: Controllable memory footprint, reuses `LV_FREETYPE_CACHE_FT_GLYPH_CNT` config
- **Clean**: L1 lifetime tied to `cache_node`, no global state

## 3. Architecture

```
lv_freetype_cache_node_t (per font face)
├── glyph_cache      (L2: LRU RB-tree)
├── draw_data_cache  (L2: LRU RB-tree)
├── generation       (L1 invalidation counter)
└── glyph_l1[]       (L1: 2-way set-associative)

Hot path: get_glyph_dsc_cb()
  → L1 lookup (lock-free)
    → HIT:  return metrics directly
    → MISS: L2 lv_cache_acquire_or_create() → backfill L1
```

## 4. Data Structures

### 4.1 L1 Entry

```c
typedef struct {
    uint32_t unicode;           /* primary key */
    uint32_t size;              /* font size */
    uint32_t generation;        /* compared against cache_node->generation */
    lv_font_glyph_dsc_t dsc;   /* cached metrics */
} lv_freetype_glyph_l1_entry_t;

typedef struct {
    lv_freetype_glyph_l1_entry_t ways[LV_FREETYPE_GLYPH_L1_WAYS];
    uint8_t lru_bits;           /* simple LRU */
} lv_freetype_glyph_l1_set_t;
```

### 4.2 Configuration

```c
/* Number of sets reuses FreeType cache config (default 256) */
#define LV_FREETYPE_GLYPH_L1_SETS  ((uint32_t)LV_FREETYPE_CACHE_FT_GLYPH_CNT)
/* 2 ways per set */
#define LV_FREETYPE_GLYPH_L1_WAYS  2u
```

### 4.3 Embedded in cache_node

```c
struct _lv_freetype_cache_node_t {
    /* ... existing fields ... */
    uint32_t generation;
    lv_freetype_glyph_l1_set_t glyph_l1[LV_FREETYPE_GLYPH_L1_SETS];
};
```

## 5. Core Algorithms

### 5.1 Hash (FNV-1a)

```c
static inline uint32_t lv_freetype_l1_hash(uint32_t unicode, uint32_t size)
{
    uint32_t h = 2166136261u;
    h ^= unicode;
    h *= 16777619u;
    h ^= size;
    h *= 16777619u;
    return h;
}
```

### 5.2 Lookup

Iterate over 2 ways within the set, compare generation + unicode + size. On hit, update lru_bits.

### 5.3 Backfill

Select LRU victim way and write. Set `entry` pointer to NULL (L1 does not hold references).

### 5.4 Invalidation

```c
node->generation++;  /* O(1) lazy invalidation */
```

## 6. Changed Files

| File | Changes |
|------|---------|
| `lv_freetype_private.h` | +118 lines: L1 data structures + inline helpers (lookup/fill/invalidate/init) |
| `lv_freetype.c` | +2 lines: call `lv_freetype_glyph_l1_init()` in `cache_node_cache_create_cb` |
| `lv_freetype_glyph.c` | +26/-13 lines: integrate L1 lookup and backfill in `freetype_get_glyph_dsc_cb` |

## 7. Comparison with PR #9400

| Aspect | PR #9400 | This Design |
|--------|----------|-------------|
| Storage | Global static array | Embedded in cache_node |
| Associativity | 1-way direct-mapped | 2-way set-associative |
| Identity check | Pointer comparison | Generation counter |
| Invalidation | memzero entire array | generation++ O(1) |
| Font isolation | None | Fully isolated |
| Conditional compilation | None | None (always-on) |
| Configuration | Hardcoded 256 | Reuses LV_FREETYPE_CACHE_FT_GLYPH_CNT |

## 8. Test Results

- Unit tests: 120/120 all passed
- FreeType module coverage: 87.57%


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
