### PR TITLE
fix(tiny_ttf): kerning cache use after free

### DIFF
--- a/src/libs/tiny_ttf/lv_tiny_ttf.c
+++ b/src/libs/tiny_ttf/lv_tiny_ttf.c
@@ -286,8 +286,9 @@ static uint16_t ttf_get_glyph_pair_kerning_width(const ttf_font_desc_t * dsc, ui
     tiny_ttf_kerning_cache_data_t * data = lv_cache_entry_get_data(kerning_entry);
     LV_ASSERT_NULL(data);
 
+    uint16_t adv_w16 = data->adv_w16;
     lv_cache_release(dsc->kerning_cache, kerning_entry, NULL);
-    return data->adv_w16;
+    return adv_w16;
 }
 
 static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, uint32_t unicode_letter,


### PR DESCRIPTION
This might fix issue #9765.