### PR TITLE
ci(pr-title): add automated PR title format check

### DIFF
--- a/.github/workflows/check_pr_title.yml
+++ b/.github/workflows/check_pr_title.yml
@@ -11,7 +11,6 @@ concurrency:
 
 jobs:
   check-pr-title:
-    if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout

--- a/.github/workflows/check_pr_title.yml
+++ b/.github/workflows/check_pr_title.yml
@@ -1,0 +1,30 @@
+name: Verify PR title format
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency
+# Ensure that only one commit will be running tests at a time on each PR
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  check-pr-title:
+    if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Self-test commit message checker
+        run: python3 scripts/commit_msg_check.py --self-test
+      - name: Check PR title format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: python3 scripts/commit_msg_check.py --check-title "$PR_TITLE"

--- a/docs/src/contributing/pull_requests.mdx
+++ b/docs/src/contributing/pull_requests.mdx
@@ -61,18 +61,24 @@ The following structure should be used:
 
 Possible `<type>`s:
 
-- `fix` bugfix in LVGL source code
 - `feat` new feature
+- `fix` bugfix in LVGL source code
 - `arch` architectural changes
 - `perf` changes that affect performance
 - `example` anything related to examples (including fixes and new examples)
+- `refactor` code restructuring without changing behavior
+- `revert` reverting a previous commit
 - `docs` anything related to documentation (including fixes, formatting, and new pages)
+- `style` code formatting changes (not CSS-like style)
 - `test` anything related to tests (new and updated tests or CI actions)
 - `chore` any minor formatting or style changes that would make the changelog noisy
+- `ci` changes to CI configuration files and scripts
+- `build` changes that affect the build system or external dependencies
 
 `<scope>` is the name of the module, file, or subsystem affected by the
 commit. It's usually one word and can be chosen freely. For example
-`img`, `layout`, `txt`, `anim`. The scope can be omitted.
+`img`, `layout`, `txt`, `anim`. The scope is required for all types
+except `chore`, where it can be omitted.
 
 `<subject>` contains a short description of the change following these guidelines:
 
@@ -106,7 +112,7 @@ Fixes: #1234
 ```
 
 ```text
-feat: add span widget
+feat(span): add span widget
 
 The span widget allows mixing different font sizes, colors and styles.
 It's similar to HTML <span>
@@ -114,4 +120,38 @@ It's similar to HTML <span>
 
 ```text
 docs(porting): fix typo
+```
+
+```text
+chore: bump version to release candidate tag
+```
+
+### PR Title
+
+Since the repository uses squash merge by default, the PR title becomes
+the final commit message. Please make sure your PR title follows the
+same format described above.
+
+A CI check (`Verify PR title format`) will automatically verify the
+format when you open or update a PR. If the check fails, simply edit
+your PR title to fix the format — the check will re-run automatically.
+
+If your PR contains multiple independent commits that should **not** be
+squashed (i.e. the maintainer will use rebase merge), include
+"don't squash" in the PR title. The title check will be skipped in this
+case.
+
+### Automated Checker
+
+You can validate commit messages locally using the checker script:
+
+```bash
+# Check a single message
+python3 scripts/commit_msg_check.py --check-title "feat(draw): add gradient support"
+
+# Check commits between base branch and HEAD
+python3 scripts/commit_msg_check.py --base origin/master
+
+# Run self-tests
+python3 scripts/commit_msg_check.py --self-test
 ```

--- a/docs/src/contributing/pull_requests.mdx
+++ b/docs/src/contributing/pull_requests.mdx
@@ -77,8 +77,8 @@ Possible `<type>`s:
 
 `<scope>` is the name of the module, file, or subsystem affected by the
 commit. It's usually one word and can be chosen freely. For example
-`img`, `layout`, `txt`, `anim`. The scope is required for all types
-except `chore`, where it can be omitted.
+`img`, `layout`, `txt`, `anim`. The scope is required for most types
+but can be omitted for `chore`, `docs`, and `ci`.
 
 `<subject>` contains a short description of the change following these guidelines:
 

