### PR TITLE
feat(opengl/egl): bind opengl context to egl

### DIFF
--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -230,27 +230,6 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
     #define LV_LOG_TRACE_ANIM       0
 #endif  /*LV_USE_LOG*/
 
-#if LV_USE_WAYLAND
-    /*Automatically detect wayland backend*/
-    #if LV_USE_OPENGLES
-        #define LV_WAYLAND_USE_EGL 1
-        #define LV_WAYLAND_USE_G2D 0
-        #define LV_WAYLAND_USE_SHM 0
-    #elif LV_USE_G2D
-        #define LV_WAYLAND_USE_EGL 0
-        #define LV_WAYLAND_USE_G2D 1
-        #define LV_WAYLAND_USE_SHM 0
-    #else
-        #define LV_WAYLAND_USE_EGL 0
-        #define LV_WAYLAND_USE_G2D 0
-        #define LV_WAYLAND_USE_SHM 1
-    #endif
-#else
-    #define LV_WAYLAND_USE_G2D 0
-    #define LV_WAYLAND_USE_SHM 0
-    #define LV_WAYLAND_USE_EGL 0
-#endif
-
 #if LV_USE_LINUX_DRM
     #if LV_USE_OPENGLES
         #define LV_LINUX_DRM_USE_EGL 1
@@ -307,6 +286,12 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
     #define LV_SDL_USE_EGL 1
 #else
     #define LV_SDL_USE_EGL 0
+#endif
+
+#if LV_USE_WAYLAND && LV_USE_OPENGLES
+    #define LV_WAYLAND_USE_EGL 1
+#else
+    #define LV_WAYLAND_USE_EGL 0
 #endif
 
 #ifndef LV_USE_EGL

--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -17,10 +17,12 @@
 #include "lv_opengles_private.h"
 
 #include "../../display/lv_display_private.h"
-#include "../../draw/nanovg/lv_draw_nanovg.h"
 #include "../../misc/lv_area_private.h"
 #include "opengl_shader/lv_opengl_shader_internal.h"
 #include "assets/lv_opengles_shader.h"
+
+#include "../../draw/nanovg/lv_draw_nanovg.h"
+#include "../../draw/opengles/lv_draw_opengles.h"
 
 /*********************
  *      DEFINES
@@ -38,31 +40,34 @@
 
 static void lv_opengles_enable_blending(bool blend_opt);
 static void lv_opengles_disable_blending(void);
-static void lv_opengles_vertex_buffer_init(const void * data, unsigned int size);
-static void lv_opengles_vertex_buffer_deinit(void);
-static void lv_opengles_vertex_buffer_bind(void);
+static void lv_opengles_vertex_buffer_init(lv_opengles_gl_t * ctx, const void * data, unsigned int size);
+static void lv_opengles_vertex_buffer_deinit(lv_opengles_gl_t * ctx);
+static void lv_opengles_vertex_buffer_bind(lv_opengles_gl_t * ctx);
 static void lv_opengles_vertex_buffer_unbind(void);
-static void lv_opengles_vertex_array_init(void);
-static void lv_opengles_vertex_array_deinit(void);
-static void lv_opengles_vertex_array_bind(void);
+static void lv_opengles_vertex_array_init(lv_opengles_gl_t * ctx);
+static void lv_opengles_vertex_array_deinit(lv_opengles_gl_t * ctx);
+static void lv_opengles_vertex_array_bind(lv_opengles_gl_t * ctx);
 static void lv_opengles_vertex_array_unbind(void);
-static void lv_opengles_vertex_array_add_buffer(void);
-static void lv_opengles_index_buffer_init(const unsigned int * data, unsigned int count);
-static void lv_opengles_index_buffer_deinit(void);
-static unsigned int lv_opengles_index_buffer_get_count(void);
-static void lv_opengles_index_buffer_bind(void);
+static void lv_opengles_vertex_array_add_buffer(lv_opengles_gl_t * ctx);
+static void lv_opengles_index_buffer_init(lv_opengles_gl_t * ctx, const unsigned int * data,
+                                          unsigned int count);
+static void lv_opengles_index_buffer_deinit(lv_opengles_gl_t * ctx);
+static unsigned int lv_opengles_index_buffer_get_count(lv_opengles_gl_t * ctx);
+static void lv_opengles_index_buffer_bind(lv_opengles_gl_t * ctx);
 static void lv_opengles_index_buffer_unbind(void);
 static unsigned int lv_opengles_shader_manager_init(void);
-static lv_result_t lv_opengles_shader_init(void);
-static void lv_opengles_shader_deinit(void);
-static void lv_opengles_shader_bind(void);
+static lv_result_t lv_opengles_shader_init(lv_opengles_gl_t * ctx);
+static void lv_opengles_shader_deinit(lv_opengles_gl_t * ctx);
+static void lv_opengles_shader_bind(lv_opengles_gl_t * ctx);
 static void lv_opengles_shader_unbind(void);
-static int lv_opengles_shader_get_uniform_location(const char * name);
-static void lv_opengles_shader_set_uniform1i(const char * name, int value);
-static void lv_opengles_shader_set_uniformmatrix3fv(const char * name, int count, const float * values);
-static void lv_opengles_shader_set_uniform1f(const char * name, float value);
-static void lv_opengles_shader_set_uniform3f(const char * name, float value_0, float value_1, float value_2);
-static void lv_opengles_render_draw(void);
+static int lv_opengles_shader_get_uniform_location(lv_opengles_gl_t * ctx, const char * name);
+static void lv_opengles_shader_set_uniform1i(lv_opengles_gl_t * ctx, const char * name, int value);
+static void lv_opengles_shader_set_uniformmatrix3fv(lv_opengles_gl_t * ctx, const char * name, int count,
+                                                    const float * values);
+static void lv_opengles_shader_set_uniform1f(lv_opengles_gl_t * ctx, const char * name, float value);
+static void lv_opengles_shader_set_uniform3f(lv_opengles_gl_t * ctx, const char * name, float value_0,
+                                             float value_1, float value_2);
+static void lv_opengles_render_draw(lv_opengles_gl_t * ctx);
 static float lv_opengles_map_float(float x, float min_in, float max_in, float min_out, float max_out);
 static void populate_vertex_buffer(float vertex_buffer[LV_OPENGLES_VERTEX_BUFFER_LEN],
                                    lv_display_rotation_t rotation, bool * h_flip, bool * v_flip,
@@ -75,21 +80,24 @@ static void populate_vertex_buffer(float vertex_buffer[LV_OPENGLES_VERTEX_BUFFER
 /**********************
  *  STATIC VARIABLES
  **********************/
-static bool is_init;
 
+static const char * shader_names[LV_OPENGLES_SHADER_NAMES_COUNT] = {
+    "u_Texture",
+    "u_ColorDepth",
+    "u_VertexTransform",
+    "u_Opa",
+    "u_IsFill",
+    "u_FillColor",
+    "u_SwapRB",
+    "u_Hue",
+    "u_Saturation",
+    "u_Value"
+};
+
+static bool global_init = false;
 static lv_opengl_shader_manager_t shader_manager;
+static lv_opengles_gl_t * bound_ctx; /* Used for backwards compatibility*/
 
-static unsigned int vertex_buffer_id = 0;
-
-static unsigned int vertex_array_id = 0;
-
-static unsigned int index_buffer_id = 0;
-static unsigned int index_buffer_count = 0;
-
-static unsigned int shader_id;
-
-static const char * shader_names[] = { "u_Texture", "u_ColorDepth", "u_VertexTransform", "u_Opa", "u_IsFill", "u_FillColor", "u_SwapRB", "u_Hue", "u_Saturation", "u_Value" };
-static int shader_location[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
 /**********************
  *      MACROS
@@ -101,26 +109,47 @@ static int shader_location[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
 void lv_opengles_init(void)
 {
-    if(is_init) return;
+    bound_ctx = lv_opengles_context_create();
+}
 
-    lv_opengles_enable_blending(false);
+void lv_opengles_deinit(void)
+{
+    lv_opengles_context_delete(bound_ctx);
+    bound_ctx = NULL;
+}
+
+void lv_opengles_context_bind(lv_opengles_gl_t * ctx)
+{
+    if(!ctx) {
+        return;
+    }
+    bound_ctx = ctx;
+}
+
+lv_opengles_gl_t * lv_opengles_context_create(void)
+{
+    lv_opengles_gl_t * ctx = lv_zalloc(sizeof(*ctx));
+    LV_ASSERT_MALLOC(ctx);
+    if(!ctx) {
+        return NULL;
+    }
 
     unsigned int indices[] = {
         0, 1, 2,
         2, 3, 0
     };
 
-    lv_opengles_vertex_buffer_init(NULL, sizeof(float) * LV_OPENGLES_VERTEX_BUFFER_LEN);
+    lv_opengles_vertex_buffer_init(ctx, NULL, sizeof(float) * LV_OPENGLES_VERTEX_BUFFER_LEN);
 
-    lv_opengles_vertex_array_init();
-    lv_opengles_vertex_array_add_buffer();
+    lv_opengles_vertex_array_init(ctx);
+    lv_opengles_vertex_array_add_buffer(ctx);
 
-    lv_opengles_index_buffer_init(indices, 6);
+    lv_opengles_index_buffer_init(ctx, indices, 6);
 
-    lv_result_t res = lv_opengles_shader_init();
+    lv_result_t res = lv_opengles_shader_init(ctx);
     LV_ASSERT_MSG(res == LV_RESULT_OK, "Failed to initialize shaders");
 
-    lv_opengles_shader_bind();
+    lv_opengles_shader_bind(ctx);
 
     /* unbind everything */
     lv_opengles_vertex_array_unbind();
@@ -128,23 +157,29 @@ void lv_opengles_init(void)
     lv_opengles_index_buffer_unbind();
     lv_opengles_shader_unbind();
 
+    if(!global_init) {
+        lv_opengles_enable_blending(false);
 #if LV_USE_DRAW_NANOVG
-    lv_draw_nanovg_init();
+        lv_draw_nanovg_init();
+#elif LV_USE_DRAW_OPENGLES
+        lv_draw_opengles_init();
 #endif /*LV_USE_DRAW_NANOVG*/
+        global_init = true;
+    }
 
-    is_init = true;
+    return ctx;
 }
 
