### PR TITLE
fix(core): add NULL checks for unsafe realloc in style and transform

### DIFF
--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -1283,6 +1283,7 @@ void lv_obj_set_transform(lv_obj_t * obj, const lv_matrix_t * matrix)
     if(!obj->spec_attr->matrix) {
         obj->spec_attr->matrix = lv_malloc(sizeof(lv_matrix_t));
         LV_ASSERT_MALLOC(obj->spec_attr->matrix);
+        if(obj->spec_attr->matrix == NULL) return;
     }
 
     /* Invalidate the old area */

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -762,10 +762,23 @@ static lv_style_t * get_local_style(lv_obj_t * obj, lv_style_selector_t selector
         }
     }
 
+    /*Allocate the individual style first so obj->styles stays valid on failure*/
+    lv_style_t * new_style = lv_malloc_zeroed(sizeof(lv_style_t));
+    if(new_style == NULL) {
+        LV_LOG_WARN("couldn't allocate local style");
+        return NULL;
+    }
+
     obj->style_cnt++;
     LV_ASSERT(obj->style_cnt != 0);
-    obj->styles = lv_realloc(obj->styles, obj->style_cnt * sizeof(lv_obj_style_t));
-    LV_ASSERT_MALLOC(obj->styles);
+    lv_obj_style_t * new_styles = lv_realloc(obj->styles, obj->style_cnt * sizeof(lv_obj_style_t));
+    if(new_styles == NULL) {
+        obj->style_cnt--;
+        lv_free(new_style);
+        LV_LOG_WARN("couldn't allocate styles");
+        return NULL;
+    }
+    obj->styles = new_styles;
 
     for(i = obj->style_cnt - 1; i > 0 ; i--) {
         /*Copy only normal styles (not local and transition).
@@ -775,7 +788,7 @@ static lv_style_t * get_local_style(lv_obj_t * obj, lv_style_selector_t selector
     }
 
     lv_memzero(&obj->styles[i], sizeof(lv_obj_style_t));
-    obj->styles[i].style = lv_malloc_zeroed(sizeof(lv_style_t));
+    obj->styles[i].style = new_style;
     lv_style_init((lv_style_t *)obj->styles[i].style);
 
     obj->styles[i].is_local = 1;
@@ -800,16 +813,30 @@ static lv_obj_style_t * get_trans_style(lv_obj_t * obj,  lv_style_selector_t sel
     /*Already have a transition style for it*/
     if(i != obj->style_cnt) return &obj->styles[i];
 
+    /*Allocate the individual style first so obj->styles stays valid on failure*/
+    lv_style_t * new_style = lv_malloc(sizeof(lv_style_t));
+    if(new_style == NULL) {
+        LV_LOG_WARN("couldn't allocate transition style");
+        return NULL;
+    }
+
     obj->style_cnt++;
     LV_ASSERT(obj->style_cnt != 0);
-    obj->styles = lv_realloc(obj->styles, obj->style_cnt * sizeof(lv_obj_style_t));
+    lv_obj_style_t * new_styles = lv_realloc(obj->styles, obj->style_cnt * sizeof(lv_obj_style_t));
+    if(new_styles == NULL) {
+        obj->style_cnt--;
+        lv_free(new_style);
+        LV_LOG_WARN("couldn't allocate styles");
+        return NULL;
+    }
+    obj->styles = new_styles;
 
     for(i = obj->style_cnt - 1; i > 0 ; i--) {
         obj->styles[i] = obj->styles[i - 1];
     }
 
     lv_memzero(&obj->styles[0], sizeof(lv_obj_style_t));
-    obj->styles[0].style = lv_malloc(sizeof(lv_style_t));
+    obj->styles[0].style = new_style;
     lv_style_init((lv_style_t *)obj->styles[0].style);
 
     obj->styles[0].is_trans = 1;


### PR DESCRIPTION
Fix unsafe realloc pattern in lv_obj_style.c where realloc result was assigned directly to obj->styles, causing memory leak and dangling pointer on allocation failure. Use a temp variable and rollback style_cnt on failure.

Add NULL guard for lv_malloc in lv_obj_set_transform() to prevent NULL pointer dereference.

Ref: lvgl/lvgl#6865, lvgl/lvgl#9794, lvgl/lvgl#7489

Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