--- a/scripts/commit_msg_check.py
+++ b/scripts/commit_msg_check.py
@@ -1,0 +1,589 @@
+#!/usr/bin/env python3
+
+"""
+LVGL Commit Message Style Checker
+
+Format: type(scope): description
+
+Valid types: feat, fix, arch, test, perf, example, refactor, revert, docs, style, chore, ci, build
+Scope:       required, lowercase, e.g. (draw), (obj)
+Description: lowercase start, no trailing period
+
+Usage:
+    commit_msg_check.py                     # Check commits between base branch and HEAD
+    commit_msg_check.py --base <branch>     # Specify base branch
+    commit_msg_check.py --check-title "msg" # Check a single PR title / commit message
+    commit_msg_check.py --self-test         # Run self-tests
+
+See: https://docs.lvgl.io/master/contributing/pull_requests.html#commit-message-format
+"""
+
+import os
+import re
+import subprocess
+import sys
+import argparse
+
+VALID_TYPES = [
+    "feat",
+    "fix",
+    "arch",
+    "test",
+    "perf",
+    "example",
+    "refactor",
+    "revert",
+    "docs",
+    "style",
+    "chore",
+    "ci",
+    "build",
+]
+
+# Common typos/aliases -> correct type
+TYPE_TYPOS = {
+    "feature": "feat",
+    "fea": "feat",
+    "refact": "refactor",
+    "doc": "docs",
+    "tests": "test",
+    "bugfix": "fix",
+    "hotfix": "fix",
+    "perf_opt": "perf",
+    "optimize": "perf",
+}
+
+VALID_TYPES_RE = "|".join(VALID_TYPES)
+
+# type(scope): description  (chore allows omitting scope)
+FULL_PATTERN = re.compile(rf"^({VALID_TYPES_RE})\(([a-zA-Z0-9_/-]+)\): (.+)$")
+
+# chore: description (no scope)
+CHORE_NO_SCOPE_PATTERN = re.compile(r"^chore: (.+)$")
+
+# type( or type:
+TYPE_ONLY_PATTERN = re.compile(r"^([a-zA-Z_]+)")
+
+# "don't squash" PR pattern (rebase merge, title won't become commit msg)
+DONT_SQUASH_PATTERN = re.compile(r"don'?t'?s?\s+squash", re.IGNORECASE)
+
+# Commit message format documentation URL
+COMMIT_MSG_DOC_URL = (
+    "https://docs.lvgl.io/master/contributing/pull_requests.html"
+    "#commit-message-format"
+)
+
+
+def check_commit_msg(msg):
+    """Check a single commit message subject line.
+
+    Returns a list of error strings. Empty list means OK.
+    """
+    errors = []
+
+    # Strip leading/trailing whitespace (common in git log output)
+    msg = msg.strip()
+
+    if not msg:
+        errors.append("Commit message is empty")
+        return errors
+
+    # Allow Revert commits
+    if msg.startswith('Revert "') or msg.startswith('Revert "'):
+        return errors
+
+    # Allow merge commits
+    if msg.startswith("Merge "):
+        return errors
+
+    # Allow "don't squash" PRs (rebase merge, title won't become commit msg)
+    if DONT_SQUASH_PATTERN.search(msg):
+        return errors
+
+    # Check for Chinese punctuation (common mistake)
+    cn_punctuation = {
+        "\uff08": "(",  # （ -> (
+        "\uff09": ")",  # ） -> )
+        "\uff1a": ":",  # ： -> :
+        "\u3002": ".",  # 。 -> .
+        "\uff0c": ",",  # ， -> ,
+        "\uff1b": ";",  # ； -> ;
+    }
+    found_cn = [
+        f"'{ch}'(U+{ord(ch):04X}) -> '{en}'"
+        for ch, en in cn_punctuation.items()
+        if ch in msg
+    ]
+    if found_cn:
+        errors.append(
+            f"Chinese punctuation detected: {', '.join(found_cn)}. "
+            "Please use English punctuation only"
+        )
+        return errors
+
+    # Extract type word
+    m = TYPE_ONLY_PATTERN.match(msg)
+    type_word = m.group(1) if m else ""
+    type_lower = type_word.lower()
+
+    # Check common typos first
+    if type_lower in TYPE_TYPOS:
+        correct = TYPE_TYPOS[type_lower]
+        errors.append(f"Type '{type_word}' is not standard, did you mean '{correct}'?")
+        return errors
+
+    # Check type is valid and followed by '('
+    type_with_paren = re.compile(rf"^({VALID_TYPES_RE})\(")
+    if not type_with_paren.match(msg):
+        # type: desc (missing scope)
+        type_with_colon = re.compile(rf"^({VALID_TYPES_RE}):")
+        if type_with_colon.match(msg):
+            # Allow chore: without scope
+            if type_lower == "chore":
+                chore_match = CHORE_NO_SCOPE_PATTERN.match(msg)
+                if chore_match:
+                    desc = chore_match.group(1)
+                    if desc and desc[0].isupper():
+                        errors.append(
+                            f"Description should start with lowercase: '{desc[:30]}...'"
+                        )
+                    if desc.endswith("."):
+                        errors.append("Description should not end with a period")
+                    return errors
+            errors.append(
+                "Missing scope. Use 'type(scope): description' "
+                "instead of 'type: description'"
+            )
+        elif msg and msg[0].isupper():
+            errors.append(
+                "Do not start with a capital letter. "
+                "Use conventional commit format: type(scope): description"
+            )
+        else:
+            errors.append(
+                f"Invalid type '{type_word}'. "
+                f"Allowed types: {', '.join(VALID_TYPES)}"
+            )
+        return errors
+
+    # Full format check
+    full = FULL_PATTERN.match(msg)
+    if not full:
+        # Diagnose specific issues
+        empty_scope = re.compile(rf"^({VALID_TYPES_RE})\(\)")
+        no_space = re.compile(rf"^({VALID_TYPES_RE})\([^)]*\):[^ ]")
+        no_colon = re.compile(rf"^({VALID_TYPES_RE})\([^)]*\)[^:]")
+
+        if empty_scope.match(msg):
+            errors.append("Scope cannot be empty")
+        elif no_space.match(msg):
+            errors.append("Missing space after colon. Use 'type(scope): description'")
+        elif no_colon.match(msg):
+            errors.append("Missing colon after scope. Use 'type(scope): description'")
+        else:
+            # Check if scope contains filename or PR reference
+            scope_match = re.match(rf"^({VALID_TYPES_RE})\(([^)]+)\): .+", msg)
+            if scope_match:
+                scope = scope_match.group(2)
+                if re.search(r"\.[a-zA-Z]+$", scope):
+                    errors.append(
+                        f"Scope '{scope}' looks like a filename. "
+                        "Use a module name instead, e.g. 'obj' not 'lv_obj.h'"
+                    )
+                elif "#" in scope:
+                    errors.append(
+                        f"Scope '{scope}' should be a module name, "
+                        "not a PR reference. Put PR number in description, "
+                        "e.g. 'fix(module): description (#1234)'"
+                    )
+                else:
+                    errors.append("Invalid format. Expected: type(scope): description")
+            else:
+                errors.append("Invalid format. Expected: type(scope): description")
+        return errors
+
+    # Validate description
+    desc = full.group(3)
+
+    if desc and desc[0].isupper():
+        errors.append(f"Description should start with lowercase: '{desc[:30]}...'")
+
+    if desc.endswith("."):
+        errors.append("Description should not end with a period")
+
+    return errors
+
+
+def git_run(*args):
+    """Run a git command and return stdout."""
+    result = subprocess.run(["git"] + list(args), capture_output=True, text=True)
+    return result.stdout.strip(), result.returncode
+
+
+def find_base_branch():
+    """Find the base branch for comparison."""
+    candidates = ["vela/dev-graphic", "m/dev-graphic", "mainline/master"]
+    for branch in candidates:
+        _, rc = git_run("rev-parse", "--verify", branch)
+        if rc == 0:
+            return branch
+    return None
+
+
+def check_commits(base_branch=None, last_n=None):
+    """Check all commits between base branch and HEAD."""
+    if last_n:
+        log_output, _ = git_run("log", "--oneline", f"-{last_n}")
+        if not log_output:
+            print("No commits to check.")
+            return 0
+        print(f"Checking commit message style (last {last_n} commits)...")
+    else:
+        if not base_branch:
+            base_branch = find_base_branch()
+            if not base_branch:
+                print(
+                    "Warning: Could not determine base branch, "
+                    "skipping commit message style check."
+                )
+                return 0
+
+        merge_base, rc = git_run("merge-base", base_branch, "HEAD")
+        if rc != 0 or not merge_base:
+            print(
+                "Warning: Could not determine merge base, "
+                "skipping commit message style check."
+            )
+            return 0
+
+        head, _ = git_run("rev-parse", "HEAD")
+        if head == merge_base:
+            print("No new commits to check, skipping commit message style check.")
+            return 0
+
+        log_output, _ = git_run("log", "--oneline", f"{merge_base}..HEAD")
+        if not log_output:
+            print("No new commits to check.")
+            return 0
+
+        print(f"Checking commit message style (base: {base_branch})...")
+
+    error_count = 0
+    total_count = 0
+    for line in log_output.splitlines():
+        parts = line.split(" ", 1)
+        if len(parts) < 2:
+            continue
+        hash_str, msg = parts[0], parts[1]
+        total_count += 1
+        errors = check_commit_msg(msg)
+        if errors:
+            error_count += 1
+            print(f"\n  Commit: {hash_str[:12]} {msg}")
+            for e in errors:
+                print(f"  ✗ {e}")
+        else:
+            print(f"  ✓ {hash_str[:12]} {msg}")
+
+    if error_count > 0:
+        print(
+            f"""
+==========================================
+ Commit message style check FAILED
+ {error_count} commit(s) with bad format
+==========================================
+
+Expected format: type(scope): description
+
+  Valid types: {', '.join(VALID_TYPES)}
+  Scope:       required, e.g. (draw), (obj), (style)
+  Description: lowercase start, no trailing period
+
+Good examples:
+  feat(draw): add new gradient support
+  fix(obj): fix crash when object is deleted
+  test(cache): add complete cache test cases
+  perf(style): optimize style removal performance
+
+See: {COMMIT_MSG_DOC_URL}
+
+Use 'git commit --amend' or 'git rebase -i' to fix your commit messages."""
+        )
+        return 1
+
+    print("Commit message style check passed")
+    return 0
+
+
+# ============================================================================
+# Self-test
+# ============================================================================
+
+
+def self_test():
+    """Run self-tests to verify the checker works correctly."""
+
+    pass_cases = [
+        # Standard format
+        ("feat(draw): add support for dashed line rendering", "standard feat"),
+        ("fix(render): resolve null pointer in flush callback", "standard fix"),
+        ("test(cache): add unit tests for eviction policy", "standard test"),
+        ("perf(style): reduce redundant lookups in style resolve", "standard perf"),
+        ("refactor(obj): split tree logic into separate module", "standard refactor"),
+        ("docs(readme): update build instructions for linux", "standard docs"),
+        ("style(src): apply clang-format to all source files", "standard style"),
+        ("chore(deps): bump third-party library to latest tag", "standard chore"),
+        ("ci(github): add workflow for automated testing", "standard ci"),
+        ("build(cmake): add option to disable example targets", "standard build"),
+        ("arch(core): restructure module dependency graph", "standard arch"),
+        ("example(widgets): add demo for new button styles", "standard example"),
+        # Scope with special chars
+        ("fix(mod_a/sub_b): handle edge case in sub module", "scope with slash"),
+        ("fix(draw-sw): prevent buffer overflow in blend op", "scope with hyphen"),
+        ("feat(widget_v2): expose new public api for widgets", "scope with underscore"),
+        ("feat(myGFX): add hardware acceleration support", "scope with uppercase"),
+        # Revert / Merge (always allowed)
+        ('Revert "fix(render): disable fast path for now"', "revert commit"),
+        ("Merge branch 'main' into dev", "merge commit"),
+        ("revert(render): undo fast path optimization change", "revert with scope"),
+        # Edge: description exactly 10 chars
+        ("feat(core): 0123456789", "description exactly 10 chars"),
+        # PR number in description
+        ("fix(render): handle opacity reset on layer fail (#9521)", "with PR number"),
+        # chore without scope (allowed)
+        ("chore: bump version to release candidate tag", "chore without scope"),
+        ("chore: fix typos in configuration file names", "chore without scope 2"),
+        # Don't squash variants (rebase merge, skip title check)
+        ("Dont's squash: minor docs fixes", "dont squash variant 1"),
+        (
+            "Dont' Squash: improvements and fixes to workflow",
+            "dont squash variant 2",
+        ),
+        ("Dont's squash - gradient updates", "dont squash variant 3"),
+        (
+            "feat(gdb): add lvgl GDB plugin (don't squash)",
+            "dont squash in parens",
+        ),
+        ("DONT SQUASH: feat(draw): add new gradient support", "dont squash caps"),
+        ("dont squash - multiple independent fixes", "dont squash lowercase"),
+        # Leading/trailing whitespace (should be stripped)
+        ("  feat(draw): add gradient support  ", "leading/trailing spaces"),
+    ]
+
+    fail_cases = [
+        # Common typos
+        ("feature(anim): add transition support for opacity", "typo: feature -> feat"),
+        ("fea(scroll): add force elastic attribute to scroll", "typo: fea -> feat"),
+        (
+            "refact(gif): restructure decoder and add testcase",
+            "typo: refact -> refactor",
+        ),
+        ("doc(readme): update build instructions for linux", "typo: doc -> docs"),
+        ("tests(cache): add unit tests for eviction policy", "typo: tests -> test"),
+        ("bugfix(render): resolve null pointer in callback", "typo: bugfix -> fix"),
+        ("hotfix(obj): fix crash when object is deleted", "typo: hotfix -> fix"),
+        # Missing scope
+        ("fix: handle invalid escape sequence in parser", "missing scope"),
+        ("feat: add something really cool to the project", "missing scope"),
+        ("test: add unit tests without specifying a scope", "missing scope test"),
+        # Capital letter start (no type)
+        ("Add new parameter for module initialization", "capital letter start"),
+        ("Update documentation with new build instructions", "capital letter start"),
+        # Invalid type
+        ("update(core): change default config values here", "invalid type"),
+        ("add(draw): introduce new gradient for objects", "invalid type"),
+        ("wayland: add API to get fullscreen state", "invalid type module name"),
+        # Empty scope
+        ("feat(): add something without a scope name", "empty scope"),
+        # Missing space after colon
+        ("feat(draw):implement dashed line rendering now", "no space after colon"),
+        ("fix(parser):handle edge case in token scanner", "no space after colon 2"),
+        # Scope is a filename (not allowed)
+        ("fix(helper_sw.c): prevent buffer overflow in blend", "scope is filename .c"),
+        ("feat(lv_obj.h): expose new public api for widgets", "scope is filename .h"),
+        ("docs(README.md): update build instructions for dev", "scope is filename .md"),
+        # Scope is a PR reference (not allowed)
+        (
+            "fix(PR#1234): address review comments from reviewer",
+            "scope is PR reference",
+        ),
+        # Space before colon
+        ("fix(parser) :handle edge case in token scanner", "space before colon"),
+        # Missing colon
+        ("feat(draw) implement dashed line rendering now", "no colon after scope"),
+        # Description starts with uppercase
+        ("feat(draw): Implement dashed line rendering now", "uppercase description"),
+        ("fix(scale): Don't return early on main drawing", "uppercase contraction"),
+        (
+            "chore(cmsis-pack): Prepare for v9.5.0",
+            "uppercase description chore with scope",
+        ),
+        # Description ends with period
+        ("feat(draw): implement dashed line rendering now.", "trailing period"),
+        (
+            "feat(nema_gfx): integrate hardware acceleration.",
+            "trailing period 2",
+        ),
+        # Chinese punctuation
+        ("fix\uff08draw\uff09: handle edge case in flush callback", "chinese parens"),
+        ("fix(draw)\uff1ahandle edge case in flush callback", "chinese colon"),
+        ("fix(draw): handle edge case in flush callback\u3002", "chinese period"),
+        (
+            "fix(draw)\uff1a handle edge case in flush callback",
+            "chinese colon with space",
+        ),
+        (
+            "feat\uff08core\uff09\uff1aadd new public api for widget tree",
+            "all chinese punctuation",
+        ),
+        # Random garbage
+        ("this is not a valid commit message at all", "random text"),
+        ("just some random words without any structure", "random text 2"),
+        ("WIP something something something something", "WIP commit"),
+        ("Feat/lv check obj", "branch name as title"),
+        ("Initial commit", "initial commit"),
+        # Empty message
+        ("", "empty message"),
+        ("   ", "whitespace only"),
+    ]
+
+    passed = 0
+    failed = 0
+    total = len(pass_cases) + len(fail_cases)
+
+    print("=" * 60)
+    print(" Commit Message Checker Self-Test")
+    print("=" * 60)
+
+    # Test cases that should PASS
+    print("\n--- Should PASS ---")
+    for msg, desc in pass_cases:
+        errors = check_commit_msg(msg)
+        if not errors:
+            passed += 1
+            print(f"  ✓ PASS  [{desc}]")
+        else:
+            failed += 1
+            print(f"  ✗ FAIL  [{desc}]")
+            print(f"          msg: {msg}")
+            for e in errors:
+                print(f"          err: {e}")
+
+    # Test cases that should FAIL
+    print("\n--- Should FAIL ---")
+    for msg, desc in fail_cases:
+        errors = check_commit_msg(msg)
+        if errors:
+            passed += 1
+            print(f"  ✓ PASS  [{desc}] -> caught: {errors[0]}")
+        else:
+            failed += 1
+            print(f"  ✗ FAIL  [{desc}] -> should have been rejected!")
+            print(f"          msg: {msg}")
+
+    print(f"\n{'=' * 60}")
+    print(f" Results: {passed}/{total} passed, {failed} failed")
+    print(f"{'=' * 60}")
+
+    # Lint self
+    print(f"\n{'=' * 60}")
+    print(" Lint Check (self)")
+    print(f"{'=' * 60}")
+
+    script_path = os.path.abspath(__file__)
+    lint_failed = False
+
+    # Syntax check
+    try:
+        import py_compile
+
+        py_compile.compile(script_path, doraise=True)
+        print("  ✓ py_compile: syntax OK")
+    except py_compile.PyCompileError as e:
+        print(f"  ✗ py_compile: {e}")
+        lint_failed = True
+
+    # flake8 if available
+    try:
+        result = subprocess.run(
+            ["flake8", "--max-line-length=120", "--ignore=E501,W503", script_path],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            print("  ✓ flake8: no issues")
+        else:
+            print("  ✗ flake8:")
+            for line in result.stdout.strip().splitlines():
+                print(f"    {line}")
+            lint_failed = True
+    except FileNotFoundError:
+        print("  - flake8: not installed, skipped")
+
+    if lint_failed:
+        failed += 1
+
+    return 0 if (failed == 0 and not lint_failed) else 1
+
+
+def check_title(title):
+    """Check a single PR title / commit message string."""
+    errors = check_commit_msg(title)
+    if errors:
+        print(f"\n  PR Title: {title}")
+        for e in errors:
+            print(f"  ✗ {e}")
+        print(
+            f"\nExpected format: type(scope): description\n"
+            f"\n"
+            f"  Valid types: {', '.join(VALID_TYPES)}\n"
+            f"  Scope:       required (except chore), e.g. (draw), (obj)\n"
+            f"  Description: lowercase start, no trailing period\n"
+            f"\n"
+            f"Examples:\n"
+            f"  feat(draw): add new gradient support\n"
+            f"  fix(obj): fix crash when object is deleted\n"
+            f"\n"
+            f"See: {COMMIT_MSG_DOC_URL}"
+        )
+        return 1
+    print(f"✓ PR title OK: {title}")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="LVGL Commit Message Style Checker")
+    parser.add_argument(
+        "--self-test", action="store_true", help="Run self-tests to verify the checker"
+    )
+    parser.add_argument(
+        "--base",
+        type=str,
+        default=None,
+        help="Base branch for comparison (auto-detected if omitted)",
+    )
+    parser.add_argument(
+        "--last",
+        type=int,
+        default=None,
+        help="Check the last N commits (useful for local testing)",
+    )
+    parser.add_argument(
+        "--check-title",
+        type=str,
+        default=None,
+        help="Check a single PR title / commit message string",
+    )
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    if args.check_title:
+        return check_title(args.check_title)
+
+    return check_commits(args.base, args.last)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/commit_msg_check.py
+++ b/scripts/commit_msg_check.py
@@ -6,7 +6,7 @@ LVGL Commit Message Style Checker
 Format: type(scope): description
 
 Valid types: feat, fix, arch, test, perf, example, refactor, revert, docs, style, chore, ci, build
