### PR TITLE
ci(review): add Copilot code review instructions 

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,7 +26,7 @@ Code must be portable, memory-efficient, and bare-metal safe.
 - `lv_<module>_<action>_<subject>` for public API; `_lv_` prefix for internal
 - ALL_CAPS for enums/defines; `_t` suffix for typedefs
 - 4 spaces, no tabs; function brace on new line; `if`/`for` brace on same line
-- `<stdint.h>` types; block comments `/* */` only; `"%" LV_PRId32` for format strings
+- `<stdint.h>` types; block comments `/* */` only, never `//` (C++ style); `"%" LV_PRId32` for format strings
 - File-scope variables must be `static`; no globals outside `lv_global_t`
 
 ## Code Organization

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # LVGL Code Review Instructions
 
-LVGL is an embedded C99 graphics library for MCUs (64KB+ RAM), MPUs, and simulators.
+LVGL is an embedded C99 graphics library for MCUs, MPUs, and simulators.
 Code must be portable, memory-efficient, and bare-metal safe.
 
 ## Critical Issues (always flag)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,8 +41,8 @@ Code must be portable, memory-efficient, and bare-metal safe.
 
 - Prefer graceful degradation over assert for recoverable failures (e.g. cache alloc fail → log + disable, not crash)
 - `LV_LOG_WARN` for unexpected recoverable conditions; `LV_LOG_ERROR` for bugs
-- `LV_ASSERT_NULL` for debug invariants; `LV_CHECK_ARG` for public API validation
-- Public API functions should validate arguments at entry with `LV_ASSERT_OBJ`/`LV_ASSERT_NULL` (unless the API contract explicitly defines caller-side validation)
+- `LV_ASSERT_NULL` for debug invariants; `LV_CHECK_ARG` for public API runtime argument validation
+- Public API functions should validate arguments at entry with `LV_CHECK_ARG` (unless the API contract explicitly defines caller-side validation); use `LV_ASSERT_OBJ`/`LV_ASSERT_NULL` only for debug-time invariants
 
 ## GPU / Draw Units
 
@@ -55,7 +55,7 @@ Code must be portable, memory-efficient, and bare-metal safe.
 
 - Commit: `<type>(<scope>): <subject>` — imperative, lowercase, no period, max 90 chars
 - Types: `fix`, `feat`, `arch`, `perf`, `example`, `docs`, `test`, `chore`
-- CI enforces patch coverage checks on new coverable lines
+- CI analyzes and reports patch coverage on new coverable lines
 - New features need tests; bug fixes need regression tests when feasible
 - New features and API changes should include examples in `examples/`
 - If `lv_conf_template.h` was modified, check that `lv_conf_internal_gen.py` was run and `Kconfig` updated

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,8 +41,8 @@ Code must be portable, memory-efficient, and bare-metal safe.
 
 - Prefer graceful degradation over assert for recoverable failures (e.g. cache alloc fail → log + disable, not crash)
 - `LV_LOG_WARN` for unexpected recoverable conditions; `LV_LOG_ERROR` for bugs
-- `LV_ASSERT_NULL` for debug invariants; `LV_CHECK_ARG` for public API runtime argument validation
-- Public API functions should validate arguments at entry with `LV_CHECK_ARG` (unless the API contract explicitly defines caller-side validation); use `LV_ASSERT_OBJ`/`LV_ASSERT_NULL` only for debug-time invariants
+- `LV_ASSERT_NULL` for debug invariants
+- Public API functions should validate arguments at entry with `LV_ASSERT_OBJ`/`LV_ASSERT_NULL`
 
 ## GPU / Draw Units
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,7 +23,7 @@ Code must be portable, memory-efficient, and bare-metal safe.
 
 ## Naming & Style
 
-- `lv_<module>_<action>_<subject>` for public API; `_lv_` prefix for internal
+- `lv_<module>_<action>_<subject>` for public API
 - ALL_CAPS for enums/defines; `_t` suffix for typedefs
 - 4 spaces, no tabs; function brace on new line; `if`/`for` brace on same line
 - `<stdint.h>` types; C files use block comments `/* */` only (no `//`), C++ files may use `//`; `"%" LV_PRId32` for format strings
