### PR TITLE
fix(wayland-g2d): wait for buffer_release before reusing buffers to avoid flicker

### DIFF
--- a/src/drivers/wayland/lv_wl_g2d_backend.c
+++ b/src/drivers/wayland/lv_wl_g2d_backend.c
@@ -51,7 +51,7 @@ typedef struct {
     lv_wl_buffer_t rotate_buffer;
 #endif
     uint32_t drm_cf;
-    uint8_t act_buf_idx;
+    uint8_t next_buf_idx;
 } lv_wl_g2d_display_data_t;
 
 typedef struct {
@@ -112,8 +112,6 @@ static void init_buffer(lv_wl_g2d_ctx_t * ctx, lv_wl_buffer_t * buffer, uint32_t
 
 static void delete_buffer(lv_wl_buffer_t * buffer);
 static void flush_wait_cb(lv_display_t * disp);
-
-static lv_wl_buffer_t * get_next_buffer(lv_wl_g2d_display_data_t * ddata);
 
 /**********************
  *  STATIC VARIABLES
@@ -572,21 +570,13 @@ static void dmabuf_format(void * data, struct zwp_linux_dmabuf_v1 * zwp_linux_dm
     }
 }
 
-static lv_wl_buffer_t * get_active_buffer(lv_wl_g2d_display_data_t * ddata)
-{
-    lv_wl_buffer_t * ret = &ddata->buffers[ddata->act_buf_idx];
-    if(ret->busy) {
-        /* In theory this should never happen, log a warning in case it does */
-        LV_LOG_WARN("Failed to acquire a non-busy buffer");
-    }
-    ddata->act_buf_idx = (ddata->act_buf_idx + 1) % (LV_WL_G2D_BUF_COUNT);
-    return ret;
-}
-
 static void flush_wait_cb(lv_display_t * disp)
 {
     while(disp->flushing) {
-        wl_display_dispatch(lv_wl_ctx.wl_display);
+        if(wl_display_dispatch(lv_wl_ctx.wl_display) == -1) {
+            LV_LOG_ERROR("Failed to dispatch Wayland display");
+            break;
+        }
     }
 }
 
@@ -611,11 +601,10 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, unsigned char 
         return;
     }
 
-    lv_wl_buffer_t * buf = get_active_buffer(ddata);
-
-    if(!buf) {
-        LV_LOG_ERROR("Failed to acquire a wayland window body buffer");
-        return;
+    lv_wl_buffer_t * buf = &ddata->buffers[ddata->next_buf_idx];
+    if(buf->busy) {
+        /* In theory this should never happen, log a warning in case it does */
+        LV_LOG_WARN("Buffer is still in use by the compositor");
     }
 
     buf->busy = true;
@@ -642,11 +631,15 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, unsigned char 
     wl_surface_attach(surface, buf->wl_buffer, 0, 0);
     wl_surface_commit(surface);
 
-    /* Wait for the compositor to release the next active buffer before returning,
+    /* Wait for the compositor to release the next buffer before returning,
        so it is safe to render into it on the next frame */
-    lv_wl_buffer_t * next_act_buf = &ddata->buffers[ddata->act_buf_idx];
-    while(next_act_buf->busy) {
-        wl_display_dispatch(lv_wl_ctx.wl_display);
+    ddata->next_buf_idx = (ddata->next_buf_idx + 1) % LV_WL_G2D_BUF_COUNT;
+    lv_wl_buffer_t * next_buf = &ddata->buffers[ddata->next_buf_idx];
+    while(next_buf->busy) {
+        if(wl_display_dispatch(lv_wl_ctx.wl_display) == -1) {
+            LV_LOG_ERROR("Failed to dispatch Wayland display");
+            break;
+        }
     }
 
     return;

--- a/src/drivers/wayland/lv_wl_g2d_backend.c
+++ b/src/drivers/wayland/lv_wl_g2d_backend.c
@@ -51,8 +51,7 @@ typedef struct {
     lv_wl_buffer_t rotate_buffer;
 #endif
     uint32_t drm_cf;
-    uint8_t last_used;
-    bool flushing;
+    uint8_t act_buf_idx;
 } lv_wl_g2d_display_data_t;
 
 typedef struct {
@@ -573,14 +572,14 @@ static void dmabuf_format(void * data, struct zwp_linux_dmabuf_v1 * zwp_linux_dm
     }
 }
 
-static lv_wl_buffer_t * get_next_buffer(lv_wl_g2d_display_data_t * ddata)
+static lv_wl_buffer_t * get_active_buffer(lv_wl_g2d_display_data_t * ddata)
 {
-    lv_wl_buffer_t * ret =  &ddata->buffers[ddata->last_used];
+    lv_wl_buffer_t * ret = &ddata->buffers[ddata->act_buf_idx];
     if(ret->busy) {
         /* In theory this should never happen, log a warning in case it does */
         LV_LOG_WARN("Failed to acquire a non-busy buffer");
     }
-    ddata->last_used = (ddata->last_used + 1) % (LV_WL_G2D_BUF_COUNT);
+    ddata->act_buf_idx = (ddata->act_buf_idx + 1) % (LV_WL_G2D_BUF_COUNT);
     return ret;
 }
 
@@ -612,12 +611,14 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, unsigned char 
         return;
     }
 
-    lv_wl_buffer_t * buf = get_next_buffer(ddata);
+    lv_wl_buffer_t * buf = get_active_buffer(ddata);
 
     if(!buf) {
         LV_LOG_ERROR("Failed to acquire a wayland window body buffer");
         return;
     }
+
+    buf->busy = true;
 
     lv_draw_buf_invalidate_cache(buf->lv_draw_buf, NULL);
     /*Rerender the whole surface if we're using rotation*/
@@ -641,7 +642,13 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, unsigned char 
     wl_surface_attach(surface, buf->wl_buffer, 0, 0);
     wl_surface_commit(surface);
 
-    buf->busy = true;
+    /* Wait for the compositor to release the next active buffer before returning,
+       so it is safe to render into it on the next frame */
+    lv_wl_buffer_t * next_act_buf = &ddata->buffers[ddata->act_buf_idx];
+    while(next_act_buf->busy) {
+        wl_display_dispatch(lv_wl_ctx.wl_display);
+    }
+
     return;
 }
 

