### PR TITLE
fix(observer): fix sizeof typo and add strdup NULL check

### DIFF
--- a/src/core/lv_observer.c
+++ b/src/core/lv_observer.c
@@ -732,7 +732,7 @@ void lv_obj_add_subject_set_string_event(lv_obj_t * obj, lv_subject_t * subject,
         return;
     }
 
-    subject_set_string_user_data_t * user_data = lv_malloc(sizeof(subject_set_int_user_data_t));
+    subject_set_string_user_data_t * user_data = lv_malloc(sizeof(subject_set_string_user_data_t));
     if(user_data == NULL) {
         LV_ASSERT_MALLOC(user_data);
         LV_LOG_WARN("Couldn't allocate user_data");
@@ -741,7 +741,12 @@ void lv_obj_add_subject_set_string_event(lv_obj_t * obj, lv_subject_t * subject,
 
     user_data->subject = subject;
     user_data->value = lv_strdup(value);
-    LV_ASSERT_MALLOC(user_data->value);
+    if(user_data->value == NULL) {
+        LV_ASSERT_MALLOC(user_data->value);
+        LV_LOG_WARN("Couldn't allocate string value");
+        lv_free(user_data);
+        return;
+    }
 
     lv_obj_add_event_cb(obj, subject_set_string_cb, trigger, user_data);
     lv_obj_add_event_cb(obj, subject_set_string_free_user_data_event_cb, LV_EVENT_DELETE, user_data);


### PR DESCRIPTION
Fix copy-paste error in lv_obj_add_subject_set_string_event() where sizeof(subject_set_int_user_data_t) was used instead of sizeof(subject_set_string_user_data_t). While both structs are currently the same size on all platforms, this is semantically incorrect and fragile against future struct changes.

Also add NULL check for lv_strdup() with proper cleanup (free user_data) to prevent memory leak on allocation failure.

Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