@@ -42,7 +42,6 @@ Code must be portable, memory-efficient, and bare-metal safe.
 - Prefer graceful degradation over assert for recoverable failures (e.g. cache alloc fail → log + disable, not crash)
 - `LV_LOG_WARN` for unexpected recoverable conditions; `LV_LOG_ERROR` for bugs
 - `LV_ASSERT_NULL` for debug invariants
-- Public API functions should validate arguments at entry with `LV_ASSERT_OBJ`/`LV_ASSERT_NULL`
 
 ## GPU / Draw Units
 
@@ -54,7 +53,9 @@ Code must be portable, memory-efficient, and bare-metal safe.
 ## PR Requirements
 
 - Commit: `<type>(<scope>): <subject>` — imperative, lowercase, no period, max 90 chars
-- Types: `fix`, `feat`, `arch`, `perf`, `example`, `docs`, `test`, `chore`
+- Types with source code changes: `fix`, `feat`, `refactor`, `arch`, `perf`, `style`, `test`
+- Types without source code changes: `chore`, `ci`, `docs`, `build`
+- Exception: inline source documentation (Doxygen) uses `docs` even though it lives in source files
 - CI analyzes and reports patch coverage on new coverable lines
 - New features need tests; bug fixes need regression tests when feasible
 - New features and API changes should include examples in `examples/`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,7 +19,6 @@ Code must be portable, memory-efficient, and bare-metal safe.
 - No heap allocation in draw loops, event handlers, timer callbacks
 - Avoid `lv_obj_is_valid()` in internal callbacks — walks entire object tree
 - `lv_free(NULL)` is safe — no redundant NULL check before it
-- No `LV_ASSERT_MALLOC` after functions that already check internally
 
 ## Naming & Style
 
@@ -41,7 +40,6 @@ Code must be portable, memory-efficient, and bare-metal safe.
 
 - Prefer graceful degradation over assert for recoverable failures (e.g. cache alloc fail → log + disable, not crash)
 - `LV_LOG_WARN` for unexpected recoverable conditions; `LV_LOG_ERROR` for bugs
-- `LV_ASSERT_NULL` for debug invariants
 
 ## GPU / Draw Units
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,5 +56,8 @@ Code must be portable, memory-efficient, and bare-metal safe.
 - Types: `fix`, `feat`, `arch`, `perf`, `example`, `docs`, `test`, `chore`
 - CI enforces ≥ 50% patch coverage on 5+ new coverable lines
 - New features need tests; bug fixes need regression tests when feasible
