### PR TITLE
feat(wayland): add API to get fullscreen and maximized state

### DIFF
--- a/include/lvgl/drivers/wayland/lv_wayland_window.h
+++ b/include/lvgl/drivers/wayland/lv_wayland_window.h
@@ -71,19 +71,41 @@ void lv_wayland_assign_physical_display(lv_display_t * disp, uint8_t display);
 void lv_wayland_unassign_physical_display(lv_display_t * disp);
 
 /**
- * Sets the fullscreen state of the window
+ * Request that the window be made fullscreen/unfullscreen
  * @param disp Reference to the LVGL display associated to the window
- * @param fullscreen If true the window enters fullscreen
+ * @param fullscreen If true the window should be made fullscreen or unfullscreen
+ *
+ * @note The fullscreen request is made asynchronously and may not be fulfilled
+ * if the compositor doesn't allow it. lv_wayland_window_is_fullscreen() can be
+ * used to determine the fullscreen state of the window.
  */
 
 void lv_wayland_window_set_fullscreen(lv_display_t * disp, bool fullscreen);
 
 /**
- * Sets the maximized state of the window
+ * Check if window is fullscreen
  * @param disp Reference to the LVGL display associated to the window
- * @param fullscreen If true the window is maximized
+ * @returns the fullscreen state of the window as reported by the compositor
+ */
+bool lv_wayland_window_is_fullscreen(lv_display_t * disp);
+
+/**
+ * Requests the window be maximized/unmaximized
+ * @param disp Reference to the LVGL display associated to the window
+ * @param fullscreen If true the window should be maximized or unmaximized
+ *
+ * @note The maximized request is made asynchronously and may not be fulfilled
+ * if the compositor doesn't allow it. lv_wayland_window_is_maximized() can be
+ * used to determine the maximized state of the window.
  */
 void lv_wayland_window_set_maximized(lv_display_t * disp, bool maximize);
+
+/**
+ * Check if window is maximized
+ * @param disp Reference to the LVGL display associated to the window
+ * @returns the maximized state of the window as reported by the compositor
+ */
+bool lv_wayland_window_is_maximized(lv_display_t * disp);
 
 /**
  * Minimizes the window

--- a/src/drivers/wayland/lv_wayland_window.c
+++ b/src/drivers/wayland/lv_wayland_window.c
@@ -183,12 +183,18 @@ void lv_wayland_window_set_maximized(lv_display_t * disp, bool maximized)
     if(!window) {
         return;
     }
-    if(window->maximized != maximized) {
-        lv_wayland_xdg_set_maximized(&window->xdg, maximized);
-    }
-
-    window->maximized = maximized;
+    lv_wayland_xdg_set_maximized(&window->xdg, maximized);
 }
+
+bool lv_wayland_window_is_maximized(lv_display_t * disp)
+{
+    lv_wl_window_t * window = lv_display_get_driver_data(disp);
+    if(!window) {
+        return false;
+    }
+    return window->maximized;
+}
+
 void lv_wayland_window_set_minimized(lv_display_t * disp)
 {
     lv_wl_window_t * window = lv_display_get_driver_data(disp);
@@ -241,12 +247,16 @@ void lv_wayland_window_set_fullscreen(lv_display_t * disp, bool fullscreen)
     if(!window) {
         return;
     }
-
-    if(window->fullscreen == fullscreen) {
-        return;
-    }
     lv_wayland_xdg_set_fullscreen(&window->xdg, fullscreen, window->physical_output);
-    window->fullscreen = fullscreen;
+}
+
+bool lv_wayland_window_is_fullscreen(lv_display_t * disp)
+{
+    lv_wl_window_t * window = lv_display_get_driver_data(disp);
+    if(!window) {
+        return false;
+    }
+    return window->fullscreen;
 }
 
 /**********************

--- a/src/drivers/wayland/lv_wayland_xdg_shell.c
+++ b/src/drivers/wayland/lv_wayland_xdg_shell.c
@@ -209,9 +209,23 @@ static void xdg_toplevel_handle_configure(void * data, struct xdg_toplevel * xdg
     lv_wl_window_t * window = (lv_wl_window_t *)data;
 
     LV_UNUSED(xdg_toplevel);
-    LV_UNUSED(states);
     LV_LOG_TRACE("XDG toplevel configure: w=%d h=%d (current: %dx%d)",
                  width, height, lv_wayland_window_get_width(window), lv_wayland_window_get_height(window));
+
+    window->maximized = false;
+    window->fullscreen = false;
+    uint32_t * s;
+    wl_array_for_each(s, states) {
+        switch(*s) {
+            case XDG_TOPLEVEL_STATE_MAXIMIZED:
+                window->maximized = true;
+                break;
+
+            case XDG_TOPLEVEL_STATE_FULLSCREEN:
+                window->fullscreen = true;
+                break;
+        }
+    }
 
     if((width < 0) || (height < 0)) {
         LV_LOG_TRACE("will not resize to w:%d h:%d", width, height);


### PR DESCRIPTION
Adds API to get the state of the fullscreen or maximized mode, based on the window states from the compositor