### PR TITLE
perf(style): skip descendant cascade when no child style is keyed on the changed state bits

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -1197,11 +1197,13 @@ static void update_obj_state(lv_obj_t * obj, lv_state_t new_state)
     lv_free(ts);
 
     if(cmp_res == LV_STYLE_STATE_CMP_DIFF_REDRAW) {
-        /*Invalidation is not enough, e.g. layer type needs to be updated too*/
-        lv_obj_refresh_style(obj, LV_PART_ANY, LV_STYLE_PROP_ANY);
+        /*Invalidation is not enough, e.g. layer type needs to be updated too.
+         *Pass the changed state bits so the descendant cascade can skip
+         *LV_EVENT_STYLE_CHANGED for subtrees with no state-keyed styles.*/
+        lv_obj_style_refresh_on_state_change(obj, prev_state ^ new_state);
     }
     else if(cmp_res == LV_STYLE_STATE_CMP_DIFF_LAYOUT) {
-        lv_obj_refresh_style(obj, LV_PART_ANY, LV_STYLE_PROP_ANY);
+        lv_obj_style_refresh_on_state_change(obj, prev_state ^ new_state);
     }
     else if(cmp_res == LV_STYLE_STATE_CMP_DIFF_DRAW_PAD) {
         lv_obj_invalidate(obj);

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -34,7 +34,6 @@
 #define MY_CLASS (&lv_obj_class)
 #define LV_OBJ_DEF_WIDTH    (LV_DPX(100))
 #define LV_OBJ_DEF_HEIGHT   (LV_DPX(50))
-#define STYLE_TRANSITION_MAX 32
 
 /**********************
  *      TYPEDEFS
@@ -66,7 +65,6 @@ static void lv_obj_event(const lv_obj_class_t * class_p, lv_event_t * e);
 static void draw_scrollbar(lv_obj_t * obj, lv_layer_t * layer);
 static lv_result_t scrollbar_init_draw_dsc(lv_obj_t * obj, lv_draw_rect_dsc_t * dsc);
 static bool obj_valid_child(const lv_obj_t * parent, const lv_obj_t * obj_to_find);
-static void update_obj_state(lv_obj_t * obj, lv_state_t new_state);
 static void lv_obj_children_add_state(lv_obj_t * obj, lv_state_t state);
 static void lv_obj_children_remove_state(lv_obj_t * obj, lv_state_t state);
 static void null_on_delete_cb(lv_event_t * e);
@@ -1110,107 +1108,6 @@ static void lv_obj_event(const lv_obj_class_t * class_p, lv_event_t * e)
     else if(code == LV_EVENT_HOVER_LEAVE) {
         lv_obj_remove_state(obj, LV_STATE_HOVERED);
     }
-}
-
-/**
- * Set the state (fully overwrite) of an object.
- * If specified in the styles, transition animations will be started from the previous state to the current.
- * @param obj       pointer to an object
- * @param state     the new state
- */
-static void update_obj_state(lv_obj_t * obj, lv_state_t new_state)
-{
-    if(obj->state == new_state) return;
-
-    LV_ASSERT_OBJ(obj, MY_CLASS);
-
-    lv_state_t prev_state = obj->state;
-
-    lv_style_state_cmp_t cmp_res = lv_obj_style_state_compare(obj, prev_state, new_state);
-    /*If there is no difference in styles there is nothing else to do*/
-    if(cmp_res == LV_STYLE_STATE_CMP_SAME) {
-        obj->state = new_state;
-        lv_obj_send_event(obj, LV_EVENT_STATE_CHANGED, &prev_state);
-        return;
-    }
-
-    /*Invalidate the object in their current state*/
-    lv_obj_invalidate(obj);
-
-    obj->state = new_state;
-    lv_obj_update_layer_type(obj);
-
-    /*Skip transitions if the widget is not rendered yet. */
-    if(!obj->rendered) {
-        lv_obj_invalidate(obj);
-        if(cmp_res == LV_STYLE_STATE_CMP_DIFF_DRAW_PAD) {
-            lv_obj_refresh_ext_draw_size(obj);
-        }
-
-        lv_obj_send_event(obj, LV_EVENT_STATE_CHANGED, &prev_state);
-        return;
-    }
-
-    lv_obj_style_transition_dsc_t * ts = lv_malloc_zeroed(sizeof(lv_obj_style_transition_dsc_t) * STYLE_TRANSITION_MAX);
-    uint32_t tsi = 0;
-    uint32_t i;
-    for(i = 0; i < obj->style_cnt && tsi < STYLE_TRANSITION_MAX; i++) {
-        lv_obj_style_t * obj_style = &obj->styles[i];
-        lv_state_t state_act = lv_obj_style_get_selector_state(obj->styles[i].selector);
-        lv_part_t part_act = lv_obj_style_get_selector_part(obj->styles[i].selector);
-        if(state_act & (~new_state)) continue; /*Skip unrelated styles*/
-        if(obj_style->is_trans) continue;
-
-        lv_style_value_t v;
-        if(lv_style_get_prop_inlined(obj_style->style, LV_STYLE_TRANSITION, &v) != LV_STYLE_RES_FOUND) continue;
-        const lv_style_transition_dsc_t * tr = v.ptr;
-
-        /*Add the props to the set if not added yet or added but with smaller weight*/
-        uint32_t j;
-        for(j = 0; tr->props[j] != 0 && tsi < STYLE_TRANSITION_MAX; j++) {
-            uint32_t t;
-            for(t = 0; t < tsi; t++) {
-                lv_style_selector_t selector = ts[t].selector;
-                lv_state_t state_ts = lv_obj_style_get_selector_state(selector);
-                lv_part_t part_ts = lv_obj_style_get_selector_part(selector);
-                if(ts[t].prop == tr->props[j] && part_ts == part_act && state_ts >= state_act) break;
-            }
-
-            /*If not found  add it*/
-            if(t == tsi) {
-                ts[tsi].time = tr->time;
-                ts[tsi].delay = tr->delay;
-                ts[tsi].path_cb = tr->path_xcb;
-                ts[tsi].prop = tr->props[j];
-                ts[tsi].user_data = tr->user_data;
-                ts[tsi].selector = obj_style->selector;
-                tsi++;
-            }
-        }
-    }
-
-    for(i = 0; i < tsi; i++) {
-        lv_part_t part_act = lv_obj_style_get_selector_part(ts[i].selector);
-        lv_obj_style_create_transition(obj, part_act, prev_state, new_state, &ts[i]);
-    }
-
-    lv_free(ts);
-
-    if(cmp_res == LV_STYLE_STATE_CMP_DIFF_REDRAW) {
-        /*Invalidation is not enough, e.g. layer type needs to be updated too.
-         *Pass the changed state bits so the descendant cascade can skip
-         *LV_EVENT_STYLE_CHANGED for subtrees with no state-keyed styles.*/
-        lv_obj_style_refresh_on_state_change(obj, prev_state ^ new_state);
-    }
-    else if(cmp_res == LV_STYLE_STATE_CMP_DIFF_LAYOUT) {
-        lv_obj_style_refresh_on_state_change(obj, prev_state ^ new_state);
-    }
-    else if(cmp_res == LV_STYLE_STATE_CMP_DIFF_DRAW_PAD) {
-        lv_obj_invalidate(obj);
-        lv_obj_refresh_ext_draw_size(obj);
-    }
-
-    lv_obj_send_event(obj, LV_EVENT_STATE_CHANGED, &prev_state);
 }
 
 /**

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -62,6 +62,7 @@ static lv_style_res_t get_prop_core(const lv_obj_t * obj, lv_style_selector_t se
                                     lv_style_value_t * v);
 static void report_style_change_core(void * style, lv_obj_t * obj);
 static void refresh_children_style(lv_obj_t * obj);
+static bool obj_has_selector_on_bits(lv_obj_t * obj, lv_state_t state_bits);
 static bool trans_delete(lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop, trans_t * tr_limit);
 static void trans_anim_cb(void * _tr, int32_t v);
 static void trans_anim_start_cb(lv_anim_t * a);
@@ -82,6 +83,10 @@ static void remove_style_core(lv_obj_t * obj, const lv_style_t * style, lv_style
 /**********************
  *  STATIC VARIABLES
  **********************/
+
+/* Cascade filter for the state-transition path. See
+ * lv_obj_style_refresh_on_state_change. */
+static lv_state_t refresh_cascade_bits = 0;
 
 /**********************
  *      MACROS
@@ -924,7 +929,10 @@ static void report_style_change_core(void * style, lv_obj_t * obj)
 
 /**
  * Recursively refresh the style of the children. Go deeper until a not NULL style is found
- * because the NULL styles are inherited from the parent
+ * because the NULL styles are inherited from the parent.
+ * When refresh_cascade_bits is non-zero (state-transition path), descendants whose
+ * own styles have no selector keyed on those bits are skipped — they can't render
+ * differently because of the parent's state change.
  * @param obj pointer to an object
  */
 static void refresh_children_style(lv_obj_t * obj)
@@ -933,12 +941,55 @@ static void refresh_children_style(lv_obj_t * obj)
     uint32_t child_cnt = lv_obj_get_child_count(obj);
     for(i = 0; i < child_cnt; i++) {
         lv_obj_t * child = obj->spec_attr->children[i];
-        lv_obj_invalidate(child);
-        lv_obj_send_event(child, LV_EVENT_STYLE_CHANGED, NULL);
-        lv_obj_invalidate(child);
+        if(refresh_cascade_bits == 0 || obj_has_selector_on_bits(child, refresh_cascade_bits)) {
+            lv_obj_invalidate(child);
+            lv_obj_send_event(child, LV_EVENT_STYLE_CHANGED, NULL);
+            lv_obj_invalidate(child);
+        }
 
-        refresh_children_style(child); /*Check children too*/
+        /*Recurse unconditionally: a grandchild may have state-keyed styles
+         *its immediate parent lacks.*/
+        refresh_children_style(child);
     }
+}
+
+/**
+ * Does obj have any non-transition style whose selector intersects state_bits?
+ */
+static bool obj_has_selector_on_bits(lv_obj_t * obj, lv_state_t state_bits)
+{
+    for(uint32_t i = 0; i < obj->style_cnt; i++) {
+        if(obj->styles[i].is_trans) continue;
+        lv_state_t sel_state = lv_obj_style_get_selector_state(obj->styles[i].selector);
+        if(sel_state & state_bits) return true;
+    }
+    return false;
+}
+
+void lv_obj_style_refresh_on_state_change(lv_obj_t * obj, lv_state_t changed_bits)
+{
+    /*Single-threaded LVGL invariant: no reentry while a state refresh is in
+     *progress. Catches accidental nesting.*/
+    LV_ASSERT(refresh_cascade_bits == 0);
+
+    lv_state_t bits = changed_bits;
+
+    /*Defensive fallback: an inheritable prop (e.g. LV_STYLE_TEXT_COLOR) under a
+     *state-keyed selector affects descendants that don't have their own state-
+     *keyed styles, so filtering would drop a valid repaint.*/
+    for(uint32_t i = 0; i < obj->style_cnt; i++) {
+        if(obj->styles[i].is_trans) continue;
+        lv_state_t sel_state = lv_obj_style_get_selector_state(obj->styles[i].selector);
+        if((sel_state & changed_bits) == 0) continue;
+        if(style_has_flag(obj->styles[i].style, LV_STYLE_PROP_FLAG_INHERITABLE)) {
+            bits = 0;
+            break;
+        }
+    }
+
+    refresh_cascade_bits = bits;
+    lv_obj_refresh_style(obj, LV_PART_ANY, LV_STYLE_PROP_ANY);
+    refresh_cascade_bits = 0;
 }
 
 /**

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -968,10 +968,6 @@ static bool obj_has_selector_on_bits(lv_obj_t * obj, lv_state_t state_bits)
 
 void lv_obj_style_refresh_on_state_change(lv_obj_t * obj, lv_state_t changed_bits)
 {
-    /*Single-threaded LVGL invariant: no reentry while a state refresh is in
-     *progress. Catches accidental nesting.*/
-    LV_ASSERT(refresh_cascade_bits == 0);
-
     lv_state_t bits = changed_bits;
 
     /*Defensive fallback: an inheritable prop (e.g. LV_STYLE_TEXT_COLOR) under a
@@ -987,9 +983,14 @@ void lv_obj_style_refresh_on_state_change(lv_obj_t * obj, lv_state_t changed_bit
         }
     }
 
+    /*Save and restore: an event handler dispatched during the cascade may
+     *legally trigger another state change, re-entering this function. We
+     *want the inner cascade to use its own filter and the outer cascade to
+     *resume with its previous filter intact, not be cleared to "no filter."*/
+    lv_state_t prev_refresh_cascade_bits = refresh_cascade_bits;
     refresh_cascade_bits = bits;
     lv_obj_refresh_style(obj, LV_PART_ANY, LV_STYLE_PROP_ANY);