+- New features and API changes should include examples in `examples/`
+- If `lv_conf_template.h` was modified, check that `lv_conf_internal_gen.py` was run and `Kconfig` updated
+- Code must be formatted with `scripts/code-format.py` (astyle) — flag obvious style violations
 - Doxygen `/** */` with `@param`/`@return` for all public functions in `.h` files
 - Comments explain **why**, not what

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,60 @@
+# LVGL Code Review Instructions
+
+LVGL is an embedded C99 graphics library for MCUs (64KB+ RAM), MPUs, and simulators.
+Code must be portable, memory-efficient, and bare-metal safe.
+
+## Critical Issues (always flag)
+
+- NULL dereference: every `lv_malloc`/`lv_realloc` result must be checked
+- Buffer overflow or out-of-bounds array access
+- Memory leak: every `lv_malloc` needs matching `lv_free` on all exit paths
+- Use-after-free, uninitialized variable use
+- Integer overflow in size/coordinate calculations
+- Missing `#if LV_USE_xxx` / `#endif` guards for optional features
+- Global variables not in `lv_global_t` — must use `LV_GLOBAL_DEFAULT()`
+- Test headers included in production source (`#include "lv_test_..."` in `src/`)
+
+## Embedded Performance (flag in hot paths)
+
+- No heap allocation in draw loops, event handlers, timer callbacks
+- Avoid `lv_obj_is_valid()` in internal callbacks — walks entire object tree
+- `lv_free(NULL)` is safe — no redundant NULL check before it
+- No `LV_ASSERT_MALLOC` after functions that already check internally
+
+## Naming & Style
+
+- `lv_<module>_<action>_<subject>` for public API; `_lv_` prefix for internal
+- ALL_CAPS for enums/defines; `_t` suffix for typedefs
+- 4 spaces, no tabs; function brace on new line; `if`/`for` brace on same line
+- `<stdint.h>` types; block comments `/* */` only; `"%" LV_PRId32` for format strings
+- File-scope variables must be `static`; no globals outside `lv_global_t`
+
+## Code Organization
+
+- Extract helpers when functions exceed ~50 lines, but don't over-engineer single-use helpers
+- Eliminate code duplication across branches
+- Struct layout: pointers first, then int32, then small types/bitfields (minimize padding)
+- New files follow `src/misc/lv_templ.c` section template
+- `#if LV_USE_xxx` near top, `#endif /* LV_USE_xxx */` at bottom
+
+## Memory & Error Patterns
+
+- Prefer graceful degradation over assert for recoverable failures (e.g. cache alloc fail → log + disable, not crash)
+- `LV_LOG_WARN` for unexpected recoverable conditions; `LV_LOG_ERROR` for bugs
+- `LV_ASSERT_NULL` for debug invariants; `LV_CHECK_ARG` for public API validation
+
+## GPU / Draw Units
+
+- All `vg_lite_*` calls: check with `LV_VG_LITE_CHECK_ERROR`
+- Use current API names (`vg_lite_set_path_type` not deprecated variants)
+- GL state: save and restore (scissor, framebuffer binding, clear color)
+- `#if LV_USE_DRAW_*` guards required
+
+## PR Requirements
+
+- Commit: `<type>(<scope>): <subject>` — imperative, lowercase, no period, max 90 chars
+- Types: `fix`, `feat`, `arch`, `perf`, `example`, `docs`, `test`, `chore`
+- CI enforces ≥ 50% patch coverage on 5+ new coverable lines
+- New features need tests; bug fixes need regression tests when feasible
+- Doxygen `/** */` with `@param`/`@return` for all public functions in `.h` files
+- Comments explain **why**, not what

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,6 +42,7 @@ Code must be portable, memory-efficient, and bare-metal safe.
 - Prefer graceful degradation over assert for recoverable failures (e.g. cache alloc fail → log + disable, not crash)
 - `LV_LOG_WARN` for unexpected recoverable conditions; `LV_LOG_ERROR` for bugs
 - `LV_ASSERT_NULL` for debug invariants; `LV_CHECK_ARG` for public API validation
+- Public API functions should validate arguments with `LV_ASSERT_OBJ`, `LV_ASSERT_NULL`, etc. at entry
 
 ## GPU / Draw Units
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,7 +55,7 @@ Code must be portable, memory-efficient, and bare-metal safe.
 
 - Commit: `<type>(<scope>): <subject>` — imperative, lowercase, no period, max 90 chars
 - Types: `fix`, `feat`, `arch`, `perf`, `example`, `docs`, `test`, `chore`
-- CI enforces ≥ 50% patch coverage on 5+ new coverable lines
+- CI enforces patch coverage checks on new coverable lines
 - New features need tests; bug fixes need regression tests when feasible
 - New features and API changes should include examples in `examples/`
 - If `lv_conf_template.h` was modified, check that `lv_conf_internal_gen.py` was run and `Kconfig` updated

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,7 +42,7 @@ Code must be portable, memory-efficient, and bare-metal safe.
 - Prefer graceful degradation over assert for recoverable failures (e.g. cache alloc fail → log + disable, not crash)
 - `LV_LOG_WARN` for unexpected recoverable conditions; `LV_LOG_ERROR` for bugs
 - `LV_ASSERT_NULL` for debug invariants; `LV_CHECK_ARG` for public API validation
-- Public API functions should validate arguments with `LV_ASSERT_OBJ`, `LV_ASSERT_NULL`, etc. at entry
+- Public API functions should validate arguments at entry with `LV_ASSERT_OBJ`/`LV_ASSERT_NULL` (unless the API contract explicitly defines caller-side validation)
 
 ## GPU / Draw Units
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,7 +26,7 @@ Code must be portable, memory-efficient, and bare-metal safe.
 - `lv_<module>_<action>_<subject>` for public API; `_lv_` prefix for internal
 - ALL_CAPS for enums/defines; `_t` suffix for typedefs
 - 4 spaces, no tabs; function brace on new line; `if`/`for` brace on same line
