### PR TITLE
fix(mem): align TLSF to 8 bytes on ARMv7-M/E-M/v8-M to avoid LDRD fault

### DIFF
--- a/src/stdlib/builtin/lv_tlsf.c
+++ b/src/stdlib/builtin/lv_tlsf.c
@@ -232,6 +232,17 @@ typedef enum {
 #if defined (TLSF_64BIT)
     /* All allocation sizes and addresses are aligned to 8 bytes. */
     ALIGN_SIZE_LOG2 = 3,
+#elif (defined(__ARM_ARCH) && (__ARM_ARCH >= 7) && !defined(__ARM_ARCH_6M__))
+    /* ARMv7-M / ARMv7E-M / ARMv8-M (Cortex-M3/M4/M7/M33 …) require strict
+     * 8-byte alignment for LDRD/STRD (and LDM/STM of double words). These
+     * instructions fault with a UsageFault (UFSR.UNALIGNED) regardless of
+     * CCR.UNALIGN_TRP, so GCC may emit them for 64-bit struct accesses and
+     * expect the pointer returned by malloc to be at least 8-byte aligned
+     * (alignof(max_align_t) on these targets is 8 because of double /
+     * long long). Keeping ALIGN_SIZE at 4 causes hardfaults on external
+     * SDRAM pools where block addresses happen to be only 4-byte aligned.
+     * See e.g. https://github.com/lvgl/lvgl/issues/4747. */
+    ALIGN_SIZE_LOG2 = 3,
 #else
     /* All allocation sizes and addresses are aligned to 4 bytes. */
     ALIGN_SIZE_LOG2 = 2,


### PR DESCRIPTION
Fixes #4747 (`unaligned memory access`, previously closed as not planned — see below).

## Summary

On 32-bit ARM Cortex-M3 / M4 / M7 / M33 (ARMv7-M, ARMv7E-M, ARMv8-M) the `LDRD` / `STRD` instructions require strict 8-byte alignment and fault with a UsageFault (`UFSR.UNALIGNED`) **regardless of `CCR.UNALIGN_TRP`**. GCC emits these for 64-bit struct accesses assuming `malloc` returns pointers aligned to `alignof(max_align_t)` — which is 8 on these targets because `double` / `long long` are 8-byte aligned.

The built-in TLSF allocator currently uses `ALIGN_SIZE_LOG2 = 2` (4 bytes) on all 32-bit builds. In internal SRAM allocations usually happen to land on 8-byte boundaries and the issue stays hidden, but on external RAM pools (e.g. **STM32H7 + FMC SDRAM** configured via `LV_MEM_ADR`) the mis-aligned addresses are hit almost immediately and the CPU hard-faults inside `lv_tlsf_malloc` → `lv_mem_core_builtin.c:147` during the first non-trivial allocation from the draw path.

## Change

Detect LDRD-capable M-profile cores via `__ARM_ARCH >= 7` (excluding ARMv6-M, which has no LDRD) and promote `ALIGN_SIZE_LOG2` to 3 (8 bytes) there. `TLSF_64BIT` still takes precedence. No behavior change on AVR, RV32, ARMv6-M (Cortex-M0/M0+) or other 32-bit targets.

```c
#if defined (TLSF_64BIT)
    ALIGN_SIZE_LOG2 = 3;
#elif (defined(__ARM_ARCH) && (__ARM_ARCH >= 7) && !defined(__ARM_ARCH_6M__))
    /* ARMv7-M / ARMv7E-M / ARMv8-M need 8-byte alignment for LDRD/STRD. */
    ALIGN_SIZE_LOG2 = 3;
#else
    ALIGN_SIZE_LOG2 = 2;
#endif
```

## How it was diagnosed

Reproducer: `[env:lvgl_test]` on a STM32H743II board with 32 MB FMC SDRAM, `LV_MEM_ADR = 0xC0100000` (4 MB pool in SDRAM free region after the 800×480 RGB565 LTDC framebuffer). `lv_init()` succeeds but `lv_timer_handler()` hard-faults on the first `lv_draw_rect`.

GDB attach after fault (J-Link):

```
CFSR  = 0x01000000
  UFSR = 0x0100   → bit 8 = UNALIGNED
HFSR  = 0x40000000 (FORCED)

Backtrace:
  WWDG_IRQHandler (Default_Handler Infinite_Loop)
  <signal handler called>
  lv_draw_rect             .../lv_draw_rect.c:256
  lv_obj_draw              .../lv_obj.c:733
  ...
  lv_malloc_core           .../lv_mem_core_builtin.c:147
  lv_tlsf_malloc (tlsf=0xC0100000)  .../lv_tlsf.c:1102
```

Ruled out by direct tests before landing on TLSF:
- **SDRAM / FMC / MPU**: mixed-struct probe `{u32, u16, u8, void*, u64}` at `0xC0100000` reads/writes fine. A 25 MB pattern R/W stress alongside LVGL runs 401 iterations with 0 errors.
- **`CCR.UNALIGN_TRP`**: already `0`, clearing it explicitly has no effect (LDRD strict alignment is ISA-level, independent of that bit).
- **MPU**: SDRAM region set to Normal / non-cacheable / bufferable — no change.
- **LVGL version**: reproduced on both 9.2.2 and 9.3.0.

Workaround while the fix is not merged: build LVGL with `-mno-unaligned-access` so GCC stops emitting LDRD/STRD. This also fixes the symptom but doesn't address the root cause (TLSF's 4-byte alignment is below `alignof(max_align_t)` on these targets).

## Verification

Same board, same env, only the diff in this PR applied (no `-mno-unaligned-access`):
- `lv_init()` ✓, `lv_timer_handler()` ✓
- 8-row dashboard renders continuously, loop iter count grows, no fault
- 4 MB SDRAM heap accepted, internal AXI SRAM usage drops from 90 % to 15 %

## Notes

- Code style: single `#elif` block matching the existing `#if defined (TLSF_64BIT)` style, no reformatting.
- No new options in `lv_conf_template.h` → `lv_conf_internal_gen.py` / Kconfig not affected.
- Doc update not needed — allocator ABI is unchanged.
- Tests: none added; the existing TLSF tests still pass on x86_64 (via `TLSF_64BIT`), and adding an ARMv7-M HW test would require CI changes. Happy to add one if that's the project's preference.

## Related reports

- #4747 — `unaligned memory access`, same symptom, closed as not planned
- LVGL forum "Getting hardfault when using Ext. RAM for LV_MEM_ADR" (12766)
- STMicroelectronics community "stm32h7b0 has UNALIGNED hardfault problem when using LVGL 9.1" (695235)

Marked as **Draft** for maintainer feedback on the detection macro and whether an additional conditional (e.g. also `__ARM_FEATURE_LDRD`) is preferred.