### PR TITLE
fix(windows): pass thread handle, not pointer to handle

### DIFF
--- a/src/osal/lv_windows.c
+++ b/src/osal/lv_windows.c
@@ -108,7 +108,7 @@ lv_result_t lv_thread_delete(lv_thread_t * thread)
 {
     lv_result_t result = LV_RESULT_OK;
     if(!thread) {
-        return LV_RESULT_INVALID;
+        return LV_RESULT_OK;
     }
 
     if(!TerminateThread(*thread, 0)) {

--- a/src/osal/lv_windows.c
+++ b/src/osal/lv_windows.c
@@ -108,11 +108,11 @@ lv_result_t lv_thread_delete(lv_thread_t * thread)
 {
     lv_result_t result = LV_RESULT_OK;
 
-    if(!TerminateThread(thread, 0)) {
+    if(!TerminateThread(*thread, 0)) {
         result = LV_RESULT_INVALID;
     }
 
-    CloseHandle(thread);
+    CloseHandle(*thread);
 
     return result;
 }

--- a/src/osal/lv_windows.c
+++ b/src/osal/lv_windows.c
@@ -107,6 +107,9 @@ lv_result_t lv_thread_init(
 lv_result_t lv_thread_delete(lv_thread_t * thread)
 {
     lv_result_t result = LV_RESULT_OK;
+    if(!thread) {
+        return LV_RESULT_INVALID;
+    }
 
     if(!TerminateThread(*thread, 0)) {
         result = LV_RESULT_INVALID;


### PR DESCRIPTION
Need to pass the HANDLE here instead of a pointer to the handle, refer to the initialization function.