### PR TITLE
fix(wayland): correct memory leak on shutdown and add exit_ready function

### DIFF
--- a/src/drivers/wayland/lv_wayland_keyboard.c
+++ b/src/drivers/wayland/lv_wayland_keyboard.c
@@ -127,9 +127,15 @@ void lv_wayland_seat_keyboard_delete(lv_wl_seat_keyboard_t * seat_keyboard)
 {
     lv_wayland_update_indevs(keyboard_read, NULL);
 
-    xkb_keymap_unref(seat_keyboard->xkb_keymap);
-    xkb_state_unref(seat_keyboard->xkb_state);
-    lv_free(seat_keyboard->wl_keyboard);
+    if(seat_keyboard->xkb_keymap) {
+        xkb_keymap_unref(seat_keyboard->xkb_keymap);
+    }
+    if(seat_keyboard->xkb_state) {
+        xkb_state_unref(seat_keyboard->xkb_state);
+    }
+    if(seat_keyboard->wl_keyboard) {
+        wl_keyboard_destroy(seat_keyboard->wl_keyboard);
+    }
 
     lv_free(seat_keyboard);
 }

--- a/src/drivers/wayland/lv_wayland_keyboard.c
+++ b/src/drivers/wayland/lv_wayland_keyboard.c
@@ -126,8 +126,14 @@ lv_wl_seat_keyboard_t * lv_wayland_seat_keyboard_create(struct wl_seat * wl_seat
 void lv_wayland_seat_keyboard_delete(lv_wl_seat_keyboard_t * seat_keyboard)
 {
     lv_wayland_update_indevs(keyboard_read, NULL);
+
+    xkb_keymap_unref(seat_keyboard->xkb_keymap);
+    xkb_state_unref(seat_keyboard->xkb_state);
+    lv_free(seat_keyboard->wl_keyboard);
+
     lv_free(seat_keyboard);
 }
+
 
 /**********************
  *   STATIC FUNCTIONS

--- a/src/drivers/wayland/lv_wayland_window.c
+++ b/src/drivers/wayland/lv_wayland_window.c
@@ -301,11 +301,19 @@ void lv_wayland_window_delete(lv_wl_window_t * window)
 
     lv_ll_remove(&lv_wl_ctx.window_ll, window);
 
-    if(LV_WAYLAND_DIRECT_EXIT && lv_ll_is_empty(&lv_wl_ctx.window_ll)) {
+    if(LV_WAYLAND_DIRECT_EXIT && lv_wayland_exit_ready()) {
         /* lv_deinit will deinit the wayland driver*/
         lv_deinit();
         exit(0);
     }
+}
+
+bool lv_wayland_exit_ready()
+{
+    if(lv_ll_is_empty(&lv_wl_ctx.window_ll)) {
+        return true;
+    }
+    return false;
 }
 
 /**********************

--- a/src/drivers/wayland/lv_wayland_window.c
+++ b/src/drivers/wayland/lv_wayland_window.c
@@ -308,7 +308,7 @@ void lv_wayland_window_delete(lv_wl_window_t * window)
     }
 }
 
-bool lv_wayland_exit_ready()
+bool lv_wayland_exit_ready(void)
 {
     if(lv_ll_is_empty(&lv_wl_ctx.window_ll)) {
         return true;

--- a/src/drivers/wayland/lv_wayland_window.h
+++ b/src/drivers/wayland/lv_wayland_window.h
@@ -91,6 +91,11 @@ void lv_wayland_window_set_maximized(lv_display_t * disp, bool maximize);
  */
 void lv_wayland_window_set_minimized(lv_display_t * disp);
 
+/**
+ * True if all wayland windows are closed, false if any still open
+ */
+bool lv_wayland_exit_ready();
+
 /**********************
  *      MACROS
  **********************/

--- a/src/drivers/wayland/lv_wayland_window.h
+++ b/src/drivers/wayland/lv_wayland_window.h
@@ -94,7 +94,7 @@ void lv_wayland_window_set_minimized(lv_display_t * disp);
 /**
  * True if all wayland windows are closed, false if any still open
  */
-bool lv_wayland_exit_ready();
+bool lv_wayland_exit_ready(void);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
While working on a demo I encountered a memory leak during the shutdown of the keyboard service when using Wayland, this PR corrected that for me.  I also needed an "exit_ready()' status check function for the main control loop, so I added that.