### PR TITLE
fix(wayland/shm): correctly support transparency with ARGB8888

### DIFF
--- a/src/drivers/wayland/lv_wayland_backend_shm.c
+++ b/src/drivers/wayland/lv_wayland_backend_shm.c
@@ -131,7 +131,7 @@ static void frame_done(void * data, struct wl_callback * callback, uint32_t time
     lv_display_flush_ready(display);
 }
 
-static uint32_t lv_cf_to_shm_cf(lv_color_format_t cf)
+static int32_t lv_cf_to_shm_cf(lv_color_format_t cf)
 {
     switch(cf) {
         case LV_COLOR_FORMAT_ARGB8888_PREMULTIPLIED:
@@ -142,7 +142,7 @@ static uint32_t lv_cf_to_shm_cf(lv_color_format_t cf)
         case LV_COLOR_FORMAT_RGB565:
             return WL_SHM_FORMAT_RGB565;
         default:
-            return 0;
+            return -1;
     }
 }
 
@@ -173,14 +173,16 @@ static lv_wl_shm_display_data_t * shm_create_display_data(lv_wl_shm_ctx_t * ctx,
 
     const lv_display_rotation_t rotation = lv_display_get_rotation(display);
     lv_color_format_t cf = lv_display_get_color_format(display);
-    ddata->shm_cf = lv_cf_to_shm_cf(cf);
+    int32_t shm_cf = lv_cf_to_shm_cf(cf);
 
-    if(!ddata->shm_cf) {
+    if(shm_cf < 0) {
         LV_LOG_WARN("Unsupported color format %d. Falling back to XRGB8888", cf);
         cf = LV_COLOR_FORMAT_XRGB8888;
         lv_display_set_color_format(display, cf);
-        ddata->shm_cf = WL_SHM_FORMAT_XRGB8888;
+        shm_cf = WL_SHM_FORMAT_XRGB8888;
     }
+    /* safe cast as per check above*/
+    ddata->shm_cf = (uint32_t)shm_cf;
 
     const bool needs_rotation = rotation != LV_DISPLAY_ROTATION_0;
     const int32_t phy_width = lv_display_get_original_horizontal_resolution(display);

--- a/src/drivers/wayland/lv_wayland_window.c
+++ b/src/drivers/wayland/lv_wayland_window.c
@@ -94,6 +94,7 @@ lv_display_t * lv_wayland_window_create(uint32_t hor_res, uint32_t ver_res, char
 
     lv_wayland_xdg_configure_surface(window);
 
+    lv_display_add_event_cb(window->lv_disp, res_changed_event, LV_EVENT_COLOR_FORMAT_CHANGED, NULL);
     lv_display_add_event_cb(window->lv_disp, res_changed_event, LV_EVENT_RESOLUTION_CHANGED, NULL);
     lv_display_add_event_cb(window->lv_disp, refr_start_event, LV_EVENT_REFR_START, NULL);
     lv_display_add_event_cb(window->lv_disp, refr_end_event, LV_EVENT_REFR_READY, NULL);


### PR DESCRIPTION
Fixes #9893  <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