-    refresh_cascade_bits = 0;
+    refresh_cascade_bits = prev_refresh_cascade_bits;
 }
 
 /**

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -61,7 +61,8 @@ static lv_obj_style_t * get_trans_style(lv_obj_t * obj, lv_style_selector_t sele
 static lv_style_res_t get_prop_core(const lv_obj_t * obj, lv_style_selector_t selector, lv_style_prop_t prop,
                                     lv_style_value_t * v);
 static void report_style_change_core(void * style, lv_obj_t * obj);
-static void refresh_children_style(lv_obj_t * obj);
+static void refresh_style_internal(lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop, lv_state_t state_changed);
+static void refresh_children_style(lv_obj_t * obj, lv_state_t state_changed);
 static bool obj_has_selector_on_bits(lv_obj_t * obj, lv_state_t state_bits);
 static bool trans_delete(lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop, trans_t * tr_limit);
 static void trans_anim_cb(void * _tr, int32_t v);
@@ -83,10 +84,6 @@ static void remove_style_core(lv_obj_t * obj, const lv_style_t * style, lv_style
 /**********************
  *  STATIC VARIABLES
  **********************/
-
-/* Cascade filter for the state-transition path. See
- * lv_obj_style_refresh_on_state_change. */
-static lv_state_t refresh_cascade_bits = 0;
 
 /**********************
  *      MACROS
@@ -246,6 +243,11 @@ void lv_obj_report_style_change(lv_style_t * style)
 
 void lv_obj_refresh_style(lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop)
 {
+    refresh_style_internal(obj, part, prop, 0);
+}
+
+static void refresh_style_internal(lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop, lv_state_t state_changed)
+{
     LV_ASSERT_OBJ(obj, MY_CLASS);
 
     if(!style_refr) return;
@@ -285,7 +287,7 @@ void lv_obj_refresh_style(lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop)
 
     if(prop == LV_STYLE_PROP_ANY || (is_inheritable && (is_ext_draw || is_layout_refr))) {
         if(part != LV_PART_SCROLLBAR) {
-            refresh_children_style(obj);
+            refresh_children_style(obj, state_changed);
         }
     }
 
@@ -930,18 +932,20 @@ static void report_style_change_core(void * style, lv_obj_t * obj)
 /**
  * Recursively refresh the style of the children. Go deeper until a not NULL style is found
  * because the NULL styles are inherited from the parent.
- * When refresh_cascade_bits is non-zero (state-transition path), descendants whose
- * own styles have no selector keyed on those bits are skipped — they can't render
- * differently because of the parent's state change.
- * @param obj pointer to an object
+ * When state_changed is non-zero (state-transition path), descendants whose own styles
+ * have no selector keyed on those bits are skipped — they can't render differently because
+ * of the parent's state change.
+ * @param obj           pointer to an object
+ * @param state_changed bits that flipped on the originating object, or 0 to dispatch to
+ *                      every descendant unconditionally (the existing public callers)
  */
