### PR TITLE
fix(obj): the abnormal behavior of the x and y properties

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -95,12 +95,12 @@ static const lv_property_ops_t lv_obj_properties[] = {
     {
         .id = LV_PROPERTY_OBJ_X,
         .setter = lv_obj_set_x,
-        .getter = lv_obj_get_x,
+        .getter = lv_obj_get_x_aligned,
     },
     {
         .id = LV_PROPERTY_OBJ_Y,
         .setter = lv_obj_set_y,
-        .getter = lv_obj_get_y,
+        .getter = lv_obj_get_y_aligned,
     },
     {
         .id = LV_PROPERTY_OBJ_W,


### PR DESCRIPTION
lv_obj_set_x is actually lv_obj_set_x_aligned.

In practical use
```
local obj=Object {}
obj.x=-400
print(obj.x) -- the output is "0" But the position of the obj has indeed changed.
```