-- `<stdint.h>` types; block comments `/* */` only, never `//` (C++ style); `"%" LV_PRId32` for format strings
+- `<stdint.h>` types; C files use block comments `/* */` only (no `//`), C++ files may use `//`; `"%" LV_PRId32` for format strings
 - File-scope variables must be `static`; no globals outside `lv_global_t`
 
 ## Code Organization

--- a/.github/instructions/c-code.instructions.md
+++ b/.github/instructions/c-code.instructions.md
@@ -18,7 +18,7 @@ applyTo: "src/**/*.c,src/**/*.h"
 - Functions returning `lv_result_t` must be checked by callers
 - Error paths must clean up all allocated resources before returning
 - Use `LV_ASSERT_*` for debug-time invariant checks, not as runtime error handling
-- Public API functions should validate arguments with `LV_ASSERT_OBJ`, `LV_ASSERT_NULL`, etc. at entry
+- Public API functions should validate arguments with `LV_ASSERT_OBJ`, `LV_ASSERT_NULL`, etc. at entry unless the API contract explicitly defines caller-side validation (e.g. some `lv_fs_*` APIs)
 - Graceful runtime fallback is preferred over assert for recoverable failures (e.g. cache allocation failure should degrade, not crash)
 - Add `LV_LOG_WARN` for unexpected but recoverable conditions
 - Add `LV_LOG_ERROR` for conditions that indicate a bug
@@ -29,7 +29,7 @@ applyTo: "src/**/*.c,src/**/*.h"
 - Prefer stack allocation for small temporary buffers
 - Avoid `lv_obj_is_valid()` in internal callbacks — it walks the entire object tree
 - Cache-friendly access: sequential over random
-- Struct member ordering: group pointers together, then smaller types, to minimize padding bytes
+- Struct member ordering: pointers first, then int32_t, then smaller types/bitfields — minimizes padding
 
 ## Portability
 
@@ -42,6 +42,5 @@ applyTo: "src/**/*.c,src/**/*.h"
 ## Include Structure
 
 - `.h` files: `#ifndef LV_<MODULE>_H` / `#define` / `#endif`
-- Feature-gated: `#if LV_USE_<FEATURE>` near top, `#endif` at bottom
-- Only the matching `.h` include above the feature guard
+- Feature-gated files: keep `#if LV_USE_<FEATURE>` near the top and the matching `#endif` at the bottom; necessary includes (module headers, private headers) may appear before the feature guard
 - Never include test headers in production source files

--- a/.github/instructions/c-code.instructions.md
+++ b/.github/instructions/c-code.instructions.md
@@ -18,7 +18,7 @@ applyTo: "src/**/*.c,src/**/*.h"
 - Functions returning `lv_result_t` must be checked by callers
 - Error paths must clean up all allocated resources before returning
 - Use `LV_ASSERT_*` for debug-time invariant checks, not as runtime error handling
-- Public API functions should validate runtime arguments with `LV_CHECK_ARG`; use `LV_ASSERT_OBJ`, `LV_ASSERT_NULL`, etc. only for debug-time invariants or when the API contract explicitly requires it
+- Public API functions should validate arguments at entry with `LV_ASSERT_OBJ`, `LV_ASSERT_NULL`, etc.
 - Graceful runtime fallback is preferred over assert for recoverable failures (e.g. cache allocation failure should degrade, not crash)
 - Add `LV_LOG_WARN` for unexpected but recoverable conditions
 - Add `LV_LOG_ERROR` for conditions that indicate a bug

--- a/.github/instructions/c-code.instructions.md
+++ b/.github/instructions/c-code.instructions.md
@@ -9,7 +9,6 @@ applyTo: "src/**/*.c,src/**/*.h"
 - Every `lv_malloc` / `lv_realloc` must have a NULL check immediately after
 - Every allocation must have a matching `lv_free` on all exit paths (including error paths)
 - `lv_free(NULL)` is safe — don't add redundant NULL checks before it
