### PR TITLE
fix(wayland): fix memory leak

### DIFF
--- a/src/drivers/wayland/lv_wayland.c
+++ b/src/drivers/wayland/lv_wayland.c
@@ -180,6 +180,18 @@ void lv_wayland_deinit(void)
         lv_wl_ctx.wl_registry = NULL;
     }
 
+    if(lv_wl_ctx.wl_shm) {
+        wl_shm_destroy(lv_wl_ctx.wl_shm);
+        lv_wl_ctx.wl_shm = NULL;
+    }
+
+    for(uint8_t i = 0; i < lv_wl_ctx.wl_output_count; ++i) {
+        if(lv_wl_ctx.physical_outputs[i].wl_output) {
+            wl_output_destroy(lv_wl_ctx.physical_outputs[i].wl_output);
+            lv_wl_ctx.physical_outputs[i].wl_output = NULL;
+        }
+    }
+
     if(lv_wl_ctx.wl_compositor) {
         wl_compositor_destroy(lv_wl_ctx.wl_compositor);
         lv_wl_ctx.wl_compositor = NULL;

--- a/src/drivers/wayland/lv_wayland.c
+++ b/src/drivers/wayland/lv_wayland.c
@@ -158,12 +158,6 @@ void lv_wayland_deinit(void)
         return;
     }
 
-    lv_wl_window_t * window = NULL;
-
-    LV_LL_READ(&lv_wl_ctx.window_ll, window) {
-        lv_wayland_window_delete(window);
-    }
-
     lv_wayland_xdg_deinit();
 
     if(is_wayland_initialized) {

--- a/src/drivers/wayland/lv_wayland_backend_g2d.c
+++ b/src/drivers/wayland/lv_wayland_backend_g2d.c
@@ -190,6 +190,7 @@ static void wl_g2d_deinit(void * backend_ctx)
     }
     if(ctx->handler) {
         zwp_linux_dmabuf_v1_destroy(ctx->handler);
+        ctx->handler = NULL;
     }
 }
 

--- a/src/drivers/wayland/lv_wayland_backend_shm.c
+++ b/src/drivers/wayland/lv_wayland_backend_shm.c
@@ -157,6 +157,7 @@ static void shm_deinit(void * backend_ctx)
     lv_wl_shm_ctx_t * ctx = backend_ctx;
     if(ctx->shm) {
         wl_shm_destroy(ctx->shm);
+        ctx->shm = NULL;
     }
 }
 

--- a/src/drivers/wayland/lv_wayland_keyboard.c
+++ b/src/drivers/wayland/lv_wayland_keyboard.c
@@ -51,8 +51,6 @@ static lv_key_t keycode_xkb_to_lv(xkb_keysym_t xkb_key);
  *  STATIC VARIABLES
  **********************/
 
