### PR TITLE
feat(wayland): improve pointer and touch responsiveness

### DIFF
--- a/src/drivers/wayland/lv_wayland_keyboard.c
+++ b/src/drivers/wayland/lv_wayland_keyboard.c
@@ -45,6 +45,10 @@ static void keyboard_handle_modifiers(void * data, struct wl_keyboard * keyboard
 static void keyboard_handle_key(void * data, struct wl_keyboard * keyboard, uint32_t serial, uint32_t time,
                                 uint32_t key, uint32_t state);
 
+#ifdef WL_KEYBOARD_REPEAT_INFO_SINCE_VERSION
+    static void keyboard_handle_repeat_info(void * data, struct wl_keyboard * wl_keyboard, int32_t rate, int32_t delay);
+#endif
+
 static lv_key_t keycode_xkb_to_lv(xkb_keysym_t xkb_key);
 
 /**********************
@@ -54,11 +58,14 @@ static lv_key_t keycode_xkb_to_lv(xkb_keysym_t xkb_key);
 static struct xkb_context * xkb_context;
 
 static const struct wl_keyboard_listener keyboard_listener = {
-    .keymap    = keyboard_handle_keymap,
-    .enter     = keyboard_handle_enter,
-    .leave     = keyboard_handle_leave,
-    .key       = keyboard_handle_key,
-    .modifiers = keyboard_handle_modifiers,
+    .keymap      = keyboard_handle_keymap,
+    .enter       = keyboard_handle_enter,
+    .leave       = keyboard_handle_leave,
+    .key         = keyboard_handle_key,
+    .modifiers   = keyboard_handle_modifiers,
+#ifdef WL_KEYBOARD_REPEAT_INFO_SINCE_VERSION
+    .repeat_info = keyboard_handle_repeat_info,
+#endif
 };
 
 /**********************
@@ -250,6 +257,17 @@ static void keyboard_handle_modifiers(void * data, struct wl_keyboard * keyboard
 
     xkb_state_update_mask(kbdata->xkb_state, mods_depressed, mods_latched, mods_locked, 0, 0, group);
 }
+
+#ifdef WL_KEYBOARD_REPEAT_INFO_SINCE_VERSION
+static void keyboard_handle_repeat_info(void * data, struct wl_keyboard * wl_keyboard, int32_t rate, int32_t delay)
+{
+    LV_UNUSED(data);
+    LV_UNUSED(wl_keyboard);
+    LV_UNUSED(rate);
+    LV_UNUSED(delay);
+}
+#endif
+
 static lv_key_t keycode_xkb_to_lv(xkb_keysym_t xkb_key)
 {
 

--- a/src/drivers/wayland/lv_wayland_pointer.c
+++ b/src/drivers/wayland/lv_wayland_pointer.c
@@ -50,6 +50,10 @@ static void pointer_handle_button(void * data, struct wl_pointer * wl_pointer, u
 static void pointer_handle_axis(void * data, struct wl_pointer * wl_pointer, uint32_t time, uint32_t axis,
                                 wl_fixed_t value);
 
+#ifdef WL_POINTER_FRAME_SINCE_VERSION
+    static void pointer_handle_frame(void * data, struct wl_pointer * pointer);
+#endif
+
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -62,6 +66,9 @@ static const struct wl_pointer_listener pointer_listener = {
     .motion = pointer_handle_motion,
     .button = pointer_handle_button,
     .axis   = pointer_handle_axis,
+#ifdef WL_POINTER_FRAME_SINCE_VERSION
+    .frame  = pointer_handle_frame,
+#endif
 };
 
 /**********************
@@ -258,5 +265,15 @@ static void pointer_handle_axis(void * data, struct wl_pointer * pointer, uint32
     }
     seat_pointer->wheel_diff += diff;
 }
+
+#ifdef WL_POINTER_FRAME_SINCE_VERSION
+static void pointer_handle_frame(void * data, struct wl_pointer * pointer)
+{
+    LV_UNUSED(data);
+    LV_UNUSED(pointer);
+    lv_wayland_indevs_ready(pointer_read);
+    lv_wayland_indevs_ready(pointeraxis_read);
+}
+#endif
 
 #endif /* LV_USE_WAYLAND */

--- a/src/drivers/wayland/lv_wayland_private.h
+++ b/src/drivers/wayland/lv_wayland_private.h
@@ -210,6 +210,8 @@ void lv_wayland_seat_keyboard_delete(lv_wl_seat_keyboard_t * seat_keyboard);
 /* Updates indev's driver data with the given 'read_cb' to 'new_driver_data' */
 void lv_wayland_update_indevs(lv_indev_read_cb_t read_cb, void * new_driver_data);
 
+void lv_wayland_indevs_ready(lv_indev_read_cb_t read_cb);
+
 #endif /* LV_USE_WAYLAND */
 
 #ifdef __cplusplus

--- a/src/drivers/wayland/lv_wayland_seat.c
+++ b/src/drivers/wayland/lv_wayland_seat.c
@@ -16,6 +16,8 @@
  *      DEFINES
  *********************/
 
+#define SEAT_VERSION (5)
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -26,6 +28,10 @@
 
 static void seat_handle_capabilities(void * data, struct wl_seat * wl_seat, enum wl_seat_capability caps);
 
+#ifdef WL_SEAT_NAME_SINCE_VERSION
+    static void seat_handle_name(void * data, struct wl_seat * wl_seat, char const * name);
+#endif
+
 static lv_wl_seat_pointer_t * create_pointer(struct wl_seat * wl_seat);
 static void delete_pointer(lv_wl_seat_pointer_t * seat_pointer);
 
@@ -35,6 +41,9 @@ static void delete_pointer(lv_wl_seat_pointer_t * seat_pointer);
 
 static const struct wl_seat_listener seat_listener = {
     .capabilities = seat_handle_capabilities,
+#ifdef WL_SEAT_NAME_SINCE_VERSION
+    .name = seat_handle_name,
+#endif
 };
 
 /**********************
@@ -53,7 +62,7 @@ void lv_wayland_seat_init(lv_wl_seat_t * seat, struct wl_registry * registry, ui
 {
     LV_ASSERT_NULL(seat);
     LV_UNUSED(version);
-    seat->wl_seat = wl_registry_bind(registry, name, &wl_seat_interface, 1);
+    seat->wl_seat = wl_registry_bind(registry, name, &wl_seat_interface, (version < SEAT_VERSION) ? version : SEAT_VERSION);
     wl_seat_add_listener(seat->wl_seat, &seat_listener, seat);
 }
 
@@ -85,6 +94,17 @@ void lv_wayland_update_indevs(lv_indev_read_cb_t read_cb, void * new_driver_data
     }
 }
 
+void lv_wayland_indevs_ready(lv_indev_read_cb_t read_cb)
+{
+    lv_indev_t * indev = NULL;
+    while((indev = lv_indev_get_next(indev))) {
+        if(lv_indev_get_read_cb(indev) != read_cb) {
+            continue;
+        }
+        lv_timer_t * timer = lv_indev_get_read_timer(indev);
+        lv_timer_ready(timer);
+    }
+}
 
 /**********************
  *   STATIC FUNCTIONS
@@ -140,5 +160,14 @@ static void seat_handle_capabilities(void * data, struct wl_seat * wl_seat, enum
         seat->touch = NULL;
     }
 }
+
+#ifdef WL_SEAT_NAME_SINCE_VERSION
+static void seat_handle_name(void * data, struct wl_seat * wl_seat, char const * name)
+{
+    LV_UNUSED(data);
+    LV_UNUSED(wl_seat);
+    LV_UNUSED(name);
+}
+#endif
 
 #endif /* LV_USE_WAYLAND */

--- a/src/drivers/wayland/lv_wayland_touch.c
+++ b/src/drivers/wayland/lv_wayland_touch.c
@@ -252,6 +252,7 @@ static void touch_handle_frame(void * data, struct wl_touch * wl_touch)
 {
     LV_UNUSED(wl_touch);
     LV_UNUSED(data);
+    lv_wayland_indevs_ready(touch_read);
 }
 
 static void touch_handle_cancel(void * data, struct wl_touch * wl_touch)


### PR DESCRIPTION
Wayland send a frame event for the pointer and touch inputs when they are finished and should be processed. Instead of waiting for the next input timer interval, mark their timers as immediately ready to process when one of these occurs. This requires bumping up the seat protocol version to 5, but the code handles negotiating the version with the compositor and correctly compiling in the code if it is available.