### PR TITLE
ci(coverage): enforce 50% patch coverage gate for PRs

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -141,7 +141,10 @@ jobs:
           git fetch --no-tags --prune origin ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }}
           MB=$(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
           echo "Merge-base: $MB"
-          python scripts/check_gcov_coverage.py --commit="${MB}...${{ github.event.pull_request.head.sha }}"
+          python scripts/check_gcov_coverage.py \
+            --commit="${MB}...${{ github.event.pull_request.head.sha }}" \
+            --fail-under=50 \
+            --min-lines=5
         else
           echo "Not a pull request, skipping code coverage analysis."
         fi

--- a/gcovr.cfg
+++ b/gcovr.cfg
@@ -1,0 +1,18 @@
+# gcovr configuration
+#
+# Auto-discovered when --root points to this directory.
+# Shared by tests/main.py and scripts/check_gcov_coverage.py.
+
+# Only include LVGL source files
+filter = src/(?:.*/)?lv_.*\.c
+
+# Exclude hardware/GPU-dependent code that cannot be tested in CI.
+# These modules require physical hardware or OS features unavailable
+# in the CI environment and always show 0% coverage.
+exclude = src/draw/nanovg/
+exclude = src/draw/opengles/
+exclude = src/drivers/opengles/
+exclude = src/drivers/wayland/
+exclude = src/drivers/display/drm/
+exclude = src/drivers/display/fb/
+exclude = src/drivers/libinput/

--- a/scripts/check_gcov_coverage.py
+++ b/scripts/check_gcov_coverage.py
@@ -41,6 +41,18 @@ def create_argument_parser() -> argparse.ArgumentParser:
         help="Fail if coverage is below this percentage (0-100), default: 0 (no failure)",
     )
 
+    parser.add_argument(
+        "--min-lines",
+        type=int,
+        metavar="N",
+        default=0,
+        help=(
+            "Skip --fail-under enforcement when new coverable lines < N. "
+            "Small patches produce noisy percentages; this avoids false positives. "
+            "Default: 0 (always enforce)"
+        ),
+    )
+
     return parser
 
 
@@ -92,7 +104,6 @@ def get_coverage_data(root: str) -> Dict[str, Dict[int, int]]:
         non-coverable and will be ignored by the uncovered check.
     Raises: subprocess.CalledProcessError if gcovr fails
     """
-    filter_pattern = os.path.join(root, r"src/(?:.*/)?lv_.*\.c")
     cmd = [
         "gcovr",
         "--gcov-ignore-parse-errors",
@@ -100,8 +111,6 @@ def get_coverage_data(root: str) -> Dict[str, Dict[int, int]]:
         "-",
         "--root",
         root,
-        "--filter",
-        filter_pattern,
     ]
 
     result = subprocess.run(
@@ -296,6 +305,7 @@ def report_coverage(
     *,
     total_label: str,
     skipped_noncoverable: Optional[int] = None,
+    min_lines: int = 0,
 ) -> int:
     """
     Print a standardized coverage report and return exit code (0/1).
@@ -305,6 +315,7 @@ def report_coverage(
       "New coverable lines (per gcovr)" for commit mode, or
       "Coverable lines (per gcovr)" for path mode)
     - skipped_noncoverable: when provided, prints the skipped non-coverable count
