### PR TITLE
fix(eve): fix incorrect rendering of transparent edges

### DIFF
--- a/src/draw/eve/lv_eve.c
+++ b/src/draw/eve/lv_eve.c
@@ -197,10 +197,10 @@ void lv_eve_draw_rect_simple(int16_t coord_x1, int16_t coord_y1, int16_t coord_x
         lv_eve_line_width(radius * 16);
     }
     if(radius > 0) {
-        // With radius 1, the EVE engine draws one half-opacity
-        // pixel outline around the rectangle. Subtracting one
-        // here ensures that the full-opacity rectangle reaches
-        // the coordinate pixels we were passed in.
+        /* With radius 1, the EVE engine draws one half-opacity
+         * pixel outline around the rectangle. Subtracting one
+         * here ensures that the full-opacity rectangle reaches
+         * the coordinate pixels we were passed in. */
         radius--;
     }
 

--- a/src/draw/eve/lv_eve.c
+++ b/src/draw/eve/lv_eve.c
@@ -88,17 +88,12 @@ void lv_eve_primitive(uint8_t context)
 
 void lv_eve_scissor(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2)
 {
-    if(x1 != scissor_x1 || y1 != scissor_y1) {
-        int16_t adjusted_x1 = x1 > 0 ? x1 - 1 : 0;
-        int16_t adjusted_y1 = y1 > 0 ? y1 - 1 : 0;
-        EVE_cmd_dl_burst(SCISSOR_XY(adjusted_x1, adjusted_y1));
+    if(x1 != scissor_x1 || y1 != scissor_y1 || x2 != scissor_x2 || y2 != scissor_y2) {
+        EVE_cmd_dl_burst(SCISSOR_XY(x1, y1));
         scissor_x1 = x1;
         scissor_y1 = y1;
-    }
-
-    if(x2 != scissor_x2 || y2 != scissor_y2) {
-        uint16_t w = x2 - x1 + 3;
-        uint16_t h = y2 - y1 + 3;
+        uint16_t w = x2 - x1 + 1;
+        uint16_t h = y2 - y1 + 1;
         EVE_cmd_dl_burst(SCISSOR_SIZE(w, h));
         scissor_x2 = x2;
         scissor_y2 = y2;
@@ -200,6 +195,13 @@ void lv_eve_draw_rect_simple(int16_t coord_x1, int16_t coord_y1, int16_t coord_x
     lv_eve_primitive(LV_EVE_PRIMITIVE_RECTS);
     if(radius > 1) {
         lv_eve_line_width(radius * 16);
+    }
+    if(radius > 0) {
+        // With radius 1, the EVE engine draws one half-opacity
+        // pixel outline around the rectangle. Subtracting one
+        // here ensures that the full-opacity rectangle reaches
+        // the coordinate pixels we were passed in.
+        radius--;
     }
 
     lv_eve_vertex_2f(coord_x1 + radius, coord_y1 + radius);


### PR DESCRIPTION
Fixes cases where the transparent edges of primitives inside EVE overlap in ways that cause visual bleed.

Implemented changes:

- Make scissor function cut the defined area precisely
- Move the edges of rectangle primitives to account for how the EVE devices draw their transparent outlines
- Fix the scissor function cached values in cases where the top left corner has changed, but not the bottom right

Before:

<img width="406" height="558" alt="image" src="https://github.com/user-attachments/assets/a982f00b-6021-4fb2-be93-0c00155b40ae" />

After:

<img width="409" height="558" alt="image" src="https://github.com/user-attachments/assets/b6f9e120-2332-44ed-b6b7-7607c1c8daaf" />
