### PR TITLE
fix(timer): correct timer execution order to handle queue processing …

### DIFF
--- a/src/misc/lv_timer.c
+++ b/src/misc/lv_timer.c
@@ -98,11 +98,11 @@ LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler(void)
         state_p->timer_deleted             = false;
         state_p->timer_created             = false;
 
-        timer_active = lv_ll_get_head(timer_head);
+        timer_active = lv_ll_get_tail(timer_head);
         while(timer_active) {
             /*The timer might be deleted if it runs only once ('repeat_count = 1')
              *So get next element until the current is surely valid*/
-            next = lv_ll_get_next(timer_head, timer_active);
+            next = lv_ll_get_prev(timer_head, timer_active);
 
             if(lv_timer_exec(timer_active)) {
                 /*If a timer was created or deleted then this or the next item might be corrupted*/
@@ -117,7 +117,7 @@ LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler(void)
     } while(timer_active);
 
     uint32_t time_until_next = LV_NO_TIMER_READY;
-    next = lv_ll_get_head(timer_head);
+    next = lv_ll_get_tail(timer_head);
     while(next) {
         if(!next->paused) {
             uint32_t delay = lv_timer_time_remaining(next);
@@ -125,7 +125,7 @@ LV_ATTRIBUTE_TIMER_HANDLER uint32_t lv_timer_handler(void)
                 time_until_next = delay;
         }
 
-        next = lv_ll_get_next(timer_head, next); /*Find the next timer*/
+        next = lv_ll_get_prev(timer_head, next); /*Find the next timer*/
     }
 
     state_p->busy_time += lv_tick_elaps(handler_start);


### PR DESCRIPTION
# Description
lv_async_call is positioned at the head of the timer queue, causing it to execute prematurely, before the subsequent draw event.

sample example
```c

// The function will execute first, unable to obtain object information because the drawing event queue has not yet been processed.
static void next_event_call(void *user){
    lv_obj_t  *object = (lv_obj_t*)user;
    lv_area_t area;
    lv_obj_get_content_coords(object,&area);
    printf("area: %d %d %d %d\n"); // Cannot obtain the size of the object,
}

lv_obj_t *object;

int main(int argc, char **argv)
{
  (void)argc; /*Unused*/
  (void)argv; /*Unused*/

  /*Initialize LVGL*/
  lv_init();

  /*Initialize the HAL (display, input devices, tick) for LVGL*/
  sdl_hal_init(320, 480);

  object = lv_obj_create(lv_screen_active());
  lv_obj_set_pos(object,100,100);
  lv_obj_set_size(object,150,200);

  lv_async_call(next_event_call,object);

  while(1) {
    /* Periodically call the lv_task handler.
     * It could be done in a timer interrupt or an OS task too.*/
    uint32_t sleep_time_ms = lv_timer_handler();
    if(sleep_time_ms == LV_NO_TIMER_READY){
	sleep_time_ms =  LV_DEF_REFR_PERIOD;
    }
#ifdef _MSC_VER
    Sleep(sleep_time_ms);
#else
    usleep(sleep_time_ms * 1000);
#endif
  }

  return 0;
}
```

