### PR TITLE
tests(dockerfile): resolve xargs failure caused by CRLF line endings

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -8,7 +8,7 @@ RUN apt update
 COPY ./scripts/prerequisites-apt.txt .
 COPY ./scripts/prerequisites-pip.txt .
 
-RUN cat prerequisites-apt.txt | xargs apt install -y
+RUN cat prerequisites-apt.txt | tr -d '\r' | xargs apt install -y
 
 RUN pip install --break-system-packages -r prerequisites-pip.txt
 


### PR DESCRIPTION
On Windows  , git clone converts line endings to CRLF by default.  When xargs processes these files, it interprets the trailing carriage  return (\r) as part of the argument, leading to execution errors.

This change ensures consistent LF line endings for prerequisites-apt.txt.

#9991