-static void refresh_children_style(lv_obj_t * obj)
+static void refresh_children_style(lv_obj_t * obj, lv_state_t state_changed)
 {
     uint32_t i;
     uint32_t child_cnt = lv_obj_get_child_count(obj);
     for(i = 0; i < child_cnt; i++) {
         lv_obj_t * child = obj->spec_attr->children[i];
-        if(refresh_cascade_bits == 0 || obj_has_selector_on_bits(child, refresh_cascade_bits)) {
+        if(state_changed == 0 || obj_has_selector_on_bits(child, state_changed)) {
             lv_obj_invalidate(child);
             lv_obj_send_event(child, LV_EVENT_STYLE_CHANGED, NULL);
             lv_obj_invalidate(child);
@@ -949,7 +953,7 @@ static void refresh_children_style(lv_obj_t * obj)
 
         /*Recurse unconditionally: a grandchild may have state-keyed styles
          *its immediate parent lacks.*/
-        refresh_children_style(child);
+        refresh_children_style(child, state_changed);
     }
 }
 
@@ -966,9 +970,9 @@ static bool obj_has_selector_on_bits(lv_obj_t * obj, lv_state_t state_bits)
     return false;
 }
 
-void lv_obj_style_refresh_on_state_change(lv_obj_t * obj, lv_state_t changed_bits)
+void lv_obj_style_refresh_on_state_change(lv_obj_t * obj, lv_state_t state_changed)
 {
-    lv_state_t bits = changed_bits;
+    lv_state_t cascade_filter = state_changed;
 
     /*Defensive fallback: an inheritable prop (e.g. LV_STYLE_TEXT_COLOR) under a
      *state-keyed selector affects descendants that don't have their own state-
@@ -976,21 +980,14 @@ void lv_obj_style_refresh_on_state_change(lv_obj_t * obj, lv_state_t changed_bit
     for(uint32_t i = 0; i < obj->style_cnt; i++) {
         if(obj->styles[i].is_trans) continue;
         lv_state_t sel_state = lv_obj_style_get_selector_state(obj->styles[i].selector);
-        if((sel_state & changed_bits) == 0) continue;
+        if((sel_state & state_changed) == 0) continue;
         if(style_has_flag(obj->styles[i].style, LV_STYLE_PROP_FLAG_INHERITABLE)) {
-            bits = 0;
+            cascade_filter = 0;
             break;
         }
     }
 
-    /*Save and restore: an event handler dispatched during the cascade may
-     *legally trigger another state change, re-entering this function. We
-     *want the inner cascade to use its own filter and the outer cascade to
-     *resume with its previous filter intact, not be cleared to "no filter."*/
-    lv_state_t prev_refresh_cascade_bits = refresh_cascade_bits;
-    refresh_cascade_bits = bits;
-    lv_obj_refresh_style(obj, LV_PART_ANY, LV_STYLE_PROP_ANY);
-    refresh_cascade_bits = prev_refresh_cascade_bits;
+    refresh_style_internal(obj, LV_PART_ANY, LV_STYLE_PROP_ANY, cascade_filter);
 }
 
 /**

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -25,6 +25,7 @@
 #define style_trans_ll_p &(LV_GLOBAL_DEFAULT()->style_trans_ll)
 #define _style_custom_prop_flag_lookup_table LV_GLOBAL_DEFAULT()->style_custom_prop_flag_lookup_table
 #define STYLE_PROP_SHIFTED(prop) ((uint32_t)1 << ((prop) >> 3))
+#define STYLE_TRANSITION_MAX 32
 
 /**********************
  *      TYPEDEFS
@@ -970,7 +971,7 @@ static bool obj_has_selector_on_bits(lv_obj_t * obj, lv_state_t state_bits)
     return false;
 }
 
-void lv_obj_style_refresh_on_state_change(lv_obj_t * obj, lv_state_t state_changed)
+static void lv_obj_style_refresh_on_state_change(lv_obj_t * obj, lv_state_t state_changed)
 {
     lv_state_t cascade_filter = state_changed;
 
@@ -988,6 +989,101 @@ void lv_obj_style_refresh_on_state_change(lv_obj_t * obj, lv_state_t state_chang
     }
 
     refresh_style_internal(obj, LV_PART_ANY, LV_STYLE_PROP_ANY, cascade_filter);
+}
+
+void update_obj_state(lv_obj_t * obj, lv_state_t new_state)
+{
+    if(obj->state == new_state) return;
+
+    LV_ASSERT_OBJ(obj, MY_CLASS);
+
+    lv_state_t prev_state = obj->state;
+
+    lv_style_state_cmp_t cmp_res = lv_obj_style_state_compare(obj, prev_state, new_state);
+    /*If there is no difference in styles there is nothing else to do*/
+    if(cmp_res == LV_STYLE_STATE_CMP_SAME) {
+        obj->state = new_state;
+        lv_obj_send_event(obj, LV_EVENT_STATE_CHANGED, &prev_state);
+        return;
+    }
+
+    /*Invalidate the object in their current state*/
+    lv_obj_invalidate(obj);
+
+    obj->state = new_state;
+    lv_obj_update_layer_type(obj);
+
+    /*Skip transitions if the widget is not rendered yet. */
+    if(!obj->rendered) {
+        lv_obj_invalidate(obj);
+        if(cmp_res == LV_STYLE_STATE_CMP_DIFF_DRAW_PAD) {
+            lv_obj_refresh_ext_draw_size(obj);
+        }
+
+        lv_obj_send_event(obj, LV_EVENT_STATE_CHANGED, &prev_state);
+        return;
+    }
+
+    lv_obj_style_transition_dsc_t * ts = lv_malloc_zeroed(sizeof(lv_obj_style_transition_dsc_t) * STYLE_TRANSITION_MAX);
+    uint32_t tsi = 0;
+    uint32_t i;
+    for(i = 0; i < obj->style_cnt && tsi < STYLE_TRANSITION_MAX; i++) {
+        lv_obj_style_t * obj_style = &obj->styles[i];
+        lv_state_t state_act = lv_obj_style_get_selector_state(obj->styles[i].selector);
+        lv_part_t part_act = lv_obj_style_get_selector_part(obj->styles[i].selector);
+        if(state_act & (~new_state)) continue; /*Skip unrelated styles*/
+        if(obj_style->is_trans) continue;
+
+        lv_style_value_t v;
+        if(lv_style_get_prop_inlined(obj_style->style, LV_STYLE_TRANSITION, &v) != LV_STYLE_RES_FOUND) continue;
+        const lv_style_transition_dsc_t * tr = v.ptr;
+
+        /*Add the props to the set if not added yet or added but with smaller weight*/
+        uint32_t j;
+        for(j = 0; tr->props[j] != 0 && tsi < STYLE_TRANSITION_MAX; j++) {
+            uint32_t t;
+            for(t = 0; t < tsi; t++) {
+                lv_style_selector_t selector = ts[t].selector;
+                lv_state_t state_ts = lv_obj_style_get_selector_state(selector);
+                lv_part_t part_ts = lv_obj_style_get_selector_part(selector);
+                if(ts[t].prop == tr->props[j] && part_ts == part_act && state_ts >= state_act) break;
+            }
+
+            /*If not found  add it*/
+            if(t == tsi) {
+                ts[tsi].time = tr->time;
+                ts[tsi].delay = tr->delay;
+                ts[tsi].path_cb = tr->path_xcb;
+                ts[tsi].prop = tr->props[j];
+                ts[tsi].user_data = tr->user_data;
+                ts[tsi].selector = obj_style->selector;
+                tsi++;
+            }
+        }
+    }
+
+    for(i = 0; i < tsi; i++) {
+        lv_part_t part_act = lv_obj_style_get_selector_part(ts[i].selector);
+        lv_obj_style_create_transition(obj, part_act, prev_state, new_state, &ts[i]);
+    }
+
+    lv_free(ts);
+
+    if(cmp_res == LV_STYLE_STATE_CMP_DIFF_REDRAW) {
+        /*Invalidation is not enough, e.g. layer type needs to be updated too.
+         *Pass the changed state bits so the descendant cascade can skip
+         *LV_EVENT_STYLE_CHANGED for subtrees with no state-keyed styles.*/
+        lv_obj_style_refresh_on_state_change(obj, prev_state ^ new_state);
+    }
+    else if(cmp_res == LV_STYLE_STATE_CMP_DIFF_LAYOUT) {
+        lv_obj_style_refresh_on_state_change(obj, prev_state ^ new_state);
+    }
+    else if(cmp_res == LV_STYLE_STATE_CMP_DIFF_DRAW_PAD) {
+        lv_obj_invalidate(obj);
+        lv_obj_refresh_ext_draw_size(obj);
+    }
+
+    lv_obj_send_event(obj, LV_EVENT_STATE_CHANGED, &prev_state);
 }
 
 /**

--- a/src/core/lv_obj_style_private.h
+++ b/src/core/lv_obj_style_private.h
@@ -86,6 +86,18 @@ lv_style_state_cmp_t lv_obj_style_state_compare(lv_obj_t * obj, lv_state_t state
  */
 void lv_obj_update_layer_type(lv_obj_t * obj);
 
