### PR TITLE
fix(glad): fix compilation errors by using relative includes

### DIFF
--- a/src/drivers/opengles/glad/include/EGL/eglplatform.h
+++ b/src/drivers/opengles/glad/include/EGL/eglplatform.h
@@ -18,7 +18,7 @@
  * https://www.github.com/KhronosGroup/EGL-Registry/
  */
 
-#include <KHR/khrplatform.h>
+#include "../KHR/khrplatform.h"
 
 /* Macros used in EGL function prototype declarations.
  *

--- a/src/drivers/opengles/glad/include/glad/egl.h
+++ b/src/drivers/opengles/glad/include/glad/egl.h
@@ -378,8 +378,8 @@ typedef void (*GLADpostcallback)(void *ret, const char *name, GLADapiproc apipro
 #define EGL_YUV_NARROW_RANGE_EXT 0x3283
 
 
-#include <KHR/khrplatform.h>
-#include <EGL/eglplatform.h>
+#include "../KHR/khrplatform.h"
+#include "../EGL/eglplatform.h"
 
 
 

--- a/src/drivers/opengles/glad/include/glad/gl.h
+++ b/src/drivers/opengles/glad/include/glad/gl.h
@@ -2251,7 +2251,7 @@ typedef void (*GLADpostcallback)(void *ret, const char *name, GLADapiproc apipro
 #define GL_ZOOM_Y 0x0D17
 
 
-#include <KHR/khrplatform.h>
+#include "../KHR/khrplatform.h"
 typedef unsigned int GLenum;
 typedef unsigned char GLboolean;
 typedef unsigned int GLbitfield;

--- a/src/drivers/opengles/glad/include/glad/gles2.h
+++ b/src/drivers/opengles/glad/include/glad/gles2.h
@@ -526,7 +526,7 @@ typedef void (*GLADpostcallback)(void *ret, const char *name, GLADapiproc apipro
 #define GL_ZERO 0
 
 
-#include <KHR/khrplatform.h>
+#include "../KHR/khrplatform.h"
 typedef unsigned int GLenum;
 typedef unsigned char GLboolean;
 typedef unsigned int GLbitfield;


### PR DESCRIPTION
We load EGL dynamically at runtime which means the user doesn't need to have it installed in order to cross-compile it, this correctly makes it that it catches the correct headers instead of the system ones