### PR TITLE
feat(indev_gesture): various gesture fixes

### DIFF
--- a/include/lvgl/indev/lv_indev_gesture.h
+++ b/include/lvgl/indev/lv_indev_gesture.h
@@ -124,6 +124,16 @@ void lv_indev_gesture_detect_two_fingers_swipe(lv_indev_gesture_recognizer_t * r
                                                uint16_t touch_cnt);
 
 /**
+ * Obtains the center point for the gesture
+ * @param gesture_event     pointer to a gesture event
+ * @param type              the gesture type
+ * @param point             the center point of the gesture
+ * @return                  true if the gesture has a center point, false if not
+ */
+bool lv_event_get_gesture_center_point(lv_event_t * gesture_event, lv_indev_gesture_type_t type,
+                                       lv_point_t * point);
+
+/**
  * Set the threshold for the pinch gesture scale up, when the scale factor of gesture
  * reaches the threshold events get sent
  * @param indev             pointer to the indev device containing the pinch recognizer

--- a/include/lvgl/indev/lv_indev_gesture.h
+++ b/include/lvgl/indev/lv_indev_gesture.h
@@ -124,6 +124,21 @@ void lv_indev_gesture_detect_two_fingers_swipe(lv_indev_gesture_recognizer_t * r
                                                uint16_t touch_cnt);
 
 /**
+ * Obtains the center point for the gesture.
+ * @param gesture_event     pointer to a gesture event
+ * @param type              the gesture type
+ * @param point             output pointer for the center of the gesture; must
+ *                          not be `NULL`. When this function returns `true`,
+ *                          *point contains the center point of the gesture.
+ *                          When this function returns `false`, the contents of
+ *                          *point are unchanged.
+ * @return                  true if the gesture has a center point, false
+ *                          otherwise
+ */
+bool lv_event_get_gesture_center_point(lv_event_t * gesture_event, lv_indev_gesture_type_t type,
+                                       lv_point_t * point);
+
+/**
  * Set the threshold for the pinch gesture scale up, when the scale factor of gesture
  * reaches the threshold events get sent
  * @param indev             pointer to the indev device containing the pinch recognizer

--- a/src/indev/lv_indev_gesture.c
+++ b/src/indev/lv_indev_gesture.c
@@ -346,11 +346,13 @@ void lv_indev_gesture_detect_pinch(lv_indev_gesture_recognizer_t * recognizer, l
                 reset_recognizer(r);
                 break;
             default:
-                LV_ASSERT_MSG(true, "invalid gesture recognizer state");
+                LV_ASSERT_FORMAT_MSG(false, "invalid gesture recognizer state: %d", r->state);
         }
     }
     else {
         switch(r->state) {
+            case LV_INDEV_GESTURE_STATE_NONE:
+                break;
             case LV_INDEV_GESTURE_STATE_RECOGNIZED:
                 /* Gesture has ended */
                 r->state = LV_INDEV_GESTURE_STATE_ENDED;
@@ -365,7 +367,7 @@ void lv_indev_gesture_detect_pinch(lv_indev_gesture_recognizer_t * recognizer, l
                 break;
 
             default:
-                LV_ASSERT_MSG(true, "invalid gesture recognizer state");
+                LV_ASSERT_FORMAT_MSG(false, "invalid gesture recognizer state: %d", r->state);
         }
     }
 }
@@ -432,11 +434,13 @@ void lv_indev_gesture_detect_rotation(lv_indev_gesture_recognizer_t * recognizer
                 r->state = LV_INDEV_GESTURE_STATE_CANCELED;
                 break;
             default:
-                LV_ASSERT_MSG(true, "invalid gesture recognizer state");
+                LV_ASSERT_FORMAT_MSG(false, "invalid gesture recognizer state: %d", r->state);
         }
     }
     else {
         switch(r->state) {
+            case LV_INDEV_GESTURE_STATE_NONE:
+                break;
             case LV_INDEV_GESTURE_STATE_RECOGNIZED:
                 /* Gesture has ended */
                 r->type = LV_INDEV_GESTURE_ROTATE;
@@ -451,7 +455,7 @@ void lv_indev_gesture_detect_rotation(lv_indev_gesture_recognizer_t * recognizer
                 reset_recognizer(r);
                 break;
             default:
-                LV_ASSERT_MSG(true, "invalid gesture recognizer state");
+                LV_ASSERT_FORMAT_MSG(false, "invalid gesture recognizer state: %d", r->state);
         }
     }
 }
