### PR TITLE
docs(examples): add @title/@brief doc tags to examples

### DIFF
--- a/examples/anim/lv_example_anim_1.c
+++ b/examples/anim/lv_example_anim_1.c
@@ -35,7 +35,14 @@ static void sw_event_cb(lv_event_t * e)
 }
 
 /**
- * Start animation on an event
+ * @title Start animation on an event
+ * @brief Animate a label's x position when a switch's state changes.
+ *
+ * A label and a switch (initially checked) are placed on the active screen.
+ * The switch's `LV_EVENT_VALUE_CHANGED` callback configures and starts an
+ * `lv_anim_t`: when checked, the label animates to x=100 with
+ * `lv_anim_path_overshoot`; when unchecked, it animates to `-width` with
+ * `lv_anim_path_ease_in`. Both animations run for 500 ms.
  */
 void lv_example_anim_1(void)
 {

--- a/examples/event/lv_example_event_click.c
+++ b/examples/event/lv_example_event_click.c
@@ -13,7 +13,12 @@ static void event_cb(lv_event_t * e)
 }
 
 /**
- * Add click event to a button
+ * @title Click event on a button
+ * @brief Update a button's label with an incrementing counter on each click.
+ *
+ * A button with a child label is placed on the active screen. An
+ * `LV_EVENT_CLICKED` callback retrieves the button, updates its label with
+ * a static incrementing counter, and logs `Clicked`.
  */
 void lv_example_event_click(void)
 {

--- a/examples/event/lv_example_event_streak.c
+++ b/examples/event/lv_example_event_streak.c
@@ -1,18 +1,6 @@
 #include "../lv_examples.h"
 #if LV_BUILD_EXAMPLES && LV_USE_LABEL
 
-/**
- * @title Click streaks (single, double, triple)
- * @brief React to single, double, and triple click events plus the short-click streak count.
- *
- * A button is registered with four event callbacks: `LV_EVENT_SHORT_CLICKED`
- * reads `lv_indev_get_short_click_streak()` and writes the count to a
- * separate label; `LV_EVENT_SINGLE_CLICKED`, `LV_EVENT_DOUBLE_CLICKED`, and
- * `LV_EVENT_TRIPLE_CLICKED` each set the button's label to a matching string.
- *
- * @hide_in_docs
- */
-
 static void short_click_event_cb(lv_event_t * e)
 {
     LV_LOG_USER("Short clicked");
@@ -31,6 +19,17 @@ static void streak_event_cb(lv_event_t * e)
     lv_label_set_text(label, text);
 }
 
+/**
+ * @title Click streaks (single, double, triple)
+ * @brief React to single, double, and triple click events plus the short-click streak count.
+ *
+ * A button is registered with four event callbacks: `LV_EVENT_SHORT_CLICKED`
+ * reads `lv_indev_get_short_click_streak()` and writes the count to a
+ * separate label; `LV_EVENT_SINGLE_CLICKED`, `LV_EVENT_DOUBLE_CLICKED`, and
+ * `LV_EVENT_TRIPLE_CLICKED` each set the button's label to a matching string.
+ *
+ * @hide_in_docs
+ */
 void lv_example_event_streak(void)
 {
     lv_obj_t * info_label = lv_label_create(lv_screen_active());

--- a/examples/event/lv_example_event_streak.c
+++ b/examples/event/lv_example_event_streak.c
@@ -1,6 +1,18 @@
 #include "../lv_examples.h"
 #if LV_BUILD_EXAMPLES && LV_USE_LABEL
 
+/**
+ * @title Click streaks (single, double, triple)
+ * @brief React to single, double, and triple click events plus the short-click streak count.
+ *
+ * A button is registered with four event callbacks: `LV_EVENT_SHORT_CLICKED`
+ * reads `lv_indev_get_short_click_streak()` and writes the count to a
+ * separate label; `LV_EVENT_SINGLE_CLICKED`, `LV_EVENT_DOUBLE_CLICKED`, and
+ * `LV_EVENT_TRIPLE_CLICKED` each set the button's label to a matching string.
+ *
+ * @hide_in_docs
+ */
+
 static void short_click_event_cb(lv_event_t * e)
 {
     LV_LOG_USER("Short clicked");

--- a/examples/get_started/lv_example_get_started_1.c
+++ b/examples/get_started/lv_example_get_started_1.c
@@ -2,7 +2,12 @@
 #if LV_BUILD_EXAMPLES && LV_USE_LABEL
 
 /**
- * Basic example to create a "Hello world" label
+ * @title Hello world label
+ * @brief Set the screen background color and place a centered label.
+ *
+ * Sets the active screen's background color, creates a label with the text
+ * `Hello world`, sets the screen's text color to white, and centers the
+ * label on the screen.
  */
 void lv_example_get_started_1(void)
 {

--- a/examples/layouts/flex/lv_example_flex_1.c
+++ b/examples/layouts/flex/lv_example_flex_1.c
@@ -2,7 +2,13 @@
 #if LV_USE_FLEX && LV_BUILD_EXAMPLES
 
 /**
- * A simple row and a column layout with flexbox
+ * @title Flex row and column basics
+ * @brief A row container and a column container, each filled with buttons.
+ *
+ * Two containers are created on the active screen: one with
+ * `LV_FLEX_FLOW_ROW` and one with `LV_FLEX_FLOW_COLUMN`. Each is populated
+ * with ten buttons. Row items use a fixed 100 px width and full container
+ * height; column items use full container width with `LV_SIZE_CONTENT` height.
  */
 void lv_example_flex_1(void)
 {

--- a/examples/layouts/grid/lv_example_grid_3.c
+++ b/examples/layouts/grid/lv_example_grid_3.c
@@ -2,7 +2,13 @@
 #if LV_USE_GRID && LV_BUILD_EXAMPLES
 
 /**
- * Demonstrate grid's "free unit"
+ * @title Grid free units (FR)
+ * @brief Distribute leftover space between grid tracks using FR units.
+ *
+ * A 300x220 container uses three columns (60 px, FR(1), FR(2)) and three
+ * rows (50 px, FR(1), 50 px). Nine child objects fill the cells with
+ * `LV_GRID_ALIGN_STRETCH`. Pixel tracks take their fixed size first; the
+ * remaining space is divided between FR tracks in proportion to their weights.
  */
 void lv_example_grid_3(void)
 {

--- a/examples/widgets/button/lv_example_button_1.c
+++ b/examples/widgets/button/lv_example_button_1.c
@@ -1,6 +1,17 @@
 #include "../../lv_examples.h"
 #if LV_USE_BUTTON && LV_BUILD_EXAMPLES
 
+/**
+ * @title Button basics
+ * @brief A momentary button and a checkable toggle button sharing one event handler.
+ *
+ * Two buttons are created on the active screen. Both register `event_handler`,
+ * which logs `Clicked` on `LV_EVENT_CLICKED` and `Toggled` on
+ * `LV_EVENT_VALUE_CHANGED`. The first button has `LV_OBJ_FLAG_PRESS_LOCK`
+ * removed; the second has `LV_OBJ_FLAG_CHECKABLE` set so it stays checked
+ * when pressed and emits `LV_EVENT_VALUE_CHANGED` on toggle.
+ */
+
 static void event_handler(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);

--- a/examples/widgets/button/lv_example_button_1.c
+++ b/examples/widgets/button/lv_example_button_1.c
@@ -1,17 +1,6 @@
 #include "../../lv_examples.h"
 #if LV_USE_BUTTON && LV_BUILD_EXAMPLES
 
-/**
- * @title Button basics
- * @brief A momentary button and a checkable toggle button sharing one event handler.
- *
- * Two buttons are created on the active screen. Both register `event_handler`,
- * which logs `Clicked` on `LV_EVENT_CLICKED` and `Toggled` on
- * `LV_EVENT_VALUE_CHANGED`. The first button has `LV_OBJ_FLAG_PRESS_LOCK`
- * removed; the second has `LV_OBJ_FLAG_CHECKABLE` set so it stays checked
- * when pressed and emits `LV_EVENT_VALUE_CHANGED` on toggle.
- */
-
 static void event_handler(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
@@ -24,6 +13,16 @@ static void event_handler(lv_event_t * e)
     }
 }
 
+/**
+ * @title Button basics
+ * @brief A momentary button and a checkable toggle button sharing one event handler.
+ *
+ * Two buttons are created on the active screen. Both register `event_handler`,
+ * which logs `Clicked` on `LV_EVENT_CLICKED` and `Toggled` on
+ * `LV_EVENT_VALUE_CHANGED`. The first button has `LV_OBJ_FLAG_PRESS_LOCK`
+ * removed; the second has `LV_OBJ_FLAG_CHECKABLE` set so it stays checked
+ * when pressed and emits `LV_EVENT_VALUE_CHANGED` on toggle.
+ */
 void lv_example_button_1(void)
 {
     lv_obj_t * label;


### PR DESCRIPTION
## Summary

Adds structured doc comment tags to 7 example files as an initial test of a documentation parsing pipeline. No functional or style changes — comments only.

## Tag format

- `@title` — page title
- `@brief` — one-line summary
- untagged body — detailed description, after a blank line
- `@hide_in_docs` — presence-only flag to exclude an example from rendered docs

## Context

Prototyping a parser that extracts these tags from `/examples` to improve docs. Opening as a draft to get feedback on the tag format before migrating the remaining examples.

## Scope

One file per category is updated (anim, event × 2, get_started, flex, grid, button). `event_streak` includes `@hide_in_docs` to exercise the hidden path. Remaining examples are unchanged.