### PR TITLE
docs(lv_st7735): add initialization notes and example

### DIFF
--- a/docs/src/integration/external_display_controllers/st7735.rst
+++ b/docs/src/integration/external_display_controllers/st7735.rst
@@ -78,6 +78,26 @@ To create an ST7735-based display use the function
      */
     lv_display_t * lv_st7735_create(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,
                                     lv_st7735_send_cmd_cb_t send_cmd_cb, lv_st7735_send_color_cb_t send_color_cb);
+.. important::
+
+    Function :cpp:func:`lv_st7735_create` does NOT allocate any draw buffers.
+
+    Setting up own draw buffers manually is required (please refer to :ref:`draw_buffers`).
+    When no draw buffers are provided, LVGL cannot operate on the display.
+
+    Setting color format is also recommended (please refer to :ref:`display_color_format`).
+
+.. code-block::c
+    /* Example of initializing ST7735 display and its draw buffers */
+    uint32_t buf_size = 128 * 160 / 10 * sizeof(lv_color_t);
+	lv_color_t *buf1 = malloc(buf_size);
+	lv_color_t *buf2 = malloc(buf_size);
+	assert(buf1 != NULL && buf2 != NULL);
+	lv_disp_t *const disp = lv_st7735_create(128, 160, LV_LCD_FLAG_NONE,
+			my_lcd_send_cmd, my_lcd_send_color);
+	lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB565_SWAPPED);
+	lv_display_set_buffers(disp, buf1, buf2, buf_size,
+			LV_DISPLAY_RENDER_MODE_PARTIAL);
 
 For additional details and a working example see the :ref:`generic MIPI driver`
 documentation.

--- a/docs/src/integration/external_display_controllers/st7735.rst
+++ b/docs/src/integration/external_display_controllers/st7735.rst
@@ -80,12 +80,12 @@ To create an ST7735-based display use the function
                                     lv_st7735_send_cmd_cb_t send_cmd_cb, lv_st7735_send_color_cb_t send_color_cb);
 .. important::
 
-    Function :cpp:func:`lv_st7735_create` does NOT allocate any draw buffers.
+    The :cpp:func:`lv_st7735_create` function does not allocate any draw buffers.
 
-    Setting up own draw buffers manually is required (please refer to :ref:`draw_buffers`).
+    You must set up your own draw buffers manually (please refer to :ref:`draw_buffers`).
     When no draw buffers are provided, LVGL cannot operate on the display.
 
-    Setting color format is also recommended (please refer to :ref:`display_color_format`).
+    Setting the color format is also recommended (please refer to :ref:`display_color_format`).
 
 .. code-block::c
     /* Example of initializing ST7735 display and its draw buffers */
@@ -93,7 +93,7 @@ To create an ST7735-based display use the function
 	lv_color_t *buf1 = malloc(buf_size);
 	lv_color_t *buf2 = malloc(buf_size);
 	assert(buf1 != NULL && buf2 != NULL);
-	lv_disp_t *const disp = lv_st7735_create(128, 160, LV_LCD_FLAG_NONE,
+	lv_display_t *const disp = lv_st7735_create(128, 160, LV_LCD_FLAG_NONE,
 			my_lcd_send_cmd, my_lcd_send_color);
 	lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB565_SWAPPED);
 	lv_display_set_buffers(disp, buf1, buf2, buf_size,


### PR DESCRIPTION
Add important notes and example for lv_st7735_create function. Docs didn't mention following:
- lv_st7735_create() doesn't internally allocate any draw buffers
- lv_st7735_create() doesn't internally set any color format

> Other drivers, such as lv_st7789, would require the same notes
