### PR TITLE
fix(uefi): correct vertical resolution check in display flush callback

### DIFF
--- a/src/drivers/uefi/lv_uefi_display.c
+++ b/src/drivers/uefi/lv_uefi_display.c
@@ -228,7 +228,7 @@ static void _display_flush_cb(lv_display_t * display, const lv_area_t * area, ui
         goto error;
     }
 
-    if((uint32_t)(area->y1 + h) > display_ctx->gop_protocol->Mode->Info->HorizontalResolution) {
+    if((uint32_t)(area->y1 + h) > display_ctx->gop_protocol->Mode->Info->VerticalResolution) {
         LV_LOG_ERROR("[lv_uefi] Invalid lv_display_flush_cb call (invalid height).");
         goto error;
     }


### PR DESCRIPTION
The UEFI display initialization fails when the screen width is less than the height.