-Scope:       required, lowercase, e.g. (draw), (obj)
+Scope:       required (except chore), letters/digits/_/-/ allowed, e.g. (draw), (obj)
 Description: lowercase start, no trailing period
 
 Usage:
@@ -92,7 +92,7 @@ def check_commit_msg(msg):
         return errors
 
     # Allow Revert commits
-    if msg.startswith('Revert "') or msg.startswith('Revert "'):
+    if msg.startswith('Revert "'):
         return errors
 
     # Allow merge commits

--- a/scripts/commit_msg_check.py
+++ b/scripts/commit_msg_check.py
@@ -65,7 +65,10 @@ CHORE_NO_SCOPE_PATTERN = re.compile(r"^chore: (.+)$")
 TYPE_ONLY_PATTERN = re.compile(r"^([a-zA-Z_]+)")
 
 # "don't squash" PR pattern (rebase merge, title won't become commit msg)
-DONT_SQUASH_PATTERN = re.compile(r"don'?t'?s?\s+squash", re.IGNORECASE)
+# Covers: don't squash, dont squash, dont's squash, do not squash, do-not-squash
+DONT_SQUASH_PATTERN = re.compile(
+    r"(?:don'?t'?s?|do[\s-]+not)[\s-]+squash", re.IGNORECASE
+)
 
 # Commit message format documentation URL
 COMMIT_MSG_DOC_URL = (
@@ -366,6 +369,8 @@ def self_test():
         ),
         ("DONT SQUASH: feat(draw): add new gradient support", "dont squash caps"),
         ("dont squash - multiple independent fixes", "dont squash lowercase"),
