### PR TITLE
fix(libinput): fix memory leak

### DIFF
--- a/src/drivers/libinput/lv_libinput.c
+++ b/src/drivers/libinput/lv_libinput.c
@@ -236,6 +236,7 @@ static bool _rescan_devices(void)
             perror("could not allocate memory for device node path");
             libinput_unref(context);
             _reset_scanned_devices();
+            closedir(dir);
             return false;
         }
         strcpy(path, "/dev/input/");
@@ -265,11 +266,13 @@ static bool _rescan_devices(void)
             free(path);
             libinput_unref(context);
             _reset_scanned_devices();
+            closedir(dir);
             return false;
         }
     }
 
     libinput_unref(context);
+    closedir(dir);
     return true;
 }
 

--- a/src/drivers/libinput/lv_libinput.c
+++ b/src/drivers/libinput/lv_libinput.c
@@ -181,8 +181,20 @@ lv_indev_t * lv_libinput_create(lv_indev_type_t indev_type, const char * dev_pat
     lv_indev_add_event_cb(indev, _indev_delete, LV_EVENT_DELETE, NULL);
 
     /* Set up thread & lock */
-    pthread_mutex_init(&dsc->event_lock, NULL);
-    pthread_create(&dsc->worker_thread, NULL, _poll_thread, dsc);
+    if(pthread_mutex_init(&dsc->event_lock, NULL) != 0) {
+        LV_LOG_ERROR("pthread_mutex_init failed");
+        lv_indev_delete(indev);
+        return NULL;
+    }
+
+    if(pthread_create(&dsc->worker_thread, NULL, _poll_thread, dsc) != 0) {
+        LV_LOG_ERROR("pthread_create failed");
+        pthread_mutex_destroy(&dsc->event_lock);
+        lv_indev_delete(indev);
+        return NULL;
+    }
+
+    dsc->running = 1;
 
     return indev;
 }
@@ -312,17 +324,13 @@ static void * _poll_thread(void * data)
 
     LV_LOG_INFO("libinput: poll worker started");
 
