### PR TITLE
Bug in LVGL 9.3 find_track_end – the grow branch ignores hidden first…

### DIFF
--- a/src/layouts/flex/lv_flex.c
+++ b/src/layouts/flex/lv_flex.c
@@ -265,13 +265,13 @@ static int32_t find_track_end(lv_obj_t * cont, flex_t * f, int32_t item_start_id
                                    : lv_obj_get_style_min_height(item, LV_PART_MAIN);
 
                 int32_t req_size = min_size;
-                if(item_id != item_start_id) req_size += item_gap; /*No gap before the first item*/
+                if(!first_item) req_size += item_gap; /*No gap before the first item*/
 
                 /*Wrap if can't fit*/
                 if(f->wrap && t->track_fix_main_size + grow_min_size_sum  + req_size > max_main_size) break;
 
                 grow_min_size_sum += req_size;
-                if(item_id != item_start_id) {
+                if(!first_item) {
                     t->track_fix_main_size += item_gap; /*The gap is always taken from the space*/
                 }
 


### PR DESCRIPTION
 I have LVGL 9.3 and fill a obj with other objects, via flex flow. some of the objects are hidden. everything works well as long the fist object is not hidden. if it is the last object in the first row jumps into the next row, even though there is still space left. the issue is only when padding is >0 and the first obj is hidden. if others are hidden and the first is visible all works fine, even with padding >0.



Inside find_track_end (LVGL 9.3) the loop has two branches – one for items with flex_grow > 0, one for items with a fixed size. They differ in how they detect "is this the first item in the track":
`
/* GROW branch */
if(item_id != item_start_id) req_size += item_gap; /* No gap before the first item */

/* NON-GROW branch */
if(!first_item) req_size += item_gap; /* No gap before the first item */
`
first_item is only flipped to false when a visible item is processed, so the non-grow branch is correct. The grow branch compares item_id against item_start_id directly, so if item_start_id is hidden, the very first visible item gets an extra item_gap added to its required size. That extra gap can be exactly what pushes the last item of row 1 into row 2 — and it only manifests when pad_column > 0.

➡ If any of your icons has flex_grow set (or the theme adds it), this is your root cause. Same bug exists in current main on the grow branch.

Fix in LVGL: replace item_id != item_start_id with !first_item in the grow branch. (Or upgrade once the fix lands upstream — the test test_flex_hide_items in tests/src/test_cases/test_align_flex.c exercises hidden items but uses fixed-size objects, so the grow bug is not caught.)

Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