-void lv_opengles_deinit(void)
+void lv_opengles_context_delete(lv_opengles_gl_t * ctx)
 {
-    if(!is_init) return;
-
-    lv_opengles_shader_deinit();
-    lv_opengles_index_buffer_deinit();
-    lv_opengles_vertex_buffer_deinit();
-    lv_opengles_vertex_array_deinit();
-
-    is_init = false;
+    if(!ctx) {
+        return;
+    }
+    lv_opengles_shader_deinit(ctx);
+    lv_opengles_index_buffer_deinit(ctx);
+    lv_opengles_vertex_buffer_deinit(ctx);
+    lv_opengles_vertex_array_deinit(ctx);
+    lv_free(ctx);
 }
 
 void lv_opengles_render_params_init(lv_opengles_render_params_t * params)
@@ -153,10 +188,16 @@ void lv_opengles_render_params_init(lv_opengles_render_params_t * params)
     lv_memzero(params, sizeof(lv_opengles_render_params_t));
 }
 
-void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa, int32_t disp_w,
+void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_area,
+                                lv_opa_t opa, int32_t disp_w,
                                 int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip)
 {
+    if(!bound_ctx) {
+        LV_LOG_WARN("Can't render texture without a bound OpenGL context");
+        return;
+    }
     LV_PROFILER_DRAW_BEGIN;
+
     lv_opengles_render_params_t params;
     lv_opengles_render_params_init(&params);
     params.texture = texture;
@@ -171,7 +212,8 @@ void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_
     LV_PROFILER_DRAW_END;
 }
 
-void lv_opengles_render_texture_rbswap(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
+void lv_opengles_render_texture_rbswap(unsigned int texture,
+                                       const lv_area_t * texture_area, lv_opa_t opa,
                                        int32_t disp_w,
                                        int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip)
 {
@@ -191,7 +233,8 @@ void lv_opengles_render_texture_rbswap(unsigned int texture, const lv_area_t * t
     LV_PROFILER_DRAW_END;
 }
 
-void lv_opengles_render_fill(lv_color_t color, const lv_area_t * area, lv_opa_t opa, int32_t disp_w, int32_t disp_h)
+void lv_opengles_render_fill(lv_color_t color, const lv_area_t * area, lv_opa_t opa,
+                             int32_t disp_w, int32_t disp_h)
 {
     LV_PROFILER_DRAW_BEGIN;
     lv_opengles_render_params_t params;
@@ -209,6 +252,8 @@ void lv_opengles_render_fill(lv_color_t color, const lv_area_t * area, lv_opa_t 
 
 void lv_opengles_render_display(lv_display_t * display, const lv_opengles_render_params_t * params)
 {
+    LV_ASSERT_NULL(display);
+    LV_ASSERT_NULL(params);
     LV_PROFILER_DRAW_BEGIN;
     unsigned int texture = (lv_uintptr_t)display->layer_head->user_data;
     GL_CALL(glActiveTexture(GL_TEXTURE0));
@@ -220,7 +265,7 @@ void lv_opengles_render_display(lv_display_t * display, const lv_opengles_render
 
     float vert_buffer[LV_OPENGLES_VERTEX_BUFFER_LEN];
     populate_vertex_buffer(vert_buffer, rotation, &h_flip, &v_flip, 0.f, 0.f, 1.f, 1.f);
-    lv_opengles_vertex_buffer_init(vert_buffer, sizeof(vert_buffer));
+    lv_opengles_vertex_buffer_init(bound_ctx, vert_buffer, sizeof(vert_buffer));
 
     float hor_scale = 1.0f;
     float ver_scale = 1.0f;
@@ -235,20 +280,21 @@ void lv_opengles_render_display(lv_display_t * display, const lv_opengles_render
         hor_translate, ver_translate, 1.0f
     };
 
-    lv_opengles_shader_bind();
-    lv_opengles_shader_set_uniform1f("u_ColorDepth", LV_COLOR_DEPTH);
-    lv_opengles_shader_set_uniform1i("u_Texture", 0);
-    lv_opengles_shader_set_uniformmatrix3fv("u_VertexTransform", 1, transposed_matrix);
-    lv_opengles_shader_set_uniform1f("u_Opa", 1);
-    lv_opengles_shader_set_uniform1i("u_IsFill", 0);
-    lv_opengles_shader_set_uniform3f("u_FillColor", 1.0f, 1.0f, 1.0f);
-    lv_opengles_shader_set_uniform1i("u_SwapRB", params->rb_swap);
+    lv_opengles_shader_bind(bound_ctx);
+    lv_opengles_shader_set_uniform1f(bound_ctx, "u_ColorDepth", LV_COLOR_DEPTH);
+    lv_opengles_shader_set_uniform1i(bound_ctx, "u_Texture", 0);
+    lv_opengles_shader_set_uniformmatrix3fv(bound_ctx, "u_VertexTransform", 1, transposed_matrix);
+    lv_opengles_shader_set_uniform1f(bound_ctx, "u_Opa", 1);
+    lv_opengles_shader_set_uniform1i(bound_ctx, "u_IsFill", 0);
+    lv_opengles_shader_set_uniform3f(bound_ctx, "u_FillColor", 1.0f, 1.0f, 1.0f);
+    lv_opengles_shader_set_uniform1i(bound_ctx, "u_SwapRB", params->rb_swap);
 
-    lv_opengles_render_draw();
+    lv_opengles_render_draw(bound_ctx);
     LV_PROFILER_DRAW_END;
 }
 
-void lv_opengles_render_display_texture(lv_display_t * display, bool h_flip, bool v_flip)
+void lv_opengles_render_display_texture(lv_display_t * display, bool h_flip,
+                                        bool v_flip)
 {
     /*TODO: Deprecate this function and make lv_opengles_render_display public instead*/
 
@@ -279,9 +325,9 @@ void lv_opengles_reinit_state(void)
     LV_PROFILER_DRAW_BEGIN;
 
     /* Rebind VAO, VBO, IBO to restore state after NanoVG or other external GL operations */
-    lv_opengles_vertex_array_bind();
-    lv_opengles_vertex_buffer_bind();
-    lv_opengles_index_buffer_bind();
+    lv_opengles_vertex_array_bind(bound_ctx);
+    lv_opengles_vertex_buffer_bind(bound_ctx);
+    lv_opengles_index_buffer_bind(bound_ctx);
 
     /* Re-setup vertex attributes since NanoVG may have modified them */
     for(unsigned int i = 0; i < 2; i++) {
@@ -295,6 +341,10 @@ void lv_opengles_reinit_state(void)
 void lv_opengles_render(const lv_opengles_render_params_t * params)
 {
     LV_ASSERT_NULL(params);
+    if(!bound_ctx) {
+        LV_LOG_WARN("Can't render texture without a bound OpenGL context");
+        return;
+    }
     LV_PROFILER_DRAW_BEGIN;
     lv_area_t intersection;
     if(!lv_area_intersect(&intersection, params->texture_area, params->texture_clip_area)) {
@@ -352,7 +402,7 @@ void lv_opengles_render(const lv_opengles_render_params_t * params)
             1.0f, -1.0f, clip_x2, clip_y1,
             -1.f, -1.0f, clip_x1, clip_y1
         };
-        lv_opengles_vertex_buffer_init(positions, sizeof(positions));
+        lv_opengles_vertex_buffer_init(bound_ctx, positions, sizeof(positions));
     }
 
     lv_matrix_t matrix;
@@ -399,19 +449,19 @@ void lv_opengles_render(const lv_opengles_render_params_t * params)
     lv_matrix_t gl_matrix;
     lv_matrix_transpose(&matrix, &gl_matrix);
 
-    lv_opengles_shader_bind();
+    lv_opengles_shader_bind(bound_ctx);
     lv_opengles_enable_blending(params->blend_opt);
-    lv_opengles_shader_set_uniform1f("u_ColorDepth", LV_COLOR_DEPTH);
-    lv_opengles_shader_set_uniform1i("u_Texture", 0);
-    lv_opengles_shader_set_uniformmatrix3fv("u_VertexTransform", 1, (float *)&gl_matrix);
-    lv_opengles_shader_set_uniform1f("u_Opa", (float)params->opa / (float)LV_OPA_100);
-    lv_opengles_shader_set_uniform1i("u_IsFill", params->texture == 0);
-    lv_opengles_shader_set_uniform3f("u_FillColor", (float)params->fill_color.red / 255.0f,
+    lv_opengles_shader_set_uniform1f(bound_ctx, "u_ColorDepth", LV_COLOR_DEPTH);
+    lv_opengles_shader_set_uniform1i(bound_ctx, "u_Texture", 0);
+    lv_opengles_shader_set_uniformmatrix3fv(bound_ctx, "u_VertexTransform", 1, (float *)&gl_matrix);
+    lv_opengles_shader_set_uniform1f(bound_ctx, "u_Opa", (float)params->opa / (float)LV_OPA_100);
+    lv_opengles_shader_set_uniform1i(bound_ctx, "u_IsFill", params->texture == 0);
+    lv_opengles_shader_set_uniform3f(bound_ctx, "u_FillColor", (float)params->fill_color.red / 255.0f,
                                      (float)params->fill_color.green / 255.0f,
                                      (float)params->fill_color.blue / 255.0f);
-    lv_opengles_shader_set_uniform1i("u_SwapRB", params->rb_swap ? 1 : 0);
+    lv_opengles_shader_set_uniform1i(bound_ctx, "u_SwapRB", params->rb_swap ? 1 : 0);
 
-    lv_opengles_render_draw();
+    lv_opengles_render_draw(bound_ctx);
     lv_opengles_disable_blending();
     LV_PROFILER_DRAW_END;
 }
@@ -431,23 +481,23 @@ static void lv_opengles_disable_blending(void)
     GL_CALL(glDisable(GL_BLEND));
 }
 
-static void lv_opengles_vertex_buffer_init(const void * data, unsigned int size)
+static void lv_opengles_vertex_buffer_init(lv_opengles_gl_t * ctx, const void * data, unsigned int size)
 {
-    if(vertex_buffer_id == 0) GL_CALL(glGenBuffers(1, &vertex_buffer_id));
-    GL_CALL(glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer_id));
+    if(ctx->vertex_buffer_id == 0) GL_CALL(glGenBuffers(1, &ctx->vertex_buffer_id));
+    GL_CALL(glBindBuffer(GL_ARRAY_BUFFER, ctx->vertex_buffer_id));
     GL_CALL(glBufferData(GL_ARRAY_BUFFER, size, data, GL_DYNAMIC_DRAW));
 }
 
-static void lv_opengles_vertex_buffer_deinit(void)
+static void lv_opengles_vertex_buffer_deinit(lv_opengles_gl_t * ctx)
 {
-    if(vertex_buffer_id == 0) return;
-    GL_CALL(glDeleteBuffers(1, &vertex_buffer_id));
-    vertex_buffer_id = 0;
+    if(ctx->vertex_buffer_id == 0) return;
+    GL_CALL(glDeleteBuffers(1, &ctx->vertex_buffer_id));
+    ctx->vertex_buffer_id = 0;
 }
 
-static void lv_opengles_vertex_buffer_bind(void)
+static void lv_opengles_vertex_buffer_bind(lv_opengles_gl_t * ctx)
 {
-    GL_CALL(glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer_id));
+    GL_CALL(glBindBuffer(GL_ARRAY_BUFFER, ctx->vertex_buffer_id));
 }
 
 static void lv_opengles_vertex_buffer_unbind(void)
@@ -455,21 +505,21 @@ static void lv_opengles_vertex_buffer_unbind(void)
     GL_CALL(glBindBuffer(GL_ARRAY_BUFFER, 0));
 }
 
-static void lv_opengles_vertex_array_init(void)
+static void lv_opengles_vertex_array_init(lv_opengles_gl_t * ctx)
 {
-    if(vertex_array_id == 0) GL_CALL(glGenVertexArrays(1, &vertex_array_id));
+    if(ctx->vertex_array_id == 0) GL_CALL(glGenVertexArrays(1, &ctx->vertex_array_id));
 }
 
-static void lv_opengles_vertex_array_deinit(void)
+static void lv_opengles_vertex_array_deinit(lv_opengles_gl_t * ctx)
 {
-    if(vertex_array_id == 0) return;
-    GL_CALL(glDeleteVertexArrays(1, &vertex_array_id));
-    vertex_array_id = 0;
+    if(ctx->vertex_array_id == 0) return;
+    GL_CALL(glDeleteVertexArrays(1, &ctx->vertex_array_id));
+    ctx->vertex_array_id = 0;
 }
 
-static void lv_opengles_vertex_array_bind(void)
+static void lv_opengles_vertex_array_bind(lv_opengles_gl_t * ctx)
 {
-    GL_CALL(glBindVertexArray(vertex_array_id));
+    GL_CALL(glBindVertexArray(ctx->vertex_array_id));
 }
 
 static void lv_opengles_vertex_array_unbind(void)
@@ -477,44 +527,48 @@ static void lv_opengles_vertex_array_unbind(void)
     GL_CALL(glBindVertexArray(0));
 }
 
-static void lv_opengles_vertex_array_add_buffer(void)
+static void lv_opengles_vertex_array_add_buffer(lv_opengles_gl_t * ctx)
 {
-    lv_opengles_vertex_buffer_bind();
+    lv_opengles_vertex_buffer_bind(ctx);
     intptr_t offset = 0;
 
     for(unsigned int i = 0; i < 2; i++) {
-        lv_opengles_vertex_array_bind();
+        lv_opengles_vertex_array_bind(ctx);
         GL_CALL(glEnableVertexAttribArray(i));
         GL_CALL(glVertexAttribPointer(i, 2, GL_FLOAT, GL_FALSE, 16, (const void *)offset));
         offset += 2 * 4;
     }
 }
 
-static void lv_opengles_index_buffer_init(const unsigned int * data, unsigned int count)
+static void lv_opengles_index_buffer_init(lv_opengles_gl_t * ctx, const unsigned int * data,
+                                          unsigned int count)
 {
-    index_buffer_count = count;
-    if(index_buffer_id == 0) GL_CALL(glGenBuffers(1, &index_buffer_id));
+    LV_ASSERT_NULL(ctx);
+    ctx->index_buffer_count = count;
+    if(ctx->index_buffer_id == 0) GL_CALL(glGenBuffers(1, &ctx->index_buffer_id));
 
-    GL_CALL(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, index_buffer_id));
+    GL_CALL(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ctx->index_buffer_id));
 
     GL_CALL(glBufferData(GL_ELEMENT_ARRAY_BUFFER, count * sizeof(GLuint), data, GL_STATIC_DRAW));
 }
 