@@ -521,12 +525,14 @@ void lv_indev_gesture_detect_two_fingers_swipe(lv_indev_gesture_recognizer_t * r
                 reset_recognizer(r);
                 break;
             default:
-                LV_ASSERT_MSG(true, "invalid gesture recognizer state");
+                LV_ASSERT_FORMAT_MSG(false, "invalid gesture recognizer state: %d", r->state);
         }
     }
     else {
 
         switch(r->state) {
+            case LV_INDEV_GESTURE_STATE_NONE:
+                break;
             case LV_INDEV_GESTURE_STATE_RECOGNIZED:
                 /* Gesture has ended */
                 r->state = LV_INDEV_GESTURE_STATE_ENDED;
@@ -543,7 +549,7 @@ void lv_indev_gesture_detect_two_fingers_swipe(lv_indev_gesture_recognizer_t * r
                 r->state = LV_INDEV_GESTURE_STATE_NONE;
                 break;
             default:
-                LV_ASSERT_MSG(true, "invalid gesture recognizer state");
+                LV_ASSERT_FORMAT_MSG(false, "invalid gesture recognizer state: %d", r->state);
         }
     }
 }

--- a/src/indev/lv_indev_gesture.c
+++ b/src/indev/lv_indev_gesture.c
@@ -189,6 +189,26 @@ lv_dir_t lv_event_get_two_fingers_swipe_dir(lv_event_t * gesture_event)
     return recognizer->two_fingers_swipe_dir;
 }
 
