### PR TITLE
fix(slider): allow knob update while dragging even if scroll object is active

### DIFF
--- a/src/widgets/slider/lv_slider.c
+++ b/src/widgets/slider/lv_slider.c
@@ -559,7 +559,7 @@ static void update_knob_pos(lv_obj_t * obj, bool check_drag)
     lv_indev_t * indev = lv_indev_active();
     if(lv_indev_get_type(indev) != LV_INDEV_TYPE_POINTER)
         return;
-    if(lv_indev_get_scroll_obj(indev) != NULL)
+    if(lv_indev_get_scroll_obj(indev) != NULL && !slider->dragging)
         return;
 
     lv_point_t p;


### PR DESCRIPTION
## Problem
When dragging a horizontal slider, `lv_indev_get_scroll_obj()` may 
return non-NULL causing `update_knob_pos()` to return early without 
sending `LV_EVENT_VALUE_CHANGED`. This prevents the slider from 
updating continuously during drag as documented.

## Root cause
In `update_knob_pos()`, the check:
```c
if(lv_indev_get_scroll_obj(indev) != NULL)
    return;
```
exits the function even when the slider is already in dragging mode.

## Fix
Skip the scroll object check when the slider is already dragging:
```c
if(lv_indev_get_scroll_obj(indev) != NULL && !slider->dragging)
    return;
```

## Tested
Verified on ESP32-S3 with touchscreen display running ESPHome.