### PR TITLE
fix(nanovg): support dynamic font engines

### DIFF
--- a/src/draw/nanovg/lv_draw_nanovg_label.c
+++ b/src/draw/nanovg/lv_draw_nanovg_label.c
@@ -18,6 +18,7 @@
 #include "../../misc/cache/lv_cache_entry_private.h"
 #include "../../misc/lv_pending.h"
 #include "../../libs/freetype/lv_freetype.h"
+#include "../../font/lv_font_private.h"
 
 /*********************
 *      DEFINES
@@ -285,28 +286,7 @@ static void letter_free_cb(letter_item_t * item, void * user_data)
 
 static lv_cache_compare_res_t letter_compare_cb(const letter_item_t * lhs, const letter_item_t * rhs)
 {
-    if(lhs->g_dsc.resolved_font != rhs->g_dsc.resolved_font) {
-        return lhs->g_dsc.resolved_font > rhs->g_dsc.resolved_font ? 1 : -1;
-    }
-
-    lv_cache_compare_res_t ret = lhs->g_dsc.format - rhs->g_dsc.format;
-    if(ret != 0) {
-        return ret;
-    }
-
-    if(lhs->g_dsc.format == LV_FONT_GLYPH_FORMAT_IMAGE) {
-        if(lhs->g_dsc.gid.src == rhs->g_dsc.gid.src) {
-            return 0;
-        }
-        return lhs->g_dsc.gid.src > rhs->g_dsc.gid.src ? 1 : -1;
-    }
-    else {
-        if(lhs->g_dsc.gid.index == rhs->g_dsc.gid.index) {
-            return 0;
-        }
-        return lhs->g_dsc.gid.index > rhs->g_dsc.gid.index ? 1 : -1;
-    }
-    return 0;
+    return lv_font_glyph_dsc_compare(&lhs->g_dsc, &rhs->g_dsc);
 }
 
 

--- a/src/draw/nanovg/lv_draw_nanovg_label.c
+++ b/src/draw/nanovg/lv_draw_nanovg_label.c
@@ -255,14 +255,18 @@ static bool letter_create_cb(letter_item_t * item, void * user_data)
         return false;
     }
 
-    if(!lv_font_get_glyph_bitmap(g_dsc, image_buf)) {
+    const lv_draw_buf_t * bitmap_draw_buf = (const lv_draw_buf_t *)lv_font_get_glyph_bitmap(g_dsc, image_buf);
+    if(!bitmap_draw_buf) {
         LV_PROFILER_DRAW_END;
         return false;
     }
 
     LV_PROFILER_DRAW_BEGIN_TAG("nvgCreateImage");
-    item->image_handle = nvgCreateImage(item->u->vg, w, h, 0, NVG_TEXTURE_ALPHA, lv_draw_buf_goto_xy(image_buf, 0, 0));
+    item->image_handle = nvgCreateImage(item->u->vg, w, h, 0, NVG_TEXTURE_ALPHA, lv_draw_buf_goto_xy(bitmap_draw_buf, 0,
+                                                                                                     0));
     LV_PROFILER_DRAW_END_TAG("nvgCreateImage");
+
+    lv_font_glyph_release_draw_data(g_dsc);
 
     LV_LOG_TRACE("image_handle: %d", item->image_handle);
     LV_PROFILER_DRAW_END;

--- a/src/draw/nanovg/lv_draw_nanovg_label.c
+++ b/src/draw/nanovg/lv_draw_nanovg_label.c
@@ -206,7 +206,6 @@ static inline int letter_get_image_handle(lv_draw_nanovg_unit_t * u, lv_font_gly
     letter_item_t search_key = { 0 };
     search_key.u = u;
     search_key.g_dsc = *g_dsc;
-    search_key.g_dsc.entry = NULL; /* Exclude the cache entry from the key */
 
     lv_cache_entry_t * cache_node_entry = lv_cache_acquire(u->letter_cache, &search_key, NULL);
     if(cache_node_entry == NULL) {
@@ -282,11 +281,27 @@ static void letter_free_cb(letter_item_t * item, void * user_data)
 
 static lv_cache_compare_res_t letter_compare_cb(const letter_item_t * lhs, const letter_item_t * rhs)
 {
-    int cmp_res = lv_memcmp(&lhs->g_dsc, &rhs->g_dsc, sizeof(lv_font_glyph_dsc_t));
-    if(cmp_res != 0) {
-        return cmp_res > 0 ? 1 : -1;
+    if(lhs->g_dsc.resolved_font != rhs->g_dsc.resolved_font) {
+        return lhs->g_dsc.resolved_font > rhs->g_dsc.resolved_font ? 1 : -1;
     }
 
+    lv_cache_compare_res_t ret = lhs->g_dsc.format - rhs->g_dsc.format;
+    if(ret != 0) {
+        return ret;
+    }
+
+    if(lhs->g_dsc.format == LV_FONT_GLYPH_FORMAT_IMAGE) {
+        if(lhs->g_dsc.gid.src == rhs->g_dsc.gid.src) {
+            return 0;
+        }
+        return lhs->g_dsc.gid.src > rhs->g_dsc.gid.src ? 1 : -1;
+    }
+    else {
+        if(lhs->g_dsc.gid.index == rhs->g_dsc.gid.index) {
+            return 0;
+        }
+        return lhs->g_dsc.gid.index > rhs->g_dsc.gid.index ? 1 : -1;
+    }
     return 0;
 }
 

--- a/src/draw/vg_lite/lv_vg_lite_bitmap_font_cache.c
+++ b/src/draw/vg_lite/lv_vg_lite_bitmap_font_cache.c
@@ -15,6 +15,7 @@
 #include "lv_vg_lite_pending.h"
 #include "lv_vg_lite_utils.h"
 #include "../../core/lv_global.h"
+#include "../../font/lv_font_private.h"
 
 /*********************
  *      DEFINES
@@ -189,16 +190,7 @@ static void cache_free_cb(cache_item_t * item, void * user_data)
 
 static lv_cache_compare_res_t cache_compare_cb(const cache_item_t * lhs, const cache_item_t * rhs)
 {
-    /* Because const font pointers are unique, matching can be performed using only the pointer. */
-    if(lhs->g_dsc.resolved_font != rhs->g_dsc.resolved_font) {
-        return lhs->g_dsc.resolved_font > rhs->g_dsc.resolved_font ? 1 : -1;
-    }
-
-    if(lhs->g_dsc.gid.index != rhs->g_dsc.gid.index) {
-        return lhs->g_dsc.gid.index > rhs->g_dsc.gid.index ? 1 : -1;
-    }
-
-    return 0;
+    return lv_font_glyph_dsc_compare(&lhs->g_dsc, &rhs->g_dsc);
 }
 
 #endif /*LV_USE_DRAW_VG_LITE*/

--- a/src/font/lv_font.c
+++ b/src/font/lv_font.c
@@ -8,6 +8,7 @@
  *********************/
 
 #include "lv_font.h"
+#include "lv_font_private.h"
 #include "../misc/lv_text_private.h"
 #include "../misc/lv_utils.h"
 #include "../misc/lv_log.h"
@@ -197,6 +198,32 @@ bool lv_font_info_is_equal(const lv_font_info_t * ft_info_1, const lv_font_info_
 bool lv_font_has_static_bitmap(const lv_font_t * font)
 {
     return font->static_bitmap;
+}
+
+int32_t lv_font_glyph_dsc_compare(const lv_font_glyph_dsc_t * lhs, const lv_font_glyph_dsc_t * rhs)
+{
+    if(lhs->resolved_font != rhs->resolved_font) {
+        return lhs->resolved_font > rhs->resolved_font ? 1 : -1;
+    }
+
+    int32_t ret = lhs->format - rhs->format;
+    if(ret != 0) {
+        return ret;
+    }
+
+    if(lhs->format == LV_FONT_GLYPH_FORMAT_IMAGE) {
+        if(lhs->gid.src == rhs->gid.src) {
+            return 0;
+        }
+        return lhs->gid.src > rhs->gid.src ? 1 : -1;
+    }
+    else {
+        if(lhs->gid.index == rhs->gid.index) {
+            return 0;
+        }
+        return lhs->gid.index > rhs->gid.index ? 1 : -1;
+    }
+    return 0;
 }
 
 /**********************

--- a/src/font/lv_font.c
+++ b/src/font/lv_font.c
@@ -203,7 +203,7 @@ bool lv_font_has_static_bitmap(const lv_font_t * font)
 int32_t lv_font_glyph_dsc_compare(const lv_font_glyph_dsc_t * lhs, const lv_font_glyph_dsc_t * rhs)
 {
     if(lhs->resolved_font != rhs->resolved_font) {
-        return lhs->resolved_font > rhs->resolved_font ? 1 : -1;
+        return (lv_uintptr_t)lhs->resolved_font > (lv_uintptr_t)rhs->resolved_font ? 1 : -1;
     }
 
     int32_t ret = lhs->format - rhs->format;
@@ -215,15 +215,13 @@ int32_t lv_font_glyph_dsc_compare(const lv_font_glyph_dsc_t * lhs, const lv_font
         if(lhs->gid.src == rhs->gid.src) {
             return 0;
         }
-        return lhs->gid.src > rhs->gid.src ? 1 : -1;
+        return (lv_uintptr_t)lhs->gid.src > (lv_uintptr_t)rhs->gid.src ? 1 : -1;
     }
-    else {
-        if(lhs->gid.index == rhs->gid.index) {
-            return 0;
-        }
-        return lhs->gid.index > rhs->gid.index ? 1 : -1;
+
+    if(lhs->gid.index == rhs->gid.index) {
+        return 0;
     }
-    return 0;
+    return lhs->gid.index > rhs->gid.index ? 1 : -1;
 }
 
 /**********************

--- a/src/font/lv_font_private.h
+++ b/src/font/lv_font_private.h
@@ -1,0 +1,41 @@
+/**
+ * @file lv_font_private.h
+ *
+ */
+
+#ifndef LV_FONT_PRIVATE_H
+#define LV_FONT_PRIVATE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "lv_font.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+int32_t lv_font_glyph_dsc_compare(const lv_font_glyph_dsc_t * lhs, const lv_font_glyph_dsc_t * rhs);
+
+/**********************
+ *      MACROS
+ **********************/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_FONT_PRIVATE_H*/
+


### PR DESCRIPTION
I encountered a bunch of issues when using NanoVG with TinyTTF

A crash that was due to the way the values were stored in cache. Using `memcmp` with g_dsc is fragile as the struct contains padding. Instead we can simply check for the font and the glyph index

Another issue was that for libs like tinyttf and freetype, the glyph draw_buf is directly returned in `lv_font_get_glyph_bitmap` instead of having draw_buf populated

PTAL @FASTSHIFT 