+        ("do not squash: multiple independent fixes", "do not squash"),
+        ("do-not-squash: multiple independent fixes", "do-not-squash"),
         # Leading/trailing whitespace (should be stripped)
         ("  feat(draw): add gradient support  ", "leading/trailing spaces"),
     ]
@@ -579,7 +584,7 @@ def main():
     if args.self_test:
         return self_test()
 
-    if args.check_title:
+    if args.check_title is not None:
         return check_title(args.check_title)
 
     return check_commits(args.base, args.last)

--- a/scripts/commit_msg_check.py
+++ b/scripts/commit_msg_check.py
@@ -102,10 +102,6 @@ def check_commit_msg(msg):
     if msg.startswith("Merge "):
         return errors
 
-    # Allow "don't squash" PRs (rebase merge, title won't become commit msg)
-    if DONT_SQUASH_PATTERN.search(msg):
-        return errors
-
     # Check for Chinese punctuation (common mistake)
     cn_punctuation = {
         "\uff08": "(",  # （ -> (
@@ -228,7 +224,7 @@ def git_run(*args):
 
 def find_base_branch():
     """Find the base branch for comparison."""
-    candidates = ["vela/dev-graphic", "m/dev-graphic", "mainline/master"]
+    candidates = ["origin/master", "origin/main", "upstream/master", "upstream/main"]
     for branch in candidates:
         _, rc = git_run("rev-parse", "--verify", branch)
         if rc == 0:
@@ -363,7 +359,12 @@ def self_test():
         ("docs: add hero image", "docs without scope 2"),
         ("ci: add workflow for automated testing", "ci without scope"),
         ("ci: deploy doc builds to release folders", "ci without scope 2"),
-        # Don't squash variants (rebase merge, skip title check)
+        # Leading/trailing whitespace (should be stripped)
+        ("  feat(draw): add gradient support  ", "leading/trailing spaces"),
+    ]
+
+    # Don't squash cases: should pass check_title() but NOT check_commit_msg()
+    dont_squash_cases = [
         ("Dont's squash: minor docs fixes", "dont squash variant 1"),
         (
             "Dont' Squash: improvements and fixes to workflow",
@@ -378,8 +379,6 @@ def self_test():
         ("dont squash - multiple independent fixes", "dont squash lowercase"),
         ("do not squash: multiple independent fixes", "do not squash"),
         ("do-not-squash: multiple independent fixes", "do-not-squash"),
-        # Leading/trailing whitespace (should be stripped)
-        ("  feat(draw): add gradient support  ", "leading/trailing spaces"),
     ]
 
     fail_cases = [
@@ -493,6 +492,20 @@ def self_test():
             print(f"  ✗ FAIL  [{desc}] -> should have been rejected!")
             print(f"          msg: {msg}")
 
+    # Test don't squash: should bypass check_title() but NOT check_commit_msg()
+    total += len(dont_squash_cases)
+    print("\n--- Don't Squash (check_title should pass, check_commit_msg should fail) ---")
+    for msg, desc in dont_squash_cases:
+        title_rc = check_title(msg)
+        # check_title should return 0 (pass) due to don't squash bypass
+        if title_rc == 0:
+            passed += 1
+            print(f"  ✓ PASS  [{desc}] -> check_title bypassed")
+        else:
+            failed += 1
+            print(f"  ✗ FAIL  [{desc}] -> check_title should have bypassed!")
+            print(f"          msg: {msg}")
+
     print(f"\n{'=' * 60}")
     print(f" Results: {passed}/{total} passed, {failed} failed")
     print(f"{'=' * 60}")
@@ -540,6 +553,10 @@ def self_test():
 
 def check_title(title):
     """Check a single PR title / commit message string."""
+    # Allow "don't squash" PRs (rebase merge, title won't become commit msg)
+    if DONT_SQUASH_PATTERN.search(title):
+        print(f"✓ PR title OK (don't squash): {title}")
+        return 0
     errors = check_commit_msg(title)
     if errors:
         print(f"\n  PR Title: {title}")

--- a/scripts/commit_msg_check.py
+++ b/scripts/commit_msg_check.py
@@ -6,7 +6,7 @@ LVGL Commit Message Style Checker
 Format: type(scope): description
 
 Valid types: feat, fix, arch, test, perf, example, refactor, revert, docs, style, chore, ci, build
-Scope:       required (except chore), letters/digits/_/-/ allowed, e.g. (draw), (obj)
+Scope:       required (except chore/docs/ci), letters/digits/_/-/ allowed, e.g. (draw), (obj)
 Description: lowercase start, no trailing period
 
 Usage:
@@ -55,11 +55,14 @@ TYPE_TYPOS = {
 
 VALID_TYPES_RE = "|".join(VALID_TYPES)
 
-# type(scope): description  (chore allows omitting scope)
+# type(scope): description  (chore/docs/ci allow omitting scope)
 FULL_PATTERN = re.compile(rf"^({VALID_TYPES_RE})\(([a-zA-Z0-9_/-]+)\): (.+)$")
 
-# chore: description (no scope)
-CHORE_NO_SCOPE_PATTERN = re.compile(r"^chore: (.+)$")
+# Types that allow omitting scope
+SCOPE_OPTIONAL_TYPES = {"chore", "docs", "ci"}
+
+# type: description (no scope, for scope-optional types)
+NO_SCOPE_PATTERN = re.compile(rf"^({'|'.join(SCOPE_OPTIONAL_TYPES)}): (.+)$")
 
 # type( or type:
 TYPE_ONLY_PATTERN = re.compile(r"^([a-zA-Z_]+)")
@@ -141,11 +144,11 @@ def check_commit_msg(msg):
         # type: desc (missing scope)
         type_with_colon = re.compile(rf"^({VALID_TYPES_RE}):")
         if type_with_colon.match(msg):
-            # Allow chore: without scope
-            if type_lower == "chore":
-                chore_match = CHORE_NO_SCOPE_PATTERN.match(msg)
-                if chore_match:
-                    desc = chore_match.group(1)
+            # Allow scope-optional types (chore, docs, ci) without scope
+            if type_lower in SCOPE_OPTIONAL_TYPES:
+                no_scope_match = NO_SCOPE_PATTERN.match(msg)
+                if no_scope_match:
+                    desc = no_scope_match.group(2)
                     if desc and desc[0].isupper():
                         errors.append(
                             f"Description should start with lowercase: '{desc[:30]}...'"
@@ -299,7 +302,7 @@ def check_commits(base_branch=None, last_n=None):
 Expected format: type(scope): description
 
   Valid types: {', '.join(VALID_TYPES)}
-  Scope:       required, e.g. (draw), (obj), (style)
+  Scope:       required (except chore/docs/ci), e.g. (draw), (obj), (style)
   Description: lowercase start, no trailing period
 
 Good examples:
@@ -353,9 +356,13 @@ def self_test():
         ("feat(core): 0123456789", "description exactly 10 chars"),
         # PR number in description
         ("fix(render): handle opacity reset on layer fail (#9521)", "with PR number"),
-        # chore without scope (allowed)
+        # chore/docs/ci without scope (allowed)
         ("chore: bump version to release candidate tag", "chore without scope"),
         ("chore: fix typos in configuration file names", "chore without scope 2"),
+        ("docs: fix typos", "docs without scope"),
+        ("docs: add hero image", "docs without scope 2"),
+        ("ci: add workflow for automated testing", "ci without scope"),
+        ("ci: deploy doc builds to release folders", "ci without scope 2"),
         # Don't squash variants (rebase merge, skip title check)
         ("Dont's squash: minor docs fixes", "dont squash variant 1"),
         (
@@ -542,7 +549,7 @@ def check_title(title):
             f"\nExpected format: type(scope): description\n"
             f"\n"
             f"  Valid types: {', '.join(VALID_TYPES)}\n"
-            f"  Scope:       required (except chore), e.g. (draw), (obj)\n"
+            f"  Scope:       required (except chore/docs/ci), e.g. (draw), (obj)\n"
             f"  Description: lowercase start, no trailing period\n"
             f"\n"
             f"Examples:\n"

--- a/scripts/commit_msg_check.py
+++ b/scripts/commit_msg_check.py
@@ -497,20 +497,28 @@ def self_test():
     print("\n--- Don't Squash (check_title should pass, check_commit_msg should fail) ---")
     for msg, desc in dont_squash_cases:
         title_rc = check_title(msg)
+        commit_errors = check_commit_msg(msg)
         # check_title should return 0 (pass) due to don't squash bypass
-        if title_rc == 0:
+        # check_commit_msg should return errors (unless msg is independently valid)
+        msg_is_valid = not check_commit_msg(msg.replace("don't squash", "").replace("dont squash", ""))
+        if title_rc == 0 and (commit_errors or msg_is_valid):
             passed += 1
-            print(f"  ✓ PASS  [{desc}] -> check_title bypassed")
+            if commit_errors:
+                print(f"  ✓ PASS  [{desc}] -> title bypassed, commit rejected")
+            else:
+                print(f"  ✓ PASS  [{desc}] -> title bypassed, commit valid independently")
         else:
             failed += 1
-            print(f"  ✗ FAIL  [{desc}] -> check_title should have bypassed!")
+            if title_rc != 0:
+                print(f"  ✗ FAIL  [{desc}] -> check_title should have bypassed!")
+            else:
+                print(f"  ✗ FAIL  [{desc}] -> check_commit_msg should have rejected!")
             print(f"          msg: {msg}")
 
     print(f"\n{'=' * 60}")
-    print(f" Results: {passed}/{total} passed, {failed} failed")
-    print(f"{'=' * 60}")
 
     # Lint self
+    total += 1
     print(f"\n{'=' * 60}")
     print(" Lint Check (self)")
     print(f"{'=' * 60}")
@@ -547,8 +555,14 @@ def self_test():
 
     if lint_failed:
         failed += 1
+    else:
+        passed += 1
 
-    return 0 if (failed == 0 and not lint_failed) else 1
+    print(f"\n{'=' * 60}")
+    print(f" Final Results: {passed}/{total} passed, {failed} failed")
+    print(f"{'=' * 60}")
+
+    return 0 if failed == 0 else 1
 
 
 def check_title(title):


### PR DESCRIPTION
### Problem

LVGL uses squash merge by default, which means the PR title becomes the final commit message in the mainline history. Maintaining a clean, consistent commit history following the [conventional commit format](https://docs.lvgl.io/master/contributing/pull_requests.html#commit-message-format) currently relies entirely on maintainers manually reviewing and correcting PR titles before merging.

This creates two pain points:

1. **Maintainer burden** — Reviewers spend time asking contributors to fix titles, often across multiple review rounds, delaying the merge cycle.
2. **Inconsistent history** — Some non-conforming titles still slip through. A scan of the last 200 merged commits shows 11 violations (5.5%) that made it into the mainline.

### Data Analysis

We ran `scripts/commit_msg_check.py` against the last 200 merged commits and the latest 200 GitHub PRs (open + merged + closed) to quantify the current state:

#### Merged Commits (last 200 on master)

| Metric | Value |
|--------|-------|
| Total | 200 |
| Pass | 189 (94.5%) |
| Would be blocked | 11 (5.5%) |

#### PR Titles (latest 200 PRs across all states)

| Metric | Value |
|--------|-------|
| Total | 200 |
| Pass | 174 (87.0%) |
| Would be blocked | 26 (13.0%) |

Breakdown by PR state:

| State | Total | Would block | Rate |
|-------|-------|-------------|------|
| Merged | 55 | 7 | 12.7% |
| Open | 39 | 9 | 23.1% |
| Closed | 6 | 2 | 33.3% |

The open PR block rate (23.1%) is nearly double the merged rate (12.7%), confirming that maintainers are currently doing manual title correction work that this CI check would automate.

#### Failure Category Distribution (PR titles)

| Category | Count | Share |
|----------|-------|-------|
| Missing scope (e.g. `docs: xxx`) | 8 | 31% |
| No conventional format (e.g. `Initial commit`, `Feat/lv check obj`) | 5 | 19% |
| Type typo (e.g. `tests` → `test`, `fixed` → `fix`) | 5 | 19% |
| Uppercase description (e.g. `fix(scale): Don't return...`) | 5 | 19% |
| Trailing period | 3 | 12% |

#### Representative Examples

```
✗ wayland: Add API to get fullscreen and maximized state
  → Invalid type 'wayland' (should be: feat(wayland): add API...)

✗ Feat/lv check obj
  → Branch name used as title, not conventional commit format

✗ tests(dockerfile): resolve xargs failure caused by CRLF line endings
  → Type typo: 'tests' should be 'test'

✗ fix(scale): Don't return early on main drawing
  → Description must start with lowercase

✗ feat(nema_gfx): integrate NeoChrom GPU2D hardware acceleration.
  → Description must not end with a period
```

#### Scope Requirement Analysis (last 2000 commits)

We analyzed which types historically omit scope to decide which types should allow it:

| Type | Total uses | Without scope | Without scope authors | Decision |
|------|-----------|---------------|----------------------|----------|
| `docs` | 290 | 39 (13.4%) | Multiple contributors | **Allow** — broad changes like `docs: fix typos` lack a meaningful scope |
| `ci` | 65 | 19 (29.2%) | Multiple contributors | **Allow** — CI changes often span multiple workflows |
| `chore` | 182 | 33 (18.1%) | Multiple contributors | **Allow** — already allowed before this PR |
| `build` | 27 | 2 (7.4%) | André Costa only (core maintainer) | **Require** — too rare, maintainer-only edge case |
| `refactor` | 44 | 0 (0%) | N/A | **Require** — never used without scope |
| `fix` | 797 | 10 (1.3%) | Various | **Require** — fix should always specify what was fixed |
| `feat` | 472 | 3 (0.6%) | Various | **Require** — feature should always specify the module |
| `test` | 42 | 4 (9.5%) | Various | **Require** — test should specify what is being tested |

**Conclusion:** `chore`, `docs`, and `ci` allow omitting scope. All other types require it.

#### Documentation Gap Analysis

The existing documentation (`docs/src/contributing/pull_requests.mdx`) had several gaps compared to actual usage:

| Issue | Before | After |
|-------|--------|-------|
| Missing types | Only listed 8 types | All 13 types documented |
| Missing types detail | No `refactor`, `revert`, `ci`, `build`, `style` | Added with descriptions |
| Scope rule | "The scope can be omitted" | "Required for most types, optional for `chore`/`docs`/`ci`" |
| PR title convention | Not mentioned | Added section explaining squash merge → PR title = commit msg |
| Don't squash | Not mentioned | Added section documenting the rebase merge convention |
| Local tooling | Not mentioned | Added `Automated Checker` section with usage examples |

### Solution

This PR adds a lightweight CI check that validates PR titles against the existing `scripts/commit_msg_check.py` rules. The checker covers:

- 13 valid types: `feat`, `fix`, `arch`, `test`, `perf`, `example`, `refactor`, `revert`, `docs`, `style`, `chore`, `ci`, `build`
- Scope validation (required for all types except `chore`, `docs`, `ci`)
- Description rules (lowercase start, no trailing period)
- Common typo detection with suggestions (`feature` → `feat`, `doc` → `docs`, etc.)
- Chinese punctuation detection (common for CJK contributors)
- "Don't squash" whitelist (various spelling variants, case-insensitive)

### Changes

**New file: `.github/workflows/check_pr_title.yml`**
- Triggers on PR `opened`, `edited`, `synchronize`, `reopened` events
- Runs the checker's self-test first to ensure the tool itself is sound
- Then validates the PR title using `--check-title`
- Follows the same `concurrency` patterns as existing CI workflows

**Modified: `scripts/commit_msg_check.py`**
- Added `--check-title` CLI argument for single-message validation
- Added "don't squash" whitelist — covers `don't squash`, `dont squash`, `dont's squash`, `do not squash`, `do-not-squash` (case-insensitive)
- Allow `docs` and `ci` types to omit scope (matching historical usage)
- Added leading/trailing whitespace stripping and empty message detection
- Removed duplicated `Revert "` check
- All error output now includes a link to the commit message format documentation
- Self-test expanded from 52 to 77 cases

**Modified: `docs/src/contributing/pull_requests.mdx`**
- Added 5 missing types: `refactor`, `revert`, `ci`, `build`, `style`
- Corrected scope rule to match checker behavior
- Added PR Title, Don't Squash, and Automated Checker sections

### Behavior

When a PR title doesn't conform:
- The "Verify PR title format" check fails with a clear error message
- The error includes the specific violation, expected format, examples, and a link to the full documentation
- Contributors can fix the title directly — the `edited` trigger re-runs the check immediately without requiring a new push

When a PR title contains "don't squash" (case-insensitive, various spelling variants):
- The check passes unconditionally, since the title won't become a commit message

### Testing

```bash
# Run the full self-test suite (77 cases)
python3 scripts/commit_msg_check.py --self-test

# Test a valid title
python3 scripts/commit_msg_check.py --check-title "feat(draw): add gradient support"

# Test scope-optional types
python3 scripts/commit_msg_check.py --check-title "docs: fix typos"
python3 scripts/commit_msg_check.py --check-title "ci: add workflow"

# Test an invalid title
python3 scripts/commit_msg_check.py --check-title "Add something cool"

# Test don't squash bypass
python3 scripts/commit_msg_check.py --check-title "do not squash: multiple fixes"
```


cc @kisvegabor @AndreCostaaa 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