-static void lv_opengles_index_buffer_deinit(void)
+static void lv_opengles_index_buffer_deinit(lv_opengles_gl_t * ctx)
 {
-    if(index_buffer_id == 0) return;
-    GL_CALL(glDeleteBuffers(1, &index_buffer_id));
-    index_buffer_id = 0;
+    LV_ASSERT_NULL(ctx);
+    if(ctx->index_buffer_id == 0) return;
+    GL_CALL(glDeleteBuffers(1, &ctx->index_buffer_id));
+    ctx->index_buffer_id = 0;
 }
 
-static unsigned int lv_opengles_index_buffer_get_count(void)
+static unsigned int lv_opengles_index_buffer_get_count(lv_opengles_gl_t * ctx)
 {
-    return index_buffer_count;
+    return ctx->index_buffer_count;
 }
 
-static void lv_opengles_index_buffer_bind(void)
+static void lv_opengles_index_buffer_bind(lv_opengles_gl_t * ctx)
 {
-    GL_CALL(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, index_buffer_id));
+    LV_ASSERT_NULL(ctx);
+    GL_CALL(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ctx->index_buffer_id));
 }
 
 static void lv_opengles_index_buffer_unbind(void)
@@ -551,26 +605,29 @@ static unsigned int lv_opengles_shader_manager_init(void)
     return 0;
 }
 
-static lv_result_t lv_opengles_shader_init(void)
+static lv_result_t lv_opengles_shader_init(lv_opengles_gl_t * ctx)
 {
-    if(shader_id != 0) {
+    LV_ASSERT_NULL(ctx);
+    if(ctx->shader_id != 0) {
         return LV_RESULT_OK;
     }
-    shader_id = lv_opengles_shader_manager_init();
-    return shader_id != 0 ? LV_RESULT_OK : LV_RESULT_INVALID;
+    ctx->shader_id = lv_opengles_shader_manager_init();
+    return ctx->shader_id != 0 ? LV_RESULT_OK : LV_RESULT_INVALID;
 }
 
-static void lv_opengles_shader_deinit(void)
+static void lv_opengles_shader_deinit(lv_opengles_gl_t * ctx)
 {
-    if(shader_id == 0) return;
+    LV_ASSERT_NULL(ctx);
+    if(ctx->shader_id == 0) return;
     /* The program is part of the manager and as such will be destroyed inside */
     lv_opengl_shader_manager_deinit(&shader_manager);
-    shader_id = 0;
+    ctx->shader_id = 0;
 }
 
-static void lv_opengles_shader_bind(void)
+static void lv_opengles_shader_bind(lv_opengles_gl_t * ctx)
 {
-    GL_CALL(glUseProgram(shader_id));
+    LV_ASSERT_NULL(ctx);
+    GL_CALL(glUseProgram(ctx->shader_id));
 }
 
 static void lv_opengles_shader_unbind(void)
@@ -578,10 +635,12 @@ static void lv_opengles_shader_unbind(void)
     GL_CALL(glUseProgram(0));
 }
 
