### PR TITLE
feat(sdl/egl): detect driver at runtime and explain x11 limitation

### DIFF
--- a/docs/src/integration/pc/sdl.mdx
+++ b/docs/src/integration/pc/sdl.mdx
@@ -127,7 +127,14 @@ The SDL driver can leverage OpenGL for hardware-accelerated rendering. LVGL prov
 See the [Complete OpenGL overview](/integration/embedded_linux/opengl) for more information.
 
 <Callout type="info" title="Driver Support">
-OpenGL-based rendering is only supported on Linux when using x11 as the SDL video driver.
+OpenGL-based rendering is only supported on Linux when using `x11` as the SDL video driver.
+
+When the EGL/OpenGL path is enabled, LVGL currently forces SDL to use the `x11`
+video driver, overriding `SDL_VIDEODRIVER`. As a result, selecting drivers such as
+`wayland` or `kmsdrm` via `SDL_VIDEODRIVER` will not take effect in this mode.
+
+To use those SDL backends, do not enable the OpenGL/EGL rendering path; use the
+regular SDL renderer instead.
 </Callout>
 
 ## See Also

--- a/docs/src/integration/pc/sdl.mdx
+++ b/docs/src/integration/pc/sdl.mdx
@@ -126,6 +126,10 @@ The SDL driver can leverage OpenGL for hardware-accelerated rendering. LVGL prov
 
 See the [Complete OpenGL overview](/integration/embedded_linux/opengl) for more information.
 
+<Callout type="info" title="Driver Support">
+OpenGL-based rendering is only supported on Linux when using x11 as the SDL video driver.
+</Callout>
+
 ## See Also
 
 - [SDL Draw Unit](/integration/embedded_linux/draw_sdl) - SDL texture-based rendering

--- a/src/drivers/sdl/lv_sdl_egl.c
+++ b/src/drivers/sdl/lv_sdl_egl.c
@@ -79,7 +79,9 @@ static lv_result_t init_display(lv_display_t * display)
     }
     ddata->egl_ctx = lv_opengles_egl_context_create(&ifc);
     if(!ddata->egl_ctx) {
-        LV_LOG_ERROR("Failed to initialize EGL context");
+        LV_LOG_ERROR("Failed to initialize EGL context.");
+        LV_LOG_ERROR("This probably means you're trying to use an unsupported SDL_VIDEO_DRIVER.");
+        LV_LOG_ERROR("Try setting SDL_VIDEODRIVER=x11 via an environment variable");
         lv_free(ddata);
         return LV_RESULT_INVALID;
     }
@@ -164,16 +166,20 @@ static void * create_window_cb(void * driver_data, const lv_egl_native_window_pr
     SDL_GetWindowWMInfo(lv_sdl_window_get_window(display), &wmInfo);
 
     EGLNativeWindowType native_window;
-#if defined(SDL_VIDEO_DRIVER_WINDOWS)
-    native_window = wmInfo.info.win.window;
-#elif defined(SDL_VIDEO_DRIVER_X11)
-    native_window = wmInfo.info.x11.window;
-#elif defined(SDL_VIDEO_DRIVER_WAYLAND)
-    native_window = wmInfo.info.wl.surface;
+    const char * driver = SDL_GetCurrentVideoDriver();
+
+    if(driver && strcmp(driver, "x11") == 0) {
+#if defined(SDL_VIDEO_DRIVER_X11)
+        native_window = (EGLNativeWindowType)wmInfo.info.x11.window;
 #else
-    LV_LOG_ERROR("Unsupported platform for EGL");
-    return NULL;
+        LV_LOG_ERROR("SDL built without X11 support");
+        return NULL;
 #endif
+    }
+    else {
+        LV_LOG_ERROR("Unsupported SDL video driver: (%s)", driver);
+        return NULL;
+    }
     return (void *)native_window;
 }
 

--- a/src/drivers/sdl/lv_sdl_egl.c
+++ b/src/drivers/sdl/lv_sdl_egl.c
@@ -163,7 +163,10 @@ static void * create_window_cb(void * driver_data, const lv_egl_native_window_pr
     lv_display_t * display = (lv_display_t *)driver_data;
     SDL_SysWMinfo wmInfo;
     SDL_VERSION(&wmInfo.version);
-    SDL_GetWindowWMInfo(lv_sdl_window_get_window(display), &wmInfo);
+    if(SDL_GetWindowWMInfo(lv_sdl_window_get_window(display), &wmInfo) != SDL_TRUE) {
+        LV_LOG_ERROR("SDL_GetWindowWMInfo failed: %s", SDL_GetError());
+        return NULL;
+    }
 
     EGLNativeWindowType native_window;
     const char * driver = SDL_GetCurrentVideoDriver();
@@ -177,7 +180,7 @@ static void * create_window_cb(void * driver_data, const lv_egl_native_window_pr
 #endif
     }
     else {
-        LV_LOG_ERROR("Unsupported SDL video driver: (%s)", driver);
+        LV_LOG_ERROR("Unsupported SDL video driver: (%s)", driver ? driver : "(null)");
         return NULL;
     }
     return (void *)native_window;

--- a/src/drivers/sdl/lv_sdl_window.c
+++ b/src/drivers/sdl/lv_sdl_window.c
@@ -61,6 +61,7 @@ lv_display_t * lv_sdl_window_create(int32_t hor_res, int32_t ver_res)
 {
     if(!inited) {
 #if LV_SDL_USE_EGL && defined(SDL_VIDEO_DRIVER_X11)
+        /* We only support x11 with EGL for now*/
         SDL_SetHintWithPriority("SDL_VIDEODRIVER", "x11", SDL_HINT_OVERRIDE);
         SDL_SetHint(SDL_HINT_VIDEO_X11_FORCE_EGL, "1");
 #endif


### PR DESCRIPTION
Fixes #9941

This adds the basis work to support other sdl video drivers besides x11 by detecting the video driver at runtime. We're still going to force x11 as it's the only supported video driver for now

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
