### PR TITLE
feat(chart): crowded-mode rendering on opengles support, with head/tail tint gradients

### DIFF
--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -236,6 +236,26 @@ void lv_chart_set_axis_range(lv_obj_t * obj, lv_chart_axis_t axis, int32_t min, 
 
 #if LV_USE_CHART_SCISSOR_FILL_MODE
 
+void lv_chart_set_force_crowded(lv_obj_t * obj, bool force_enable)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_chart_t * chart  = (lv_chart_t *)obj;
+    if(chart->force_crowded_mode == force_enable) return;
+
+    chart->force_crowded_mode = force_enable;
+    lv_obj_invalidate(obj);
+}
+
+bool lv_chart_get_force_crowded(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_chart_t * chart  = (lv_chart_t *)obj;
+
+    return chart->force_crowded_mode;
+}
+
 void lv_chart_set_head_percent(lv_obj_t * obj, uint32_t norm)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
@@ -1165,6 +1185,9 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
 
     /* For OpenGLES rendering, force crowded mode with no extra space allocation */
 #if LV_USE_CHART_SCISSOR_FILL_MODE
+    if(lv_chart_get_force_crowded(obj)) {
+        crowded_mode = true;
+    }
     if(crowded_mode == true) {
         crowded_scissor_fill_mode = true;
         extra_space_x = 0;

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -234,6 +234,120 @@ void lv_chart_set_axis_range(lv_obj_t * obj, lv_chart_axis_t axis, int32_t min, 
     lv_chart_set_axis_max_value(obj, axis, max);
 }
 
+#if LV_USE_CHART_SCISSOR_FILL_MODE
+
+void lv_chart_set_head_percent(lv_obj_t * obj, uint32_t norm)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_chart_t * chart  = (lv_chart_t *)obj;
+    if(chart->head_percent == norm) return;
+
+    chart->head_percent = norm;
+    lv_obj_invalidate(obj);
+}
+
+void lv_chart_set_head_size_offset(lv_obj_t * obj, int32_t pixels)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_chart_t * chart  = (lv_chart_t *)obj;
+    if(chart->head_size_offset == pixels) return;
+
+    chart->head_size_offset = pixels;
+    lv_obj_invalidate(obj);
+}
+
+void lv_chart_set_head_color(lv_obj_t * obj, lv_color_t color)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_chart_t * chart  = (lv_chart_t *)obj;
+
+    chart->head_color = color;
+    lv_obj_invalidate(obj);
+}
+
+uint32_t lv_chart_get_head_percent(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_chart_t * chart  = (lv_chart_t *)obj;
+    return chart->head_percent;
+}
+int32_t lv_chart_get_head_size_offset(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_chart_t * chart  = (lv_chart_t *)obj;
+    return chart->head_size_offset;
+}
+
+lv_color_t lv_chart_get_head_color(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_chart_t * chart  = (lv_chart_t *)obj;
+    return chart->head_color;
+}
+
+void lv_chart_set_tail_percent(lv_obj_t * obj, uint32_t norm)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_chart_t * chart  = (lv_chart_t *)obj;
+    if(chart->tail_percent == norm) return;
+
+    chart->tail_percent = norm;
+    lv_obj_invalidate(obj);
+}
+
+void lv_chart_set_tail_size_offset(lv_obj_t * obj, int32_t pixels)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_chart_t * chart  = (lv_chart_t *)obj;
+    if(chart->tail_size_offset == pixels) return;
+
+    chart->tail_size_offset = pixels;
+    lv_obj_invalidate(obj);
+}
+
+void lv_chart_set_tail_color(lv_obj_t * obj, lv_color_t color)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_chart_t * chart  = (lv_chart_t *)obj;
+
+    chart->tail_color = color;
+    lv_obj_invalidate(obj);
+}
+
+uint32_t lv_chart_get_tail_percent(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_chart_t * chart  = (lv_chart_t *)obj;
+    return chart->tail_percent;
+}
+
+int32_t lv_chart_get_tail_size_offset(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_chart_t * chart  = (lv_chart_t *)obj;
+    return chart->tail_size_offset;
+}
+
+lv_color_t lv_chart_get_tail_color(lv_obj_t * obj)
+{
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_chart_t * chart  = (lv_chart_t *)obj;
+    return chart->tail_color;
+}
+#endif
+
 void lv_chart_set_update_mode(lv_obj_t * obj, lv_chart_update_mode_t update_mode)
 {
     LV_ASSERT_OBJ(obj, MY_CLASS);
@@ -1041,12 +1155,20 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
 
     /*If there are at least as many points as pixels then draw only vertical lines*/
     bool crowded_mode = (int32_t)chart->point_cnt >= w;
+    bool crowded_scissor_fill_mode = false;
 
     int32_t bullet_w = lv_obj_get_style_width(obj, LV_PART_INDICATOR) / 2;
     int32_t bullet_h = lv_obj_get_style_height(obj, LV_PART_INDICATOR) / 2;
     int32_t extra_space_x;
     if(chart->point_cnt <= 1) extra_space_x = 0;
     else extra_space_x = w  / (chart->point_cnt - 1) + bullet_w + line_dsc.width;
+
+    /* For OpenGLES rendering, force crowded mode with no extra space allocation */
+#if LV_USE_CHART_SCISSOR_FILL_MODE
+    crowded_mode = true;
+    crowded_scissor_fill_mode = true;
+    extra_space_x = 0;
+#endif
 
     lv_draw_rect_dsc_t point_draw_dsc;
     if(crowded_mode == false) {
@@ -1093,7 +1215,35 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
         line_dsc.point_cnt = 0;
 
         uint32_t i;
+        int32_t next_none = -1;
+        for(uint32_t ii = 0; ii < chart->point_cnt; ii++) {
+            uint32_t p_test = (start_point + ii) % chart->point_cnt;
+            if(ser->y_points[p_test] == LV_CHART_POINT_NONE) {
+                next_none = p_test;
+                break;
+            }
+        }
+
+        float active_norm = -1.f;
+        float next_none_norm_dist = -1.f;
+        float next_none_norm = -1.f;
+
+#if LV_USE_CHART_SCISSOR_FILL_MODE
+        float head_norm = 0.f;
+        float tail_norm = 0.f;
+        if(next_none > -1) {
+            head_norm = (float)chart->head_percent / (float)1024.f;
+            tail_norm = ((float)chart->tail_percent / (float)1024.f);
+            next_none_norm = ((float)(next_none) / (float)(chart->point_cnt));
+        }
+#endif
+
         for(i = 0; i < chart->point_cnt; i++) {
+            if(next_none > -1) {
+                active_norm = (float)p_act / (float)(chart->point_cnt);
+                next_none_norm_dist = ((LV_ABS((next_none_norm - 1.f) - active_norm) < LV_ABS(next_none_norm - active_norm)) ?
+                                       (next_none_norm - 1.f) : next_none_norm) - active_norm;
+            }
             lv_value_precise_t p_x = (int32_t)((w * i) / (chart->point_cnt - 1)) + x_ofs;
             if(p_x > layer->_clip_area.x2 + extra_space_x + 1) break;
             if(p_x < layer->_clip_area.x1 - extra_space_x - 1) {
@@ -1126,21 +1276,73 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
                     y_max = LV_MAX(y_max, p_y);
                     y_min = LV_MIN(y_min, p_y);
                     if(x_prev != p_x) {
-                        line_dsc.points[line_dsc.point_cnt].y = y_min;
-                        line_dsc.points[line_dsc.point_cnt].x = p_x;
-                        line_dsc.points[line_dsc.point_cnt + 1].y = y_max;
-                        line_dsc.points[line_dsc.point_cnt + 1].x = p_x;
-                        line_dsc.points[line_dsc.point_cnt + 2].y = LV_DRAW_LINE_POINT_NONE;
-                        line_dsc.points[line_dsc.point_cnt + 2].x = p_x;
+                        if(crowded_scissor_fill_mode) {
+                            /*Draw the line from the accumulated points*/
+                            lv_area_t coords;
+                            float norm_edge_effect = 0.f;
+                            bool in_head = false;
+                            bool in_tail = false;
+                            int32_t ex_size = 1;
 
-                        /*If they are the same no line would be drawn*/
-                        if(line_dsc.points[line_dsc.point_cnt].y == line_dsc.points[line_dsc.point_cnt + 1].y) {
-                            line_dsc.points[line_dsc.point_cnt + 1].y++;
+#if LV_USE_CHART_SCISSOR_FILL_MODE
+                            in_head = ((next_none_norm_dist < head_norm) && (next_none_norm_dist > 0.f));
+                            in_tail = ((next_none_norm_dist > -tail_norm) && (next_none_norm_dist > -1.f) && (next_none_norm_dist < 0.f));
+                            if(in_head) {
+                                norm_edge_effect = 1.f - (next_none_norm_dist / head_norm);
+                                norm_edge_effect *= norm_edge_effect;
+                                ex_size += (norm_edge_effect * chart->head_size_offset);
+                            }
+                            else if(in_tail) {
+                                norm_edge_effect = 1.f - (-next_none_norm_dist / tail_norm);
+                                norm_edge_effect *= norm_edge_effect;
+                                ex_size += (norm_edge_effect * chart->tail_size_offset);
+                            }
+#endif
+                            coords.x1 = p_x;
+                            coords.x2 = p_x + ex_size;
+                            coords.y1 = y_min;
+                            coords.y2 = y_max + ex_size;
+                            if(y_min == y_max) {
+                                coords.y2 = y_min + 1;
+                            }
+
+                            lv_draw_task_t * t;
+                            t = lv_draw_add_task(layer, &coords, LV_DRAW_TASK_TYPE_FILL);
+                            lv_draw_fill_dsc_t * bg_dsc = t->draw_dsc;
+                            lv_draw_fill_dsc_init(bg_dsc);
+                            bg_dsc->radius = 0;
+                            lv_color_t outcol = ser->color;
+#if LV_USE_CHART_SCISSOR_FILL_MODE
+                            if(in_head) {
+                                outcol = lv_color_mix(chart->head_color, outcol, (int8_t)(norm_edge_effect * 255.f));
+                            }
+                            else if(in_tail) {
+                                outcol = lv_color_mix(chart->tail_color, outcol, (int8_t)(norm_edge_effect * 255.f));
+
+                            }
+#endif
+                            bg_dsc->color = outcol;
+                            bg_dsc->opa = LV_OPA_COVER;
+
+                            lv_draw_finalize_task_creation(layer, t);
+                        }
+                        else {
+                            line_dsc.points[line_dsc.point_cnt].y = y_min;
+                            line_dsc.points[line_dsc.point_cnt].x = p_x;
+                            line_dsc.points[line_dsc.point_cnt + 1].y = y_max;
+                            line_dsc.points[line_dsc.point_cnt + 1].x = p_x;
+                            line_dsc.points[line_dsc.point_cnt + 2].y = LV_DRAW_LINE_POINT_NONE;
+                            line_dsc.points[line_dsc.point_cnt + 2].x = p_x;
+
+                            /*If they are the same no line would be drawn*/
+                            if(line_dsc.points[line_dsc.point_cnt].y == line_dsc.points[line_dsc.point_cnt + 1].y) {
+                                line_dsc.points[line_dsc.point_cnt + 1].y++;
+                            }
+                            line_dsc.point_cnt += 3;
                         }
                         y_min = p_y;  /*Start the line of the next x from the current last y*/
                         y_max = p_y;
                         x_prev = p_x;
-                        line_dsc.point_cnt += 3;
                     }
                 }
             }
@@ -1149,25 +1351,27 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
         }
 
         /*Draw the line from the accumulated points*/
-        lv_draw_line(layer, &line_dsc);
-        if(!crowded_mode) {
-            point_draw_dsc.bg_color = ser->color;
-            point_draw_dsc.base.id1 = line_dsc.base.id1;
-            /*Add the bullets too*/
-            if(bullet_w > 0 && bullet_h > 0) {
-                point_draw_dsc.base.id2 = i - 1; /*Start from the last rendered point*/
-                int32_t j;
-                for(j = line_dsc.point_cnt - 1; j >= 0; j--) {
-                    if(points[j].y == LV_DRAW_LINE_POINT_NONE) continue;
+        if(!crowded_scissor_fill_mode) {
+            lv_draw_line(layer, &line_dsc);
+            if(!crowded_mode) {
+                point_draw_dsc.bg_color = ser->color;
+                point_draw_dsc.base.id1 = line_dsc.base.id1;
+                /*Add the bullets too*/
+                if(bullet_w > 0 && bullet_h > 0) {
+                    point_draw_dsc.base.id2 = i - 1; /*Start from the last rendered point*/
+                    int32_t j;
+                    for(j = line_dsc.point_cnt - 1; j >= 0; j--) {
+                        if(points[j].y == LV_DRAW_LINE_POINT_NONE) continue;
 
-                    lv_area_t point_area;
-                    point_area.x1 = (int32_t)points[j].x - bullet_w;
-                    point_area.x2 = (int32_t)points[j].x + bullet_w;
-                    point_area.y1 = (int32_t)points[j].y - bullet_h;
-                    point_area.y2 = (int32_t)points[j].y + bullet_h;
+                        lv_area_t point_area;
+                        point_area.x1 = (int32_t)points[j].x - bullet_w;
+                        point_area.x2 = (int32_t)points[j].x + bullet_w;
+                        point_area.y1 = (int32_t)points[j].y - bullet_h;
+                        point_area.y2 = (int32_t)points[j].y + bullet_h;
 
-                    lv_draw_rect(layer, &point_draw_dsc, &point_area);
-                    point_draw_dsc.base.id2--;
+                        lv_draw_rect(layer, &point_draw_dsc, &point_area);
+                        point_draw_dsc.base.id2--;
+                    }
                 }
             }
         }

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -1290,12 +1290,12 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
                             if(in_head) {
                                 norm_edge_effect = 1.f - (next_none_norm_dist / head_norm);
                                 norm_edge_effect *= norm_edge_effect;
-                                ex_size += (norm_edge_effect * chart->head_size_offset);
+                                ex_size += (int32_t)(norm_edge_effect * (float)chart->head_size_offset);
                             }
                             else if(in_tail) {
                                 norm_edge_effect = 1.f - (-next_none_norm_dist / tail_norm);
                                 norm_edge_effect *= norm_edge_effect;
-                                ex_size += (norm_edge_effect * chart->tail_size_offset);
+                                ex_size += (int32_t)(norm_edge_effect * (float)chart->tail_size_offset);
                             }
 #endif
                             coords.x1 = p_x;

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -1165,9 +1165,10 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
 
     /* For OpenGLES rendering, force crowded mode with no extra space allocation */
 #if LV_USE_CHART_SCISSOR_FILL_MODE
-    crowded_mode = true;
-    crowded_scissor_fill_mode = true;
-    extra_space_x = 0;
+    if(crowded_mode == true) {
+        crowded_scissor_fill_mode = true;
+        extra_space_x = 0;
+    }
 #endif
 
     lv_draw_rect_dsc_t point_draw_dsc;

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -1224,23 +1224,23 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
             }
         }
 
-        float active_norm = -1.f;
-        float next_none_norm_dist = -1.f;
-        float next_none_norm = -1.f;
+        lv_value_precise_t active_norm = -1.f;
+        lv_value_precise_t next_none_norm_dist = -1.f;
+        lv_value_precise_t next_none_norm = -1.f;
 
 #if LV_USE_CHART_SCISSOR_FILL_MODE
-        float head_norm = 0.f;
-        float tail_norm = 0.f;
+        lv_value_precise_t head_norm = 0.f;
+        lv_value_precise_t tail_norm = 0.f;
         if(next_none > -1) {
-            head_norm = (float)chart->head_percent / (float)1024.f;
-            tail_norm = ((float)chart->tail_percent / (float)1024.f);
-            next_none_norm = ((float)(next_none) / (float)(chart->point_cnt));
+            head_norm = (lv_value_precise_t)chart->head_percent / (lv_value_precise_t)1024.f;
+            tail_norm = ((lv_value_precise_t)chart->tail_percent / (lv_value_precise_t)1024.f);
+            next_none_norm = ((lv_value_precise_t)(next_none) / (lv_value_precise_t)(chart->point_cnt));
         }
 #endif
 
         for(i = 0; i < chart->point_cnt; i++) {
             if(next_none > -1) {
-                active_norm = (float)p_act / (float)(chart->point_cnt);
+                active_norm = (lv_value_precise_t)p_act / (lv_value_precise_t)(chart->point_cnt);
                 next_none_norm_dist = ((LV_ABS((next_none_norm - 1.f) - active_norm) < LV_ABS(next_none_norm - active_norm)) ?
                                        (next_none_norm - 1.f) : next_none_norm) - active_norm;
             }
@@ -1279,7 +1279,7 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
                         if(crowded_scissor_fill_mode) {
                             /*Draw the line from the accumulated points*/
                             lv_area_t coords;
-                            float norm_edge_effect = 0.f;
+                            lv_value_precise_t norm_edge_effect = 0.f;
                             bool in_head = false;
                             bool in_tail = false;
                             int32_t ex_size = 1;
@@ -1290,20 +1290,20 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
                             if(in_head) {
                                 norm_edge_effect = 1.f - (next_none_norm_dist / head_norm);
                                 norm_edge_effect *= norm_edge_effect;
-                                ex_size += (int32_t)(norm_edge_effect * (float)chart->head_size_offset);
+                                ex_size += (int32_t)(norm_edge_effect * (lv_value_precise_t)chart->head_size_offset);
                             }
                             else if(in_tail) {
                                 norm_edge_effect = 1.f - (-next_none_norm_dist / tail_norm);
                                 norm_edge_effect *= norm_edge_effect;
-                                ex_size += (int32_t)(norm_edge_effect * (float)chart->tail_size_offset);
+                                ex_size += (int32_t)(norm_edge_effect * (lv_value_precise_t)chart->tail_size_offset);
                             }
 #endif
-                            coords.x1 = p_x;
-                            coords.x2 = p_x + ex_size;
-                            coords.y1 = y_min;
-                            coords.y2 = y_max + ex_size;
-                            if(y_min == y_max) {
-                                coords.y2 = y_min + 1;
+                            coords.x1 = (int32_t)p_x;
+                            coords.x2 = (int32_t)p_x + ex_size;
+                            coords.y1 = (int32_t)y_min;
+                            coords.y2 = (int32_t)y_max + ex_size;
+                            if((int32_t)y_min == (int32_t)y_max) {
+                                coords.y2 = (int32_t)y_min + 1;
                             }
 
                             lv_draw_task_t * t;

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -1229,8 +1229,8 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
         lv_value_precise_t next_none_norm = (lv_value_precise_t)(-1.0);
 
 #if LV_USE_CHART_SCISSOR_FILL_MODE
-        lv_value_precise_t head_norm = 0.f;
-        lv_value_precise_t tail_norm = 0.f;
+        lv_value_precise_t head_norm = (lv_value_precise_t)(0.0);
+        lv_value_precise_t tail_norm = (lv_value_precise_t)(0.0);
         if(next_none > -1) {
             head_norm = (lv_value_precise_t)chart->head_percent / (lv_value_precise_t)1024.f;
             tail_norm = ((lv_value_precise_t)chart->tail_percent / (lv_value_precise_t)1024.f);
@@ -1280,15 +1280,15 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
                         if(crowded_scissor_fill_mode) {
                             /*Draw the line from the accumulated points*/
                             lv_area_t coords;
-                            lv_value_precise_t norm_edge_effect = 0.f;
+                            lv_value_precise_t norm_edge_effect = (lv_value_precise_t)(0.0);
                             bool in_head = false;
                             bool in_tail = false;
                             int32_t ex_size = 1;
 
 #if LV_USE_CHART_SCISSOR_FILL_MODE
-                            in_head = ((next_none_norm_dist < head_norm) && (next_none_norm_dist > 0.f));
+                            in_head = ((next_none_norm_dist < head_norm) && (next_none_norm_dist > (lv_value_precise_t)(0.0)));
                             in_tail = ((next_none_norm_dist > -tail_norm) && (next_none_norm_dist > (lv_value_precise_t)(-1.0)) &&
-                                       (next_none_norm_dist < 0.f));
+                                       (next_none_norm_dist < (lv_value_precise_t)(0.0)));
                             if(in_head) {
                                 norm_edge_effect = (lv_value_precise_t)(1.0) - (next_none_norm_dist / head_norm);
                                 norm_edge_effect *= norm_edge_effect;

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -1257,8 +1257,8 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
         lv_value_precise_t tail_norm = (lv_value_precise_t)(0.0);
         if(next_none > -1) {
             head_norm = (lv_value_precise_t)chart->head_percent / (lv_value_precise_t)(1024.0);
-            tail_norm = ((lv_value_precise_t)chart->tail_percent / (lv_value_precise_t)(1024.0);
-                         next_none_norm = ((lv_value_precise_t)(next_none) / (lv_value_precise_t)(chart->point_cnt));
+            tail_norm = (lv_value_precise_t)chart->tail_percent / (lv_value_precise_t)(1024.0);
+            next_none_norm = ((lv_value_precise_t)(next_none) / (lv_value_precise_t)(chart->point_cnt));
         }
 #endif
 

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -1224,9 +1224,9 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
             }
         }
 
-        lv_value_precise_t active_norm = -1.f;
-        lv_value_precise_t next_none_norm_dist = -1.f;
-        lv_value_precise_t next_none_norm = -1.f;
+        lv_value_precise_t active_norm = (lv_value_precise_t)(-1.0);
+        lv_value_precise_t next_none_norm_dist = (lv_value_precise_t)(-1.0);
+        lv_value_precise_t next_none_norm = (lv_value_precise_t)(-1.0);
 
 #if LV_USE_CHART_SCISSOR_FILL_MODE
         lv_value_precise_t head_norm = 0.f;
@@ -1241,8 +1241,9 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
         for(i = 0; i < chart->point_cnt; i++) {
             if(next_none > -1) {
                 active_norm = (lv_value_precise_t)p_act / (lv_value_precise_t)(chart->point_cnt);
-                next_none_norm_dist = ((LV_ABS((next_none_norm - 1.f) - active_norm) < LV_ABS(next_none_norm - active_norm)) ?
-                                       (next_none_norm - 1.f) : next_none_norm) - active_norm;
+                next_none_norm_dist = ((LV_ABS((next_none_norm - (lv_value_precise_t)(1.0)) - active_norm) < LV_ABS(
+                                            next_none_norm - active_norm)) ?
+                                       (next_none_norm - (lv_value_precise_t)(1.0)) : next_none_norm) - active_norm;
             }
             lv_value_precise_t p_x = (int32_t)((w * i) / (chart->point_cnt - 1)) + x_ofs;
             if(p_x > layer->_clip_area.x2 + extra_space_x + 1) break;
@@ -1286,14 +1287,15 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
 
 #if LV_USE_CHART_SCISSOR_FILL_MODE
                             in_head = ((next_none_norm_dist < head_norm) && (next_none_norm_dist > 0.f));
-                            in_tail = ((next_none_norm_dist > -tail_norm) && (next_none_norm_dist > -1.f) && (next_none_norm_dist < 0.f));
+                            in_tail = ((next_none_norm_dist > -tail_norm) && (next_none_norm_dist > (lv_value_precise_t)(-1.0)) &&
+                                       (next_none_norm_dist < 0.f));
                             if(in_head) {
-                                norm_edge_effect = 1.f - (next_none_norm_dist / head_norm);
+                                norm_edge_effect = (lv_value_precise_t)(1.0) - (next_none_norm_dist / head_norm);
                                 norm_edge_effect *= norm_edge_effect;
                                 ex_size += (int32_t)(norm_edge_effect * (lv_value_precise_t)chart->head_size_offset);
                             }
                             else if(in_tail) {
-                                norm_edge_effect = 1.f - (-next_none_norm_dist / tail_norm);
+                                norm_edge_effect = (lv_value_precise_t)(1.0) - (-next_none_norm_dist / tail_norm);
                                 norm_edge_effect *= norm_edge_effect;
                                 ex_size += (int32_t)(norm_edge_effect * (lv_value_precise_t)chart->tail_size_offset);
                             }

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -1256,9 +1256,9 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
         lv_value_precise_t head_norm = (lv_value_precise_t)(0.0);
         lv_value_precise_t tail_norm = (lv_value_precise_t)(0.0);
         if(next_none > -1) {
-            head_norm = (lv_value_precise_t)chart->head_percent / (lv_value_precise_t)1024.f;
-            tail_norm = ((lv_value_precise_t)chart->tail_percent / (lv_value_precise_t)1024.f);
-            next_none_norm = ((lv_value_precise_t)(next_none) / (lv_value_precise_t)(chart->point_cnt));
+            head_norm = (lv_value_precise_t)chart->head_percent / (lv_value_precise_t)(1024.0);
+            tail_norm = ((lv_value_precise_t)chart->tail_percent / (lv_value_precise_t)(1024.0);
+                         next_none_norm = ((lv_value_precise_t)(next_none) / (lv_value_precise_t)(chart->point_cnt));
         }
 #endif
 
@@ -1340,10 +1340,10 @@ static void draw_series_line(lv_obj_t * obj, lv_layer_t * layer)
                             lv_color_t outcol = ser->color;
 #if LV_USE_CHART_SCISSOR_FILL_MODE
                             if(in_head) {
-                                outcol = lv_color_mix(chart->head_color, outcol, (int8_t)(norm_edge_effect * 255.f));
+                                outcol = lv_color_mix(chart->head_color, outcol, (int8_t)(norm_edge_effect * 255.0));
                             }
                             else if(in_tail) {
-                                outcol = lv_color_mix(chart->tail_color, outcol, (int8_t)(norm_edge_effect * 255.f));
+                                outcol = lv_color_mix(chart->tail_color, outcol, (int8_t)(norm_edge_effect * 255.0));
 
                             }
 #endif

--- a/src/widgets/chart/lv_chart.h
+++ b/src/widgets/chart/lv_chart.h
@@ -26,6 +26,10 @@ extern "C" {
 #define LV_CHART_POINT_NONE     (INT32_MAX)
 LV_EXPORT_CONST_INT(LV_CHART_POINT_NONE);
 
+/* Enable crowded mode rendering on Opengles output using
+    glScissor fills.  Also enables head/tail tint gradients */
+#define LV_USE_CHART_SCISSOR_FILL_MODE 1
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -123,6 +127,96 @@ void lv_chart_set_axis_min_value(lv_obj_t * obj, lv_chart_axis_t axis, int32_t m
  */
 void lv_chart_set_axis_max_value(lv_obj_t * obj, lv_chart_axis_t axis, int32_t max);
 
+#if LV_USE_CHART_SCISSOR_FILL_MODE
+/**
+ * Set the head percentage
+ * @param obj       pointer to a chart object
+ * @param norm      set a 0 to 1024 value representing what portion of the chart should be the head
+ */
+void lv_chart_set_head_percent(lv_obj_t * obj, uint32_t norm);
+
+/**
+ * Set the head size offset
+ * @param obj       pointer to a chart object
+ * @param pixels    set how many pixels to grow or shrink the line at the head
+ */
+void lv_chart_set_head_size_offset(lv_obj_t * obj, int32_t pixels);
+
+/**
+ * Set the head color
+ * @param obj       pointer to a chart object
+ * @param color     set the color of the line at the tip of the head
+ */
+void lv_chart_set_head_color(lv_obj_t * obj, lv_color_t color);
+
+/**
+ * Get the head percentage
+ * @param obj       pointer to a chart object
+ */
+uint32_t lv_chart_get_head_percent(lv_obj_t * obj);
+
+/**
+ * Get the head size offset
+ * @param obj       pointer to a chart object
+ */
+int32_t lv_chart_get_head_size_offset(lv_obj_t * obj);
+
+/**
+ * Get the head color
+ * @param obj       pointer to a chart object
+ */
+lv_color_t lv_chart_get_head_color(lv_obj_t * obj);
+
+/**
+ * Set the tail percentage
+ * @param obj       pointer to a chart object
+ * @param norm      set a 0 to 1024 value representing what portion of the chart should be the tail
+ */
+void lv_chart_set_tail_percent(lv_obj_t * obj, uint32_t norm);
+
+/**
+ * Set the tail power
+ * @param obj       pointer to a chart object
+ * @param norm      set a 0 to 4096 value representing how sharply the tail effect should taper in, 1024 = linear
+ */
+//void lv_chart_set_tail_pow(lv_obj_t * obj, uint32_t norm);
+
+/**
+ * Set the tail size offset
+ * @param obj       pointer to a chart object
+ * @param pixels    set how many pixels to grow or shrink the line at the tail
+ */
+void lv_chart_set_tail_size_offset(lv_obj_t * obj, int32_t pixels);
+
+/**
+ * Get the tail color
+ * @param obj       pointer to a chart object
+ * @param color     set the color of the line at the tip of the tail
+ */
+void lv_chart_set_tail_color(lv_obj_t * obj, lv_color_t color);
+
+/**
+ * Get the tail percentage
+ * @param obj       pointer to a chart object
+ * @return          the 0 to 1024 value representing what portion of the chart should be the tail
+ */
+uint32_t lv_chart_get_tail_percent(lv_obj_t * obj);
+
+/**
+ * Get the tail size offset
+ * @param obj       pointer to a chart object
+ * @return          how many pixels to grow or shrink the line at the tail
+ */
+int32_t lv_chart_get_tail_size_offset(lv_obj_t * obj);
+
+/**
+ * Get the tail color
+ * @param obj       pointer to a chart object
+ * @return          the color of the line at the tip of the tail
+ */
+lv_color_t lv_chart_get_tail_color(lv_obj_t * obj);
+
+#endif
 
 /**
  * Set update mode of the chart object. Affects

--- a/src/widgets/chart/lv_chart.h
+++ b/src/widgets/chart/lv_chart.h
@@ -129,6 +129,19 @@ void lv_chart_set_axis_max_value(lv_obj_t * obj, lv_chart_axis_t axis, int32_t m
 
 #if LV_USE_CHART_SCISSOR_FILL_MODE
 /**
+ * Force crowded mode chart rendering
+ * @param obj           pointer to a chart object
+ * @param force_enable  true to force crowded mode rendering, false to only enable if needed
+ */
+void lv_chart_set_force_crowded(lv_obj_t * obj, bool force_enable);
+
+/**
+ * Get the force crowded mode chart rendering flag state
+ * @param obj           pointer to a chart object
+ */
+bool lv_chart_get_force_crowded(lv_obj_t * obj);
+
+/**
  * Set the head percentage
  * @param obj       pointer to a chart object
  * @param norm      set a 0 to 1024 value representing what portion of the chart should be the head

--- a/src/widgets/chart/lv_chart_private.h
+++ b/src/widgets/chart/lv_chart_private.h
@@ -65,6 +65,17 @@ struct _lv_chart_t {
     uint32_t point_cnt;         /**< Number of points in all series */
     lv_chart_type_t type  : 4;  /**< Chart type */
     lv_chart_update_mode_t update_mode : 2;
+
+#if LV_USE_CHART_SCISSOR_FILL_MODE
+    uint32_t head_percent;
+    int32_t head_size_offset;
+    lv_color_t head_color;
+
+    uint32_t tail_percent;
+    int32_t tail_size_offset;
+    lv_color_t tail_color;
+#endif
+
 };
 
 

--- a/src/widgets/chart/lv_chart_private.h
+++ b/src/widgets/chart/lv_chart_private.h
@@ -67,6 +67,7 @@ struct _lv_chart_t {
     lv_chart_update_mode_t update_mode : 2;
 
 #if LV_USE_CHART_SCISSOR_FILL_MODE
+    bool force_crowded_mode;
     uint32_t head_percent;
     int32_t head_size_offset;
     lv_color_t head_color;


### PR DESCRIPTION
This is in progress work and needs more testing before merging.  I'm using github's code review and build tests to confirm this code works on it's own, outside of a larger use of it and other modified code in a demo.  I'm carving just this part out of that into this PR.

This PR adds support for "crowded-mode" rendering of lv_chart's on OpenGL ES targets.  

It also adds the idea of a head and tail of the data, with each having it's own normalized length and color.
<img width="654" height="563" alt="Screenshot from 2026-04-05 03-51-27" src="https://github.com/user-attachments/assets/18218d72-7c69-4a4e-b91b-ab2457581efa" />