--- a/src/drivers/wayland/lv_wl_xdg_shell.c
+++ b/src/drivers/wayland/lv_wl_xdg_shell.c
@@ -146,7 +146,7 @@ void lv_wayland_xdg_configure_surface(lv_wl_window_t * window)
      * configure event */
     wl_surface_commit(window->body);
     wl_display_roundtrip(lv_wl_ctx.wl_display);
-    LV_ASSERT_MSG(window->resize_event.pending, "Failed to receive the xdg_surface configuration event");
+    LV_ASSERT_MSG(window->xdg.configured, "Failed to receive the xdg_surface configuration event");
 }
 bool lv_wayland_xdg_is_resize_pending(lv_wl_window_t * window)
 {

--- a/src/drivers/wayland/lv_wl_xdg_shell.c
+++ b/src/drivers/wayland/lv_wl_xdg_shell.c
@@ -146,8 +146,10 @@ void lv_wayland_xdg_configure_surface(lv_wl_window_t * window)
      * configure event */
     wl_surface_commit(window->body);
     wl_display_roundtrip(lv_wl_ctx.wl_display);
-    LV_ASSERT_MSG(window->xdg.configured, "Failed to receive the xdg_surface configuration event");
+    LV_ASSERT_MSG(window->xdg.configured || window->resize_event.pending,
+                  "Failed to receive the xdg_surface configuration event");
 }
+
 bool lv_wayland_xdg_is_resize_pending(lv_wl_window_t * window)
 {
     return window->resize_event.pending;


### PR DESCRIPTION
I am currently using Wayland with G2D (draw unit G2D + SW fallback) on an NXP i.MX93 board.

At application startup, a crash occurs due to an assertion failure in lv_wayland_xdg_configure_surface (file lv_wl_xdg_shell.c). After addressing the assertion issue, I observed another problem during page transitions: frequent warnings of the form:

`get_next_buffer: Failed to acquire a non-busy buffer`

Alongside this warning, visible screen flickering occurs (only when LV_USE_ROTATE_G2D is set to 0; otherwise, the flickering is not noticeable).

Upon investigation, I found that the next buffer selected for rendering is still marked as “in use.” Specifically, the buffer_release callback for that buffer has not yet been invoked, even though the corresponding frame_done event has already been received.

According to the Wayland protocol documentation, there is no strict ordering or dependency between buffer_release and frame_done, which explains this behavior.

To address the issue, I implemented a fix that ensures the next buffer intended for rendering is not reused until its buffer_release callback has been received. Concretely, this means waiting for buffer_release before completing the flush callback.

Initially, I attempted to handle this by adding the wait logic inside flush_wait_cb, but this callback is only invoked when `disp->flushing` is set to true, which does not consistently cover this scenario.

My current approach enforces waiting for buffer_release before completing the flush operation.

Is this approach acceptable, or would you recommend a different synchronization strategy?