### PR TITLE
fix(windows): fix first frame coordinates and refresh issues after minimize

### DIFF
--- a/src/drivers/windows/lv_windows_context.c
+++ b/src/drivers/windows/lv_windows_context.c
@@ -17,6 +17,9 @@
 #include "lv_windows_display.h"
 #include "lv_windows_input_private.h"
 #include "../../osal/lv_os_private.h"
+#include "../../osal/lv_os.h"
+#include "../../display/lv_display.h"
+#include "../../core/lv_obj_pos.h"
 
 /*********************
  *      DEFINES
@@ -649,6 +652,20 @@ static bool lv_windows_window_message_callback_nolock(
 
                 PostQuitMessage(0);
 
+                break;
+            }
+            case WM_PAINT: {
+                lv_lock();
+
+                PAINTSTRUCT ps;
+                lv_windows_window_context_t * context = (lv_windows_window_context_t *)(lv_windows_get_window_context(hWnd));
+                if(context && context->display_device_object) {
+                    HDC hdc = BeginPaint(hWnd, &ps);
+                    lv_obj_invalidate(lv_screen_active());
+                    EndPaint(hWnd, &ps);
+                }
+
+                lv_unlock();
                 break;
             }
         default: {

--- a/src/drivers/windows/lv_windows_context.c
+++ b/src/drivers/windows/lv_windows_context.c
@@ -661,7 +661,7 @@ static bool lv_windows_window_message_callback_nolock(
                 lv_windows_window_context_t * context = (lv_windows_window_context_t *)(lv_windows_get_window_context(hWnd));
                 if(context && context->display_device_object) {
                     HDC hdc = BeginPaint(hWnd, &ps);
-                    lv_obj_invalidate(lv_screen_active());
+                    lv_obj_invalidate(lv_display_get_screen_active(context->display_device_object));
                     EndPaint(hWnd, &ps);
                 }
 

--- a/src/drivers/windows/lv_windows_display.c
+++ b/src/drivers/windows/lv_windows_display.c
@@ -11,6 +11,7 @@
 #if LV_USE_WINDOWS
 
 #include "lv_windows_context.h"
+#include "../../misc/lv_timer.h"
 
 #include <process.h>
 
@@ -82,6 +83,8 @@ lv_display_t * lv_windows_create_display(
     if(data.mutex) {
         CloseHandle(data.mutex);
     }
+
+    lv_timer_handler();
 
     return data.display;
 }


### PR DESCRIPTION
The first frame display issue caused by unupdated coordinates: In the Win32 development environment, after creating a Windows display, due to an internal not-ready state, if components are created at this time, the coordinate parameters cannot be updated due to the not-ready state, resulting in abnormal screen display. Only a small border is visible, and manual input operations are required to focus on specific objects before it becomes normal. If there are no objects within the group that can be focused on, the interface will remain stuck and cannot be restored.
Display issue when reopening a minimized window: After minimizing a window, expanding it again can result in a white screen due to unhandled redraw events. Add a redraw event to force a redraw of the currently active screen.
This is a screenshot of the phenomenon:
First frame:
<img width="1201" height="943" alt="first frame coordinates" src="https://github.com/user-attachments/assets/92bb4c84-df8f-4c53-a6c2-61aec51d04e4" />
After minimize:
<img width="1201" height="943" alt="refresh after minimize" src="https://github.com/user-attachments/assets/cb2b0bc8-11bd-49c6-a6a3-c4f9217c83b0" />