### PR TITLE
fix(opengl): red-blue color swapping on external textures

### DIFF
--- a/src/draw/nanovg/lv_draw_nanovg.c
+++ b/src/draw/nanovg/lv_draw_nanovg.c
@@ -275,25 +275,24 @@ static void on_layer_readback(lv_draw_nanovg_unit_t * u, lv_layer_t * layer)
     lv_draw_buf_t * draw_buf = layer->draw_buf;
 
     /* Read pixels from FBO */
-    GLenum format;
     GLenum type;
 
     /* OpenGL reads bottom-to-top, but LVGL expects top-to-bottom */
+    bool rb_swap = false;
     switch(draw_buf->header.cf) {
         case LV_COLOR_FORMAT_ARGB8888:
         case LV_COLOR_FORMAT_XRGB8888:
         case LV_COLOR_FORMAT_ARGB8888_PREMULTIPLIED:
-            format = GL_BGRA;
             type = GL_UNSIGNED_BYTE;
+            rb_swap = true;
             break;
 
         case LV_COLOR_FORMAT_RGB888:
-            format = GL_RGB;
             type = GL_UNSIGNED_BYTE;
+            rb_swap = true;
             break;
 
         case LV_COLOR_FORMAT_RGB565:
-            format = GL_RGB;
             type = GL_UNSIGNED_SHORT_5_6_5;
             break;
 
@@ -307,10 +306,10 @@ static void on_layer_readback(lv_draw_nanovg_unit_t * u, lv_layer_t * layer)
         /* Reverse Y coordinate */
         void * row = lv_draw_buf_goto_xy(draw_buf, 0, h - 1 - y);
         LV_PROFILER_DRAW_BEGIN_TAG("glReadPixels");
-        glReadPixels(0, y, w, 1, format, type, row);
+        glReadPixels(0, y, w, 1, GL_RGB, type, row);
         LV_PROFILER_DRAW_END_TAG("glReadPixels");
 
-        if(draw_buf->header.cf == LV_COLOR_FORMAT_RGB888) {
+        if(rb_swap) {
             /* Swizzle RGB -> BGR */
             lv_color_t * px = row;
             for(int32_t x = 0; x < w; x++) {

--- a/src/draw/nanovg/lv_draw_nanovg.c
+++ b/src/draw/nanovg/lv_draw_nanovg.c
@@ -274,25 +274,24 @@ static void on_layer_readback(lv_draw_nanovg_unit_t * u, lv_layer_t * layer)
     lv_draw_buf_t * draw_buf = layer->draw_buf;
 
     /* Read pixels from FBO */
-    GLenum format;
     GLenum type;
 
     /* OpenGL reads bottom-to-top, but LVGL expects top-to-bottom */
+    bool rb_swap = false;
     switch(draw_buf->header.cf) {
         case LV_COLOR_FORMAT_ARGB8888:
         case LV_COLOR_FORMAT_XRGB8888:
         case LV_COLOR_FORMAT_ARGB8888_PREMULTIPLIED:
-            format = GL_BGRA;
             type = GL_UNSIGNED_BYTE;
+            rb_swap = true;
             break;
 
         case LV_COLOR_FORMAT_RGB888:
-            format = GL_RGB;
             type = GL_UNSIGNED_BYTE;
+            rb_swap = true;
             break;
 
         case LV_COLOR_FORMAT_RGB565:
-            format = GL_RGB;
             type = GL_UNSIGNED_SHORT_5_6_5;
             break;
 
@@ -306,10 +305,10 @@ static void on_layer_readback(lv_draw_nanovg_unit_t * u, lv_layer_t * layer)
         /* Reverse Y coordinate */
         void * row = lv_draw_buf_goto_xy(draw_buf, 0, h - 1 - y);
         LV_PROFILER_DRAW_BEGIN_TAG("glReadPixels");
-        glReadPixels(0, y, w, 1, format, type, row);
+        glReadPixels(0, y, w, 1, GL_RGB, type, row);
         LV_PROFILER_DRAW_END_TAG("glReadPixels");
 
-        if(draw_buf->header.cf == LV_COLOR_FORMAT_RGB888) {
+        if(rb_swap) {
             /* Swizzle RGB -> BGR */
             lv_color_t * px = row;
             for(int32_t x = 0; x < w; x++) {

--- a/src/draw/nanovg/lv_draw_nanovg_3d.c
+++ b/src/draw/nanovg/lv_draw_nanovg_3d.c
@@ -80,7 +80,6 @@ void lv_draw_nanovg_3d(lv_draw_task_t * t, const lv_draw_3d_dsc_t * dsc, const l
     params.texture_clip_area = &clip_area;
     params.h_flip = dsc->h_flip;
     params.v_flip = dsc->v_flip;
-    params.rb_swap = true;
 #if LV_DRAW_TRANSFORM_USE_MATRIX
     params.matrix = &layer->matrix;
 #endif

--- a/src/draw/nanovg/lv_draw_nanovg_3d.c
+++ b/src/draw/nanovg/lv_draw_nanovg_3d.c
@@ -78,7 +78,6 @@ void lv_draw_nanovg_3d(lv_draw_task_t * t, const lv_draw_3d_dsc_t * dsc, const l
     params.texture_clip_area = &clip_area;
     params.h_flip = dsc->h_flip;
     params.v_flip = dsc->v_flip;
-    params.rb_swap = true;
 #if LV_DRAW_TRANSFORM_USE_MATRIX
     params.matrix = &layer->matrix;
 #endif

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -446,6 +446,26 @@ static void blend_texture_layer(lv_draw_task_t * t)
     LV_PROFILER_DRAW_END;
 }
 
+static void render_texture_rbswap(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
+                                  int32_t disp_w, int32_t disp_h, const lv_area_t * texture_clip_area,
+                                  bool h_flip, bool v_flip)
+{
+    LV_PROFILER_DRAW_BEGIN;
+    lv_opengles_render_params_t params;
+    lv_opengles_render_params_init(&params);
+    params.texture = texture;
+    params.texture_area = texture_area;
+    params.opa = opa;
+    params.disp_w = disp_w;
+    params.disp_h = disp_h;
+    params.texture_clip_area = texture_clip_area;
+    params.h_flip = h_flip;
+    params.v_flip = v_flip;
+    params.rb_swap = true;
+    lv_opengles_render(&params);
+    LV_PROFILER_DRAW_END;
+}
+
 static void draw_from_cached_texture(lv_draw_task_t * t)
 {
     LV_PROFILER_DRAW_BEGIN;
@@ -533,7 +553,10 @@ static void draw_from_cached_texture(lv_draw_task_t * t)
     lv_area_move(&t->clip_area, -dest_layer->buf_area.x1, -dest_layer->buf_area.y1);
     lv_area_t render_area = t->_real_area;
     lv_area_move(&render_area, -dest_layer->buf_area.x1, -dest_layer->buf_area.y1);
-    lv_opengles_render_texture_rbswap(texture, &render_area, 0xff, targ_tex_w, targ_tex_h, &t->clip_area, h_flip, v_flip);
+    /* LVGL renders in BGR color format, but for compatibility with GLES 2.0,
+     * only RGB textures are used in OpenGL. When rendering a cached texture,
+     * the color channels need to be swapped using the shader */
+    render_texture_rbswap(texture, &render_area, 0xff, targ_tex_w, targ_tex_h, &t->clip_area, h_flip, v_flip);
 
     if(target_texture) {
         GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -533,7 +533,7 @@ static void draw_from_cached_texture(lv_draw_task_t * t)
     lv_area_move(&t->clip_area, -dest_layer->buf_area.x1, -dest_layer->buf_area.y1);
     lv_area_t render_area = t->_real_area;
     lv_area_move(&render_area, -dest_layer->buf_area.x1, -dest_layer->buf_area.y1);
-    lv_opengles_render_texture(texture, &render_area, 0xff, targ_tex_w, targ_tex_h, &t->clip_area, h_flip, v_flip);
+    lv_opengles_render_texture_rbswap(texture, &render_area, 0xff, targ_tex_w, targ_tex_h, &t->clip_area, h_flip, v_flip);
 
     if(target_texture) {
         GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
@@ -596,9 +596,8 @@ static void execute_drawing(lv_draw_opengles_unit_t * u)
                 float tex_h = (float)lv_area_get_height(&fill_area);
                 GL_CALL(glEnable(GL_SCISSOR_TEST));
                 GL_CALL(glScissor(fill_area.x1, targ_tex_h - fill_area.y1 - tex_h, tex_w, tex_h));
-                /* swap red and blue channels here as they will be swapped back during flushing*/
-                GL_CALL(glClearColor((float)fill_dsc->color.blue / 255.0f, (float)fill_dsc->color.green / 255.0f,
-                                     (float)fill_dsc->color.red / 255.0f, 1.0f));
+                GL_CALL(glClearColor((float)fill_dsc->color.red / 255.0f, (float)fill_dsc->color.green / 255.0f,
+                                     (float)fill_dsc->color.blue / 255.0f, 1.0f));
                 GL_CALL(glClearDepthf(1.0f));
                 GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
                 GL_CALL(glDisable(GL_SCISSOR_TEST));

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -518,7 +518,7 @@ static void draw_texture_to_framebuffer(lv_draw_opengles_unit_t * u, unsigned in
     lv_area_move(&t->clip_area, -dest_layer->buf_area.x1, -dest_layer->buf_area.y1);
     lv_area_t render_area = t->_real_area;
     lv_area_move(&render_area, -dest_layer->buf_area.x1, -dest_layer->buf_area.y1);
-    lv_opengles_render_texture(texture, &render_area, 0xff, targ_tex_w, targ_tex_h, &t->clip_area, h_flip, v_flip);
+    lv_opengles_render_texture_rbswap(texture, &render_area, 0xff, targ_tex_w, targ_tex_h, &t->clip_area, h_flip, v_flip);
 
     if(target_texture) {
         GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
@@ -643,9 +643,8 @@ static void execute_drawing(lv_draw_opengles_unit_t * u)
                         float tex_h = (float)lv_area_get_height(&fill_area);
                         GL_CALL(glEnable(GL_SCISSOR_TEST));
                         GL_CALL(glScissor(fill_area.x1, targ_tex_h - fill_area.y1 - tex_h, tex_w, tex_h));
-                        /* swap red and blue channels here as they will be swapped back during flushing*/
-                        GL_CALL(glClearColor((float)fill_dsc->color.blue / 255.0f, (float)fill_dsc->color.green / 255.0f,
-                                             (float)fill_dsc->color.red / 255.0f, 1.0f));
+                        GL_CALL(glClearColor((float)fill_dsc->color.red / 255.0f, (float)fill_dsc->color.green / 255.0f,
+                                             (float)fill_dsc->color.blue / 255.0f, 1.0f));
                         GL_CALL(glClearDepthf(1.0f));
                         GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
                         GL_CALL(glDisable(GL_SCISSOR_TEST));

--- a/src/draw/opengles/lv_draw_opengles.c
+++ b/src/draw/opengles/lv_draw_opengles.c
@@ -489,6 +489,26 @@ static void blend_texture_layer(lv_draw_task_t * t)
     LV_PROFILER_DRAW_END;
 }
 
+static void render_texture_rbswap(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
+                                  int32_t disp_w, int32_t disp_h, const lv_area_t * texture_clip_area,
+                                  bool h_flip, bool v_flip)
+{
+    LV_PROFILER_DRAW_BEGIN;
+    lv_opengles_render_params_t params;
+    lv_opengles_render_params_init(&params);
+    params.texture = texture;
+    params.texture_area = texture_area;
+    params.opa = opa;
+    params.disp_w = disp_w;
+    params.disp_h = disp_h;
+    params.texture_clip_area = texture_clip_area;
+    params.h_flip = h_flip;
+    params.v_flip = v_flip;
+    params.rb_swap = true;
+    lv_opengles_render(&params);
+    LV_PROFILER_DRAW_END;
+}
+
 static void draw_texture_to_framebuffer(lv_draw_opengles_unit_t * u, unsigned int texture)
 {
     lv_draw_task_t * t = u->task_act;
@@ -518,7 +538,7 @@ static void draw_texture_to_framebuffer(lv_draw_opengles_unit_t * u, unsigned in
     lv_area_move(&t->clip_area, -dest_layer->buf_area.x1, -dest_layer->buf_area.y1);
     lv_area_t render_area = t->_real_area;
     lv_area_move(&render_area, -dest_layer->buf_area.x1, -dest_layer->buf_area.y1);
-    lv_opengles_render_texture_rbswap(texture, &render_area, 0xff, targ_tex_w, targ_tex_h, &t->clip_area, h_flip, v_flip);
+    render_texture_rbswap(texture, &render_area, 0xff, targ_tex_w, targ_tex_h, &t->clip_area, h_flip, v_flip);
 
     if(target_texture) {
         GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));

--- a/src/drivers/display/drm/lv_linux_drm_egl.c
+++ b/src/drivers/display/drm/lv_linux_drm_egl.c
@@ -257,7 +257,6 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_m
         lv_opengles_render_params_t params = {
             .h_flip = false,
             .v_flip = false,
-            .rb_swap = LV_COLOR_DEPTH == 32,
         };
         lv_opengles_render_display(disp, &params);
         lv_opengles_egl_update(ctx->egl_ctx);

--- a/src/drivers/display/drm/lv_linux_drm_egl.c
+++ b/src/drivers/display/drm/lv_linux_drm_egl.c
@@ -250,7 +250,6 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_m
         lv_opengles_render_params_t params = {
             .h_flip = false,
             .v_flip = false,
-            .rb_swap = LV_COLOR_DEPTH == 32,
         };
         lv_opengles_render_display(disp, &params);
         lv_opengles_egl_update(ctx->egl_ctx);

--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -171,26 +171,6 @@ void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_
     LV_PROFILER_DRAW_END;
 }
 
-void lv_opengles_render_texture_rbswap(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
-                                       int32_t disp_w,
-                                       int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip)
-{
-    LV_PROFILER_DRAW_BEGIN;
-    lv_opengles_render_params_t params;
-    lv_opengles_render_params_init(&params);
-    params.texture = texture;
-    params.texture_area = texture_area;
-    params.opa = opa;
-    params.disp_w = disp_w;
-    params.disp_h = disp_h;
-    params.texture_clip_area = texture_clip_area;
-    params.h_flip = h_flip;
-    params.v_flip = v_flip;
-    params.rb_swap = true;
-    lv_opengles_render(&params);
-    LV_PROFILER_DRAW_END;
-}
-
 void lv_opengles_render_fill(lv_color_t color, const lv_area_t * area, lv_opa_t opa, int32_t disp_w, int32_t disp_h)
 {
     LV_PROFILER_DRAW_BEGIN;

--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -202,7 +202,6 @@ void lv_opengles_render_fill(lv_color_t color, const lv_area_t * area, lv_opa_t 
     params.disp_h = disp_h;
     params.texture_clip_area = area;
     params.fill_color = color;
-    params.rb_swap = true;
     lv_opengles_render(&params);
     LV_PROFILER_DRAW_END;
 }
@@ -255,7 +254,6 @@ void lv_opengles_render_display_texture(lv_display_t * display, bool h_flip, boo
     lv_opengles_render_params_t params = {
         .v_flip = v_flip,
         .h_flip = h_flip,
-        .rb_swap = true
     };
     lv_opengles_render_display(display, &params);
 }

--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -199,7 +199,6 @@ void lv_opengles_render_fill(lv_color_t color, const lv_area_t * area, lv_opa_t 
     params.disp_h = disp_h;
     params.texture_clip_area = area;
     params.fill_color = color;
-    params.rb_swap = true;
     lv_opengles_render(&params);
     LV_PROFILER_DRAW_END;
 }
@@ -252,7 +251,6 @@ void lv_opengles_render_display_texture(lv_display_t * display, bool h_flip, boo
     lv_opengles_render_params_t params = {
         .v_flip = v_flip,
         .h_flip = h_flip,
-        .rb_swap = true
     };
     lv_opengles_render_display(display, &params);
 }

--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -168,26 +168,6 @@ void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_
     LV_PROFILER_DRAW_END;
 }
 
-void lv_opengles_render_texture_rbswap(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
-                                       int32_t disp_w,
-                                       int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip)
-{
-    LV_PROFILER_DRAW_BEGIN;
-    lv_opengles_render_params_t params;
-    lv_opengles_render_params_init(&params);
-    params.texture = texture;
-    params.texture_area = texture_area;
-    params.opa = opa;
-    params.disp_w = disp_w;
-    params.disp_h = disp_h;
-    params.texture_clip_area = texture_clip_area;
-    params.h_flip = h_flip;
-    params.v_flip = v_flip;
-    params.rb_swap = true;
-    lv_opengles_render(&params);
-    LV_PROFILER_DRAW_END;
-}
-
 void lv_opengles_render_fill(lv_color_t color, const lv_area_t * area, lv_opa_t opa, int32_t disp_w, int32_t disp_h)
 {
     LV_PROFILER_DRAW_BEGIN;

--- a/src/drivers/opengles/lv_opengles_glfw.c
+++ b/src/drivers/opengles/lv_opengles_glfw.c
@@ -539,9 +539,9 @@ static void window_update_handler(lv_timer_t * t)
 
                 GL_CALL(glBindTexture(GL_TEXTURE_2D, 0));
 
-                lv_opengles_render_texture_rbswap(window_display_texture, &texture->area, texture->opa, window->hor_res,
-                                                  window->ver_res,
-                                                  &texture->area, window->h_flip, window->v_flip);
+                lv_opengles_render_texture(window_display_texture, &texture->area, texture->opa, window->hor_res,
+                                           window->ver_res,
+                                           &texture->area, window->h_flip, window->v_flip);
 #endif
             }
             else {
@@ -558,11 +558,11 @@ static void window_update_handler(lv_timer_t * t)
                 }
 
 #if LV_USE_DRAW_OPENGLES
-                lv_opengles_render_texture_rbswap(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
-                                                  &texture->area, window->h_flip, texture->disp == NULL ? window->v_flip : !window->v_flip);
+                lv_opengles_render_texture(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
+                                           &texture->area, window->h_flip, texture->disp == NULL ? window->v_flip : !window->v_flip);
 #else
-                lv_opengles_render_texture_rbswap(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
-                                                  &texture->area, window->h_flip, window->v_flip);
+                lv_opengles_render_texture(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
+                                           &texture->area, window->h_flip, window->v_flip);
 #endif
             }
         }

--- a/src/drivers/opengles/lv_opengles_glfw.c
+++ b/src/drivers/opengles/lv_opengles_glfw.c
@@ -532,9 +532,9 @@ static void window_update_handler(lv_timer_t * t)
 
                 GL_CALL(glBindTexture(GL_TEXTURE_2D, 0));
 
-                lv_opengles_render_texture_rbswap(window_display_texture, &texture->area, texture->opa, window->hor_res,
-                                                  window->ver_res,
-                                                  &texture->area, window->h_flip, window->v_flip);
+                lv_opengles_render_texture(window_display_texture, &texture->area, texture->opa, window->hor_res,
+                                           window->ver_res,
+                                           &texture->area, window->h_flip, window->v_flip);
 #endif
             }
             else {
@@ -551,11 +551,11 @@ static void window_update_handler(lv_timer_t * t)
                 }
 
 #if LV_USE_DRAW_OPENGLES
-                lv_opengles_render_texture_rbswap(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
-                                                  &texture->area, window->h_flip, texture->disp == NULL ? window->v_flip : !window->v_flip);
+                lv_opengles_render_texture(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
+                                           &texture->area, window->h_flip, texture->disp == NULL ? window->v_flip : !window->v_flip);
 #else
-                lv_opengles_render_texture_rbswap(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
-                                                  &texture->area, window->h_flip, window->v_flip);
+                lv_opengles_render_texture(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
+                                           &texture->area, window->h_flip, window->v_flip);
 #endif
             }
         }

--- a/src/drivers/opengles/lv_opengles_private.h
+++ b/src/drivers/opengles/lv_opengles_private.h
@@ -146,20 +146,6 @@ void lv_opengles_render_params_init(lv_opengles_render_params_t * params);
 void lv_opengles_render(const lv_opengles_render_params_t * params);
 
 /**
- * Render a texture using alternate blending mode, with red and blue channels flipped in the shader.
- * @param texture        OpenGL texture ID
- * @param texture_area   the area in the window to render the texture in
- * @param opa            opacity to blend the texture with existing contents
- * @param disp_w         width of the window/framebuffer being rendered to
- * @param disp_h         height of the window/framebuffer being rendered to
- * @param h_flip         horizontal flip
- * @param v_flip         vertical flip
- */
-void lv_opengles_render_texture_rbswap(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
-                                       int32_t disp_w, int32_t disp_h, const lv_area_t * texture_clip_area,
-                                       bool h_flip, bool v_flip);
-
-/**
  * Set the OpenGL viewport, with vertical co-ordinate conversion
  * @param x        x position of the viewport
  * @param y        y position of the viewport

--- a/src/drivers/opengles/lv_opengles_private.h
+++ b/src/drivers/opengles/lv_opengles_private.h
@@ -143,20 +143,6 @@ void lv_opengles_render_params_init(lv_opengles_render_params_t * params);
 void lv_opengles_render(const lv_opengles_render_params_t * params);
 
 /**
- * Render a texture using alternate blending mode, with red and blue channels flipped in the shader.
- * @param texture        OpenGL texture ID
- * @param texture_area   the area in the window to render the texture in
- * @param opa            opacity to blend the texture with existing contents
- * @param disp_w         width of the window/framebuffer being rendered to
- * @param disp_h         height of the window/framebuffer being rendered to
- * @param h_flip         horizontal flip
- * @param v_flip         vertical flip
- */
-void lv_opengles_render_texture_rbswap(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
-                                       int32_t disp_w, int32_t disp_h, const lv_area_t * texture_clip_area,
-                                       bool h_flip, bool v_flip);
-
-/**
  * Set the OpenGL viewport, with vertical co-ordinate conversion
  * @param x        x position of the viewport
  * @param y        y position of the viewport

--- a/src/drivers/opengles/lv_opengles_texture.c
+++ b/src/drivers/opengles/lv_opengles_texture.c
@@ -276,7 +276,7 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_m
         GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB565, disp->hor_res, disp->ver_res, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5,
                              texture->fb1));
 #elif LV_COLOR_DEPTH == 32
-        GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, disp->hor_res, disp->ver_res, 0, GL_BGRA, GL_UNSIGNED_BYTE,
+        GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, disp->hor_res, disp->ver_res, 0, GL_RGBA, GL_UNSIGNED_BYTE,
                              texture->fb1));
 #else
 #error("Unsupported color format")

--- a/src/drivers/opengles/lv_opengles_texture.c
+++ b/src/drivers/opengles/lv_opengles_texture.c
@@ -274,7 +274,7 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_m
         GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB565, disp->hor_res, disp->ver_res, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5,
                              texture->fb1));
 #elif LV_COLOR_DEPTH == 32
-        GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, disp->hor_res, disp->ver_res, 0, GL_BGRA, GL_UNSIGNED_BYTE,
+        GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, disp->hor_res, disp->ver_res, 0, GL_RGBA, GL_UNSIGNED_BYTE,
                              texture->fb1));
 #else
 #error("Unsupported color format")

--- a/src/drivers/wayland/lv_wayland_backend_egl.c
+++ b/src/drivers/wayland/lv_wayland_backend_egl.c
@@ -255,7 +255,6 @@ static void egl_flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * 
     lv_opengles_render_params_t params = {
         .h_flip = false,
         .v_flip = false,
-        .rb_swap = LV_COLOR_DEPTH == 32,
     };
     lv_opengles_render_display(disp, &params);
     lv_opengles_egl_update(ddata->egl_ctx);

--- a/src/drivers/wayland/lv_wayland_backend_egl.c
+++ b/src/drivers/wayland/lv_wayland_backend_egl.c
@@ -254,7 +254,6 @@ static void egl_flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * 
     lv_opengles_render_params_t params = {
         .h_flip = false,
         .v_flip = false,
-        .rb_swap = LV_COLOR_DEPTH == 32,
     };
     lv_opengles_render_display(disp, &params);
     lv_opengles_egl_update(ddata->egl_ctx);


### PR DESCRIPTION
Change https://github.com/lvgl/lvgl/pull/9304 introduced a regression where the red and blue channels
from externally generated textures were swapped (e.g. when using
lv_3dtexture), with no way to specify that this should not occur. The
reason for doing this was to avoid the BGR color format format on GLES
implementations; however it did this by flipping the channels for almost
all textures. This is actually not necessary however; the only the
things that need to be colors swapped are the ones that LVGL is drawing,
since its internal color format is BGR(A). Conveniently, all the items
that LVGL draws are stored in the texture cache so the simplest solution
is to allow LVGL to draw to the texture cache, then swap the red and
blue channels of any textures in the texture cache when they are draw to
the final layer texture.

This has several advantages:
  1) Many awkward double color channel swaps are eliminated
  2) More textures are in the correct (native) color format, which aids is
     debugging
  3) External textures work correctly since they are not color swapped.

Fixes: https://github.com/lvgl/lvgl/issues/9965