+/**
+ * Same as `lv_obj_refresh_style(obj, LV_PART_ANY, LV_STYLE_PROP_ANY)` but the
+ * descendant cascade (`refresh_children_style`) skips dispatching
+ * `LV_EVENT_STYLE_CHANGED` to subtrees with no styles keyed on the changed
+ * state bits. Intended for the state-transition path in `update_obj_state`
+ * where the only thing that changed is a set of state bits and descendants
+ * without selectors on those bits can't render differently.
+ * @param obj           the object whose state changed
+ * @param changed_bits  `prev_state ^ new_state` — the bits that flipped
+ */
+void lv_obj_style_refresh_on_state_change(lv_obj_t * obj, lv_state_t changed_bits);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/core/lv_obj_style_private.h
+++ b/src/core/lv_obj_style_private.h
@@ -87,16 +87,14 @@ lv_style_state_cmp_t lv_obj_style_state_compare(lv_obj_t * obj, lv_state_t state
 void lv_obj_update_layer_type(lv_obj_t * obj);
 
 /**
- * Same as `lv_obj_refresh_style(obj, LV_PART_ANY, LV_STYLE_PROP_ANY)` but the
- * descendant cascade (`refresh_children_style`) skips dispatching
- * `LV_EVENT_STYLE_CHANGED` to subtrees with no styles keyed on the changed
- * state bits. Intended for the state-transition path in `update_obj_state`
- * where the only thing that changed is a set of state bits and descendants
- * without selectors on those bits can't render differently.
- * @param obj           the object whose state changed
- * @param state_changed `prev_state ^ new_state` — the bits that flipped
+ * Apply a new state to the object: compute style differences, start any
+ * transitions, refresh styles (with the descendant cascade filtered by the
+ * changed state bits when safe), and dispatch LV_EVENT_STATE_CHANGED. Called
+ * from lv_obj_add_state / lv_obj_remove_state.
+ * @param obj       the object whose state should change
+ * @param new_state the state to apply
  */
-void lv_obj_style_refresh_on_state_change(lv_obj_t * obj, lv_state_t state_changed);
+void update_obj_state(lv_obj_t * obj, lv_state_t new_state);
 
 /**********************
  *      MACROS

--- a/src/core/lv_obj_style_private.h
+++ b/src/core/lv_obj_style_private.h
@@ -94,9 +94,9 @@ void lv_obj_update_layer_type(lv_obj_t * obj);
  * where the only thing that changed is a set of state bits and descendants
  * without selectors on those bits can't render differently.
  * @param obj           the object whose state changed
- * @param changed_bits  `prev_state ^ new_state` — the bits that flipped
+ * @param state_changed `prev_state ^ new_state` — the bits that flipped
  */
-void lv_obj_style_refresh_on_state_change(lv_obj_t * obj, lv_state_t changed_bits);
+void lv_obj_style_refresh_on_state_change(lv_obj_t * obj, lv_state_t state_changed);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
### Summary

Reworked based on @kisvegabor's and the @copilot-pull-request-reviewer feedback on the original approach (correctly flagged as a semantic break — `lv_table` pressed-state suppression and list `LV_PART_MAIN` scrolled styling both consume `LV_STATE_SCROLLED` regardless of scrollbar mode). This version attacks the real root cause: the descendant style cascade itself, not the state toggle.

### Root cause

`update_obj_state` already short-circuits via `lv_obj_style_state_compare` when the parent's own styles don't change. But once the cascade fires, `refresh_children_style` unconditionally calls `lv_obj_invalidate` + `lv_obj_send_event(..., LV_EVENT_STYLE_CHANGED, ...)` on every descendant — regardless of whether the descendant has any style whose selector actually uses the state bit(s) that flipped. The per-widget `LV_EVENT_STYLE_CHANGED` handler work dominates on deep trees; most descendants do no observable work because nothing they render depends on the changed bits.

### Approach

1. New entry point `lv_obj_style_refresh_on_state_change(obj, changed_bits)` sets a file-static `refresh_cascade_bits = changed_bits`, runs the existing `lv_obj_refresh_style(obj, LV_PART_ANY, LV_STYLE_PROP_ANY)`, then clears. Asserts `refresh_cascade_bits == 0` on entry to catch accidental nesting — LVGL is single-threaded at this boundary.

2. `refresh_children_style` consults the filter: when non-zero, it invalidates + dispatches only if the child has at least one non-transition style whose selector state intersects the filter bits (new static `obj_has_selector_on_bits`). Recursion into grandchildren stays unconditional — a grandchild may have state-keyed styles its immediate parent lacks.

3. `update_obj_state` routes its two state-transition calls (`CMP_DIFF_REDRAW` and `CMP_DIFF_LAYOUT`) through the new entry point with `prev_state ^ new_state` as the changed bits. `CMP_DIFF_DRAW_PAD` is untouched (no cascade there).

4. Defensive inheritable-prop fallback: before activating the filter, the entry point walks `obj->styles[]`. If any non-transition style whose selector intersects `changed_bits` carries `LV_STYLE_PROP_FLAG_INHERITABLE` (e.g. `LV_STYLE_TEXT_COLOR`), the filter is disabled for that refresh — descendants inheriting the prop need the repaint even without their own state-keyed selector.

### Why this preserves semantics

- `LV_STATE_SCROLLED` (and every other state bit) toggles unconditionally, as in master. `lv_table`'s pressed-state suppression and any list `LV_PART_MAIN | LV_STATE_SCROLLED` styling see the state exactly as before.
- The parent object itself always goes through `lv_obj_refresh_style` — nothing changes about its own invalidate / layer-type / transition handling.
- Descendants with state-keyed styles still receive `LV_EVENT_STYLE_CHANGED`.
- Descendants without state-keyed styles skip the dispatch — they had no style-dependent response to give, so the event was no-op work.
- The inheritable-prop fallback covers the "parent has state-keyed inheritable style" case conservatively.

### Generalizes

This applies to every state bit, not just `LV_STATE_SCROLLED`. Pressed / Focused / Edited / Hovered transitions on deep trees benefit identically.

### Measurement

The cascade cost was previously established on this PR: on an embedded Linux device (454×454 single-buffer fbdev, `-O2`) with a tileview containing ~100+ widgets per tile, `LV_EVENT_STYLE_CHANGED` was 190 ms / 4638 calls (~31% of scroll self-time) over a 613 ms scroll window. That work was the descendant cascade walking a subtree with no state-keyed consumers — exactly what this revision's filter skips.

Visually re-verified on the same hardware with the new patch: scroll UX matches the previously-measured behaviour. Happy to re-run the profiler with an instrumented cascade-hit counter if reviewers want empirical confirmation that the inheritable-prop fallback isn't triggering on the hot path. LVGL's CI benchmark bot will also cover this on the force-push automatically.