-- Don't add `LV_ASSERT_MALLOC` after functions that already check internally (e.g. `lv_vg_lite_path_create`)
 - Pointer parameters: NULL-check before dereference when caller could reasonably pass NULL
 - Array access must be bounds-checked
 
@@ -17,7 +16,6 @@ applyTo: "src/**/*.c,src/**/*.h"
 
 - Functions returning `lv_result_t` must be checked by callers
 - Error paths must clean up all allocated resources before returning
-- Use `LV_ASSERT_*` for debug-time invariant checks, not as runtime error handling
 - Graceful runtime fallback is preferred over assert for recoverable failures (e.g. cache allocation failure should degrade, not crash)
 - Add `LV_LOG_WARN` for unexpected but recoverable conditions
 - Add `LV_LOG_ERROR` for conditions that indicate a bug

--- a/.github/instructions/c-code.instructions.md
+++ b/.github/instructions/c-code.instructions.md
@@ -18,7 +18,7 @@ applyTo: "src/**/*.c,src/**/*.h"
 - Functions returning `lv_result_t` must be checked by callers
 - Error paths must clean up all allocated resources before returning
 - Use `LV_ASSERT_*` for debug-time invariant checks, not as runtime error handling
-- Public API functions should validate arguments with `LV_ASSERT_OBJ`, `LV_ASSERT_NULL`, etc. at entry unless the API contract explicitly defines caller-side validation (e.g. some `lv_fs_*` APIs)
+- Public API functions should validate runtime arguments with `LV_CHECK_ARG`; use `LV_ASSERT_OBJ`, `LV_ASSERT_NULL`, etc. only for debug-time invariants or when the API contract explicitly requires it
 - Graceful runtime fallback is preferred over assert for recoverable failures (e.g. cache allocation failure should degrade, not crash)
 - Add `LV_LOG_WARN` for unexpected but recoverable conditions
 - Add `LV_LOG_ERROR` for conditions that indicate a bug

--- a/.github/instructions/c-code.instructions.md
+++ b/.github/instructions/c-code.instructions.md
@@ -1,0 +1,46 @@
+---
+applyTo: "src/**/*.c,src/**/*.h"
+---
+
+# LVGL C Source Review Rules
+
+## Memory Safety
+
+- Every `lv_malloc` / `lv_realloc` must have a NULL check immediately after
+- Every allocation must have a matching `lv_free` on all exit paths (including error paths)
+- `lv_free(NULL)` is safe — don't add redundant NULL checks before it
+- Don't add `LV_ASSERT_MALLOC` after functions that already check internally (e.g. `lv_vg_lite_path_create`)
+- Pointer parameters: NULL-check before dereference when caller could reasonably pass NULL
+- Array access must be bounds-checked
+
+## Error Handling
+
+- Functions returning `lv_result_t` must be checked by callers
+- Error paths must clean up all allocated resources before returning
+- Use `LV_ASSERT_*` for debug-time invariant checks, not as runtime error handling
+- Graceful runtime fallback is preferred over assert for recoverable failures (e.g. cache allocation failure should degrade, not crash)
+- Add `LV_LOG_WARN` for unexpected but recoverable conditions
+- Add `LV_LOG_ERROR` for conditions that indicate a bug
+
+## Performance
+
+- No heap allocation in hot paths (draw loops, event handlers, timer callbacks)
+- Prefer stack allocation for small temporary buffers
+- Avoid `lv_obj_is_valid()` in internal callbacks — it walks the entire object tree
+- Cache-friendly access: sequential over random
+- Struct member ordering: group pointers together, then smaller types, to minimize padding bytes
+
+## Portability
+
+- No platform headers without `#if` guards
+- No compiler extensions without fallback
+- No `float`/`double` in core code unless behind `LV_USE_FLOAT`
+- Use `LV_ATTRIBUTE_*` macros for alignment/section placement
+- Use `"%" LV_PRId32` for `int32_t` format strings, not `"%d"`
+
+## Include Structure
+
+- `.h` files: `#ifndef LV_<MODULE>_H` / `#define` / `#endif`
+- Feature-gated: `#if LV_USE_<FEATURE>` near top, `#endif` at bottom
+- Only the matching `.h` include above the feature guard
+- Never include test headers in production source files

