### PR TITLE
fix(wayland): fix non-gesture touch point when gestures are enabled

### DIFF
--- a/src/drivers/wayland/lv_wayland_private.h
+++ b/src/drivers/wayland/lv_wayland_private.h
@@ -54,11 +54,10 @@ typedef struct {
 #if LV_USE_GESTURE_RECOGNITION
     lv_indev_touch_data_t touches[LV_WAYLAND_MAX_TOUCHES];
     uint8_t event_cnt;
-    uint8_t primary_id;
-#else
+#endif /*LV_USE_GESTURE_RECOGNITION*/
+    int32_t primary_id;
     lv_point_t point;
     lv_indev_state_t state;
-#endif /*LV_USE_GESTURE_RECOGNITION*/
 } lv_wl_seat_touch_t;
 
 typedef struct {

--- a/src/drivers/wayland/lv_wayland_private.h
+++ b/src/drivers/wayland/lv_wayland_private.h
@@ -30,6 +30,7 @@ extern "C" {
 
 #define LV_WAYLAND_DEFAULT_CURSOR_NAME "left_ptr"
 #define LV_WAYLAND_MAX_OUTPUTS 8
+#define LV_WAYLAND_MAX_TOUCHES 10
 
 /**********************
  *      TYPEDEFS
@@ -51,7 +52,7 @@ typedef struct {
     struct wl_touch * wl_touch;
 
 #if LV_USE_GESTURE_RECOGNITION
-    lv_indev_touch_data_t touches[10];
+    lv_indev_touch_data_t touches[LV_WAYLAND_MAX_TOUCHES];
     uint8_t event_cnt;
     uint8_t primary_id;
 #else

--- a/src/drivers/wayland/lv_wayland_touch.c
+++ b/src/drivers/wayland/lv_wayland_touch.c
@@ -165,14 +165,16 @@ static void touch_handle_down(void * data, struct wl_touch * wl_touch, uint32_t 
     }
 
 #if LV_USE_GESTURE_RECOGNITION
-    uint8_t i = tdata->event_cnt;
+    if(tdata->event_cnt < LV_WAYLAND_MAX_TOUCHES) {
+        uint8_t i = tdata->event_cnt;
 
-    tdata->touches[i].point.x   = wl_fixed_to_int(x_w);
-    tdata->touches[i].point.y   = wl_fixed_to_int(y_w);
-    tdata->touches[i].id        = id;
-    tdata->touches[i].timestamp = time;
-    tdata->touches[i].state     = LV_INDEV_STATE_PRESSED;
-    tdata->event_cnt++;
+        tdata->touches[i].point.x   = wl_fixed_to_int(x_w);
+        tdata->touches[i].point.y   = wl_fixed_to_int(y_w);
+        tdata->touches[i].id        = id;
+        tdata->touches[i].timestamp = time;
+        tdata->touches[i].state     = LV_INDEV_STATE_PRESSED;
+        tdata->event_cnt++;
+    }
 #else
     tdata->point.x = wl_fixed_to_int(x_w);
     tdata->point.y = wl_fixed_to_int(y_w);
@@ -190,15 +192,17 @@ static void touch_handle_up(void * data, struct wl_touch * wl_touch, uint32_t se
 
     /* Create a released event */
 #if LV_USE_GESTURE_RECOGNITION
-    uint8_t i = tdata->event_cnt;
+    if(tdata->event_cnt < LV_WAYLAND_MAX_TOUCHES) {
+        uint8_t i = tdata->event_cnt;
 
-    tdata->touches[i].point.x   = 0;
-    tdata->touches[i].point.y   = 0;
-    tdata->touches[i].id        = id;
-    tdata->touches[i].timestamp = time;
-    tdata->touches[i].state     = LV_INDEV_STATE_RELEASED;
+        tdata->touches[i].point.x   = 0;
+        tdata->touches[i].point.y   = 0;
+        tdata->touches[i].id        = id;
+        tdata->touches[i].timestamp = time;
+        tdata->touches[i].state     = LV_INDEV_STATE_RELEASED;
 
-    tdata->event_cnt++;
+        tdata->event_cnt++;
+    }
 #else
     tdata->state = LV_INDEV_STATE_RELEASED;
 #endif
@@ -225,20 +229,17 @@ static void touch_handle_motion(void * data, struct wl_touch * wl_touch, uint32_
         touch++;
     }
 
-    if(cur == NULL) {
-        uint8_t i = tdata->event_cnt;
-        tdata->touches[i].point.x   = wl_fixed_to_int(x_w);
-        tdata->touches[i].point.y   = wl_fixed_to_int(y_w);
-        tdata->touches[i].id        = id;
-        tdata->touches[i].timestamp = time;
-        tdata->touches[i].state     = LV_INDEV_STATE_PRESSED;
+    if(cur == NULL && tdata->event_cnt < LV_WAYLAND_MAX_TOUCHES) {
+        cur = &tdata->touches[tdata->event_cnt];
         tdata->event_cnt++;
     }
-    else {
+
+    if(cur != NULL) {
         cur->point.x   = wl_fixed_to_int(x_w);
         cur->point.y   = wl_fixed_to_int(y_w);
         cur->id        = id;
         cur->timestamp = time;
+        cur->state     = LV_INDEV_STATE_PRESSED;
     }
 #else
     tdata->point.x = wl_fixed_to_int(x_w);

--- a/src/drivers/wayland/lv_wayland_touch.c
+++ b/src/drivers/wayland/lv_wayland_touch.c
@@ -99,6 +99,7 @@ lv_wl_seat_touch_t * lv_wayland_seat_touch_create(struct wl_seat * seat)
         wl_touch_destroy(touch);
         return NULL;
     }
+    wl_seat_touch->primary_id = -1;
     wl_touch_add_listener(touch, &touch_listener, NULL);
     wl_touch_set_user_data(touch, wl_seat_touch);
 
@@ -128,26 +129,19 @@ static void touch_read(lv_indev_t * indev, lv_indev_data_t * data)
     }
 #if LV_USE_GESTURE_RECOGNITION
     /* Collect touches if there are any - send them to the gesture recognizer */
-    lv_indev_gesture_recognizers_update(indev, tdata->touches, tdata->event_cnt);
 
     LV_LOG_TRACE("collected touch events: %d", tdata->event_cnt);
 
     if(tdata->event_cnt > 0) {
-        data->point = tdata->touches[0].point;
+        lv_indev_gesture_recognizers_update(indev, tdata->touches, tdata->event_cnt);
+        lv_indev_gesture_recognizers_set_data(indev, data);
+
+        tdata->event_cnt = 0;
     }
-    else {
-        data->point.x = data->point.y = 0;
-    }
+#endif
 
-    tdata->event_cnt = 0;
-
-    /* Set the gesture information, before returning to LVGL */
-    lv_indev_gesture_recognizers_set_data(indev, data);
-
-#else
     data->point = tdata->point;
     data->state = tdata->state;
-#endif
 }
 
 static void touch_handle_down(void * data, struct wl_touch * wl_touch, uint32_t serial, uint32_t time,
@@ -175,11 +169,17 @@ static void touch_handle_down(void * data, struct wl_touch * wl_touch, uint32_t 
         tdata->touches[i].state     = LV_INDEV_STATE_PRESSED;
         tdata->event_cnt++;
     }
-#else
-    tdata->point.x = wl_fixed_to_int(x_w);
-    tdata->point.y = wl_fixed_to_int(y_w);
-    tdata->state = LV_INDEV_STATE_PRESSED;
+    else {
+        LV_LOG_ERROR("Touch event overrun. Touch ID %d down event dropped", id);
+    }
 #endif
+
+    if(tdata->primary_id < 0) {
+        tdata->primary_id = id;
+        tdata->point.x = wl_fixed_to_int(x_w);
+        tdata->point.y = wl_fixed_to_int(y_w);
+        tdata->state = LV_INDEV_STATE_PRESSED;
+    }
 }
 
 static void touch_handle_up(void * data, struct wl_touch * wl_touch, uint32_t serial, uint32_t time, int32_t id)
@@ -203,9 +203,15 @@ static void touch_handle_up(void * data, struct wl_touch * wl_touch, uint32_t se
 
         tdata->event_cnt++;
     }
-#else
-    tdata->state = LV_INDEV_STATE_RELEASED;
+    else {
+        LV_LOG_ERROR("Touch event overrun. Touch ID %d up event dropped", id);
+    }
 #endif
+
+    if(id == tdata->primary_id) {
+        tdata->state = LV_INDEV_STATE_RELEASED;
+        tdata->primary_id = -1;
+    }
 }
 
 static void touch_handle_motion(void * data, struct wl_touch * wl_touch, uint32_t time, int32_t id, wl_fixed_t x_w,
@@ -219,19 +225,25 @@ static void touch_handle_motion(void * data, struct wl_touch * wl_touch, uint32_
 
 #if LV_USE_GESTURE_RECOGNITION
     /* Update the contact point of the corresponding id with the latest coordinate */
-    lv_indev_touch_data_t * touch = &tdata->touches[0];
     lv_indev_touch_data_t * cur = NULL;
 
     for(uint8_t i = 0; i < tdata->event_cnt; i++) {
+        lv_indev_touch_data_t * touch = &tdata->touches[i];
         if(touch->id == id) {
             cur = touch;
+            break;
         }
-        touch++;
     }
 
-    if(cur == NULL && tdata->event_cnt < LV_WAYLAND_MAX_TOUCHES) {
-        cur = &tdata->touches[tdata->event_cnt];
-        tdata->event_cnt++;
+    if(cur == NULL) {
+        if(tdata->event_cnt < LV_WAYLAND_MAX_TOUCHES) {
+            cur = &tdata->touches[tdata->event_cnt];
+            tdata->event_cnt++;
+        }
+        else {
+            LV_LOG_ERROR("Touch event overrun. Touch ID %d motion event dropped",
+                         id);
+        }
     }
 
     if(cur != NULL) {
@@ -241,10 +253,12 @@ static void touch_handle_motion(void * data, struct wl_touch * wl_touch, uint32_
         cur->timestamp = time;
         cur->state     = LV_INDEV_STATE_PRESSED;
     }
-#else
-    tdata->point.x = wl_fixed_to_int(x_w);
-    tdata->point.y = wl_fixed_to_int(y_w);
 #endif
+
+    if(id == tdata->primary_id) {
+        tdata->point.x = wl_fixed_to_int(x_w);
+        tdata->point.y = wl_fixed_to_int(y_w);
+    }
 }
 
 static void touch_handle_frame(void * data, struct wl_touch * wl_touch)


### PR DESCRIPTION
Fixes a potential buffer overrun in wayland gesture handling, and improves the normal touch handling when gestures are enabled.