### PR TITLE
fix(draw): resolve infinite loop and out-of-bounds access in circular mask cache calculation

### DIFF
--- a/src/draw/sw/lv_draw_sw_mask.c
+++ b/src/draw/sw/lv_draw_sw_mask.c
@@ -1209,7 +1209,7 @@ static void circ_calc_aa4(lv_draw_sw_mask_radius_circle_dsc_t * c, int32_t radiu
     while(i < cir_size) {
         c->opa_start_on_y[y] = i;
         c->x_start_on_y[y] = cir_x[i];
-        for(; i < (int32_t)cir_size && cir_y[i] == y; i++) {
+        for(; i < (int32_t)cir_size && cir_y[i] <= y; i++) {
             c->x_start_on_y[y] = LV_MIN(c->x_start_on_y[y], cir_x[i]);
         }
         y++;

--- a/tests/src/test_cases/draw/test_draw_sw_mask.c
+++ b/tests/src/test_cases/draw/test_draw_sw_mask.c
@@ -1,0 +1,27 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+#include "unity/unity.h"
+
+void setUp(void)
+{
+    /* Function run before every test */
+}
+
+void tearDown(void)
+{
+    /* Function run after every test */
+    lv_obj_clean(lv_screen_active());
+}
+
+void test_radius_mask_overflow(void)
+{
+    int width = 1280;
+    int heigh = 1280;
+    lv_obj_t* obj = lv_obj_create(lv_screen_active());
+    lv_obj_set_size(obj, width * 2, heigh * 2);
+    lv_obj_set_style_radius(obj, heigh, LV_PART_MAIN);
+
+    lv_timer_handler();
+}
+
+#endif

--- a/tests/src/test_cases/draw/test_draw_sw_mask.c
+++ b/tests/src/test_cases/draw/test_draw_sw_mask.c
@@ -17,7 +17,7 @@ void test_radius_mask_overflow(void)
 {
     int width = 1280;
     int heigh = 1280;
-    lv_obj_t* obj = lv_obj_create(lv_screen_active());
+    lv_obj_t * obj = lv_obj_create(lv_screen_active());
     lv_obj_set_size(obj, width * 2, heigh * 2);
     lv_obj_set_style_radius(obj, heigh, LV_PART_MAIN);
 


### PR DESCRIPTION
**Description:**
The circular mask cache calculation in lv_draw_sw_mask.c assumed that the cir_y coordinates are perfectly contiguous for every row y. When radius > 628, discrete sampling can lead to gaps in cir_y rows, causing the inner for loop to terminate without incrementing i. This results in an infinite while loop and subsequent buffer overflow in opa_start_on_y and x_start_on_y.

**Changes:**
Updated inner loop condition from cir_y[i] == y to cir_y[i] <= y to correctly skip gaps and advance the index i through non-contiguous rows.