-    while(true) {
+    while(!dsc->deinit) {
         rc = poll(dsc->fds, nfds, timeout);
         switch(rc) {
             case -1:
                 perror(NULL);
                 __attribute__((fallthrough));
             case 0:
-                if(dsc->deinit) {
-                    dsc->deinit = false; /* Signal that we're done */
-                    return NULL;
-                }
                 continue;
             default:
                 break;
@@ -337,6 +345,8 @@ static void * _poll_thread(void * data)
         pthread_mutex_unlock(&dsc->event_lock);
         LV_LOG_INFO("libinput: event read");
     }
+
+    dsc->deinit = false; /* Signal that we're done */
 
     return NULL;
 }
@@ -642,19 +652,23 @@ static void _close_restricted(int fd, void * user_data)
 
 static void _delete(lv_libinput_t * dsc)
 {
-    if(dsc->fd)
+    if(dsc->running) {
         dsc->deinit = true;
 
-    /* Give worker thread a whole second to quit */
-    for(int i = 0; i < 100; i++) {
-        if(!dsc->deinit)
-            break;
-        usleep(10000);
-    }
+        /* Give worker thread a whole second to quit */
+        for(int i = 0; i < 100; i++) {
+            if(!dsc->deinit)
+                break;
+            usleep(10000);
+        }
 
-    if(dsc->deinit) {
-        LV_LOG_ERROR("libinput worker thread did not quit in time, cancelling it");
-        pthread_cancel(dsc->worker_thread);
+        if(dsc->deinit) {
+            LV_LOG_ERROR("libinput worker thread did not quit in time, cancelling it");
+            pthread_cancel(dsc->worker_thread);
+        }
+
+        pthread_join(dsc->worker_thread, NULL);
+        pthread_mutex_destroy(&dsc->event_lock);
     }
 
     if(dsc->libinput_device) {

--- a/src/drivers/libinput/lv_libinput.c
+++ b/src/drivers/libinput/lv_libinput.c
@@ -66,6 +66,7 @@ static int _open_restricted(const char * path, int flags, void * user_data);
 static void _close_restricted(int fd, void * user_data);
 
 static void _delete(lv_libinput_t * dsc);
+static void _indev_delete(lv_event_t * e);
 
 /**********************
  *  STATIC VARIABLES
@@ -177,6 +178,7 @@ lv_indev_t * lv_libinput_create(lv_indev_type_t indev_type, const char * dev_pat
     lv_indev_set_type(indev, indev_type);
     lv_indev_set_read_cb(indev, _read);
     lv_indev_set_driver_data(indev, dsc);
+    lv_indev_add_event_cb(indev, _indev_delete, LV_EVENT_DELETE, NULL);
 
     /* Set up thread & lock */
     pthread_mutex_init(&dsc->event_lock, NULL);
@@ -187,7 +189,6 @@ lv_indev_t * lv_libinput_create(lv_indev_type_t indev_type, const char * dev_pat
 
 void lv_libinput_delete(lv_indev_t * indev)
 {
-    _delete(lv_indev_get_driver_data(indev));
     lv_indev_delete(indev);
 }
 
@@ -670,6 +671,14 @@ static void _delete(lv_libinput_t * dsc)
 #endif /* LV_LIBINPUT_XKB */
 
     lv_free(dsc);
+}
+
+static void _indev_delete(lv_event_t * e)
+{
+    lv_indev_t * indev = lv_event_get_target(e);
+    lv_libinput_t * dsc = lv_indev_get_driver_data(indev);
+    LV_ASSERT_NULL(dsc);
+    _delete(dsc);
 }
 
 #endif /* LV_USE_LIBINPUT */

--- a/src/drivers/libinput/lv_libinput.c
+++ b/src/drivers/libinput/lv_libinput.c
@@ -132,6 +132,11 @@ size_t lv_libinput_find_devs(lv_libinput_capability capabilities, char ** found,
     return num_found;
 }
 
+void lv_libinput_find_clear(void)
+{
+    _reset_scanned_devices();
+}
+
 lv_indev_t * lv_libinput_create(lv_indev_type_t indev_type, const char * dev_path)
 {
     lv_libinput_t * dsc = lv_malloc_zeroed(sizeof(lv_libinput_t));

--- a/src/drivers/libinput/lv_libinput.c
+++ b/src/drivers/libinput/lv_libinput.c
@@ -264,6 +264,7 @@ static bool _rescan_devices(void)
             perror("could not allocate memory for device node path");
             libinput_unref(context);
             _reset_scanned_devices();
+            closedir(dir);
             return false;
         }
         strcpy(path, "/dev/input/");
@@ -293,11 +294,13 @@ static bool _rescan_devices(void)
             free(path);
             libinput_unref(context);
             _reset_scanned_devices();
+            closedir(dir);
             return false;
         }
     }
 
     libinput_unref(context);
+    closedir(dir);
     return true;
 }
 

--- a/src/drivers/libinput/lv_libinput.c
+++ b/src/drivers/libinput/lv_libinput.c
@@ -81,6 +81,7 @@ static int _open_restricted(const char * path, int flags, void * user_data);
 static void _close_restricted(int fd, void * user_data);
 
 static void _delete(lv_libinput_t * dsc);
+static void _indev_delete(lv_event_t * e);
 
 /**********************
  *  STATIC VARIABLES
@@ -203,6 +204,7 @@ lv_indev_t * lv_libinput_create(lv_indev_type_t indev_type, const char * dev_pat
     lv_indev_set_type(indev, indev_type);
     lv_indev_set_read_cb(indev, _read);
     lv_indev_set_driver_data(indev, dsc);
+    lv_indev_add_event_cb(indev, _indev_delete, LV_EVENT_DELETE, NULL);
 
     /* Set up thread & lock */
     pthread_mutex_init(&dsc->event_lock, NULL);
@@ -215,7 +217,6 @@ void lv_libinput_delete(lv_indev_t * indev)
 {
     if(indev == NULL) return;
 
-    _delete(lv_indev_get_driver_data(indev));
     lv_indev_delete(indev);
 }
 
@@ -710,6 +711,14 @@ static void _delete(lv_libinput_t * dsc)
 #endif /* LV_LIBINPUT_XKB */
 
     lv_free(dsc);
+}
+
+static void _indev_delete(lv_event_t * e)
+{
+    lv_indev_t * indev = lv_event_get_target(e);
+    lv_libinput_t * dsc = lv_indev_get_driver_data(indev);
+    LV_ASSERT_NULL(dsc);
+    _delete(dsc);
 }
 
 #endif /* LV_USE_LIBINPUT */