+    - min_lines: when > 0, skip --fail-under enforcement if total < min_lines
     """
 
     title = f" Coverage analysis results for {header} "
@@ -320,7 +331,14 @@ def report_coverage(
     if total > 0:
         coverage_percent = (covered / total) * 100
         print(f"Coverage: {coverage_percent:.2f}%")
-        if coverage_percent < fail_under:
+
+        # Check if this patch is too small to enforce the threshold
+        if min_lines > 0 and fail_under > 0 and total < min_lines:
+            print(
+                f"\nℹ Only {total} new coverable line(s) (< {min_lines}), "
+                f"skipping --fail-under enforcement."
+            )
+        elif coverage_percent < fail_under:
             print(
                 f"\n✗ Coverage {coverage_percent:.2f}% is below required {fail_under}%"
             )
@@ -354,6 +372,7 @@ def main() -> int:
 
         if args.path:
             # Path mode: ignore commit, compute coverage for file/dir
+            # --min-lines is not applied here since it targets patch (commit) mode.
             covered, total, uncovered = check_path_coverage(args.path, root)
 
             return report_coverage(
@@ -378,6 +397,7 @@ def main() -> int:
                 fail_under=args.fail_under,
                 total_label="New coverable lines (per gcovr)",
                 skipped_noncoverable=skipped_noncoverable,
+                min_lines=args.min_lines,
             )
 
     except subprocess.CalledProcessError as e:

--- a/tests/main.py
+++ b/tests/main.py
@@ -182,7 +182,7 @@ def generate_code_coverage_report():
            '--root', root_dir, '--html-details', '--output',
            html_report_file, '--xml', 'report/coverage.xml',
            '-j', str(os.cpu_count()), '--print-summary', '--merge-mode-functions=merge-use-line-min',
-           '--html-title', 'LVGL Test Coverage', '--filter', os.path.join(root_dir, 'src/.*/lv_.*\\.c')]
+           '--html-title', 'LVGL Test Coverage']
 
     subprocess.check_call(cmd)
     print("Done: See %s" % html_report_file, flush=True)


### PR DESCRIPTION
### What does this PR do?

Enables automatic enforcement of code coverage requirements for pull requests. PRs that add new code with insufficient test coverage will now fail CI, eliminating the need to manually remind contributors to write tests.

### Changes

| File | Change |
|------|--------|
| `gcovr.cfg` | New unified config — filter (`src/**/lv_*.c`) and exclude rules, replaces `--filter` args previously scattered in `main.py` and `check_gcov_coverage.py` |
| `scripts/check_gcov_coverage.py` | Add `--min-lines` parameter; remove inline `--filter` (now in `gcovr.cfg`) |
| `tests/main.py` | Remove inline `--filter` (now in `gcovr.cfg`) |
| `.github/workflows/ccpp.yml` | Enable `--fail-under=50 --min-lines=5` in the coverage step |

### How it works

The existing `check_gcov_coverage.py` already runs on every PR and reports patch coverage. This PR enables its `--fail-under` flag to make it a blocking check, and adds `gcovr.cfg` to centralize filter/exclude configuration.

### Exemption rules

| Rule | What it does | How |
|------|-------------|-----|
| **Hardware path exclusion** | Excludes code that cannot run in CI (no GPU, no Wayland, etc.) | `gcovr.cfg` — shared by both report generation and coverage gate |
| **Small patch exemption** | Patches with < 5 new coverable lines skip threshold enforcement | `--min-lines=5` — avoids noisy percentages on tiny fixes |
| **Non-source files** | Headers, configs, docs are not tracked | gcovr `filter` only matches `src/**/lv_*.c` |

**Excluded paths** (0% coverage in full test suite — require hardware unavailable in CI):
- `src/draw/nanovg/` — requires NanoVG + GPU context
- `src/draw/opengles/` — requires OpenGL ES
- `src/drivers/opengles/` — requires EGL + GPU
- `src/drivers/wayland/` — requires Wayland compositor
- `src/drivers/display/drm/` — requires Linux DRM/KMS
- `src/drivers/display/fb/` — requires Linux framebuffer
- `src/drivers/libinput/` — requires libinput daemon

**NOT excluded** (confirmed testable in CI):
- `src/draw/sw/` — 77.2% coverage
- `src/draw/vg_lite/` — 77.8% coverage (emulated)
- All core, widgets, libs, misc, layouts, themes, etc.

**After applying excludes**, full test suite coverage improved from 75.3% → 81.3% line coverage (by removing ~4,500 untestable lines from the denominator).

See [report.zip](https://github.com/user-attachments/files/27039816/report.zip).

### Why 50%?

Based on analysis of the last 90 days of merged PRs (205 total, 133 with coverage data):

**Coverage stats** (39 PRs with ≥ 5 new coverable lines, excluding hardware paths):

| Metric | Value |
|--------|-------|
| Average | 80.4% |
| Median | 93.9% |
| P25 | 70.0% |
| Full test suite line coverage | 81.3% |

**Threshold simulation** (with all exemptions applied):

| Threshold | Blocked | Block rate | Notes |
|-----------|---------|------------|-------|
| 30% | 2 / 39 | 5% | Only catches 0% PRs |
| **50%** | **5 / 39** | **13%** | Catches genuinely under-tested code |
| 70% | 9 / 39 | 23% | Includes 3 false positives from stale forks |

The 5 PRs blocked at 50% all have < 43% coverage on testable code — they are genuinely under-tested, not edge cases. 50% means "at least test half of what you add", which is a reasonable and intuitive bar.

50% is a practical starting point. It can be raised (e.g. → 60% → 70%) as test infrastructure and contributor habits improve.

### What gets blocked vs. what passes

**Blocked** (correctly):
- Adding 5+ lines of testable code with < 50% coverage

**Passes**:
- Any PR with even minimal test effort (≥ 50% on 5+ lines)
- Small fixes (< 5 coverable lines) — exempt regardless of coverage %
- Hardware/GPU code — excluded from analysis entirely
- Docs, CI, config-only changes — no coverable lines, auto-pass

### Author coverage ranking (top 10 by contribution, excluding hardware paths)

| Rank | Author | PRs | New Lines | Covered | Uncovered | Avg Cov | Weighted Cov |
|------|--------|-----|-----------|---------|-----------|---------|--------------|
| 1 | @clydebarrow | 2 | 25,760 | 17,586 | 8,174 | 34.1% | 68.3% |
| 2 | @AndyEveritt | 3 | 18,244 | 9,166 | 9,078 | 50.1% | 50.2% |
| 3 | @kisvegabor | 10 | 320 | 283 | 37 | 89.4% | 88.4% |
| 4 | @AndreCostaaa | 15 | 291 | 244 | 47 | 85.3% | 83.8% |
| 5 | @uLipe | 1 | 155 | 127 | 28 | 81.9% | 81.9% |
| 6 | @FASTSHIFT | 2 | 68 | 67 | 1 | 99.3% | 98.5% |
| 7 | @mr-sven | 1 | 36 | 22 | 14 | 61.1% | 61.1% |
| 8 | @tanguy-rdt | 1 | 33 | 31 | 2 | 93.9% | 93.9% |
| 9 | @HongChao6 | 2 | 31 | 13 | 18 | 26.0% | 41.9% |
| 10 | @mn89h | 2 | 26 | 2 | 24 | 50.0% | 7.7% |

> Note: @clydebarrow and @AndyEveritt show inflated line counts due to stale fork branches (merge-base drift includes other PRs' changes in the diff). Their actual changes are much smaller.

### Reproducing the analysis

The analysis script ([analyze_pr_coverage.py](https://github.com/user-attachments/files/27039523/analyze_pr_coverage.py), attached) fetches CI logs via GitHub API and extracts coverage data. To reproduce:

```bash
export GITHUB_TOKEN=<token>  # fine-grained, public repos read-only
python analyze_pr_coverage.py --days 90
```

cc @kisvegabor @AndreCostaaa 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