-static struct xkb_context * xkb_context;
-
 static const struct wl_keyboard_listener keyboard_listener = {
     .keymap    = keyboard_handle_keymap,
     .enter     = keyboard_handle_enter,
@@ -104,7 +102,9 @@ lv_wl_seat_keyboard_t * lv_wayland_seat_keyboard_create(struct wl_seat * wl_seat
         LV_LOG_WARN("Failed to get seat keyboard");
         return NULL;
     }
-    if(!xkb_context && !(xkb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS))) {
+
+    struct xkb_context * xkb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    if(!xkb_context) {
         LV_LOG_WARN("Failed to create xkb context");
         return NULL;
     }
@@ -118,6 +118,7 @@ lv_wl_seat_keyboard_t * lv_wayland_seat_keyboard_create(struct wl_seat * wl_seat
     wl_keyboard_add_listener(keyboard, &keyboard_listener, NULL);
     wl_keyboard_set_user_data(keyboard, wl_seat_keyboard);
 
+    wl_seat_keyboard->xkb_context = xkb_context;
     wl_seat_keyboard->wl_keyboard = keyboard;
     lv_wayland_update_indevs(keyboard_read, wl_seat_keyboard);
 
@@ -127,6 +128,7 @@ void lv_wayland_seat_keyboard_delete(lv_wl_seat_keyboard_t * seat_keyboard)
 {
     lv_wayland_update_indevs(keyboard_read, NULL);
     wl_keyboard_destroy(seat_keyboard->wl_keyboard);
+    xkb_context_unref(seat_keyboard->xkb_context);
     xkb_keymap_unref(seat_keyboard->xkb_keymap);
     xkb_state_unref(seat_keyboard->xkb_state);
     lv_free(seat_keyboard);
@@ -165,7 +167,7 @@ static void keyboard_handle_keymap(void * data, struct wl_keyboard * keyboard, u
     }
 
     /* Set up XKB keymap */
-    struct xkb_keymap * keymap = xkb_keymap_new_from_string(xkb_context, map_str, XKB_KEYMAP_FORMAT_TEXT_V1, 0);
+    struct xkb_keymap * keymap = xkb_keymap_new_from_string(kbdata->xkb_context, map_str, XKB_KEYMAP_FORMAT_TEXT_V1, 0);
     munmap(map_str, size);
     close(fd);
 

--- a/src/drivers/wayland/lv_wayland_keyboard.c
+++ b/src/drivers/wayland/lv_wayland_keyboard.c
@@ -126,6 +126,9 @@ lv_wl_seat_keyboard_t * lv_wayland_seat_keyboard_create(struct wl_seat * wl_seat
 void lv_wayland_seat_keyboard_delete(lv_wl_seat_keyboard_t * seat_keyboard)
 {
     lv_wayland_update_indevs(keyboard_read, NULL);
+    wl_keyboard_destroy(seat_keyboard->wl_keyboard);
+    xkb_keymap_unref(seat_keyboard->xkb_keymap);
+    xkb_state_unref(seat_keyboard->xkb_state);
     lv_free(seat_keyboard);
 }
 

--- a/src/drivers/wayland/lv_wayland_pointer.c
+++ b/src/drivers/wayland/lv_wayland_pointer.c
@@ -54,8 +54,6 @@ static void pointer_handle_axis(void * data, struct wl_pointer * wl_pointer, uin
  *  STATIC VARIABLES
  **********************/
 
-static struct wl_cursor_theme * cursor_theme = NULL;
-
 static const struct wl_pointer_listener pointer_listener = {
     .enter  = pointer_handle_enter,
     .leave  = pointer_handle_leave,
@@ -118,7 +116,9 @@ lv_wl_seat_pointer_t * lv_wayland_seat_pointer_create(struct wl_seat * seat, str
 {
     LV_ASSERT_NULL(seat);
     LV_ASSERT_NULL(surface);
-    if(!cursor_theme && !(cursor_theme = wl_cursor_theme_load(NULL, 32, lv_wl_ctx.wl_shm))) {
+
+    struct wl_cursor_theme * cursor_theme = wl_cursor_theme_load(NULL, 32, lv_wl_ctx.wl_shm);
+    if(!cursor_theme) {
         LV_LOG_WARN("Failed to load cursor theme for pointer");
         return NULL;
     }
@@ -126,6 +126,7 @@ lv_wl_seat_pointer_t * lv_wayland_seat_pointer_create(struct wl_seat * seat, str
     struct wl_pointer * pointer = wl_seat_get_pointer(seat);
     if(!pointer) {
         LV_LOG_WARN("Failed to get seat pointer");
+        wl_cursor_theme_destroy(cursor_theme);
         return NULL;
     }
 
@@ -133,11 +134,14 @@ lv_wl_seat_pointer_t * lv_wayland_seat_pointer_create(struct wl_seat * seat, str
     LV_ASSERT_MALLOC(wl_seat_pointer);
     if(!wl_seat_pointer) {
         LV_LOG_WARN("Failed to allocate memory for wayland pointer");
+        wl_pointer_destroy(pointer);
+        wl_cursor_theme_destroy(cursor_theme);
         return NULL;
     }
     wl_pointer_add_listener(pointer, &pointer_listener, NULL);
     wl_pointer_set_user_data(pointer, wl_seat_pointer);
 
+    wl_seat_pointer->cursor_theme = cursor_theme;
     wl_seat_pointer->cursor_surface = surface;
     wl_seat_pointer->wl_pointer = pointer;
     lv_wayland_update_indevs(pointer_read, wl_seat_pointer);
@@ -151,6 +155,7 @@ void lv_wayland_seat_pointer_delete(lv_wl_seat_pointer_t * seat_pointer)
     lv_wayland_update_indevs(pointer_read, NULL);
     lv_wayland_update_indevs(pointeraxis_read, NULL);
     wl_pointer_destroy(seat_pointer->wl_pointer);
+    wl_cursor_theme_destroy(seat_pointer->cursor_theme);
     lv_free(seat_pointer);
 }
 
@@ -192,7 +197,7 @@ static void pointer_handle_enter(void * data, struct wl_pointer * pointer, uint3
     seat_pointer->point.x = pos_x;
     seat_pointer->point.y = pos_y;
 
-    struct wl_cursor * wl_cursor = wl_cursor_theme_get_cursor(cursor_theme, LV_WAYLAND_DEFAULT_CURSOR_NAME);
+    struct wl_cursor * wl_cursor = wl_cursor_theme_get_cursor(seat_pointer->cursor_theme, LV_WAYLAND_DEFAULT_CURSOR_NAME);
     struct wl_cursor_image * cursor_image = wl_cursor->images[0];
 
     wl_pointer_set_cursor(pointer, serial, seat_pointer->cursor_surface, cursor_image->hotspot_x, cursor_image->hotspot_y);

--- a/src/drivers/wayland/lv_wayland_private.h
+++ b/src/drivers/wayland/lv_wayland_private.h
@@ -63,6 +63,7 @@ typedef struct {
 
 typedef struct {
     struct wl_keyboard * wl_keyboard;
+    struct xkb_context * xkb_context;
     struct xkb_keymap * xkb_keymap;
     struct xkb_state * xkb_state;
 

--- a/src/drivers/wayland/lv_wayland_private.h
+++ b/src/drivers/wayland/lv_wayland_private.h
@@ -41,6 +41,7 @@ struct _lv_wl_window_t;
 typedef struct {
     struct wl_pointer * wl_pointer;
     struct wl_surface * cursor_surface;
+    struct wl_cursor_theme * cursor_theme;
     lv_point_t point;
     lv_indev_state_t left_btn_state;
     lv_indev_state_t right_btn_state;

--- a/src/drivers/wayland/lv_wayland_window.c
+++ b/src/drivers/wayland/lv_wayland_window.c
@@ -173,8 +173,7 @@ void lv_wayland_window_close(lv_display_t * display)
         return;
     }
     window->close_cb = NULL;
-    lv_wayland_window_delete(window);
-    lv_wayland_deinit();
+    lv_display_delete(window->lv_disp);
 }
 
 bool lv_wayland_window_is_open(lv_display_t * disp)

--- a/src/drivers/wayland/lv_wayland_window.c
+++ b/src/drivers/wayland/lv_wayland_window.c
@@ -300,6 +300,7 @@ void lv_wayland_window_delete(lv_wl_window_t * window)
 
 
     lv_ll_remove(&lv_wl_ctx.window_ll, window);
+    lv_free(window);
 
     if(LV_WAYLAND_DIRECT_EXIT && lv_ll_is_empty(&lv_wl_ctx.window_ll)) {
         /* lv_deinit will deinit the wayland driver*/

--- a/src/drivers/wayland/lv_wayland_window.c
+++ b/src/drivers/wayland/lv_wayland_window.c
@@ -274,6 +274,22 @@ void lv_wayland_window_delete(lv_wl_window_t * window)
         return;
     }
 
+    lv_display_delete(window->lv_disp);
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static void delete_event(lv_event_t * e)
+{
+    lv_display_t * display = lv_event_get_target(e);
+    lv_wl_window_t * window = lv_display_get_driver_data(display);
+
+    if(window == NULL) {
+        return;
+    }
+
     if(window->close_cb) {
         window->close_cb(window->lv_disp);
     }
@@ -293,11 +309,9 @@ void lv_wayland_window_delete(lv_wl_window_t * window)
     wl_backend_ops.deinit_display(window->backend_display_data, window->lv_disp);
     window->backend_display_data = NULL;
 
-    /* Set the driver data to NULL before calling display delete
-     * so that the delete event doesn't do anything*/
-    lv_display_set_driver_data(window->lv_disp, NULL);
-    lv_display_delete(window->lv_disp);
-
+    if(LV_WAYLAND_DIRECT_EXIT) {
+        lv_display_set_driver_data(window->lv_disp, NULL);
+    }
 
     lv_ll_remove(&lv_wl_ctx.window_ll, window);
     lv_free(window);
@@ -309,16 +323,6 @@ void lv_wayland_window_delete(lv_wl_window_t * window)
     }
 }
 
-/**********************
- *   STATIC FUNCTIONS
- **********************/
-
-static void delete_event(lv_event_t * e)
-{
-    lv_display_t * display = lv_event_get_target(e);
-    lv_wl_window_t * window = lv_display_get_driver_data(display);
-    lv_wayland_window_delete(window);
-}
 
 static void refr_start_event(lv_event_t * e)
 {


### PR DESCRIPTION
This patch series fixes some memory leaks, use-after-free and double free bugs in the libinput and wayland drivers.

For the wayland driver fixes, I used the minimal example application below to run valgrind. When LVGL is configured with LV_WAYLAND_DIRECT_EXIT disabled, there are no memory leaks anymore. With LV_WAYLAND_DIRECT_EXIT enabled, there are still some memory leaks left. Those are difficult to fix and when the application exits the memory is still freed by the OS, but when running valgrind on an actual application it generates lots of extra noise.

```
#include <stdlib.h>
#include <unistd.h>
#include <stdio.h>
#include <signal.h>

#include "lvgl/lvgl.h"
#include "lvgl/examples/lv_examples.h"
#include "lvgl/demos/lv_demos.h"

static volatile sig_atomic_t g_cancel = 0;

static void
sighandler (int signum)
{
    // Restore the default signal handler.
    signal (signum, SIG_DFL);

    g_cancel = 1;
}

int main(int argc, char **argv)
{
    /* Default values. */
    unsigned int width = 800;
    unsigned int height = 480;
    bool fullscreen = false;
    bool maximized = false;

    lv_display_t *disp = NULL;

    /* Parse the command-line options. */
    int opt = 0;
    while ((opt = getopt (argc, argv, "w:h:fm")) != -1) {
        switch (opt) {
        case 'w':
            width = strtoul (optarg, NULL, 0);
            break;
        case 'h':
            height = strtoul (optarg, NULL, 0);
            break;
        case 'f':
            fullscreen = true;
            break;
        case 'm':
            maximized = true;
            break;
        case ':':
            fprintf (stderr, "Option -%c requires an argument.\n", optopt);
            return EXIT_FAILURE;
        case '?':
            fprintf (stderr, "Unknown option -%c.\n", optopt);
            return EXIT_FAILURE;
        default:
            return EXIT_FAILURE;
        }
    }

    /* Skip processed options. */
    argc -= optind;
    argv += optind;

    /* Setup the cancel signal handler. */
    signal(SIGINT, sighandler);

    /* Initialize LVGL. */
    lv_init();

    /* Initialize the HAL (display, input devices, tick) for LVGL. */
    disp = lv_wayland_window_create(width, height, "Window Title", NULL);
    lv_wayland_window_set_fullscreen(disp, fullscreen);
    lv_wayland_window_set_maximized(disp, maximized);

    lv_group_t * g = lv_group_create();
    lv_group_set_default(g);
    lv_indev_set_group(lv_wayland_get_keyboard(disp), g);
    lv_indev_set_group(lv_wayland_get_pointeraxis(disp), g);

    /* Setup the demo application. */
    lv_demo_widgets();

    /* Handle LVGL event loop. */
    while (!g_cancel) {
        uint32_t time_till_next = lv_timer_handler();
        if (time_till_next == LV_NO_TIMER_READY) {
            time_till_next = LV_DEF_REFR_PERIOD;
        }

        usleep(time_till_next * 1000);
    }

#if !LV_WAYLAND_DIRECT_EXIT
    lv_display_delete(disp);

    lv_deinit();
#endif

    return EXIT_SUCCESS;
}
```


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