+bool lv_event_get_gesture_center_point(lv_event_t * gesture_event, lv_indev_gesture_type_t type,
+                                       lv_point_t * point)
+{
+    lv_indev_gesture_recognizer_t * recognizer;
+    if((recognizer = lv_indev_get_gesture_recognizer(gesture_event, type)) == NULL) {
+        return false;
+    }
+
+    if(lv_indev_recognizer_is_active(recognizer) == false) {
+        point->x = 0;
+        point->y = 0;
+        return false;
+    }
+
+    point->x = recognizer->info->center.x;
+    point->y = recognizer->info->center.y;
+
+    return true;
+}
+
 void lv_indev_get_gesture_center_point(lv_indev_gesture_recognizer_t * recognizer, lv_point_t * point)
 {
     if(lv_indev_recognizer_is_active(recognizer) == false) {

--- a/src/indev/lv_indev_gesture.c
+++ b/src/indev/lv_indev_gesture.c
@@ -387,8 +387,9 @@ void lv_indev_gesture_detect_rotation(lv_indev_gesture_recognizer_t * recognizer
     if(r->config == NULL) {
         LV_LOG_TRACE("init gesture configuration - set defaults");
         r->config = lv_malloc_zeroed(sizeof(lv_indev_gesture_configuration_t));
+        LV_ASSERT_MALLOC(r->config);
 
-        LV_ASSERT(r->config != NULL);
+        r->config->rotation_angle_rad_threshold = LV_GESTURE_ROTATION_ANGLE_RAD_THRESHOLD;
     }
 
     /* Process collected touch events */

--- a/src/indev/lv_indev_gesture.c
+++ b/src/indev/lv_indev_gesture.c
@@ -39,8 +39,8 @@ static void process_touch_event(lv_indev_touch_data_t * touch, lv_indev_gesture_
 static void gesture_update_center_point(lv_indev_gesture_t * gesture, int touch_points_nb);
 static void gesture_calculate_factors(lv_indev_gesture_t * gesture, int touch_points_nb);
 static void reset_recognizer(lv_indev_gesture_recognizer_t * recognizer);
-static lv_indev_gesture_recognizer_t * lv_indev_get_gesture_recognizer(lv_event_t * gesture_event,
-                                                                       lv_indev_gesture_type_t type);
+static lv_indev_gesture_recognizer_t * get_gesture_recognizer(lv_event_t * gesture_event,
+                                                              lv_indev_gesture_type_t type);
 static lv_dir_t calculate_swipe_dir(lv_indev_gesture_recognizer_t * recognizer);
 static lv_indev_gesture_type_t get_first_recognized_or_ended_gesture(lv_indev_t * indev);
 static void indev_delete_event_cb(lv_event_t * e);
@@ -148,7 +148,7 @@ float lv_event_get_pinch_scale(lv_event_t * gesture_event)
 {
     lv_indev_gesture_recognizer_t * recognizer;
 
-    if((recognizer = lv_indev_get_gesture_recognizer(gesture_event, LV_INDEV_GESTURE_PINCH)) == NULL) {
+    if((recognizer = get_gesture_recognizer(gesture_event, LV_INDEV_GESTURE_PINCH)) == NULL) {
         return 0.0f;
     }
 
@@ -159,7 +159,7 @@ float lv_event_get_rotation(lv_event_t * gesture_event)
 {
     lv_indev_gesture_recognizer_t * recognizer;
 
-    if((recognizer = lv_indev_get_gesture_recognizer(gesture_event, LV_INDEV_GESTURE_ROTATE)) == NULL) {
+    if((recognizer = get_gesture_recognizer(gesture_event, LV_INDEV_GESTURE_ROTATE)) == NULL) {
         return 0.0f;
     }
 
@@ -170,7 +170,7 @@ float lv_event_get_two_fingers_swipe_distance(lv_event_t * gesture_event)
 {
     lv_indev_gesture_recognizer_t * recognizer;
 
-    if((recognizer = lv_indev_get_gesture_recognizer(gesture_event, LV_INDEV_GESTURE_TWO_FINGERS_SWIPE)) == NULL) {
+    if((recognizer = get_gesture_recognizer(gesture_event, LV_INDEV_GESTURE_TWO_FINGERS_SWIPE)) == NULL) {
         return 0.0f;
     }
 
@@ -182,7 +182,7 @@ lv_dir_t lv_event_get_two_fingers_swipe_dir(lv_event_t * gesture_event)
 
     lv_indev_gesture_recognizer_t * recognizer;
 
-    if((recognizer = lv_indev_get_gesture_recognizer(gesture_event, LV_INDEV_GESTURE_TWO_FINGERS_SWIPE)) == NULL) {
+    if((recognizer = get_gesture_recognizer(gesture_event, LV_INDEV_GESTURE_TWO_FINGERS_SWIPE)) == NULL) {
         return LV_DIR_NONE;
     }
 
@@ -193,7 +193,7 @@ bool lv_event_get_gesture_center_point(lv_event_t * gesture_event, lv_indev_gest
                                        lv_point_t * point)
 {
     lv_indev_gesture_recognizer_t * recognizer;
-    if((recognizer = lv_indev_get_gesture_recognizer(gesture_event, type)) == NULL) {
+    if((recognizer = get_gesture_recognizer(gesture_event, type)) == NULL) {
         return false;
     }
 
@@ -225,7 +225,7 @@ lv_indev_gesture_state_t lv_event_get_gesture_state(lv_event_t * gesture_event, 
 {
     lv_indev_gesture_recognizer_t * recognizer;
 
-    if((recognizer = lv_indev_get_gesture_recognizer(gesture_event, type)) == NULL) {
+    if((recognizer = get_gesture_recognizer(gesture_event, type)) == NULL) {
         return LV_INDEV_GESTURE_STATE_NONE;
     }
 
@@ -646,8 +646,8 @@ static lv_dir_t calculate_swipe_dir(lv_indev_gesture_recognizer_t * recognizer)
  * @param type              the type of the recognizer we want to get
  * @return                  a pointer to the gesture recognizer that emitted the event
  */
-lv_indev_gesture_recognizer_t * lv_indev_get_gesture_recognizer(lv_event_t * gesture_event,
-                                                                lv_indev_gesture_type_t type)
+static lv_indev_gesture_recognizer_t * get_gesture_recognizer(lv_event_t * gesture_event,
+                                                              lv_indev_gesture_type_t type)
 {
     lv_indev_t * indev;
 

--- a/src/indev/lv_indev_gesture.c
+++ b/src/indev/lv_indev_gesture.c
@@ -189,6 +189,26 @@ lv_dir_t lv_event_get_two_fingers_swipe_dir(lv_event_t * gesture_event)
     return recognizer->two_fingers_swipe_dir;
 }
 
+bool lv_event_get_gesture_center_point(lv_event_t * gesture_event, lv_indev_gesture_type_t type,
+                                       lv_point_t * point)
+{
+    LV_ASSERT_NULL(point);
+
+    lv_indev_gesture_recognizer_t * recognizer;
+    if((recognizer = lv_indev_get_gesture_recognizer(gesture_event, type)) == NULL) {
+        return false;
+    }
+
+    if(lv_indev_recognizer_is_active(recognizer) == false) {
+        return false;
+    }
+
+    point->x = recognizer->info->center.x;
+    point->y = recognizer->info->center.y;
+
+    return true;
+}
+
 void lv_indev_get_gesture_center_point(lv_indev_gesture_recognizer_t * recognizer, lv_point_t * point)
 {
     if(lv_indev_recognizer_is_active(recognizer) == false) {

--- a/src/indev/lv_indev_gesture.c
+++ b/src/indev/lv_indev_gesture.c
@@ -192,7 +192,8 @@ lv_dir_t lv_event_get_two_fingers_swipe_dir(lv_event_t * gesture_event)
 bool lv_event_get_gesture_center_point(lv_event_t * gesture_event, lv_indev_gesture_type_t type,
                                        lv_point_t * point)
 {
-    LV_ASSERT_NULL(point);
+    LV_CHECK_ARG(gesture_event != NULL, return false);
+    LV_CHECK_ARG(point != NULL, return false);
 
     lv_indev_gesture_recognizer_t * recognizer;
     if((recognizer = get_gesture_recognizer(gesture_event, type)) == NULL) {

--- a/src/indev/lv_indev_gesture.c
+++ b/src/indev/lv_indev_gesture.c
@@ -39,8 +39,8 @@ static void process_touch_event(lv_indev_touch_data_t * touch, lv_indev_gesture_
 static void gesture_update_center_point(lv_indev_gesture_t * gesture, int touch_points_nb);
 static void gesture_calculate_factors(lv_indev_gesture_t * gesture, int touch_points_nb);
 static void reset_recognizer(lv_indev_gesture_recognizer_t * recognizer);
-static lv_indev_gesture_recognizer_t * lv_indev_get_gesture_recognizer(lv_event_t * gesture_event,
-                                                                       lv_indev_gesture_type_t type);
+static lv_indev_gesture_recognizer_t * get_gesture_recognizer(lv_event_t * gesture_event,
+                                                              lv_indev_gesture_type_t type);
 static lv_dir_t calculate_swipe_dir(lv_indev_gesture_recognizer_t * recognizer);
 static lv_indev_gesture_type_t get_first_recognized_or_ended_gesture(lv_indev_t * indev);
 static void indev_delete_event_cb(lv_event_t * e);
@@ -148,7 +148,7 @@ float lv_event_get_pinch_scale(lv_event_t * gesture_event)
 {
     lv_indev_gesture_recognizer_t * recognizer;
 
-    if((recognizer = lv_indev_get_gesture_recognizer(gesture_event, LV_INDEV_GESTURE_PINCH)) == NULL) {
+    if((recognizer = get_gesture_recognizer(gesture_event, LV_INDEV_GESTURE_PINCH)) == NULL) {
         return 0.0f;
     }
 
@@ -159,7 +159,7 @@ float lv_event_get_rotation(lv_event_t * gesture_event)
 {
     lv_indev_gesture_recognizer_t * recognizer;
 
-    if((recognizer = lv_indev_get_gesture_recognizer(gesture_event, LV_INDEV_GESTURE_ROTATE)) == NULL) {
+    if((recognizer = get_gesture_recognizer(gesture_event, LV_INDEV_GESTURE_ROTATE)) == NULL) {
         return 0.0f;
     }
 
@@ -170,7 +170,7 @@ float lv_event_get_two_fingers_swipe_distance(lv_event_t * gesture_event)
 {
     lv_indev_gesture_recognizer_t * recognizer;
 
-    if((recognizer = lv_indev_get_gesture_recognizer(gesture_event, LV_INDEV_GESTURE_TWO_FINGERS_SWIPE)) == NULL) {
+    if((recognizer = get_gesture_recognizer(gesture_event, LV_INDEV_GESTURE_TWO_FINGERS_SWIPE)) == NULL) {
         return 0.0f;
     }
 
@@ -182,7 +182,7 @@ lv_dir_t lv_event_get_two_fingers_swipe_dir(lv_event_t * gesture_event)
 
     lv_indev_gesture_recognizer_t * recognizer;
 
-    if((recognizer = lv_indev_get_gesture_recognizer(gesture_event, LV_INDEV_GESTURE_TWO_FINGERS_SWIPE)) == NULL) {
+    if((recognizer = get_gesture_recognizer(gesture_event, LV_INDEV_GESTURE_TWO_FINGERS_SWIPE)) == NULL) {
         return LV_DIR_NONE;
     }
 
@@ -195,7 +195,7 @@ bool lv_event_get_gesture_center_point(lv_event_t * gesture_event, lv_indev_gest
     LV_ASSERT_NULL(point);
 
     lv_indev_gesture_recognizer_t * recognizer;
-    if((recognizer = lv_indev_get_gesture_recognizer(gesture_event, type)) == NULL) {
+    if((recognizer = get_gesture_recognizer(gesture_event, type)) == NULL) {
         return false;
     }
 
@@ -225,7 +225,7 @@ lv_indev_gesture_state_t lv_event_get_gesture_state(lv_event_t * gesture_event, 
 {
     lv_indev_gesture_recognizer_t * recognizer;
 
-    if((recognizer = lv_indev_get_gesture_recognizer(gesture_event, type)) == NULL) {
+    if((recognizer = get_gesture_recognizer(gesture_event, type)) == NULL) {
         return LV_INDEV_GESTURE_STATE_NONE;
     }
 
@@ -646,8 +646,8 @@ static lv_dir_t calculate_swipe_dir(lv_indev_gesture_recognizer_t * recognizer)
  * @param type              the type of the recognizer we want to get
  * @return                  a pointer to the gesture recognizer that emitted the event
  */
-lv_indev_gesture_recognizer_t * lv_indev_get_gesture_recognizer(lv_event_t * gesture_event,
-                                                                lv_indev_gesture_type_t type)
+static lv_indev_gesture_recognizer_t * get_gesture_recognizer(lv_event_t * gesture_event,
+                                                              lv_indev_gesture_type_t type)
 {
     lv_indev_t * indev;
 

--- a/tests/src/test_cases/test_gesture_center_point.c
+++ b/tests/src/test_cases/test_gesture_center_point.c
@@ -1,0 +1,143 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+#include "unity/unity.h"
+
+void setUp(void)
+{
+    /* Function run before every test */
+}
+
+void tearDown(void)
+{
+    /* Function run after every test */
+    lv_obj_clean(lv_screen_active());
+}
+
+/*
+ * Track the center point across multiple gesture events.
+ * center_valid and center are updated only when the function returns true
+ * so that the ENDED event (which returns false) does not clobber a valid reading.
+ */
+typedef struct {
+    bool center_valid;
+    lv_point_t center;
+    uint32_t num_gesture;
+} gesture_center_data_t;
+
+static void gesture_pinch_center_cb(lv_event_t * e)
+{
+    gesture_center_data_t * data = lv_event_get_user_data(e);
+    lv_point_t point;
+    bool valid = lv_event_get_gesture_center_point(e, LV_INDEV_GESTURE_PINCH, &point);
+
+    if(valid) {
+        data->center_valid = true;
+        data->center = point;
+    }
+    ++data->num_gesture;
+}
+
+static void gesture_wrong_type_cb(lv_event_t * e)
+{
+    gesture_center_data_t * data = lv_event_get_user_data(e);
+    lv_point_t point;
+
+    /* Query ROTATE center during a PINCH gesture - must always return false */
+    if(lv_event_get_gesture_center_point(e, LV_INDEV_GESTURE_ROTATE, &point)) {
+        data->center_valid = true;
+    }
+    ++data->num_gesture;
+}
+
+/*
+ * Capture the center point result exclusively during the ENDED state so that
+ * we can assert what the function returns once all fingers are lifted.
+ */
+typedef struct {
+    bool center_valid_on_ended;
+    lv_point_t center_on_ended;
+    uint32_t num_ended;
+} gesture_ended_data_t;
+
+static void gesture_ended_cb(lv_event_t * e)
+{
+    gesture_ended_data_t * data = lv_event_get_user_data(e);
+    lv_indev_gesture_state_t state = lv_event_get_gesture_state(e, LV_INDEV_GESTURE_PINCH);
+
+    if(state == LV_INDEV_GESTURE_STATE_ENDED) {
+        lv_point_t point = {-1, -1};
+        data->center_valid_on_ended = lv_event_get_gesture_center_point(e, LV_INDEV_GESTURE_PINCH, &point);
+        data->center_on_ended = point;
+        ++data->num_ended;
+    }
+}
+
+/* Center point is the midpoint of the two initial touch positions */
+void test_gesture_center_point_pinch_returns_midpoint(void)
+{
+    gesture_center_data_t data;
+    lv_memzero(&data, sizeof(data));
+
+    lv_obj_t * label = lv_label_create(lv_screen_active());
+    lv_obj_add_flag(label, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_set_size(label, 320, 320);
+    lv_obj_add_event_cb(label, gesture_pinch_center_cb, LV_EVENT_GESTURE, &data);
+
+    /* Begin midpoint: ((120+200)/2, (200+120)/2) = (160, 160) */
+    lv_point_t point_begin_0 = {120, 200};
+    lv_point_t point_begin_1 = {200, 120};
+    lv_point_t point_end_0   = {80, 250};
+    lv_point_t point_end_1   = {250, 80};
+    lv_test_gesture_pinch(point_begin_0, point_begin_1, point_end_0, point_end_1);
+
+    TEST_ASSERT_GREATER_THAN_UINT32(0, data.num_gesture);
+    TEST_ASSERT_TRUE(data.center_valid);
+    TEST_ASSERT_EQUAL_INT32((point_begin_0.x + point_begin_1.x) / 2, data.center.x);
+    TEST_ASSERT_EQUAL_INT32((point_begin_0.y + point_begin_1.y) / 2, data.center.y);
+}
+
+/* Querying the center point of a gesture type not currently active returns false */
+void test_gesture_center_point_wrong_type_returns_false(void)
+{
+    gesture_center_data_t data;
+    lv_memzero(&data, sizeof(data));
+
+    lv_obj_t * label = lv_label_create(lv_screen_active());
+    lv_obj_add_flag(label, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_set_size(label, 320, 320);
+    lv_obj_add_event_cb(label, gesture_wrong_type_cb, LV_EVENT_GESTURE, &data);
+
+    lv_point_t point_begin_0 = {120, 200};
+    lv_point_t point_begin_1 = {200, 120};
+    lv_point_t point_end_0   = {80, 250};
+    lv_point_t point_end_1   = {250, 80};
+    lv_test_gesture_pinch(point_begin_0, point_begin_1, point_end_0, point_end_1);
+
+    TEST_ASSERT_GREATER_THAN_UINT32(0, data.num_gesture);
+    TEST_ASSERT_FALSE(data.center_valid);
+}
+
+/* Once a gesture has ended the center point is no longer available */
+void test_gesture_center_point_ended_returns_false(void)
+{
+    gesture_ended_data_t data;
+    lv_memzero(&data, sizeof(data));
+
+    lv_obj_t * label = lv_label_create(lv_screen_active());
+    lv_obj_add_flag(label, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_set_size(label, 320, 320);
+    lv_obj_add_event_cb(label, gesture_ended_cb, LV_EVENT_GESTURE, &data);
+
+    lv_point_t point_begin_0 = {120, 200};
+    lv_point_t point_begin_1 = {200, 120};
+    lv_point_t point_end_0   = {80, 250};
+    lv_point_t point_end_1   = {250, 80};
+    lv_test_gesture_pinch(point_begin_0, point_begin_1, point_end_0, point_end_1);
+
+    TEST_ASSERT_GREATER_THAN_UINT32(0, data.num_ended);
+    TEST_ASSERT_FALSE(data.center_valid_on_ended);
+    TEST_ASSERT_EQUAL_INT32(0, data.center_on_ended.x);
+    TEST_ASSERT_EQUAL_INT32(0, data.center_on_ended.y);
+}
+
+#endif

--- a/tests/src/test_cases/test_gesture_center_point.c
+++ b/tests/src/test_cases/test_gesture_center_point.c
@@ -1,0 +1,145 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+#include "unity/unity.h"
+
+void setUp(void)
+{
+    /* Function run before every test */
+}
+
+void tearDown(void)
+{
+    /* Function run after every test */
+    lv_obj_clean(lv_screen_active());
+}
+
+/*
+ * Track the center point across multiple gesture events.
+ * center_valid and center are updated only when the function returns true
+ * so that the ENDED event (which returns false) does not clobber a valid reading.
+ */
+typedef struct {
+    bool center_valid;
+    lv_point_t center;
+    uint32_t num_gesture;
+} gesture_center_data_t;
+
+static void gesture_pinch_center_cb(lv_event_t * e)
+{
+    gesture_center_data_t * data = lv_event_get_user_data(e);
+    lv_point_t point;
+    bool valid = lv_event_get_gesture_center_point(e, LV_INDEV_GESTURE_PINCH, &point);
+
+    if(valid) {
+        data->center_valid = true;
+        data->center = point;
+    }
+    ++data->num_gesture;
+}
+
+static void gesture_wrong_type_cb(lv_event_t * e)
+{
+    gesture_center_data_t * data = lv_event_get_user_data(e);
+    lv_point_t point;
+
+    /* Query ROTATE center during a PINCH gesture - must always return false */
+    if(lv_event_get_gesture_center_point(e, LV_INDEV_GESTURE_ROTATE, &point)) {
+        data->center_valid = true;
+    }
+    ++data->num_gesture;
+}
+
+/*
+ * Capture the center point result exclusively during the ENDED state so that
+ * we can assert what the function returns once all fingers are lifted.
+ */
+typedef struct {
+    bool center_valid_on_ended;
+    lv_point_t center_on_ended;
+    uint32_t num_ended;
+} gesture_ended_data_t;
+
+static void gesture_ended_cb(lv_event_t * e)
+{
+    gesture_ended_data_t * data = lv_event_get_user_data(e);
+    lv_indev_gesture_state_t state = lv_event_get_gesture_state(e, LV_INDEV_GESTURE_PINCH);
+
+    if(state == LV_INDEV_GESTURE_STATE_ENDED) {
+        lv_point_t point = {-1, -1};
+        data->center_valid_on_ended = lv_event_get_gesture_center_point(e, LV_INDEV_GESTURE_PINCH, &point);
+        data->center_on_ended = point;
+        ++data->num_ended;
+    }
+}
+
+/* Center point is the midpoint of the two initial touch positions */
+void test_gesture_center_point_pinch_returns_midpoint(void)
+{
+    gesture_center_data_t data;
+    lv_memzero(&data, sizeof(data));
+
+    lv_obj_t * label = lv_label_create(lv_screen_active());
+    lv_obj_set_clickable(label, true);
+    lv_obj_set_size(label, 320, 320);
+    lv_obj_add_event_cb(label, gesture_pinch_center_cb, LV_EVENT_GESTURE, &data);
+
+    /* Begin midpoint: ((120+200)/2, (200+120)/2) = (160, 160) */
+    lv_point_t point_begin_0 = {120, 200};
+    lv_point_t point_begin_1 = {200, 120};
+    lv_point_t point_end_0   = {80, 250};
+    lv_point_t point_end_1   = {250, 80};
+    lv_test_gesture_pinch(point_begin_0, point_begin_1, point_end_0, point_end_1);
+
+    TEST_ASSERT_GREATER_THAN_UINT32(0, data.num_gesture);
+    TEST_ASSERT_TRUE(data.center_valid);
+    TEST_ASSERT_EQUAL_INT32((point_begin_0.x + point_begin_1.x) / 2, data.center.x);
+    TEST_ASSERT_EQUAL_INT32((point_begin_0.y + point_begin_1.y) / 2, data.center.y);
+}
+
+/* Querying the center point of a gesture type not currently active returns false */
+void test_gesture_center_point_wrong_type_returns_false(void)
+{
+    gesture_center_data_t data;
+    lv_memzero(&data, sizeof(data));
+
+    lv_obj_t * label = lv_label_create(lv_screen_active());
+    lv_obj_set_clickable(label, true);
+    lv_obj_set_size(label, 320, 320);
+    lv_obj_add_event_cb(label, gesture_wrong_type_cb, LV_EVENT_GESTURE, &data);
+
+    lv_point_t point_begin_0 = {120, 200};
+    lv_point_t point_begin_1 = {200, 120};
+    lv_point_t point_end_0   = {80, 250};
+    lv_point_t point_end_1   = {250, 80};
+    lv_test_gesture_pinch(point_begin_0, point_begin_1, point_end_0, point_end_1);
+
+    TEST_ASSERT_GREATER_THAN_UINT32(0, data.num_gesture);
+    TEST_ASSERT_FALSE(data.center_valid);
+    TEST_ASSERT_EQUAL_INT32(0, data.center.x);
+    TEST_ASSERT_EQUAL_INT32(0, data.center.y);
+}
+
+/* Once a gesture has ended the center point is no longer available */
+void test_gesture_center_point_ended_returns_false(void)
+{
+    gesture_ended_data_t data;
+    lv_memzero(&data, sizeof(data));
+
+    lv_obj_t * label = lv_label_create(lv_screen_active());
+    lv_obj_set_clickable(label, true);
+    lv_obj_set_size(label, 320, 320);
+    lv_obj_add_event_cb(label, gesture_ended_cb, LV_EVENT_GESTURE, &data);
+
+    lv_point_t point_begin_0 = {120, 200};
+    lv_point_t point_begin_1 = {200, 120};
+    lv_point_t point_end_0   = {80, 250};
+    lv_point_t point_end_1   = {250, 80};
+    lv_test_gesture_pinch(point_begin_0, point_begin_1, point_end_0, point_end_1);
+
+    TEST_ASSERT_GREATER_THAN_UINT32(0, data.num_ended);
+    TEST_ASSERT_FALSE(data.center_valid_on_ended);
+    TEST_ASSERT_EQUAL_INT32(-1, data.center_on_ended.x);
+    TEST_ASSERT_EQUAL_INT32(-1, data.center_on_ended.y);
+}
+
+#endif


### PR DESCRIPTION
Fixes the state handling the gesture code, which was using the wrong assert condition and adds `lv_event_get_gesture_center_point` to get the center point from a gesture event, since it's not easy for applications to get the center point with the `lv_indev_get_gesture_center_point` API