### PR TITLE
fix(draw): fix missing dsc_size in rect mask descriptor

### DIFF
--- a/src/draw/lv_draw_3d.c
+++ b/src/draw/lv_draw_3d.c
@@ -39,11 +39,11 @@
 void lv_draw_3d_dsc_init(lv_draw_3d_dsc_t * dsc)
 {
     lv_memzero(dsc, sizeof(lv_draw_3d_dsc_t));
-    dsc->base.dsc_size = sizeof(lv_draw_3d_dsc_t);
     dsc->tex_id = LV_3DTEXTURE_ID_NULL;
     dsc->h_flip = false;
     dsc->v_flip = false;
     dsc->opa = LV_OPA_COVER;
+    dsc->base.dsc_size = sizeof(lv_draw_3d_dsc_t);
 }
 
 lv_draw_3d_dsc_t * lv_draw_task_get_3d_dsc(lv_draw_task_t * task)

--- a/src/draw/lv_draw_mask.c
+++ b/src/draw/lv_draw_mask.c
@@ -40,6 +40,7 @@
 void LV_ATTRIBUTE_FAST_MEM lv_draw_mask_rect_dsc_init(lv_draw_mask_rect_dsc_t * dsc)
 {
     lv_memzero(dsc, sizeof(lv_draw_mask_rect_dsc_t));
+    dsc->base.dsc_size = sizeof(lv_draw_mask_rect_dsc_t);
 }
 
 lv_draw_mask_rect_dsc_t * lv_draw_task_get_mask_rect_dsc(lv_draw_task_t * task)

--- a/src/draw/lv_draw_rect.c
+++ b/src/draw/lv_draw_rect.c
@@ -55,6 +55,7 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_rect_dsc_init(lv_draw_rect_dsc_t * dsc)
     dsc->border_opa = LV_OPA_COVER;
     dsc->shadow_opa = LV_OPA_COVER;
     dsc->border_side = LV_BORDER_SIDE_FULL;
+    dsc->base.dsc_size = sizeof(lv_draw_rect_dsc_t);
 }
 
 void lv_draw_fill_dsc_init(lv_draw_fill_dsc_t * dsc)


### PR DESCRIPTION
I am using Wayland with EGL (OpenGLES draw unit + SW fallback) on an STM MP2 board (LVGL version 9.5). Occasionally, the application crashes during page transitions with fade animations.

### LVGL configuration

- LV_USE_OPENGLES 1
- LV_USE_DRAW_OPENGLES 1
- LV_USE_DRAW_SW 1

### Root Cause Analysis

While investigating the issue, I found that the crash originates in draw_to_texture(), where execution falls into the default branch of the switch statement. This happens because a draw task of type LV_DRAW_TASK_TYPE_RECT_MASK is received, which is not handled, causing draw_texture() to return false.

Returning false leads to a failure in the create_cb call inside lv_cache_acquire_or_create() (file lv_cache.c). As a result, remove_cb is invoked. However, remove_cb fails to locate the cache entry that was just added via add_cb, because compare_cb consistently returns false.

The root issue is that lv_draw_rect_mask_dsc_init() does not initialize the dsc_size field to sizeof(lv_draw_mask_rect_dsc_t). Since dsc_size remains 0, when lv_memcpy() is called in draw_to_texture(), no data is copied and the descriptor remains uninitialized.

As a consequence:

- The cache entry is created with dsc_size = 0 but is later modified, resulting in a descriptor with a random dsc_size.
- During removal, the lookup is performed using a descriptor with uninitialized content
- compare_cb fails, so the entry is not found

Despite the failure of remove_cb, both free_cb and lv_cache_entry_delete() are still executed. This results in freeing the draw_dsc inside cache_data_t.

Execution continues until the texture cache becomes full. When the same cache entry (which was not properly removed earlier) is eventually evicted, its draw_dsc is freed again, causing a double free and leading to the crash.

### Proposed Fix

Initialize the dsc_size field correctly in lv_draw_rect_mask_dsc_init() (i.e., set it to sizeof(lv_draw_mask_rect_dsc_t)).