--- a/src/drivers/libinput/lv_libinput.c
+++ b/src/drivers/libinput/lv_libinput.c
@@ -207,8 +207,20 @@ lv_indev_t * lv_libinput_create(lv_indev_type_t indev_type, const char * dev_pat
     lv_indev_add_event_cb(indev, _indev_delete, LV_EVENT_DELETE, NULL);
 
     /* Set up thread & lock */
-    pthread_mutex_init(&dsc->event_lock, NULL);
-    pthread_create(&dsc->worker_thread, NULL, _poll_thread, dsc);
+    if(pthread_mutex_init(&dsc->event_lock, NULL) != 0) {
+        LV_LOG_ERROR("pthread_mutex_init failed");
+        lv_indev_delete(indev);
+        return NULL;
+    }
+
+    if(pthread_create(&dsc->worker_thread, NULL, _poll_thread, dsc) != 0) {
+        LV_LOG_ERROR("pthread_create failed");
+        pthread_mutex_destroy(&dsc->event_lock);
+        lv_indev_delete(indev);
+        return NULL;
+    }
+
+    dsc->running = 1;
 
     return indev;
 }
@@ -342,17 +354,13 @@ static void * _poll_thread(void * data)
 
     LV_LOG_INFO("libinput: poll worker started");
 
-    while(true) {
+    while(!dsc->deinit) {
         rc = poll(dsc->fds, nfds, timeout);
         switch(rc) {
             case -1:
                 perror(NULL);
                 __attribute__((fallthrough));
             case 0:
-                if(dsc->deinit) {
-                    dsc->deinit = false; /* Signal that we're done */
-                    return NULL;
-                }
                 continue;
             default:
                 break;
@@ -367,6 +375,8 @@ static void * _poll_thread(void * data)
         pthread_mutex_unlock(&dsc->event_lock);
         LV_LOG_INFO("libinput: event read");
     }
+
+    dsc->deinit = false; /* Signal that we're done */
 
     return NULL;
 }
@@ -682,19 +692,23 @@ static void _close_restricted(int fd, void * user_data)
 
 static void _delete(lv_libinput_t * dsc)
 {
-    if(dsc->fd)
+    if(dsc->running) {
         dsc->deinit = true;
 
-    /* Give worker thread a whole second to quit */
-    for(int i = 0; i < 100; i++) {
-        if(!dsc->deinit)
-            break;
-        usleep(10000);
-    }
+        /* Give worker thread a whole second to quit */
+        for(int i = 0; i < 100; i++) {
+            if(!dsc->deinit)
+                break;
+            usleep(10000);
+        }
 
-    if(dsc->deinit) {
-        LV_LOG_ERROR("libinput worker thread did not quit in time, cancelling it");
-        pthread_cancel(dsc->worker_thread);
+        if(dsc->deinit) {
+            LV_LOG_ERROR("libinput worker thread did not quit in time, cancelling it");
+            pthread_cancel(dsc->worker_thread);
+        }
+
+        pthread_join(dsc->worker_thread, NULL);
+        pthread_mutex_destroy(&dsc->event_lock);
     }
 
     if(dsc->libinput_device) {

--- a/src/drivers/libinput/lv_libinput.h
+++ b/src/drivers/libinput/lv_libinput.h
@@ -75,6 +75,15 @@ char * lv_libinput_find_dev(lv_libinput_capability capabilities, bool force_resc
 size_t lv_libinput_find_devs(lv_libinput_capability capabilities, char ** found, size_t count, bool force_rescan);
 
 /**
+ * Clear the device cache.
+ *
+ * This frees the cached device path strings, so any pointers previously
+ * returned by lv_libinput_find_dev() or lv_libinput_find_devs() become
+ * invalid after this call.
+ */
+void lv_libinput_find_clear(void);
+
+/**
  * Create a new libinput input device
  * @param type LV_INDEV_TYPE_POINTER or LV_INDEV_TYPE_KEYPAD
  * @param dev_path device path, e.g. /dev/input/event0

--- a/src/drivers/libinput/lv_libinput_private.h
+++ b/src/drivers/libinput/lv_libinput_private.h
@@ -53,6 +53,7 @@ struct _lv_libinput_t {
     lv_libinput_event_t last_event; /* Report when no new events
                                    * to keep indev state consistent
                                    */
+    bool running; /* Worker thread is running */
     bool deinit; /* Tell worker thread to quit */
     pthread_mutex_t event_lock;
     pthread_t worker_thread;


### PR DESCRIPTION
This patch series fixes some memory leaks in the libinput driver.

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