-static int lv_opengles_shader_get_uniform_location(const char * name)
+static int lv_opengles_shader_get_uniform_location(lv_opengles_gl_t * ctx, const char * name)
 {
+    LV_ASSERT_NULL(ctx);
     int id = -1;
-    for(size_t i = 0; i < sizeof(shader_location) / sizeof(int); i++) {
+    const size_t shader_name_count = sizeof(shader_names) / sizeof(shader_names[0]);
+    for(size_t i = 0; i < shader_name_count; i++) {
         if(lv_strcmp(shader_names[i], name) == 0) {
             id = i;
         }
@@ -589,58 +648,61 @@ static int lv_opengles_shader_get_uniform_location(const char * name)
 
     LV_ASSERT_FORMAT_MSG(id > -1, "Uniform location doesn't exist for '%s'. Check `shader_location` array", name);
 
-    if(shader_location[id] != 0) {
-        return shader_location[id];
+    if(ctx->shader_location[id] != 0) {
+        return ctx->shader_location[id];
     }
 
     int location;
-    GL_CALL(location = glGetUniformLocation(shader_id, name));
+    GL_CALL(location = glGetUniformLocation(ctx->shader_id, name));
     if(location == -1)
         LV_LOG_WARN("Warning: uniform '%s' doesn't exist!", name);
 
-    shader_location[id] = location;
+    ctx->shader_location[id] = location;
     return location;
 }
 
-static void lv_opengles_shader_set_uniform1i(const char * name, int value)
+static void lv_opengles_shader_set_uniform1i(lv_opengles_gl_t * ctx, const char * name, int value)
 {
     LV_PROFILER_DRAW_BEGIN;
-    GL_CALL(glUniform1i(lv_opengles_shader_get_uniform_location(name), value));
+    GL_CALL(glUniform1i(lv_opengles_shader_get_uniform_location(ctx, name), value));
     LV_PROFILER_DRAW_END;
 }
 
-static void lv_opengles_shader_set_uniformmatrix3fv(const char * name, int count, const float * values)
+static void lv_opengles_shader_set_uniformmatrix3fv(lv_opengles_gl_t * ctx, const char * name, int count,
+                                                    const float * values)
 {
     LV_PROFILER_DRAW_BEGIN;
     /*
      * GLES2.0 doesn't support transposing the matrix via glUniformMatrix3fv so this is the transposed matrix
      * https://registry.khronos.org/OpenGL/specs/es/2.0/es_full_spec_2.0.pdf page 47
      */
-    GL_CALL(glUniformMatrix3fv(lv_opengles_shader_get_uniform_location(name), count, GL_FALSE, values));
+    GL_CALL(glUniformMatrix3fv(lv_opengles_shader_get_uniform_location(ctx, name), count, GL_FALSE, values));
     LV_PROFILER_DRAW_END;
 }
 
-static void lv_opengles_shader_set_uniform1f(const char * name, float value)
+static void lv_opengles_shader_set_uniform1f(lv_opengles_gl_t * ctx, const char * name, float value)
 {
     LV_PROFILER_DRAW_BEGIN;
-    GL_CALL(glUniform1f(lv_opengles_shader_get_uniform_location(name), value));
+    GL_CALL(glUniform1f(lv_opengles_shader_get_uniform_location(ctx, name), value));
     LV_PROFILER_DRAW_END;
 }
 
-static void lv_opengles_shader_set_uniform3f(const char * name, float value_0, float value_1, float value_2)
+static void lv_opengles_shader_set_uniform3f(lv_opengles_gl_t * ctx, const char * name, float value_0,
+                                             float value_1, float value_2)
 {
     LV_PROFILER_DRAW_BEGIN;
-    GL_CALL(glUniform3f(lv_opengles_shader_get_uniform_location(name), value_0, value_1, value_2));
+    GL_CALL(glUniform3f(lv_opengles_shader_get_uniform_location(ctx, name), value_0, value_1, value_2));
     LV_PROFILER_DRAW_END;
 }
 
-static void lv_opengles_render_draw(void)
+static void lv_opengles_render_draw(lv_opengles_gl_t * ctx)
 {
     LV_PROFILER_DRAW_BEGIN;
-    lv_opengles_shader_bind();
-    lv_opengles_vertex_array_bind();
-    lv_opengles_index_buffer_bind();
-    unsigned int count = lv_opengles_index_buffer_get_count();
+    LV_ASSERT_NULL(ctx);
+    lv_opengles_shader_bind(ctx);
+    lv_opengles_vertex_array_bind(ctx);
+    lv_opengles_index_buffer_bind(ctx);
+    unsigned int count = lv_opengles_index_buffer_get_count(ctx);
     GL_CALL(glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_INT, NULL));
     LV_PROFILER_DRAW_END;
 }

--- a/src/drivers/opengles/lv_opengles_driver.h
+++ b/src/drivers/opengles/lv_opengles_driver.h
@@ -28,21 +28,36 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
+typedef struct _lv_opengles_gl_t lv_opengles_gl_t;
+
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
 
 /**
  * Initialize OpenGL
- * @note    it is not necessary to call this if you use `lv_opengles_glfw_window_create`
  */
 void lv_opengles_init(void);
 
 /**
  * Deinitialize OpenGL
- * @note    it is not necessary to call this if you use `lv_opengles_glfw_window_create`
  */
 void lv_opengles_deinit(void);
+
+/**
+ * Binds a new OpenGL context
+ */
+void lv_opengles_context_bind(lv_opengles_gl_t * ctx);
+
+/**
+ * Create an OpenGL context
+ */
+lv_opengles_gl_t * lv_opengles_context_create(void);
+
+/**
+ * Delete an OpenGL context
+ */
+void lv_opengles_context_delete(lv_opengles_gl_t * ctx);
 
 /**
  * Render a texture using alternate blending mode for smoother translucent materials and correct anti-aliasing of glTF elements when using transparent background
@@ -54,7 +69,8 @@ void lv_opengles_deinit(void);
  * @param h_flip         horizontal flip
  * @param v_flip         vertical flip
  */
-void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa, int32_t disp_w,
+void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_area,
+                                lv_opa_t opa, int32_t disp_w,
                                 int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip);
 
 /**
@@ -63,7 +79,8 @@ void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_
  * @param h_flip            horizontal flip
  * @param v_flip            vertical flip
  */
-void lv_opengles_render_display_texture(lv_display_t * display, bool h_flip, bool v_flip);
+void lv_opengles_render_display_texture(lv_display_t * display, bool h_flip,
+                                        bool v_flip);
 
 /**
  * Render a fill
@@ -73,7 +90,8 @@ void lv_opengles_render_display_texture(lv_display_t * display, bool h_flip, boo
  * @param disp_w         width of the window/framebuffer being rendered to
  * @param disp_h         height of the window/framebuffer being rendered to
  */
-void lv_opengles_render_fill(lv_color_t color, const lv_area_t * area, lv_opa_t opa, int32_t disp_w, int32_t disp_h);
+void lv_opengles_render_fill(lv_color_t color, const lv_area_t * area, lv_opa_t opa,
+                             int32_t disp_w, int32_t disp_h);
 
 /**
  * Clear the window/display

--- a/src/drivers/opengles/lv_opengles_egl.c
+++ b/src/drivers/opengles/lv_opengles_egl.c
@@ -78,7 +78,6 @@ lv_opengles_egl_t * lv_opengles_egl_context_create(const lv_egl_interface_t * in
         lv_free(ctx);
         return NULL;
     }
-    lv_opengles_init();
     return ctx;
 }
 
@@ -134,6 +133,17 @@ void lv_opengles_egl_update(lv_opengles_egl_t * ctx)
     ctx->interface.flip_cb(ctx->interface.driver_data, ctx->vsync);
 }
 
+lv_result_t lv_opengles_egl_context_make_current(lv_opengles_egl_t * ctx)
+{
+    bool res = eglMakeCurrent(ctx->egl_display, ctx->egl_surface, ctx->egl_surface,
+                              ctx->egl_context);
+    if(!res) {
+        return LV_RESULT_INVALID;
+    }
+    lv_opengles_context_bind(ctx->gl_ctx);
+    return LV_RESULT_OK;
+}
+
 
 /**********************
 *   STATIC FUNCTIONS
@@ -170,7 +180,11 @@ static lv_result_t load_egl(lv_opengles_egl_t * ctx)
         goto err;
     }
 
-    ctx->egl_display = create_egl_display(ctx);
+    static EGLDisplay egl_display = 0;
+    if(!egl_display) {
+        egl_display = create_egl_display(ctx);
+    }
+    ctx->egl_display = egl_display;
     if(!ctx->egl_display) {
         LV_LOG_ERROR("Failed to create egl display");
         goto egl_display_err;
@@ -229,9 +243,15 @@ static lv_result_t load_egl(lv_opengles_egl_t * ctx)
         LV_LOG_ERROR("Failed to load load OpenGL entry points");
         goto load_opengl_functions_err;
     }
+    ctx->gl_ctx = lv_opengles_context_create();
+    if(!ctx->gl_ctx) {
+        LV_LOG_ERROR("Failed to create an OpenGL context");
+        goto gl_context_err;
+    }
 
     return LV_RESULT_OK;
 
+gl_context_err:
 load_opengl_functions_err:
     eglMakeCurrent(ctx->egl_display, NULL, NULL, NULL);
     eglDestroyContext(ctx->egl_display, ctx->egl_context);
@@ -451,8 +471,9 @@ static EGLContext create_egl_context(lv_opengles_egl_t * ctx)
         EGL_CONTEXT_CLIENT_VERSION, 2,
         EGL_NONE
     };
+    EGLContext context = ctx->interface.share_context ? ctx->interface.share_context->egl_context : EGL_NO_CONTEXT;
     return eglCreateContext(ctx->egl_display, ctx->egl_config,
-                            EGL_NO_CONTEXT, context_attribs);
+                            context, context_attribs);
 }
 
 lv_color_format_t lv_opengles_egl_color_format_from_egl_config(const lv_egl_config_t * config)

--- a/src/drivers/opengles/lv_opengles_egl.h
+++ b/src/drivers/opengles/lv_opengles_egl.h
@@ -40,6 +40,8 @@ typedef struct _lv_egl_config lv_egl_config_t;
 lv_opengles_egl_t * lv_opengles_egl_context_create(const lv_egl_interface_t * interface);
 lv_color_format_t lv_opengles_egl_color_format_from_egl_config(const lv_egl_config_t * config);
 
+lv_result_t lv_opengles_egl_context_make_current(lv_opengles_egl_t * ctx);
+
 void lv_opengles_egl_update(lv_opengles_egl_t * ctx);
 void lv_opengles_egl_clear(lv_opengles_egl_t * ctx);
 void lv_opengles_egl_context_destroy(lv_opengles_egl_t * ctx);

--- a/src/drivers/opengles/lv_opengles_egl_private.h
+++ b/src/drivers/opengles/lv_opengles_egl_private.h
@@ -70,6 +70,7 @@ struct _lv_egl_interface {
     lv_create_window_t create_window_cb;
     lv_destroy_window_t destroy_window_cb;
     lv_egl_flip_t flip_cb;
+    lv_opengles_egl_t * share_context;
 };
 
 
@@ -81,6 +82,7 @@ struct _lv_opengles_egl {
     EGLSurface egl_surface;
     void * egl_lib_handle;
     void * opengl_lib_handle;
+    lv_opengles_gl_t * gl_ctx;
     lv_egl_interface_t interface;
     int32_t width;
     int32_t height;

--- a/src/drivers/opengles/lv_opengles_private.h
+++ b/src/drivers/opengles/lv_opengles_private.h
@@ -20,6 +20,7 @@ extern "C" {
 
 #include "../../misc/lv_area.h"
 #include "../../misc/lv_color.h"
+#include "lv_opengles_driver.h"
 
 #if !LV_USE_MATRIX
 #error "LV_USE_OPENGLES requires LV_USE_MATRIX"
@@ -114,6 +115,8 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
+#define LV_OPENGLES_SHADER_NAMES_COUNT 10
+
 typedef struct {
     unsigned int texture;
     const lv_area_t * texture_area;
@@ -128,6 +131,15 @@ typedef struct {
     bool blend_opt;
     const lv_matrix_t * matrix;
 } lv_opengles_render_params_t;
+
+struct _lv_opengles_gl_t {
+    GLuint vertex_buffer_id;
+    GLuint vertex_array_id;
+    GLuint index_buffer_id;
+    GLuint index_buffer_count;
+    GLuint shader_id;
+    GLint shader_location[LV_OPENGLES_SHADER_NAMES_COUNT];
+};
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -155,7 +167,8 @@ void lv_opengles_render(const lv_opengles_render_params_t * params);
  * @param h_flip         horizontal flip
  * @param v_flip         vertical flip
  */
-void lv_opengles_render_texture_rbswap(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
+void lv_opengles_render_texture_rbswap(unsigned int texture,
+                                       const lv_area_t * texture_area, lv_opa_t opa,
                                        int32_t disp_w, int32_t disp_h, const lv_area_t * texture_clip_area,
                                        bool h_flip, bool v_flip);
 

--- a/src/drivers/opengles/lv_opengles_texture.c
+++ b/src/drivers/opengles/lv_opengles_texture.c
@@ -153,8 +153,14 @@ static lv_result_t lv_opengles_texture_create_draw_buffers(lv_opengles_texture_t
 
 void lv_opengles_texture_deinit(lv_opengles_texture_t * texture)
 {
+    if(!texture) {
+        return;
+    }
 #if !LV_USE_DRAW_OPENGLES
-    lv_free(texture->fb1);
+    if(texture->fb1) {
+        lv_free(texture->fb1);
+        texture->fb1 = NULL;
+    }
 #endif /*!LV_USE_DRAW_OPENGLES*/
 
     if(texture->is_texture_owner && texture->texture_id != 0) {
@@ -212,7 +218,6 @@ static lv_display_t * lv_opengles_texture_create_common(int32_t w, int32_t h)
     lv_display_set_driver_data(disp, texture);
     lv_display_add_event_cb(disp, release_disp_cb, LV_EVENT_DELETE, disp);
 
-    lv_opengles_init();
     return disp;
 }
 

--- a/src/drivers/opengles/lv_opengles_texture_private.h
+++ b/src/drivers/opengles/lv_opengles_texture_private.h
@@ -19,6 +19,7 @@ extern "C" {
 #if LV_USE_OPENGLES
 
 #include "lv_opengles_texture.h"
+#include "lv_opengles_driver.h"
 
 /*********************
  *      DEFINES

--- a/src/drivers/wayland/lv_wayland.c
+++ b/src/drivers/wayland/lv_wayland.c
@@ -125,8 +125,7 @@ lv_result_t lv_wayland_init(void)
         LV_LOG_ERROR("failed to connect to Wayland server");
         return LV_RESULT_INVALID;
     }
-
-    lv_wl_ctx.backend_data = wl_backend_ops.init();
+    lv_wayland_backend_init_all();
 
     /* Add registry listener and wait for registry reception */
     lv_wl_ctx.wl_registry = wl_display_get_registry(lv_wl_ctx.wl_display);
@@ -167,7 +166,7 @@ void lv_wayland_deinit(void)
     lv_wayland_xdg_deinit();
 
     if(is_wayland_initialized) {
-        wl_backend_ops.deinit(lv_wl_ctx.backend_data);
+        lv_wayland_backend_deinit_all();
     }
 
     if(lv_wl_ctx.seat.wl_seat) {
@@ -324,8 +323,7 @@ static void handle_global(void * data, struct wl_registry * registry, uint32_t n
             ctx->wl_output_count++;
         }
     }
-
-    wl_backend_ops.global_handler(lv_wl_ctx.backend_data, registry, name, interface, version);
+    lv_wayland_backend_global_handler(registry, name, interface, version);
 }
 
 static void handle_global_remove(void * data, struct wl_registry * registry, uint32_t name)

--- a/src/drivers/wayland/lv_wayland.h
+++ b/src/drivers/wayland/lv_wayland.h
@@ -17,11 +17,11 @@ extern "C" {
 
 #if LV_USE_WAYLAND
 
-#include "lv_wl_keyboard.h"
-#include "lv_wl_pointer.h"
-#include "lv_wl_touch.h"
-#include "lv_wl_window.h"
-#include "lv_wl_pointer_axis.h"
+#include "lv_wayland_keyboard.h"
+#include "lv_wayland_pointer.h"
+#include "lv_wayland_touch.h"
+#include "lv_wayland_window.h"
+#include "lv_wayland_pointer_axis.h"
 
 /*********************
  *      DEFINES

--- a/src/drivers/wayland/lv_wayland_backend.c
+++ b/src/drivers/wayland/lv_wayland_backend.c
@@ -1,0 +1,118 @@
+/**
+ * @file lv_wayland_backend.c
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "lv_wayland_backend_private.h"
+
+#if LV_USE_WAYLAND
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+#if LV_USE_OPENGLES
+    extern const lv_wayland_backend_ops_t wl_egl_ops;
+    extern const lv_wayland_backend_display_ops_t wl_egl_display_ops;
+#endif /*LV_USE_OPENGLES*/
+
+#if LV_USE_G2D
+    extern const lv_wayland_backend_ops_t wl_g2d_ops,
+    extern const lv_wayland_backend_display_ops_t wl_g2d_display_ops;
+#endif /*LV_USE_G2D*/
+
+extern const lv_wayland_backend_ops_t wl_shm_ops;
+extern const lv_wayland_backend_display_ops_t wl_shm_display_ops;
+
+/**********************
+ *      MACROS
+ **********************/
+
+static struct {
+    const char * name;
+    const lv_wayland_backend_ops_t * ops;
+    const lv_wayland_backend_display_ops_t * display_ops;
+    void * backend_ctx;
+} backends[] = {
+#if LV_USE_OPENGLES
+    {"EGL", &wl_egl_ops, &wl_egl_display_ops, NULL},
+#endif /*LV_USE_OPENGLES*/
+#if LV_USE_G2D
+    {"G2D", &wl_g2d_ops, &wl_g2d_display_ops, NULL},
+#endif /*LV_USE_G2D*/
+    {"SHM", &wl_shm_ops, &wl_shm_display_ops, NULL},
+};
+
+const size_t backend_count = (sizeof(backends) / sizeof(backends[0]));
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void lv_wayland_backend_init_all(void)
+{
+    for(size_t i = 0; i < backend_count; ++i) {
+        LV_LOG_INFO("Initializing '%s' wayland backend", backends[i].name);
+        backends[i].backend_ctx = backends[i].ops->init();
+    }
+}
+
+void lv_wayland_backend_deinit_all(void)
+{
+    for(size_t i = 0; i < backend_count; ++i) {
+        LV_LOG_INFO("Deinitializing '%s' wayland backend", backends[i].name);
+        backends[i].ops->deinit(backends[i].backend_ctx);
+    }
+}
+
+void lv_wayland_backend_global_handler(struct wl_registry * registry, uint32_t name,
+                                       const char * interface, uint32_t version)
+{
+    for(size_t i = 0; i < backend_count; ++i) {
+        backends[i].ops->global_handler(backends[i].backend_ctx, registry, name, interface, version);
+    }
+}
+
+lv_result_t lv_wayland_backend_init_display(lv_wayland_backend_display_data_t * backend_ddata,
+                                            lv_display_t * display,
+                                            int32_t width,
+                                            int32_t height)
+
+{
+    for(size_t i = 0; i < backend_count; ++i) {
+        void * display_data = backends[i].display_ops->init_display(backends[i].backend_ctx, display, width, height);
+        if(!display_data) {
+            LV_LOG_INFO("Failed to initialize display for '%s' wayland backend", backends[i].name);
+            continue;
+        }
+        backend_ddata->ops = backends[i].display_ops;
+        backend_ddata->backend_ctx = backends[i].backend_ctx;
+        backend_ddata->display_data = display_data;
+        LV_LOG_INFO("Initialized display with '%s' wayland backend", backends[i].name);
+        return LV_RESULT_OK;
+    }
+    return LV_RESULT_INVALID;
+}
+
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+#endif /*LV_USE_WAYLAND*/

--- a/src/drivers/wayland/lv_wayland_backend_egl.c
+++ b/src/drivers/wayland/lv_wayland_backend_egl.c
@@ -1,4 +1,4 @@
-/** @file lv_wl_egl_backend.c
+/** @file lv_wayland_backend_egl.c
  *
  */
 

--- a/src/drivers/wayland/lv_wayland_backend_egl.c
+++ b/src/drivers/wayland/lv_wayland_backend_egl.c
@@ -26,6 +26,9 @@
  *      TYPEDEFS
  **********************/
 
+typedef struct {
+    lv_opengles_egl_t * shared_egl_ctx;
+} lv_wl_egl_ctx_t;
 
 typedef struct {
     lv_opengles_texture_t texture;
@@ -49,8 +52,9 @@ static void egl_flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * 
 static void flush_wait_cb(lv_display_t * disp);
 static void frame_done(void * data, struct wl_callback * callback, uint32_t time);
 
-static lv_wl_egl_display_data_t * egl_create_display_data(lv_display_t * display,
+static lv_wl_egl_display_data_t * egl_create_display_data(lv_wl_egl_ctx_t * ctx, lv_display_t * display,
                                                           int32_t width, int32_t height);
+
 static void egl_destroy_display_data(lv_wl_egl_display_data_t * ddata);
 
 static lv_egl_interface_t wl_egl_get_interface(lv_display_t * display);
@@ -58,6 +62,8 @@ static void * wl_egl_create_window(void * driver_data, const lv_egl_native_windo
 static void wl_egl_destroy_window(void * driver_data, void * native_window);
 static size_t wl_egl_select_config_cb(void * driver_data, const lv_egl_config_t * configs, size_t config_count);
 static void wl_egl_flip_cb(void * driver_data, bool vsync);
+
+static void refr_start_event_cb(lv_event_t * e);
 
 /**********************
  *  STATIC VARIABLES
@@ -102,15 +108,15 @@ static void frame_done(void * data, struct wl_callback * callback, uint32_t time
 
 static void * wl_egl_init(void)
 {
-    return NULL;
+    return lv_zalloc(sizeof(lv_wl_egl_ctx_t));
 }
 
 static void wl_egl_deinit(void * backend_ctx)
 {
-    LV_UNUSED(backend_ctx);
+    lv_free(backend_ctx);
 }
 
-static lv_wl_egl_display_data_t * egl_create_display_data(lv_display_t * display,
+static lv_wl_egl_display_data_t * egl_create_display_data(lv_wl_egl_ctx_t * ctx, lv_display_t * display,
                                                           int32_t width, int32_t height)
 {
     lv_wl_egl_display_data_t * ddata = lv_zalloc(sizeof(*ddata));
@@ -126,10 +132,16 @@ static lv_wl_egl_display_data_t * egl_create_display_data(lv_display_t * display
 
     /* Create EGL context */
     lv_egl_interface_t egl_interface = wl_egl_get_interface(display);
+    /* In case this is not the first display, */
+    egl_interface.share_context = ctx->shared_egl_ctx;
     ddata->egl_ctx = lv_opengles_egl_context_create(&egl_interface);
     if(!ddata->egl_ctx) {
         LV_LOG_ERROR("Failed to create EGL context");
         goto egl_ctx_err;
+    }
+
+    if(!ctx->shared_egl_ctx) {
+        ctx->shared_egl_ctx = ddata->egl_ctx;
     }
 
     /* Let the opengles texture driver handle the texture lifetime */
@@ -275,12 +287,13 @@ static void egl_flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * 
 static void * wl_egl_init_display(void * backend_ctx, lv_display_t * display, int32_t width, int32_t height)
 {
     LV_UNUSED(backend_ctx);
-    lv_wl_egl_display_data_t * ddata = egl_create_display_data(display, width, height);
+    lv_wl_egl_display_data_t * ddata = egl_create_display_data(backend_ctx, display, width, height);
     if(!ddata) {
         LV_LOG_ERROR("Failed to create display data");
         return NULL;
     }
 
+    lv_display_add_event_cb(display, refr_start_event_cb, LV_EVENT_REFR_START, ddata);
     lv_display_set_flush_cb(display, egl_flush_cb);
     lv_display_set_flush_wait_cb(display, flush_wait_cb);
     lv_display_set_render_mode(display, LV_USE_DRAW_NANOVG ? LV_DISPLAY_RENDER_MODE_FULL : LV_DISPLAY_RENDER_MODE_DIRECT);
@@ -421,6 +434,16 @@ static void wl_egl_flip_cb(void * driver_data, bool vsync)
 
     /* For Wayland, buffer swapping is handled by the compositor
      * through wl_surface_commit() which is called in the flush callback */
+}
+
+static void refr_start_event_cb(lv_event_t * e)
+{
+    lv_wl_egl_display_data_t * ddata = lv_event_get_user_data(e);
+    LV_ASSERT_NULL(ddata);
+    lv_result_t res = lv_opengles_egl_context_make_current(ddata->egl_ctx);
+    if(res != LV_RESULT_OK) {
+        LV_LOG_ERROR("Failed to bind egl context to refreshing display");
+    }
 }
 
 #endif /*LV_USE_WAYLAND && LV_USE_OPENGLES*/

--- a/src/drivers/wayland/lv_wayland_backend_egl.c
+++ b/src/drivers/wayland/lv_wayland_backend_egl.c
@@ -8,7 +8,7 @@
 
 #include "lv_wayland_private.h"
 
-#if LV_WAYLAND_USE_EGL
+#if LV_USE_WAYLAND && LV_USE_OPENGLES
 
 #include "../../display/lv_display_private.h"
 #include "../opengles/lv_opengles_driver.h"
@@ -68,10 +68,13 @@ static const struct wl_callback_listener frame_listener = {
     .done = frame_done,
 };
 
-const lv_wayland_backend_ops_t wl_backend_ops = {
+const lv_wayland_backend_ops_t wl_egl_ops = {
     .init = wl_egl_init,
     .deinit = wl_egl_deinit,
     .global_handler = wl_egl_global_handler,
+};
+
+const lv_wayland_backend_display_ops_t wl_egl_display_ops = {
     .init_display = wl_egl_init_display,
     .deinit_display = wl_egl_deinit_display,
     .resize_display = wl_egl_resize_display,
@@ -420,4 +423,4 @@ static void wl_egl_flip_cb(void * driver_data, bool vsync)
      * through wl_surface_commit() which is called in the flush callback */
 }
 
-#endif /*LV_WAYLAND_USE_EGL*/
+#endif /*LV_USE_WAYLAND && LV_USE_OPENGLES*/

--- a/src/drivers/wayland/lv_wayland_backend_g2d.c
+++ b/src/drivers/wayland/lv_wayland_backend_g2d.c
@@ -1,6 +1,5 @@
-
 /**
- * @file lv_wl_g2d_backend.c
+ * @file lv_wayland_backend_g2d.c
  *
  */
 

--- a/src/drivers/wayland/lv_wayland_backend_g2d.c
+++ b/src/drivers/wayland/lv_wayland_backend_g2d.c
@@ -10,7 +10,7 @@
 
 #include "lv_wayland_private.h"
 
-#if LV_WAYLAND_USE_G2D
+#if LV_USE_WAYLAND && LV_USE_G2D
 
 #include "../../display/lv_display_private.h"
 #include <wayland_linux_dmabuf.h>
@@ -121,10 +121,13 @@ static lv_wl_buffer_t * get_next_buffer(lv_wl_g2d_display_data_t * ddata);
 
 static lv_wl_g2d_ctx_t ctx;
 
-const lv_wayland_backend_ops_t wl_backend_ops = {
+const lv_wayland_backend_ops_t wl_g2d_ops = {
     .init = wl_g2d_init,
     .deinit = wl_g2d_deinit,
     .global_handler = wl_g2d_global_handler,
+};
+
+const lv_wayland_backend_display_ops_t wl_g2d_display_ops = {
     .init_display =   wl_g2d_init_display,
     .deinit_display = wl_g2d_deinit_display,
     .resize_display = wl_g2d_resize_display,
@@ -644,4 +647,4 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, unsigned char 
     return;
 }
 
-#endif /*LV_USE_WAYLAND_G2D*/
+#endif /*LV_USE_WAYLAND && LV_USE_G2D*/

--- a/src/drivers/wayland/lv_wayland_backend_private.h
+++ b/src/drivers/wayland/lv_wayland_backend_private.h
@@ -1,10 +1,10 @@
 /**
- * @file lv_wl_backend_private.h
+ * @file lv_wayland_backend_private.h
  *
  */
 
-#ifndef LV_WL_BACKEND_PRIVATE_H
-#define LV_WL_BACKEND_PRIVATE_H
+#ifndef LV_WAYLAND_BACKEND_PRIVATE_H
+#define LV_WAYLAND_BACKEND_PRIVATE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -214,4 +214,4 @@ struct wl_surface * lv_wayland_get_window_surface(lv_display_t * display);
 } /*extern "C"*/
 #endif
 
-#endif /*LV_WL_BACKEND_PRIVATE_H*/
+#endif /*LV_WAYLAND_BACKEND_PRIVATE_H*/

--- a/src/drivers/wayland/lv_wayland_backend_private.h
+++ b/src/drivers/wayland/lv_wayland_backend_private.h
@@ -136,27 +136,74 @@ typedef void (*lv_wayland_backend_global_handler_t)(void * backend_ctx, struct w
  * @struct lv_wayland_backend_ops_t
  * @brief Wayland backend operations structure
  *
- * This structure defines the complete set of operations that a Wayland backend
+ * This structure defines the general set of operations that a Wayland backend
  * must implement. All function pointers must be non-NULL.
  *
  * @par Lifecycle Order:
  * 1. init() - Initialize backend context
  * 2. global_handler() - Called for each Wayland global (may be called multiple times)
- * 3. init_display() - Create display (may be called multiple times for multiple displays)
- * 4. resize_display() - Resize display (called as needed)
- * 5. deinit_display() - Destroy display (called once per display)
- * 6. deinit() - Clean up backend context
+ * 3. deinit() - Clean up backend context
  */
 typedef struct {
     lv_wayland_backend_init_t init;                         /**< Initialize backend context */
     lv_wayland_backend_global_handler_t global_handler;     /**< Handle Wayland global objects */
-    lv_wayland_backend_init_display_t init_display;         /**< Initialize a new display */
-    lv_wayland_backend_resize_display_t resize_display;     /**< Resize or reconfigure display */
-    lv_wayland_backend_destroy_display_t deinit_display;    /**< Destroy a display */
     lv_wayland_backend_deinit_t deinit;                     /**< Deinitialize backend context */
 } lv_wayland_backend_ops_t;
 
-extern const lv_wayland_backend_ops_t wl_backend_ops;
+/**
+ * @struct lv_wayland_backend_display_ops_t
+ * @brief Wayland backend display operations structure
+ *
+ * This structure defines the display specific set of operations that a Wayland backend
+ * must implement. All function pointers must be non-NULL.
+ *
+ * @par Lifecycle Order:
+ * 1. init_display() - Create display (may be called multiple times for multiple displays)
+ * 2. resize_display() - Resize display (called as needed)
+ * 3. deinit_display() - Destroy display (called once per display)
+ */
+typedef struct {
+    lv_wayland_backend_init_display_t init_display;         /**< Initialize a new display */
+    lv_wayland_backend_resize_display_t resize_display;     /**< Resize or reconfigure display */
+    lv_wayland_backend_destroy_display_t deinit_display;    /**< Destroy a display */
+} lv_wayland_backend_display_ops_t;
+
+
+typedef struct {
+    const lv_wayland_backend_display_ops_t * ops;    /**< Backend display specific operations */
+    void * backend_ctx;                              /**< General backend context */
+    void * display_data;                             /**< Specific display backend data */
+} lv_wayland_backend_display_data_t;
+
+/* @brief Initializes all backends
+ *
+ */
+void lv_wayland_backend_init_all(void);
+
+/* @brief Deinitializes all backends
+ *
+ */
+void lv_wayland_backend_deinit_all(void);
+
+/* @brief Deinitializes all backends
+ *
+ */
+void lv_wayland_backend_global_handler(struct wl_registry * registry, uint32_t name,
+                                       const char * interface, uint32_t version);
+
+/* @brief Loops through all available backends to find one capable of initializing a display
+ *
+ * The function loops through all available backends until it can initialize a display
+ *
+ * @return Pointer to the initialize backend operations or NULL if no backend could be probed
+ *
+ * @note this function does not initialize the backend itself
+ * */
+
+lv_result_t lv_wayland_backend_init_display(lv_wayland_backend_display_data_t * backend_ddata,
+                                            lv_display_t * display,
+                                            int32_t width,
+                                            int32_t height);
 
 /** @brief Get the backend-specific display data
  *

--- a/src/drivers/wayland/lv_wayland_backend_private.h
+++ b/src/drivers/wayland/lv_wayland_backend_private.h
@@ -185,7 +185,7 @@ void lv_wayland_backend_init_all(void);
  */
 void lv_wayland_backend_deinit_all(void);
 
-/* @brief Deinitializes all backends
+/* @brief Dispatches a global handler call to all available backends
  *
  */
 void lv_wayland_backend_global_handler(struct wl_registry * registry, uint32_t name,
@@ -193,13 +193,14 @@ void lv_wayland_backend_global_handler(struct wl_registry * registry, uint32_t n
 
 /* @brief Loops through all available backends to find one capable of initializing a display
  *
- * The function loops through all available backends until it can initialize a display
+ * The function loops through all available backends until one can initialize a display
  *
- * @return Pointer to the initialize backend operations or NULL if no backend could be probed
- *
- * @note this function does not initialize the backend itself
- * */
-
+ * @param backend_ddata[out] Backend display data
+ * @param display[in] The display to initialize for
+ * @param width[in] the display width
+ * @param height[in] the display height
+ * @return LV_RESULT_OK if the display was initialized else LV_RESULT_INVALID
+ */
 lv_result_t lv_wayland_backend_init_display(lv_wayland_backend_display_data_t * backend_ddata,
                                             lv_display_t * display,
                                             int32_t width,

--- a/src/drivers/wayland/lv_wayland_backend_shm.c
+++ b/src/drivers/wayland/lv_wayland_backend_shm.c
@@ -1,5 +1,5 @@
 /**
- * @file lv_wl_shm_backend.c
+ * @file lv_wayland_backend_shm.c
  *
  */
 

--- a/src/drivers/wayland/lv_wayland_backend_shm.c
+++ b/src/drivers/wayland/lv_wayland_backend_shm.c
@@ -9,7 +9,7 @@
 
 #include "lv_wayland_private.h"
 
-#if LV_WAYLAND_USE_SHM
+#if LV_USE_WAYLAND
 
 #include "../../draw/sw/lv_draw_sw_utils.h"
 #include "../../display/lv_display_private.h"
@@ -87,10 +87,13 @@ static const struct wl_buffer_listener buffer_listener = {
     .release = buffer_release
 };
 
-const lv_wayland_backend_ops_t wl_backend_ops = {
+const lv_wayland_backend_ops_t wl_shm_ops = {
     .init = shm_init,
     .deinit = shm_deinit,
     .global_handler = shm_global_handler,
+};
+
+const lv_wayland_backend_display_ops_t wl_shm_display_ops = {
     .init_display = shm_init_display,
     .deinit_display = shm_deinit_display,
     .resize_display = shm_resize_display,
@@ -454,4 +457,4 @@ static void shm_flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * 
     ddata->curr_wl_buffer_idx = (ddata->curr_wl_buffer_idx + 1) % LV_WL_SHM_BUF_COUNT;
 }
 
-#endif /*LV_WAYLAND_USE_SHM*/
+#endif /*LV_USE_WAYLAND*/

--- a/src/drivers/wayland/lv_wayland_keyboard.c
+++ b/src/drivers/wayland/lv_wayland_keyboard.c
@@ -1,9 +1,9 @@
 /**
- * @file lv_wl_keyboard.c
+ * @file lv_wayland_keyboard.c
  *
  */
 
-#include "lv_wl_keyboard.h"
+#include "lv_wayland_keyboard.h"
 
 #if LV_USE_WAYLAND
 

--- a/src/drivers/wayland/lv_wayland_keyboard.h
+++ b/src/drivers/wayland/lv_wayland_keyboard.h
@@ -1,12 +1,10 @@
-
-
 /**
- * @file lv_wl_touch.h
+ * @file lv_wayland_keyboard.h
  *
  */
 
-#ifndef LV_WL_TOUCH_H
-#define LV_WL_TOUCH_H
+#ifndef LV_WAYLAND_KEYBOARD_H
+#define LV_WAYLAND_KEYBOARD_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,14 +30,14 @@ extern "C" {
  * GLOBAL PROTOTYPES
  **********************/
 
-lv_indev_t * lv_wayland_touch_create(void);
+lv_indev_t * lv_wayland_keyboard_create(void);
 
 /**
- * Get touchscreen input device for given LVGL display
+ * Get keyboard input device for given LVGL display
  * @param display LVGL display
- * @return input device connected to touchscreen, or NULL on error
+ * @return input device connected to keyboard, or NULL on error
  */
-lv_indev_t * lv_wayland_get_touchscreen(lv_display_t * display);
+lv_indev_t * lv_wayland_get_keyboard(lv_display_t * display);
 
 /**********************
  *      MACROS
@@ -51,4 +49,4 @@ lv_indev_t * lv_wayland_get_touchscreen(lv_display_t * display);
 } /*extern "C"*/
 #endif
 
-#endif /*LV_WL_TOUCH_H*/
+#endif /*LV_WAYLAND_KEYBOARD_H*/

--- a/src/drivers/wayland/lv_wayland_pointer.c
+++ b/src/drivers/wayland/lv_wayland_pointer.c
@@ -1,9 +1,9 @@
 /**
- * @file lv_wl_pointer.c
+ * @file lv_wayland_pointer.c
  *
  */
 
-#include "lv_wl_pointer.h"
+#include "lv_wayland_pointer.h"
 
 #if LV_USE_WAYLAND
 

--- a/src/drivers/wayland/lv_wayland_pointer.h
+++ b/src/drivers/wayland/lv_wayland_pointer.h
@@ -1,10 +1,11 @@
+
 /**
- * @file lv_wl_keyboard.h
+ * @file lv_wayland_pointer.h
  *
  */
 
-#ifndef LV_WL_KEYBOARD_H
-#define LV_WL_KEYBOARD_H
+#ifndef LV_WAYLAND_POINTER_H
+#define LV_WAYLAND_POINTER_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,14 +31,15 @@ extern "C" {
  * GLOBAL PROTOTYPES
  **********************/
 
-lv_indev_t * lv_wayland_keyboard_create(void);
+lv_indev_t * lv_wayland_pointer_create(void);
 
 /**
- * Get keyboard input device for given LVGL display
- * @param display LVGL display
- * @return input device connected to keyboard, or NULL on error
+ * Obtains the input device of the mouse pointer
+ * @note It is used to create an input group on application start
+ * @param disp Reference to the LVGL display associated to the window
+ * @return The input device
  */
-lv_indev_t * lv_wayland_get_keyboard(lv_display_t * display);
+lv_indev_t * lv_wayland_get_pointer(lv_display_t * disp);
 
 /**********************
  *      MACROS
@@ -49,4 +51,4 @@ lv_indev_t * lv_wayland_get_keyboard(lv_display_t * display);
 } /*extern "C"*/
 #endif
 
-#endif /*LV_WL_KEYBOARD_H*/
+#endif /*LV_WAYLAND_POINTER_H*/

--- a/src/drivers/wayland/lv_wayland_pointer_axis.h
+++ b/src/drivers/wayland/lv_wayland_pointer_axis.h
@@ -1,10 +1,10 @@
 /**
- * @file lv_wl_pointer_axis.h
+ * @file lv_wayland_pointer_axis.h
  *
  */
 
-#ifndef LV_WL_POINTER_AXIS_H
-#define LV_WL_POINTER_AXIS_H
+#ifndef LV_WAYLAND_POINTER_AXIS_H
+#define LV_WAYLAND_POINTER_AXIS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -51,4 +51,4 @@ lv_indev_t * lv_wayland_get_pointeraxis(lv_display_t * display);
 } /*extern "C"*/
 #endif
 
-#endif /*LV_WL_POINTER_AXIS_H*/
+#endif /*LV_WAYLAND_POINTER_AXIS_H*/

--- a/src/drivers/wayland/lv_wayland_private.h
+++ b/src/drivers/wayland/lv_wayland_private.h
@@ -23,7 +23,7 @@ extern "C" {
 #include <wayland-client-protocol.h>
 #include <wayland_xdg_shell.h>
 #include "../../misc/lv_types.h"
-#include "lv_wl_backend_private.h"
+#include "lv_wayland_backend_private.h"
 
 /*********************
  *      DEFINES

--- a/src/drivers/wayland/lv_wayland_private.h
+++ b/src/drivers/wayland/lv_wayland_private.h
@@ -99,7 +99,6 @@ typedef struct {
     struct wl_shm * wl_shm;
     lv_wl_seat_t seat;
 
-    void * backend_data;
     lv_wl_output_info_t physical_outputs[LV_WAYLAND_MAX_OUTPUTS];
     uint8_t wl_output_count;
 
@@ -126,12 +125,12 @@ typedef struct {
 
 
 typedef struct _lv_wl_window_t {
-    void * backend_display_data;
     lv_display_t * lv_disp;
     lv_indev_t * lv_indev_pointer;
     lv_indev_t * lv_indev_pointeraxis;
     lv_indev_t * lv_indev_touch;
     lv_indev_t * lv_indev_keyboard;
+    lv_wayland_backend_display_data_t backend_ddata;
     lv_wayland_display_close_cb_t close_cb;
     lv_wl_window_xdg_t xdg;
 

--- a/src/drivers/wayland/lv_wayland_seat.c
+++ b/src/drivers/wayland/lv_wayland_seat.c
@@ -1,5 +1,5 @@
 /**
- * @file lv_wl_seat.c
+ * @file lv_wayland_seat.c
  *
  */
 

--- a/src/drivers/wayland/lv_wayland_touch.c
+++ b/src/drivers/wayland/lv_wayland_touch.c
@@ -1,9 +1,9 @@
 /**
- * @file lv_wl_touch.c
+ * @file lv_wayland_touch.c
  *
  */
 
-#include "lv_wl_touch.h"
+#include "lv_wayland_touch.h"
 
 #if LV_USE_WAYLAND
 

--- a/src/drivers/wayland/lv_wayland_touch.h
+++ b/src/drivers/wayland/lv_wayland_touch.h
@@ -1,11 +1,10 @@
-
 /**
- * @file lv_wl_pointer.h
+ * @file lv_wayland_touch.h
  *
  */
 
-#ifndef LV_WL_POINTER_H
-#define LV_WL_POINTER_H
+#ifndef LV_WAYLAND_TOUCH_H
+#define LV_WAYLAND_TOUCH_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,15 +30,14 @@ extern "C" {
  * GLOBAL PROTOTYPES
  **********************/
 
-lv_indev_t * lv_wayland_pointer_create(void);
+lv_indev_t * lv_wayland_touch_create(void);
 
 /**
- * Obtains the input device of the mouse pointer
- * @note It is used to create an input group on application start
- * @param disp Reference to the LVGL display associated to the window
- * @return The input device
+ * Get touchscreen input device for given LVGL display
+ * @param display LVGL display
+ * @return input device connected to touchscreen, or NULL on error
  */
-lv_indev_t * lv_wayland_get_pointer(lv_display_t * disp);
+lv_indev_t * lv_wayland_get_touchscreen(lv_display_t * display);
 
 /**********************
  *      MACROS
@@ -51,4 +49,4 @@ lv_indev_t * lv_wayland_get_pointer(lv_display_t * disp);
 } /*extern "C"*/
 #endif
 
-#endif /*LV_WL_POINTER_H*/
+#endif /*LV_WAYLAND_TOUCH_H*/

--- a/src/drivers/wayland/lv_wayland_window.c
+++ b/src/drivers/wayland/lv_wayland_window.c
@@ -1,12 +1,12 @@
 /**
- * @file lv_wl_window.c
+ * @file lv_wayland_window.c
  *
  */
 
 /*********************
  *      INCLUDES
  *********************/
-#include "lv_wl_window.h"
+#include "lv_wayland_window.h"
 
 #if LV_USE_WAYLAND
 
@@ -16,10 +16,10 @@
 #include <string.h>
 #include "lv_wayland_private.h"
 #include "lv_wayland_private.h"
-#include "lv_wl_pointer.h"
-#include "lv_wl_pointer_axis.h"
-#include "lv_wl_touch.h"
-#include "lv_wl_keyboard.h"
+#include "lv_wayland_pointer.h"
+#include "lv_wayland_pointer_axis.h"
+#include "lv_wayland_touch.h"
+#include "lv_wayland_keyboard.h"
 
 /*********************
  *      DEFINES

--- a/src/drivers/wayland/lv_wayland_window.c
+++ b/src/drivers/wayland/lv_wayland_window.c
@@ -90,7 +90,16 @@ lv_display_t * lv_wayland_window_create(uint32_t hor_res, uint32_t ver_res, char
     lv_display_set_driver_data(window->lv_disp, window);
 
     /* Initialize display driver */
-    window->backend_display_data = wl_backend_ops.init_display(lv_wl_ctx.backend_data, window->lv_disp, hor_res, ver_res);
+    lv_result_t res = lv_wayland_backend_init_display(&window->backend_ddata,
+                                                      window->lv_disp, hor_res,
+                                                      ver_res);
+    if(res != LV_RESULT_OK) {
+        LV_LOG_ERROR("Failed to create display");
+        goto init_display_err;
+    }
+
+    /*Assert here so tat we can freely use these operations afterwards*/
+    LV_ASSERT_NULL(window->backend_ddata.ops);
 
     lv_wayland_xdg_configure_surface(window);
 
@@ -128,7 +137,8 @@ lv_display_t * lv_wayland_window_create(uint32_t hor_res, uint32_t ver_res, char
         LV_LOG_ERROR("failed to register keyboard indev");
     }
     return window->lv_disp;
-
+init_display_err:
+    lv_wayland_xdg_delete_window(&window->xdg);
 create_window_err:
     wl_surface_destroy(window->body);
 create_surface_err:
@@ -145,7 +155,7 @@ void * lv_wayland_get_backend_display_data(lv_display_t * display)
     LV_ASSERT_NULL(display);
     lv_wl_window_t * window = lv_display_get_driver_data(display);
     LV_ASSERT_NULL(window);
-    return window->backend_display_data;
+    return window->backend_ddata.display_data;
 }
 
 void lv_wayland_set_backend_display_data(lv_display_t * display, void * data)
@@ -153,7 +163,7 @@ void lv_wayland_set_backend_display_data(lv_display_t * display, void * data)
     LV_ASSERT_NULL(display);
     lv_wl_window_t * window = lv_display_get_driver_data(display);
     LV_ASSERT_NULL(window);
-    window->backend_display_data = data;
+    window->backend_ddata.display_data = data;
 }
 
 struct wl_surface * lv_wayland_get_window_surface(lv_display_t * display)
@@ -289,8 +299,7 @@ void lv_wayland_window_delete(lv_wl_window_t * window)
     /* Make sure buffer is correctly released*/
     wl_display_roundtrip(lv_wl_ctx.wl_display);
 
-    wl_backend_ops.deinit_display(window->backend_display_data, window->lv_disp);
-    window->backend_display_data = NULL;
+    window->backend_ddata.ops->deinit_display(window->backend_ddata.backend_ctx, window->lv_disp);
 
     /* Set the driver data to NULL before calling display delete
      * so that the delete event doesn't do anything*/
@@ -338,7 +347,9 @@ static void res_changed_event(lv_event_t * e)
 {
     lv_display_t * display = (lv_display_t *) lv_event_get_target(e);
     lv_wl_window_t * window = lv_display_get_driver_data(display);
-    window->backend_display_data = wl_backend_ops.resize_display(lv_wl_ctx.backend_data, display);
+
+    window->backend_ddata.display_data = window->backend_ddata.ops->resize_display(window->backend_ddata.backend_ctx,
+                                                                                   display);
 }
 
 #endif /* LV_USE_WAYLAND */

--- a/src/drivers/wayland/lv_wayland_window.h
+++ b/src/drivers/wayland/lv_wayland_window.h
@@ -1,11 +1,11 @@
 
 /**
- * @file lv_wl_window.h
+ * @file lv_wayland_window.h
  *
  */
 
-#ifndef LV_WL_WINDOW_H
-#define LV_WL_WINDOW_H
+#ifndef LV_WAYLAND_WINDOW_H
+#define LV_WAYLAND_WINDOW_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -101,4 +101,4 @@ void lv_wayland_window_set_minimized(lv_display_t * disp);
 } /*extern "C"*/
 #endif
 
-#endif /*LV_WL_WINDOW_H*/
+#endif /*LV_WAYLAND_WINDOW_H*/

--- a/src/drivers/wayland/lv_wayland_xdg_shell.c
+++ b/src/drivers/wayland/lv_wayland_xdg_shell.c
@@ -1,5 +1,5 @@
 /**
- * @file lv_wl_xdg_shell.c
+ * @file lv_wayland_xdg_shell.c
  *
  */
 

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -4861,27 +4861,6 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
     #define LV_LOG_TRACE_ANIM       0
 #endif  /*LV_USE_LOG*/
 
-#if LV_USE_WAYLAND
-    /*Automatically detect wayland backend*/
-    #if LV_USE_OPENGLES
-        #define LV_WAYLAND_USE_EGL 1
-        #define LV_WAYLAND_USE_G2D 0
-        #define LV_WAYLAND_USE_SHM 0
-    #elif LV_USE_G2D
-        #define LV_WAYLAND_USE_EGL 0
-        #define LV_WAYLAND_USE_G2D 1
-        #define LV_WAYLAND_USE_SHM 0
-    #else
-        #define LV_WAYLAND_USE_EGL 0
-        #define LV_WAYLAND_USE_G2D 0
-        #define LV_WAYLAND_USE_SHM 1
-    #endif
-#else
-    #define LV_WAYLAND_USE_G2D 0
-    #define LV_WAYLAND_USE_SHM 0
-    #define LV_WAYLAND_USE_EGL 0
-#endif
-
 #if LV_USE_LINUX_DRM
     #if LV_USE_OPENGLES
         #define LV_LINUX_DRM_USE_EGL 1
@@ -4938,6 +4917,12 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
     #define LV_SDL_USE_EGL 1
 #else
     #define LV_SDL_USE_EGL 0
+#endif
+
+#if LV_USE_WAYLAND && LV_USE_OPENGLES
+    #define LV_WAYLAND_USE_EGL 1
+#else
+    #define LV_WAYLAND_USE_EGL 0
 #endif
 
 #ifndef LV_USE_EGL

--- a/src/lv_init.c
+++ b/src/lv_init.c
@@ -265,10 +265,6 @@ void lv_init(void)
     lv_draw_dma2d_init();
 #endif
 
-#if LV_USE_DRAW_OPENGLES
-    lv_draw_opengles_init();
-#endif
-
 #if LV_USE_PPA
     lv_draw_ppa_init();
 #endif


### PR DESCRIPTION
Currently there's no way to have multiple egl windows because we're not creating an opengl context per egl context

This fixes that and also adds the required support to wayland

Contains changes from #9826 and #9821. Will rebase when the two are merged