--- a/.github/instructions/c-code.instructions.md
+++ b/.github/instructions/c-code.instructions.md
@@ -18,6 +18,7 @@ applyTo: "src/**/*.c,src/**/*.h"
 - Functions returning `lv_result_t` must be checked by callers
 - Error paths must clean up all allocated resources before returning
 - Use `LV_ASSERT_*` for debug-time invariant checks, not as runtime error handling
+- Public API functions should validate arguments with `LV_ASSERT_OBJ`, `LV_ASSERT_NULL`, etc. at entry
 - Graceful runtime fallback is preferred over assert for recoverable failures (e.g. cache allocation failure should degrade, not crash)
 - Add `LV_LOG_WARN` for unexpected but recoverable conditions
 - Add `LV_LOG_ERROR` for conditions that indicate a bug

--- a/.github/instructions/c-code.instructions.md
+++ b/.github/instructions/c-code.instructions.md
@@ -18,7 +18,6 @@ applyTo: "src/**/*.c,src/**/*.h"
 - Functions returning `lv_result_t` must be checked by callers
 - Error paths must clean up all allocated resources before returning
 - Use `LV_ASSERT_*` for debug-time invariant checks, not as runtime error handling
-- Public API functions should validate arguments at entry with `LV_ASSERT_OBJ`, `LV_ASSERT_NULL`, etc.
 - Graceful runtime fallback is preferred over assert for recoverable failures (e.g. cache allocation failure should degrade, not crash)
 - Add `LV_LOG_WARN` for unexpected but recoverable conditions
 - Add `LV_LOG_ERROR` for conditions that indicate a bug


### PR DESCRIPTION
### Problem

Maintainers spend significant time repeating the same review feedback across PRs:
- "Use `/* */` not `//` in C files"
- "Check the return value of `lv_malloc`"
- "Add `LV_VG_LITE_CHECK_ERROR` after vg_lite calls"
- "Reorder struct members to reduce padding"
- "Add `#if LV_USE_xxx` guard"
- "Don't use `lv_obj_is_valid()` in internal callbacks — it's expensive"

Contributors often don't read the coding style docs before submitting, so the same issues come up repeatedly.

### Solution

Add [GitHub Copilot custom instructions](https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot) so that Copilot code review automatically checks for these patterns on every PR. This offloads repetitive review work to the bot, letting maintainers focus on design and logic.

### What's added

| File | Purpose |
|------|---------|
| `.github/copilot-instructions.md` | Repository-wide review rules (< 3KB, within Copilot's 4000-char limit) |
| `.github/instructions/c-code.instructions.md` | C source specific rules, applied only to `src/**/*.c` and `src/**/*.h` |

### What Copilot will now check

The instructions are distilled from LVGL's coding style docs and common patterns observed in maintainer review history:

**Memory & safety:**
- `lv_malloc`/`lv_realloc` NULL checks
- Matching `lv_free` on all exit paths
- No `LV_ASSERT_MALLOC` after functions that already check internally
- Graceful degradation preferred over assert-crash for recoverable failures

**Embedded performance:**
- No heap allocation in draw loops / event handlers / timer callbacks
- Flag expensive `lv_obj_is_valid()` in internal callbacks
- Struct member ordering to minimize padding (pointers → int32 → small types)

**Style & conventions:**
- `/* */` comments in C files (`//` only allowed in C++)
- `LV_PRId32` format specifiers instead of `%d`
- Naming: `lv_<module>_<action>_<subject>`, `_t` suffix, `_lv_` prefix for internal
- File template structure from `lv_templ.c`

**GPU / draw units:**
- `LV_VG_LITE_CHECK_ERROR` on all vg_lite API calls
- GL state save/restore
- Current API names (not deprecated variants)

**PR requirements:**
- Angular commit format
- Test coverage enforcement on new code
- Examples for new features / API changes
- `lv_conf_internal_gen.py` + Kconfig update when `lv_conf_template.h` is modified
- Code formatted with `scripts/code-format.py` (astyle)
- Doxygen comments on public API

### What this does NOT do

- Does not block PRs — Copilot review is advisory only
- Does not replace human review — it catches mechanical issues so maintainers can focus on design
- Does not affect Copilot Chat or code suggestions — only code review

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
