### PR TITLE
feat(sw): add I4 (4-bit indexed) destination support to software blender

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -296,6 +296,11 @@ menu "LVGL configuration"
 			default y
 			depends on LV_USE_DRAW_SW
 
+		config LV_DRAW_SW_SUPPORT_I4
+			bool "Enable support for I4 (4-bit indexed) color format"
+			default y
+			depends on LV_USE_DRAW_SW
+
 		config LV_DRAW_SW_I1_LUM_THRESHOLD
 			int "Luminance threshold for a pixel to be active"
 			default 127

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -187,6 +187,7 @@
     #define LV_DRAW_SW_SUPPORT_AL88         1
     #define LV_DRAW_SW_SUPPORT_A8           1
     #define LV_DRAW_SW_SUPPORT_I1           1
+    #define LV_DRAW_SW_SUPPORT_I4           1
 
     /* The threshold of the luminance to consider a pixel as
      * active in indexed color format */

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -625,6 +625,31 @@ lv_color_format_t lv_display_get_color_format(lv_display_t * disp)
     return disp->color_format;
 }
 
+void lv_display_set_palette(lv_display_t * disp, const lv_color32_t * palette, uint32_t size)
+{
+    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) return;
+
+    disp->palette = palette;
+    disp->palette_size = palette ? size : 0;
+}
+
+const lv_color32_t * lv_display_get_palette(lv_display_t * disp)
+{
+    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) return NULL;
+
+    return disp->palette;
+}
+
+uint32_t lv_display_get_palette_size(lv_display_t * disp)
+{
+    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) return 0;
+
+    return disp->palette_size;
+}
+
 void lv_display_set_tile_cnt(lv_display_t * disp, uint32_t tile_cnt)
 {
     LV_ASSERT_FORMAT_MSG(tile_cnt < 256, "tile_cnt must be smaller than 256 (%" LV_PRId32 " was used)", tile_cnt);

--- a/src/display/lv_display.h
+++ b/src/display/lv_display.h
@@ -363,6 +363,41 @@ void lv_display_set_color_format(lv_display_t * disp, lv_color_format_t color_fo
 lv_color_format_t lv_display_get_color_format(lv_display_t * disp);
 
 /**
+ * Set the palette used when the display's color format is indexed
+ * (e.g. `LV_COLOR_FORMAT_I4`, `LV_COLOR_FORMAT_I8`).
+ *
+ * The software blender uses this to quantize incoming RGB pixels to
+ * the closest palette index when rendering into an indexed framebuffer.
+ *
+ * The palette is *not* copied — the caller is responsible for ensuring
+ * the buffer outlives the display, or for keeping it valid until the
+ * next call to this function.
+ *
+ * @param disp              pointer to a display
+ * @param palette           pointer to an array of `lv_color32_t` palette
+ *                          entries, or NULL to clear (a default 16-entry
+ *                          grayscale palette will be used by the I4 blender
+ *                          when none is set).
+ * @param size              number of entries in `palette`. Must be 16
+ *                          for I4 destinations, 256 for I8 destinations.
+ */
+void lv_display_set_palette(lv_display_t * disp, const lv_color32_t * palette, uint32_t size);
+
+/**
+ * Get the palette previously set with `lv_display_set_palette`.
+ * @param disp              pointer to a display
+ * @return                  pointer to the palette, or NULL if none was set
+ */
+const lv_color32_t * lv_display_get_palette(lv_display_t * disp);
+
+/**
+ * Get the number of entries in the display's palette.
+ * @param disp              pointer to a display
+ * @return                  number of palette entries, or 0 if no palette was set
+ */
+uint32_t lv_display_get_palette_size(lv_display_t * disp);
+
+/**
  * Set the number of tiles for parallel rendering.
  * @param disp              pointer to a display
  * @param tile_cnt          number of tiles (1 =< tile_cnt < 256)

--- a/src/display/lv_display_private.h
+++ b/src/display/lv_display_private.h
@@ -126,6 +126,13 @@ struct _lv_display_t {
 
     lv_color_format_t   color_format;
 
+    /** Palette used when the display's color format is indexed (e.g. I4, I8).
+     *  May be NULL — in that case the software blender falls back to a default
+     *  16-entry grayscale palette for I4. Not owned by the display; the user
+     *  is responsible for the lifetime of the buffer. */
+    const lv_color32_t * palette;
+    uint32_t palette_size;
+
     /** Invalidated (marked to redraw) areas*/
     lv_area_t inv_areas[LV_INV_BUF_SIZE];
     uint8_t inv_area_joined[LV_INV_BUF_SIZE];

--- a/src/draw/sw/blend/lv_draw_sw_blend.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend.c
@@ -37,6 +37,9 @@
 #if LV_DRAW_SW_SUPPORT_I1
     #include "lv_draw_sw_blend_to_i1.h"
 #endif
+#if LV_DRAW_SW_SUPPORT_I4
+    #include "lv_draw_sw_blend_to_i4.h"
+#endif
 #if LV_USE_DRAW_SW
 
 /*********************
@@ -228,6 +231,11 @@ static inline void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color(lv_color_format_
             lv_draw_sw_blend_color_to_i1(fill_dsc);
             break;
 #endif
+#if LV_DRAW_SW_SUPPORT_I4
+        case LV_COLOR_FORMAT_I4:
+            lv_draw_sw_blend_color_to_i4(fill_dsc);
+            break;
+#endif
         default:
             break;
     }
@@ -286,6 +294,11 @@ static inline void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_image(lv_color_format_
 #if LV_DRAW_SW_SUPPORT_I1
         case LV_COLOR_FORMAT_I1:
             lv_draw_sw_blend_image_to_i1(image_dsc);
+            break;
+#endif
+#if LV_DRAW_SW_SUPPORT_I4
+        case LV_COLOR_FORMAT_I4:
+            lv_draw_sw_blend_image_to_i4(image_dsc);
             break;
 #endif
         default:

--- a/src/draw/sw/blend/lv_draw_sw_blend_to_i4.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend_to_i4.c
@@ -1,0 +1,842 @@
+/**
+ * @file lv_draw_sw_blend_to_i4.c
+ *
+ * Software rasterizer for the I4 (4-bit indexed) destination color format.
+ *
+ * Pixel packing follows the wire convention used by indexed-color AMOLED
+ * controllers like the CO5300 (datasheet §7.5.32 / §7.5.50): two pixels
+ * per byte, with the lower-x pixel in the upper nibble (D[7:4]) and the
+ * higher-x pixel in the lower nibble (D[3:0]). Stride is rounded up to
+ * whole bytes — for an N-pixel-wide row the natural stride is `(N+1)/2`.
+ *
+ * Because I4 has 16 freely defined palette entries (rather than the
+ * fixed black/white of I1), a palette must be supplied so that incoming
+ * RGB565/ARGB8888/etc. pixels can be quantized to the closest entry.
+ * The blender pulls the palette from the display via
+ * `lv_display_get_palette()`. If none is set, a default 16-entry
+ * grayscale palette is used (handy for development; production code
+ * should set its own palette to match the panel's COLSET registers).
+ *
+ * Quantization is a 16-entry linear search over squared RGB distance.
+ * On RV32 / Cortex-M this is well under a microsecond per pixel; for
+ * panels driven at typical refresh rates it is not the bottleneck.
+ * A faster lookup table can be added later if profiling demands it.
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "lv_draw_sw_blend_to_i4.h"
+#if LV_USE_DRAW_SW
+
+#if LV_DRAW_SW_SUPPORT_I4
+
+#include "lv_draw_sw_blend_private.h"
+#include "../../../misc/lv_math.h"
+#include "../../../display/lv_display.h"
+#include "../../../core/lv_refr.h"
+#include "../../../core/lv_refr_private.h"
+#include "../../../misc/lv_color.h"
+#include "../../../stdlib/lv_string.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+#define I4_PALETTE_SIZE 16
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+static void /* LV_ATTRIBUTE_FAST_MEM */ i4_image_blend(lv_draw_sw_blend_image_dsc_t * dsc);
+
+#if LV_DRAW_SW_SUPPORT_L8
+    static void /* LV_ATTRIBUTE_FAST_MEM */ l8_image_blend(lv_draw_sw_blend_image_dsc_t * dsc);
+#endif
+
+#if LV_DRAW_SW_SUPPORT_AL88
+    static void /* LV_ATTRIBUTE_FAST_MEM */ al88_image_blend(lv_draw_sw_blend_image_dsc_t * dsc);
+#endif
+
+#if LV_DRAW_SW_SUPPORT_RGB565
+    static void /* LV_ATTRIBUTE_FAST_MEM */ rgb565_image_blend(lv_draw_sw_blend_image_dsc_t * dsc);
+#endif
+
+#if LV_DRAW_SW_SUPPORT_RGB565_SWAPPED
+    static void /* LV_ATTRIBUTE_FAST_MEM */ rgb565_swapped_image_blend(lv_draw_sw_blend_image_dsc_t * dsc);
+#endif
+
+#if LV_DRAW_SW_SUPPORT_RGB888 || LV_DRAW_SW_SUPPORT_XRGB8888
+    static void /* LV_ATTRIBUTE_FAST_MEM */ rgb888_image_blend(lv_draw_sw_blend_image_dsc_t * dsc,
+                                                               const uint8_t src_px_size);
+#endif
+
+#if LV_DRAW_SW_SUPPORT_ARGB8888
+    static void /* LV_ATTRIBUTE_FAST_MEM */ argb8888_image_blend(lv_draw_sw_blend_image_dsc_t * dsc);
+#endif
+
+static inline void /* LV_ATTRIBUTE_FAST_MEM */ blend_non_normal_pixel(uint8_t * dest_buf, int32_t dest_x,
+                                                                      lv_color32_t src,
+                                                                      lv_blend_mode_t mode,
+                                                                      const lv_color32_t * palette);
+
+static inline void /* LV_ATTRIBUTE_FAST_MEM */ set_nibble(uint8_t * buf, int32_t idx, uint8_t val);
+static inline uint8_t /* LV_ATTRIBUTE_FAST_MEM */ get_nibble(const uint8_t * buf, int32_t idx);
+
+static inline uint8_t /* LV_ATTRIBUTE_FAST_MEM */ quantize_to_palette(lv_color32_t c,
+                                                                      const lv_color32_t * palette);
+
+static inline lv_color32_t blend_alpha_rgb(lv_color32_t src, lv_color32_t dst, uint8_t mix);
+
+static inline const lv_color32_t * get_active_palette(void);
+
+static inline void * /* LV_ATTRIBUTE_FAST_MEM */ drawbuf_next_row(const void * buf, uint32_t stride);
+
+#if LV_DRAW_SW_SUPPORT_RGB565_SWAPPED
+    static inline lv_color16_t /* LV_ATTRIBUTE_FAST_MEM */ lv_color16_from_u16(uint16_t raw);
+#endif
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**
+ * Default 16-entry grayscale palette used when the display has no
+ * `lv_display_set_palette()` registered. Index N is `(N * 17, N * 17, N * 17)`
+ * — i.e. a uniform ramp from black (0) through 0x88 to white (0xFF).
+ */
+static const lv_color32_t default_grayscale_palette[I4_PALETTE_SIZE] = {
+    {.blue = 0x00, .green = 0x00, .red = 0x00, .alpha = 0xFF},
+    {.blue = 0x11, .green = 0x11, .red = 0x11, .alpha = 0xFF},
+    {.blue = 0x22, .green = 0x22, .red = 0x22, .alpha = 0xFF},
+    {.blue = 0x33, .green = 0x33, .red = 0x33, .alpha = 0xFF},
+    {.blue = 0x44, .green = 0x44, .red = 0x44, .alpha = 0xFF},
+    {.blue = 0x55, .green = 0x55, .red = 0x55, .alpha = 0xFF},
+    {.blue = 0x66, .green = 0x66, .red = 0x66, .alpha = 0xFF},
+    {.blue = 0x77, .green = 0x77, .red = 0x77, .alpha = 0xFF},
+    {.blue = 0x88, .green = 0x88, .red = 0x88, .alpha = 0xFF},
+    {.blue = 0x99, .green = 0x99, .red = 0x99, .alpha = 0xFF},
+    {.blue = 0xAA, .green = 0xAA, .red = 0xAA, .alpha = 0xFF},
+    {.blue = 0xBB, .green = 0xBB, .red = 0xBB, .alpha = 0xFF},
+    {.blue = 0xCC, .green = 0xCC, .red = 0xCC, .alpha = 0xFF},
+    {.blue = 0xDD, .green = 0xDD, .red = 0xDD, .alpha = 0xFF},
+    {.blue = 0xEE, .green = 0xEE, .red = 0xEE, .alpha = 0xFF},
+    {.blue = 0xFF, .green = 0xFF, .red = 0xFF, .alpha = 0xFF},
+};
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_i4(lv_draw_sw_blend_fill_dsc_t * dsc)
+{
+    int32_t w = dsc->dest_w;
+    int32_t h = dsc->dest_h;
+    lv_opa_t opa = dsc->opa;
+    const lv_opa_t * mask = dsc->mask_buf;
+    int32_t mask_stride = dsc->mask_stride;
+    int32_t dest_stride = dsc->dest_stride;
+    uint8_t * dest_buf = dsc->dest_buf;
+
+    int32_t nibble_ofs = dsc->relative_area.x1 & 1;
+
+    const lv_color32_t * palette = get_active_palette();
+
+    lv_color32_t src_argb = lv_color_to_32(dsc->color, 0xFF);
+    uint8_t src_idx = quantize_to_palette(src_argb, palette);
+
+    /* Simple fill */
+    if(mask == NULL && opa >= LV_OPA_MAX) {
+        for(int32_t y = 0; y < h; y++) {
+            for(int32_t x = 0; x < w; x++) {
+                set_nibble(dest_buf, x + nibble_ofs, src_idx);
+            }
+            dest_buf = drawbuf_next_row(dest_buf, dest_stride);
+        }
+    }
+    /* Opacity only */
+    else if(mask == NULL && opa < LV_OPA_MAX) {
+        for(int32_t y = 0; y < h; y++) {
+            for(int32_t x = 0; x < w; x++) {
+                uint8_t cur_idx = get_nibble(dest_buf, x + nibble_ofs);
+                lv_color32_t mixed = blend_alpha_rgb(src_argb, palette[cur_idx], opa);
+                set_nibble(dest_buf, x + nibble_ofs, quantize_to_palette(mixed, palette));
+            }
+            dest_buf = drawbuf_next_row(dest_buf, dest_stride);
+        }
+    }
+    /* Masked with full opacity */
+    else if(mask && opa >= LV_OPA_MAX) {
+        for(int32_t y = 0; y < h; y++) {
+            for(int32_t x = 0; x < w; x++) {
+                uint8_t mask_val = mask[x];
+                if(mask_val == LV_OPA_TRANSP) continue;
+                if(mask_val == LV_OPA_COVER) {
+                    set_nibble(dest_buf, x + nibble_ofs, src_idx);
+                }
+                else {
+                    uint8_t cur_idx = get_nibble(dest_buf, x + nibble_ofs);
+                    lv_color32_t mixed = blend_alpha_rgb(src_argb, palette[cur_idx], mask_val);
+                    set_nibble(dest_buf, x + nibble_ofs, quantize_to_palette(mixed, palette));
+                }
+            }
+            dest_buf = drawbuf_next_row(dest_buf, dest_stride);
+            mask += mask_stride;
+        }
+    }
+    /* Masked with opacity */
+    else {
+        for(int32_t y = 0; y < h; y++) {
+            for(int32_t x = 0; x < w; x++) {
+                uint8_t mask_val = mask[x];
+                if(mask_val == LV_OPA_TRANSP) continue;
+                uint8_t cur_idx = get_nibble(dest_buf, x + nibble_ofs);
+                uint8_t blended_opa = LV_OPA_MIX2(mask_val, opa);
+                lv_color32_t mixed = blend_alpha_rgb(src_argb, palette[cur_idx], blended_opa);
+                set_nibble(dest_buf, x + nibble_ofs, quantize_to_palette(mixed, palette));
+            }
+            dest_buf = drawbuf_next_row(dest_buf, dest_stride);
+            mask += mask_stride;
+        }
+    }
+}
+
+void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_image_to_i4(lv_draw_sw_blend_image_dsc_t * dsc)
+{
+    switch(dsc->src_color_format) {
+#if LV_DRAW_SW_SUPPORT_RGB565
+        case LV_COLOR_FORMAT_RGB565:
+            rgb565_image_blend(dsc);
+            break;
+#endif
+#if LV_DRAW_SW_SUPPORT_RGB565_SWAPPED
+        case LV_COLOR_FORMAT_RGB565_SWAPPED:
+            rgb565_swapped_image_blend(dsc);
+            break;
+#endif
+#if LV_DRAW_SW_SUPPORT_RGB888
+        case LV_COLOR_FORMAT_RGB888:
+            rgb888_image_blend(dsc, 3);
+            break;
+#endif
+#if LV_DRAW_SW_SUPPORT_XRGB8888
+        case LV_COLOR_FORMAT_XRGB8888:
+            rgb888_image_blend(dsc, 4);
+            break;
+#endif
+#if LV_DRAW_SW_SUPPORT_ARGB8888
+        case LV_COLOR_FORMAT_ARGB8888:
+            argb8888_image_blend(dsc);
+            break;
+#endif
+#if LV_DRAW_SW_SUPPORT_L8
+        case LV_COLOR_FORMAT_L8:
+            l8_image_blend(dsc);
+            break;
+#endif
+#if LV_DRAW_SW_SUPPORT_AL88
+        case LV_COLOR_FORMAT_AL88:
+            al88_image_blend(dsc);
+            break;
+#endif
+        case LV_COLOR_FORMAT_I4:
+            i4_image_blend(dsc);
+            break;
+        default:
+            LV_LOG_WARN("Not supported source color format");
+            break;
+    }
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static void LV_ATTRIBUTE_FAST_MEM i4_image_blend(lv_draw_sw_blend_image_dsc_t * dsc)
+{
+    int32_t w = dsc->dest_w;
+    int32_t h = dsc->dest_h;
+    lv_opa_t opa = dsc->opa;
+    uint8_t * dest_buf_i4 = dsc->dest_buf;
+    int32_t dest_stride = dsc->dest_stride;
+    const uint8_t * src_buf_i4 = dsc->src_buf;
+    int32_t src_stride = dsc->src_stride;
+    const lv_opa_t * mask_buf = dsc->mask_buf;
+    int32_t mask_stride = dsc->mask_stride;
+
+    int32_t dest_nibble_ofs = dsc->relative_area.x1 & 1;
+    int32_t src_nibble_ofs = dsc->src_area.x1 & 1;
+
+    const lv_color32_t * palette = get_active_palette();
+
+    if(dsc->blend_mode == LV_BLEND_MODE_NORMAL) {
+        if(mask_buf == NULL && opa >= LV_OPA_MAX) {
+            /* I4 → I4: fast path, palette is identical, just copy nibbles. */
+            for(int32_t y = 0; y < h; y++) {
+                for(int32_t x = 0; x < w; x++) {
+                    set_nibble(dest_buf_i4, x + dest_nibble_ofs,
+                               get_nibble(src_buf_i4, x + src_nibble_ofs));
+                }
+                dest_buf_i4 = drawbuf_next_row(dest_buf_i4, dest_stride);
+                src_buf_i4 = drawbuf_next_row(src_buf_i4, src_stride);
+            }
+        }
+        else {
+            for(int32_t y = 0; y < h; y++) {
+                for(int32_t x = 0; x < w; x++) {
+                    uint8_t mask_val = mask_buf ? mask_buf[x] : LV_OPA_COVER;
+                    if(mask_val == LV_OPA_TRANSP) continue;
+                    uint8_t mix = LV_OPA_MIX2(mask_val, opa);
+                    if(mix == 0) continue;
+                    lv_color32_t src_c = palette[get_nibble(src_buf_i4, x + src_nibble_ofs)];
+                    if(mix >= LV_OPA_MAX) {
+                        set_nibble(dest_buf_i4, x + dest_nibble_ofs,
+                                   quantize_to_palette(src_c, palette));
+                    }
+                    else {
+                        uint8_t cur_idx = get_nibble(dest_buf_i4, x + dest_nibble_ofs);
+                        lv_color32_t mixed = blend_alpha_rgb(src_c, palette[cur_idx], mix);
+                        set_nibble(dest_buf_i4, x + dest_nibble_ofs,
+                                   quantize_to_palette(mixed, palette));
+                    }
+                }
+                dest_buf_i4 = drawbuf_next_row(dest_buf_i4, dest_stride);
+                src_buf_i4 = drawbuf_next_row(src_buf_i4, src_stride);
+                if(mask_buf) mask_buf += mask_stride;
+            }
+        }
+    }
+    else {
+        for(int32_t y = 0; y < h; y++) {
+            for(int32_t x = 0; x < w; x++) {
+                lv_color32_t src_c = palette[get_nibble(src_buf_i4, x + src_nibble_ofs)];
+                if(mask_buf == NULL) src_c.alpha = opa;
+                else src_c.alpha = LV_OPA_MIX2(mask_buf[x], opa);
+                blend_non_normal_pixel(dest_buf_i4, x + dest_nibble_ofs, src_c,
+                                       dsc->blend_mode, palette);
+            }
+            if(mask_buf) mask_buf += mask_stride;
+            dest_buf_i4 = drawbuf_next_row(dest_buf_i4, dest_stride);
+            src_buf_i4 = drawbuf_next_row(src_buf_i4, src_stride);
+        }
+    }
+}
+
+#if LV_DRAW_SW_SUPPORT_L8
+static void LV_ATTRIBUTE_FAST_MEM l8_image_blend(lv_draw_sw_blend_image_dsc_t * dsc)
+{
+    int32_t w = dsc->dest_w;
+    int32_t h = dsc->dest_h;
+    lv_opa_t opa = dsc->opa;
+    uint8_t * dest_buf_i4 = dsc->dest_buf;
+    int32_t dest_stride = dsc->dest_stride;
+    const uint8_t * src_buf_l8 = dsc->src_buf;
+    int32_t src_stride = dsc->src_stride;
+    const lv_opa_t * mask_buf = dsc->mask_buf;
+    int32_t mask_stride = dsc->mask_stride;
+
+    int32_t nibble_ofs = dsc->relative_area.x1 & 1;
+    const lv_color32_t * palette = get_active_palette();
+
+    if(dsc->blend_mode == LV_BLEND_MODE_NORMAL) {
+        for(int32_t y = 0; y < h; y++) {
+            for(int32_t x = 0; x < w; x++) {
+                uint8_t mask_val = mask_buf ? mask_buf[x] : LV_OPA_COVER;
+                if(mask_val == LV_OPA_TRANSP) continue;
+                uint8_t mix = LV_OPA_MIX2(mask_val, opa);
+                if(mix == 0) continue;
+
+                lv_color32_t src_c = {
+                    .blue = src_buf_l8[x],
+                    .green = src_buf_l8[x],
+                    .red = src_buf_l8[x],
+                    .alpha = 0xFF,
+                };
+                if(mix >= LV_OPA_MAX) {
+                    set_nibble(dest_buf_i4, x + nibble_ofs,
+                               quantize_to_palette(src_c, palette));
+                }
+                else {
+                    uint8_t cur_idx = get_nibble(dest_buf_i4, x + nibble_ofs);
+                    lv_color32_t mixed = blend_alpha_rgb(src_c, palette[cur_idx], mix);
+                    set_nibble(dest_buf_i4, x + nibble_ofs,
+                               quantize_to_palette(mixed, palette));
+                }
+            }
+            dest_buf_i4 = drawbuf_next_row(dest_buf_i4, dest_stride);
+            src_buf_l8 = drawbuf_next_row(src_buf_l8, src_stride);
+            if(mask_buf) mask_buf += mask_stride;
+        }
+    }
+    else {
+        for(int32_t y = 0; y < h; y++) {
+            for(int32_t x = 0; x < w; x++) {
+                lv_color32_t src_c = {
+                    .blue = src_buf_l8[x],
+                    .green = src_buf_l8[x],
+                    .red = src_buf_l8[x],
+                    .alpha = 0xFF,
+                };
+                if(mask_buf == NULL) src_c.alpha = opa;
+                else src_c.alpha = LV_OPA_MIX2(mask_buf[x], opa);
+                blend_non_normal_pixel(dest_buf_i4, x + nibble_ofs, src_c,
+                                       dsc->blend_mode, palette);
+            }
+            if(mask_buf) mask_buf += mask_stride;
+            dest_buf_i4 = drawbuf_next_row(dest_buf_i4, dest_stride);
+            src_buf_l8 = drawbuf_next_row(src_buf_l8, src_stride);
+        }
+    }
+}
+#endif
+
+#if LV_DRAW_SW_SUPPORT_AL88
+static void LV_ATTRIBUTE_FAST_MEM al88_image_blend(lv_draw_sw_blend_image_dsc_t * dsc)
+{
+    int32_t w = dsc->dest_w;
+    int32_t h = dsc->dest_h;
+    lv_opa_t opa = dsc->opa;
+    uint8_t * dest_buf_i4 = dsc->dest_buf;
+    int32_t dest_stride = dsc->dest_stride;
+    const lv_color16a_t * src_buf_al88 = dsc->src_buf;
+    int32_t src_stride = dsc->src_stride;
+    const lv_opa_t * mask_buf = dsc->mask_buf;
+    int32_t mask_stride = dsc->mask_stride;
+
+    int32_t nibble_ofs = dsc->relative_area.x1 & 1;
+    const lv_color32_t * palette = get_active_palette();
+
+    if(dsc->blend_mode == LV_BLEND_MODE_NORMAL) {
+        for(int32_t y = 0; y < h; y++) {
+            for(int32_t x = 0; x < w; x++) {
+                uint8_t mask_val = mask_buf ? mask_buf[x] : LV_OPA_COVER;
+                uint8_t mix = LV_OPA_MIX3(src_buf_al88[x].alpha, mask_val, opa);
+                if(mix == 0) continue;
+
+                lv_color32_t src_c = {
+                    .blue = src_buf_al88[x].lumi,
+                    .green = src_buf_al88[x].lumi,
+                    .red = src_buf_al88[x].lumi,
+                    .alpha = 0xFF,
+                };
+                if(mix >= LV_OPA_MAX) {
+                    set_nibble(dest_buf_i4, x + nibble_ofs,
+                               quantize_to_palette(src_c, palette));
+                }
+                else {
+                    uint8_t cur_idx = get_nibble(dest_buf_i4, x + nibble_ofs);
+                    lv_color32_t mixed = blend_alpha_rgb(src_c, palette[cur_idx], mix);
+                    set_nibble(dest_buf_i4, x + nibble_ofs,
+                               quantize_to_palette(mixed, palette));
+                }
+            }
+            dest_buf_i4 = drawbuf_next_row(dest_buf_i4, dest_stride);
+            src_buf_al88 = drawbuf_next_row(src_buf_al88, src_stride);
+            if(mask_buf) mask_buf += mask_stride;
+        }
+    }
+    else {
+        for(int32_t y = 0; y < h; y++) {
+            for(int32_t x = 0; x < w; x++) {
+                lv_color32_t src_c = {
+                    .blue = src_buf_al88[x].lumi,
+                    .green = src_buf_al88[x].lumi,
+                    .red = src_buf_al88[x].lumi,
+                    .alpha = 0xFF,
+                };
+                if(mask_buf == NULL) src_c.alpha = LV_OPA_MIX2(src_buf_al88[x].alpha, opa);
+                else src_c.alpha = LV_OPA_MIX3(src_buf_al88[x].alpha, mask_buf[x], opa);
+                blend_non_normal_pixel(dest_buf_i4, x + nibble_ofs, src_c,
+                                       dsc->blend_mode, palette);
+            }
+            if(mask_buf) mask_buf += mask_stride;
+            dest_buf_i4 = drawbuf_next_row(dest_buf_i4, dest_stride);
+            src_buf_al88 = drawbuf_next_row(src_buf_al88, src_stride);
+        }
+    }
+}
+#endif
+
+#if LV_DRAW_SW_SUPPORT_ARGB8888
+static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_dsc_t * dsc)
+{
+    int32_t w = dsc->dest_w;
+    int32_t h = dsc->dest_h;
+    lv_opa_t opa = dsc->opa;
+    uint8_t * dest_buf_i4 = dsc->dest_buf;
+    int32_t dest_stride = dsc->dest_stride;
+    const lv_color32_t * src_buf_c32 = dsc->src_buf;
+    int32_t src_stride = dsc->src_stride;
+    const lv_opa_t * mask_buf = dsc->mask_buf;
+    int32_t mask_stride = dsc->mask_stride;
+
+    int32_t nibble_ofs = dsc->relative_area.x1 & 1;
+    const lv_color32_t * palette = get_active_palette();
+
+    if(dsc->blend_mode == LV_BLEND_MODE_NORMAL) {
+        for(int32_t y = 0; y < h; y++) {
+            for(int32_t x = 0; x < w; x++) {
+                uint8_t mask_val = mask_buf ? mask_buf[x] : LV_OPA_COVER;
+                uint8_t mix = LV_OPA_MIX3(src_buf_c32[x].alpha, mask_val, opa);
+                if(mix == 0) continue;
+
+                lv_color32_t src_c = src_buf_c32[x];
+                src_c.alpha = 0xFF;
+                if(mix >= LV_OPA_MAX) {
+                    set_nibble(dest_buf_i4, x + nibble_ofs,
+                               quantize_to_palette(src_c, palette));
+                }
+                else {
+                    uint8_t cur_idx = get_nibble(dest_buf_i4, x + nibble_ofs);
+                    lv_color32_t mixed = blend_alpha_rgb(src_c, palette[cur_idx], mix);
+                    set_nibble(dest_buf_i4, x + nibble_ofs,
+                               quantize_to_palette(mixed, palette));
+                }
+            }
+            dest_buf_i4 = drawbuf_next_row(dest_buf_i4, dest_stride);
+            src_buf_c32 = drawbuf_next_row(src_buf_c32, src_stride);
+            if(mask_buf) mask_buf += mask_stride;
+        }
+    }
+    else {
+        for(int32_t y = 0; y < h; y++) {
+            for(int32_t x = 0; x < w; x++) {
+                lv_color32_t src_c = src_buf_c32[x];
+                if(mask_buf == NULL) src_c.alpha = LV_OPA_MIX2(src_c.alpha, opa);
+                else src_c.alpha = LV_OPA_MIX3(src_c.alpha, mask_buf[x], opa);
+                blend_non_normal_pixel(dest_buf_i4, x + nibble_ofs, src_c,
+                                       dsc->blend_mode, palette);
+            }
+            if(mask_buf) mask_buf += mask_stride;
+            dest_buf_i4 = drawbuf_next_row(dest_buf_i4, dest_stride);
+            src_buf_c32 = drawbuf_next_row(src_buf_c32, src_stride);
+        }
+    }
+}
+#endif
+
+#if LV_DRAW_SW_SUPPORT_RGB888 || LV_DRAW_SW_SUPPORT_XRGB8888
+static void LV_ATTRIBUTE_FAST_MEM rgb888_image_blend(lv_draw_sw_blend_image_dsc_t * dsc,
+                                                     const uint8_t src_px_size)
+{
+    int32_t w = dsc->dest_w;
+    int32_t h = dsc->dest_h;
+    lv_opa_t opa = dsc->opa;
+    uint8_t * dest_buf_i4 = dsc->dest_buf;
+    int32_t dest_stride = dsc->dest_stride;
+    const uint8_t * src_buf_rgb888 = dsc->src_buf;
+    int32_t src_stride = dsc->src_stride;
+    const lv_opa_t * mask_buf = dsc->mask_buf;
+    int32_t mask_stride = dsc->mask_stride;
+
+    int32_t nibble_ofs = dsc->relative_area.x1 & 1;
+    const lv_color32_t * palette = get_active_palette();
+
+    if(dsc->blend_mode == LV_BLEND_MODE_NORMAL) {
+        for(int32_t y = 0; y < h; y++) {
+            int32_t src_x;
+            int32_t dest_x;
+            for(dest_x = 0, src_x = 0; dest_x < w; dest_x++, src_x += src_px_size) {
+                uint8_t mask_val = mask_buf ? mask_buf[dest_x] : LV_OPA_COVER;
+                if(mask_val == LV_OPA_TRANSP) continue;
+                uint8_t mix = LV_OPA_MIX2(mask_val, opa);
+                if(mix == 0) continue;
+
+                lv_color32_t src_c = {
+                    .blue = src_buf_rgb888[src_x + 0],
+                    .green = src_buf_rgb888[src_x + 1],
+                    .red = src_buf_rgb888[src_x + 2],
+                    .alpha = 0xFF,
+                };
+                if(mix >= LV_OPA_MAX) {
+                    set_nibble(dest_buf_i4, dest_x + nibble_ofs,
+                               quantize_to_palette(src_c, palette));
+                }
+                else {
+                    uint8_t cur_idx = get_nibble(dest_buf_i4, dest_x + nibble_ofs);
+                    lv_color32_t mixed = blend_alpha_rgb(src_c, palette[cur_idx], mix);
+                    set_nibble(dest_buf_i4, dest_x + nibble_ofs,
+                               quantize_to_palette(mixed, palette));
+                }
+            }
+            dest_buf_i4 = drawbuf_next_row(dest_buf_i4, dest_stride);
+            src_buf_rgb888 = drawbuf_next_row(src_buf_rgb888, src_stride);
+            if(mask_buf) mask_buf += mask_stride;
+        }
+    }
+    else {
+        for(int32_t y = 0; y < h; y++) {
+            int32_t src_x;
+            int32_t dest_x;
+            for(dest_x = 0, src_x = 0; dest_x < w; dest_x++, src_x += src_px_size) {
+                lv_color32_t src_c = {
+                    .blue = src_buf_rgb888[src_x + 0],
+                    .green = src_buf_rgb888[src_x + 1],
+                    .red = src_buf_rgb888[src_x + 2],
+                    .alpha = 0xFF,
+                };
+                if(mask_buf == NULL) src_c.alpha = opa;
+                else src_c.alpha = LV_OPA_MIX2(mask_buf[dest_x], opa);
+                blend_non_normal_pixel(dest_buf_i4, dest_x + nibble_ofs, src_c,
+                                       dsc->blend_mode, palette);
+            }
+            if(mask_buf) mask_buf += mask_stride;
+            dest_buf_i4 = drawbuf_next_row(dest_buf_i4, dest_stride);
+            src_buf_rgb888 = drawbuf_next_row(src_buf_rgb888, src_stride);
+        }
+    }
+}
+#endif
+
+#if LV_DRAW_SW_SUPPORT_RGB565
+static void LV_ATTRIBUTE_FAST_MEM rgb565_image_blend(lv_draw_sw_blend_image_dsc_t * dsc)
+{
+    int32_t w = dsc->dest_w;
+    int32_t h = dsc->dest_h;
+    lv_opa_t opa = dsc->opa;
+    uint8_t * dest_buf_i4 = dsc->dest_buf;
+    int32_t dest_stride = dsc->dest_stride;
+    const lv_color16_t * src_buf_c16 = (const lv_color16_t *)dsc->src_buf;
+    int32_t src_stride = dsc->src_stride;
+    const lv_opa_t * mask_buf = dsc->mask_buf;
+    int32_t mask_stride = dsc->mask_stride;
+
+    int32_t nibble_ofs = dsc->relative_area.x1 & 1;
+    const lv_color32_t * palette = get_active_palette();
+
+    if(dsc->blend_mode == LV_BLEND_MODE_NORMAL) {
+        for(int32_t y = 0; y < h; y++) {
+            for(int32_t x = 0; x < w; x++) {
+                uint8_t mask_val = mask_buf ? mask_buf[x] : LV_OPA_COVER;
+                if(mask_val == LV_OPA_TRANSP) continue;
+                uint8_t mix = LV_OPA_MIX2(mask_val, opa);
+                if(mix == 0) continue;
+
+                lv_color32_t src_c = {
+                    .blue = (uint8_t)((src_buf_c16[x].blue * 2106) >> 8),
+                    .green = (uint8_t)((src_buf_c16[x].green * 1037) >> 8),
+                    .red = (uint8_t)((src_buf_c16[x].red * 2106) >> 8),
+                    .alpha = 0xFF,
+                };
+                if(mix >= LV_OPA_MAX) {
+                    set_nibble(dest_buf_i4, x + nibble_ofs,
+                               quantize_to_palette(src_c, palette));
+                }
+                else {
+                    uint8_t cur_idx = get_nibble(dest_buf_i4, x + nibble_ofs);
+                    lv_color32_t mixed = blend_alpha_rgb(src_c, palette[cur_idx], mix);
+                    set_nibble(dest_buf_i4, x + nibble_ofs,
+                               quantize_to_palette(mixed, palette));
+                }
+            }
+            dest_buf_i4 = drawbuf_next_row(dest_buf_i4, dest_stride);
+            src_buf_c16 = drawbuf_next_row(src_buf_c16, src_stride);
+            if(mask_buf) mask_buf += mask_stride;
+        }
+    }
+    else {
+        for(int32_t y = 0; y < h; y++) {
+            for(int32_t x = 0; x < w; x++) {
+                lv_color32_t src_c = {
+                    .blue = (uint8_t)((src_buf_c16[x].blue * 2106) >> 8),
+                    .green = (uint8_t)((src_buf_c16[x].green * 1037) >> 8),
+                    .red = (uint8_t)((src_buf_c16[x].red * 2106) >> 8),
+                    .alpha = 0xFF,
+                };
+                if(mask_buf == NULL) src_c.alpha = opa;
+                else src_c.alpha = LV_OPA_MIX2(mask_buf[x], opa);
+                blend_non_normal_pixel(dest_buf_i4, x + nibble_ofs, src_c,
+                                       dsc->blend_mode, palette);
+            }
+            if(mask_buf) mask_buf += mask_stride;
+            dest_buf_i4 = drawbuf_next_row(dest_buf_i4, dest_stride);
+            src_buf_c16 = drawbuf_next_row(src_buf_c16, src_stride);
+        }
+    }
+}
+#endif
+
+#if LV_DRAW_SW_SUPPORT_RGB565_SWAPPED
+static void LV_ATTRIBUTE_FAST_MEM rgb565_swapped_image_blend(lv_draw_sw_blend_image_dsc_t * dsc)
+{
+    int32_t w = dsc->dest_w;
+    int32_t h = dsc->dest_h;
+    lv_opa_t opa = dsc->opa;
+    uint8_t * dest_buf_i4 = dsc->dest_buf;
+    int32_t dest_stride = dsc->dest_stride;
+    const uint16_t * src_buf_u16 = dsc->src_buf;
+    int32_t src_stride = dsc->src_stride;
+    const lv_opa_t * mask_buf = dsc->mask_buf;
+    int32_t mask_stride = dsc->mask_stride;
+
+    int32_t nibble_ofs = dsc->relative_area.x1 & 1;
+    const lv_color32_t * palette = get_active_palette();
+
+    for(int32_t y = 0; y < h; y++) {
+        for(int32_t x = 0; x < w; x++) {
+            lv_color16_t px = lv_color16_from_u16(lv_color_swap_16(src_buf_u16[x]));
+            lv_color32_t src_c = {
+                .blue = (uint8_t)((px.blue * 2106) >> 8),
+                .green = (uint8_t)((px.green * 1037) >> 8),
+                .red = (uint8_t)((px.red * 2106) >> 8),
+                .alpha = 0xFF,
+            };
+
+            if(dsc->blend_mode == LV_BLEND_MODE_NORMAL) {
+                uint8_t mask_val = mask_buf ? mask_buf[x] : LV_OPA_COVER;
+                if(mask_val == LV_OPA_TRANSP) continue;
+                uint8_t mix = LV_OPA_MIX2(mask_val, opa);
+                if(mix == 0) continue;
+                if(mix >= LV_OPA_MAX) {
+                    set_nibble(dest_buf_i4, x + nibble_ofs,
+                               quantize_to_palette(src_c, palette));
+                }
+                else {
+                    uint8_t cur_idx = get_nibble(dest_buf_i4, x + nibble_ofs);
+                    lv_color32_t mixed = blend_alpha_rgb(src_c, palette[cur_idx], mix);
+                    set_nibble(dest_buf_i4, x + nibble_ofs,
+                               quantize_to_palette(mixed, palette));
+                }
+            }
+            else {
+                if(mask_buf == NULL) src_c.alpha = opa;
+                else src_c.alpha = LV_OPA_MIX2(mask_buf[x], opa);
+                blend_non_normal_pixel(dest_buf_i4, x + nibble_ofs, src_c,
+                                       dsc->blend_mode, palette);
+            }
+        }
+        if(mask_buf) mask_buf += mask_stride;
+        dest_buf_i4 = drawbuf_next_row(dest_buf_i4, dest_stride);
+        src_buf_u16 = drawbuf_next_row(src_buf_u16, src_stride);
+    }
+}
+#endif
+
+static inline void LV_ATTRIBUTE_FAST_MEM blend_non_normal_pixel(uint8_t * dest_buf, int32_t dest_x,
+                                                                lv_color32_t src,
+                                                                lv_blend_mode_t mode,
+                                                                const lv_color32_t * palette)
+{
+    uint8_t cur_idx = get_nibble(dest_buf, dest_x);
+    lv_color32_t dst = palette[cur_idx];
+    lv_color32_t res = dst;
+
+    switch(mode) {
+        case LV_BLEND_MODE_ADDITIVE:
+            res.red = (uint8_t)LV_MIN((int32_t)dst.red + src.red, 255);
+            res.green = (uint8_t)LV_MIN((int32_t)dst.green + src.green, 255);
+            res.blue = (uint8_t)LV_MIN((int32_t)dst.blue + src.blue, 255);
+            break;
+        case LV_BLEND_MODE_SUBTRACTIVE:
+            res.red = (uint8_t)LV_MAX((int32_t)dst.red - src.red, 0);
+            res.green = (uint8_t)LV_MAX((int32_t)dst.green - src.green, 0);
+            res.blue = (uint8_t)LV_MAX((int32_t)dst.blue - src.blue, 0);
+            break;
+        case LV_BLEND_MODE_MULTIPLY:
+            res.red = (uint8_t)((dst.red * src.red) >> 8);
+            res.green = (uint8_t)((dst.green * src.green) >> 8);
+            res.blue = (uint8_t)((dst.blue * src.blue) >> 8);
+            break;
+        case LV_BLEND_MODE_DIFFERENCE:
+            res.red = (uint8_t)LV_ABS((int32_t)dst.red - src.red);
+            res.green = (uint8_t)LV_ABS((int32_t)dst.green - src.green);
+            res.blue = (uint8_t)LV_ABS((int32_t)dst.blue - src.blue);
+            break;
+        default:
+            LV_LOG_WARN("Not supported blend mode: %d", mode);
+            return;
+    }
+    res.alpha = 0xFF;
+
+    /*Mix the post-blend result back into the destination by src.alpha.*/
+    lv_color32_t mixed = (src.alpha >= LV_OPA_MAX) ? res : blend_alpha_rgb(res, dst, src.alpha);
+    set_nibble(dest_buf, dest_x, quantize_to_palette(mixed, palette));
+}
+
+static inline lv_color32_t blend_alpha_rgb(lv_color32_t src, lv_color32_t dst, uint8_t mix)
+{
+    /*src over dst, mix is the effective opacity (0..255).*/
+    lv_color32_t out;
+    uint8_t inv = 255 - mix;
+    out.red = (uint8_t)(((uint32_t)src.red * mix + (uint32_t)dst.red * inv) >> 8);
+    out.green = (uint8_t)(((uint32_t)src.green * mix + (uint32_t)dst.green * inv) >> 8);
+    out.blue = (uint8_t)(((uint32_t)src.blue * mix + (uint32_t)dst.blue * inv) >> 8);
+    out.alpha = 0xFF;
+    return out;
+}
+
+static inline uint8_t LV_ATTRIBUTE_FAST_MEM quantize_to_palette(lv_color32_t c,
+                                                                const lv_color32_t * palette)
+{
+    uint32_t best_dist = 0xFFFFFFFFu;
+    uint8_t best_idx = 0;
+    for(uint8_t i = 0; i < I4_PALETTE_SIZE; i++) {
+        int32_t dr = (int32_t)c.red - palette[i].red;
+        int32_t dg = (int32_t)c.green - palette[i].green;
+        int32_t db = (int32_t)c.blue - palette[i].blue;
+        uint32_t d = (uint32_t)(dr * dr + dg * dg + db * db);
+        if(d < best_dist) {
+            best_dist = d;
+            best_idx = i;
+            if(d == 0) break;
+        }
+    }
+    return best_idx;
+}
+
+static inline const lv_color32_t * get_active_palette(void)
+{
+    lv_display_t * disp = lv_refr_get_disp_refreshing();
+    if(disp != NULL) {
+        const lv_color32_t * p = lv_display_get_palette(disp);
+        uint32_t n = lv_display_get_palette_size(disp);
+        if(p != NULL && n >= I4_PALETTE_SIZE) return p;
+    }
+    return default_grayscale_palette;
+}
+
+static inline void * LV_ATTRIBUTE_FAST_MEM drawbuf_next_row(const void * buf, uint32_t stride)
+{
+    return (void *)((uint8_t *)buf + stride);
+}
+
+static inline void LV_ATTRIBUTE_FAST_MEM set_nibble(uint8_t * buf, int32_t idx, uint8_t val)
+{
+    uint8_t * b = &buf[idx >> 1];
+    if(idx & 1) {
+        *b = (uint8_t)((*b & 0xF0) | (val & 0x0F));
+    }
+    else {
+        *b = (uint8_t)((*b & 0x0F) | ((val & 0x0F) << 4));
+    }
+}
+
+static inline uint8_t LV_ATTRIBUTE_FAST_MEM get_nibble(const uint8_t * buf, int32_t idx)
+{
+    uint8_t b = buf[idx >> 1];
+    return (idx & 1) ? (uint8_t)(b & 0x0F) : (uint8_t)(b >> 4);
+}
+
+#if LV_DRAW_SW_SUPPORT_RGB565_SWAPPED
+static inline lv_color16_t LV_ATTRIBUTE_FAST_MEM lv_color16_from_u16(uint16_t raw)
+{
+    lv_color16_t c;
+    c.red = (raw >> 11) & 0x1F;
+    c.green = (raw >> 5) & 0x3F;
+    c.blue = raw & 0x1F;
+    return c;
+}
+#endif
+
+#endif /*LV_DRAW_SW_SUPPORT_I4*/
+
+#endif /*LV_USE_DRAW_SW*/

--- a/src/draw/sw/blend/lv_draw_sw_blend_to_i4.h
+++ b/src/draw/sw/blend/lv_draw_sw_blend_to_i4.h
@@ -1,0 +1,65 @@
+/**
+ * @file lv_draw_sw_blend_to_i4.h
+ *
+ */
+
+#ifndef LV_DRAW_SW_BLEND_TO_I4_H
+#define LV_DRAW_SW_BLEND_TO_I4_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../lv_draw_sw.h"
+#if LV_USE_DRAW_SW
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**
+ * Solid color fill into an I4 (4-bit indexed) destination buffer.
+ *
+ * Pixel packing in the destination follows the wire convention used by
+ * indexed-color AMOLED panels (e.g. CO5300): two pixels per byte, the
+ * lower-x pixel in the upper nibble (D[7:4]), the higher-x pixel in the
+ * lower nibble (D[3:0]). Stride is in bytes; for an N-pixel-wide row
+ * the natural stride is `(N + 1) / 2`.
+ *
+ * The palette used to quantize `dsc->color` is taken from the active
+ * display via `lv_display_get_palette()`. If none is set, a default
+ * 16-entry grayscale palette is used.
+ */
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_sw_blend_color_to_i4(lv_draw_sw_blend_fill_dsc_t * dsc);
+
+/**
+ * Image (per-pixel) blend into an I4 destination buffer. Supports the
+ * same set of source color formats as the I1/L8 blenders. Non-normal
+ * blend modes (additive / subtractive / multiply / difference) round-trip
+ * each destination pixel through the palette: index → palette RGB → blend
+ * → quantize back.
+ */
+void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_sw_blend_image_to_i4(lv_draw_sw_blend_image_dsc_t * dsc);
+
+/**********************
+ *      MACROS
+ **********************/
+
+#endif /*LV_USE_DRAW_SW*/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_DRAW_SW_BLEND_TO_I4_H*/

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -552,6 +552,17 @@
             #define LV_DRAW_SW_SUPPORT_I1           1
         #endif
     #endif
+    #ifndef LV_DRAW_SW_SUPPORT_I4
+        #ifdef LV_KCONFIG_PRESENT
+            #ifdef CONFIG_LV_DRAW_SW_SUPPORT_I4
+                #define LV_DRAW_SW_SUPPORT_I4 CONFIG_LV_DRAW_SW_SUPPORT_I4
+            #else
+                #define LV_DRAW_SW_SUPPORT_I4 0
+            #endif
+        #else
+            #define LV_DRAW_SW_SUPPORT_I4           1
+        #endif
+    #endif
 
     /* The threshold of the luminance to consider a pixel as
      * active in indexed color format */

--- a/tests/src/test_cases/draw/test_draw_sw_blend_to_i4.c
+++ b/tests/src/test_cases/draw/test_draw_sw_blend_to_i4.c
@@ -1,0 +1,358 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+#include "../../lvgl_private.h"
+
+#include "unity/unity.h"
+
+#if LV_DRAW_SW_SUPPORT_I4
+
+#include "src/draw/sw/blend/lv_draw_sw_blend_to_i4.h"
+
+/*-----------------------------------------------------------------------
+ * Test palette: 16 entries chosen so each entry is uniquely identifiable
+ * in pixel-exact comparisons. Index N has R=N*16, G=N*16, B=N*16
+ * — i.e. a strictly monotonic grayscale ramp identical to the default
+ * but explicit so the tests don't depend on the blender's fallback.
+ *---------------------------------------------------------------------*/
+static const lv_color32_t s_test_palette[16] = {
+    {.blue = 0x00, .green = 0x00, .red = 0x00, .alpha = 0xFF},
+    {.blue = 0x10, .green = 0x10, .red = 0x10, .alpha = 0xFF},
+    {.blue = 0x20, .green = 0x20, .red = 0x20, .alpha = 0xFF},
+    {.blue = 0x30, .green = 0x30, .red = 0x30, .alpha = 0xFF},
+    {.blue = 0x40, .green = 0x40, .red = 0x40, .alpha = 0xFF},
+    {.blue = 0x50, .green = 0x50, .red = 0x50, .alpha = 0xFF},
+    {.blue = 0x60, .green = 0x60, .red = 0x60, .alpha = 0xFF},
+    {.blue = 0x70, .green = 0x70, .red = 0x70, .alpha = 0xFF},
+    {.blue = 0x80, .green = 0x80, .red = 0x80, .alpha = 0xFF},
+    {.blue = 0x90, .green = 0x90, .red = 0x90, .alpha = 0xFF},
+    {.blue = 0xA0, .green = 0xA0, .red = 0xA0, .alpha = 0xFF},
+    {.blue = 0xB0, .green = 0xB0, .red = 0xB0, .alpha = 0xFF},
+    {.blue = 0xC0, .green = 0xC0, .red = 0xC0, .alpha = 0xFF},
+    {.blue = 0xD0, .green = 0xD0, .red = 0xD0, .alpha = 0xFF},
+    {.blue = 0xE0, .green = 0xE0, .red = 0xE0, .alpha = 0xFF},
+    {.blue = 0xFF, .green = 0xFF, .red = 0xFF, .alpha = 0xFF},
+};
+
+/*-----------------------------------------------------------------------
+ * For nibble-level tests we need the active display to expose the test
+ * palette. setUp installs it; tearDown clears it. The blender pulls the
+ * palette via lv_refr_get_disp_refreshing(); to make that path return
+ * our display we wrap each test in lv_refr_set_disp_refreshing().
+ *---------------------------------------------------------------------*/
+
+void setUp(void)
+{
+    lv_display_t * disp = lv_display_get_default();
+    lv_display_set_palette(disp, s_test_palette, 16);
+    lv_refr_set_disp_refreshing(disp);
+}
+
+void tearDown(void)
+{
+    lv_display_t * disp = lv_display_get_default();
+    lv_display_set_palette(disp, NULL, 0);
+    lv_refr_set_disp_refreshing(NULL);
+}
+
+/* Pack two nibbles into one byte (high in upper half, low in lower half). */
+static inline uint8_t nib_pair(uint8_t hi, uint8_t lo)
+{
+    return (uint8_t)(((hi & 0x0F) << 4) | (lo & 0x0F));
+}
+
+/*-----------------------------------------------------------------------
+ * Solid fill of all 16 indices into a 16-pixel-wide row, with `dest_x` and
+ * stride aligned to a byte boundary. Each pair of pixels packs into one
+ * byte (high nibble = lower-x pixel).
+ *---------------------------------------------------------------------*/
+void test_draw_sw_blend_color_to_i4_solid_fill_all_indices(void)
+{
+    lv_color32_t pal[16];
+    lv_memcpy(pal, s_test_palette, sizeof(pal));
+
+    /* For each index, fill a 1-pixel-wide column at x=N and verify the
+     * resulting nibble. Use an 8-pixel-wide / 1-row-high buffer so the
+     * stride is 4 bytes. */
+    for(uint8_t target = 0; target < 16; target++) {
+        uint8_t buf[4] = {0};
+        lv_draw_sw_blend_fill_dsc_t dsc = {0};
+        dsc.dest_buf = buf;
+        dsc.dest_w = 8;
+        dsc.dest_h = 1;
+        dsc.dest_stride = 4;
+        dsc.opa = LV_OPA_COVER;
+        dsc.color = (lv_color_t){
+            .blue = pal[target].blue,
+            .green = pal[target].green,
+            .red = pal[target].red,
+        };
+        dsc.relative_area.x1 = 0;
+        dsc.relative_area.y1 = 0;
+        dsc.relative_area.x2 = 7;
+        dsc.relative_area.y2 = 0;
+
+        lv_draw_sw_blend_color_to_i4(&dsc);
+
+        uint8_t expected = nib_pair(target, target);
+        for(int i = 0; i < 4; i++) {
+            TEST_ASSERT_EQUAL_HEX8_MESSAGE(expected, buf[i],
+                                           "solid fill produced wrong byte");
+        }
+    }
+}
+
+/*-----------------------------------------------------------------------
+ * Odd-x start: x1=1 (start in the lower nibble of byte 0). The upper
+ * nibble of byte 0 must be left untouched.
+ *---------------------------------------------------------------------*/
+void test_draw_sw_blend_color_to_i4_odd_dest_x(void)
+{
+    /* Pre-fill with a sentinel pattern. */
+    uint8_t buf[3] = {0xAB, 0xCD, 0xEF};
+
+    lv_draw_sw_blend_fill_dsc_t dsc = {0};
+    dsc.dest_buf = buf;        /*Already at byte 0 — caller adjusted for odd x.*/
+    dsc.dest_w = 5;            /*5 pixels: lower nibble of [0], both of [1], upper nibble of [2].*/
+    dsc.dest_h = 1;
+    dsc.dest_stride = 3;
+    dsc.opa = LV_OPA_COVER;
+    dsc.color = (lv_color_t){.blue = 0xFF, .green = 0xFF, .red = 0xFF};
+    dsc.relative_area.x1 = 1;  /*Odd start.*/
+    dsc.relative_area.y1 = 0;
+    dsc.relative_area.x2 = 5;
+    dsc.relative_area.y2 = 0;
+
+    lv_draw_sw_blend_color_to_i4(&dsc);
+
+    /* Expected:
+     *   byte[0] upper nibble = 0xA (untouched), lower = 0xF (white-ish, idx 15)
+     *   byte[1] = 0xFF
+     *   byte[2] upper nibble = 0xF, lower = 0xF (untouched)
+     */
+    TEST_ASSERT_EQUAL_HEX8(0xAF, buf[0]);
+    TEST_ASSERT_EQUAL_HEX8(0xFF, buf[1]);
+    TEST_ASSERT_EQUAL_HEX8(0xFF, buf[2]);
+}
+
+/*-----------------------------------------------------------------------
+ * Odd width with even start: 7 pixels written into 4 bytes; the lower
+ * nibble of the last byte must be untouched.
+ *---------------------------------------------------------------------*/
+void test_draw_sw_blend_color_to_i4_odd_width(void)
+{
+    uint8_t buf[4] = {0xAA, 0xBB, 0xCC, 0xDD};
+
+    lv_draw_sw_blend_fill_dsc_t dsc = {0};
+    dsc.dest_buf = buf;
+    dsc.dest_w = 7;
+    dsc.dest_h = 1;
+    dsc.dest_stride = 4;
+    dsc.opa = LV_OPA_COVER;
+    dsc.color = (lv_color_t){.blue = 0x00, .green = 0x00, .red = 0x00};
+    dsc.relative_area.x1 = 0;
+    dsc.relative_area.y1 = 0;
+    dsc.relative_area.x2 = 6;
+    dsc.relative_area.y2 = 0;
+
+    lv_draw_sw_blend_color_to_i4(&dsc);
+
+    /* idx 0 = black → bytes [0..2] = 0x00, byte[3] upper = 0, lower = 0xD untouched */
+    TEST_ASSERT_EQUAL_HEX8(0x00, buf[0]);
+    TEST_ASSERT_EQUAL_HEX8(0x00, buf[1]);
+    TEST_ASSERT_EQUAL_HEX8(0x00, buf[2]);
+    TEST_ASSERT_EQUAL_HEX8(0x0D, buf[3]);
+}
+
+/*-----------------------------------------------------------------------
+ * Odd start AND odd width — both ends partial.
+ * Range x∈[1..5], 5 pixels. Buffer pre-filled to verify untouched halves.
+ *---------------------------------------------------------------------*/
+void test_draw_sw_blend_color_to_i4_odd_both(void)
+{
+    uint8_t buf[3] = {0x12, 0x34, 0x56};
+
+    lv_draw_sw_blend_fill_dsc_t dsc = {0};
+    dsc.dest_buf = buf;
+    dsc.dest_w = 5;
+    dsc.dest_h = 1;
+    dsc.dest_stride = 3;
+    dsc.opa = LV_OPA_COVER;
+    /* index 8 = mid-gray (R=G=B=0x80) */
+    dsc.color = (lv_color_t){.blue = 0x80, .green = 0x80, .red = 0x80};
+    dsc.relative_area.x1 = 1;
+    dsc.relative_area.y1 = 0;
+    dsc.relative_area.x2 = 5;
+    dsc.relative_area.y2 = 0;
+
+    lv_draw_sw_blend_color_to_i4(&dsc);
+
+    TEST_ASSERT_EQUAL_HEX8(0x18, buf[0]); /*upper: 0x1 untouched, lower: 0x8 written*/
+    TEST_ASSERT_EQUAL_HEX8(0x88, buf[1]);
+    TEST_ASSERT_EQUAL_HEX8(0x86, buf[2]); /*upper: 0x8 written, lower: 0x6 untouched*/
+}
+
+/*-----------------------------------------------------------------------
+ * Image blend from RGB565 source with the test palette. The grayscale
+ * palette + monotonic ramp means each RGB565 luminance maps to a known
+ * index. Verifies the full quantize path on the inner loop.
+ *---------------------------------------------------------------------*/
+void test_draw_sw_blend_image_to_i4_from_rgb565(void)
+{
+    /* Source: 4 RGB565 pixels with luminance close to palette entries
+     * 0, 4, 8, 15. */
+    static const lv_color16_t src_px[4] = {
+        {.red = 0x00, .green = 0x00, .blue = 0x00},  /*black ~ idx 0*/
+        {.red = 0x08, .green = 0x10, .blue = 0x08},  /*~0x40 gray ~ idx 4*/
+        {.red = 0x10, .green = 0x20, .blue = 0x10},  /*~0x80 gray ~ idx 8*/
+        {.red = 0x1F, .green = 0x3F, .blue = 0x1F},  /*white ~ idx 15*/
+    };
+
+    uint8_t dest[2] = {0, 0};
+    lv_draw_sw_blend_image_dsc_t dsc = {0};
+    dsc.dest_buf = dest;
+    dsc.dest_w = 4;
+    dsc.dest_h = 1;
+    dsc.dest_stride = 2;
+    dsc.src_buf = src_px;
+    dsc.src_stride = sizeof(src_px);
+    dsc.src_color_format = LV_COLOR_FORMAT_RGB565;
+    dsc.opa = LV_OPA_COVER;
+    dsc.blend_mode = LV_BLEND_MODE_NORMAL;
+    dsc.relative_area.x1 = 0;
+    dsc.relative_area.y1 = 0;
+    dsc.relative_area.x2 = 3;
+    dsc.relative_area.y2 = 0;
+    dsc.src_area.x1 = 0;
+    dsc.src_area.y1 = 0;
+    dsc.src_area.x2 = 3;
+    dsc.src_area.y2 = 0;
+
+    lv_draw_sw_blend_image_to_i4(&dsc);
+
+    /* Index 0 / 4 in byte[0], 8 / 15 in byte[1]. */
+    TEST_ASSERT_EQUAL_HEX8(nib_pair(0x0, 0x4), dest[0]);
+    TEST_ASSERT_EQUAL_HEX8(nib_pair(0x8, 0xF), dest[1]);
+}
+
+/*-----------------------------------------------------------------------
+ * Non-normal blend modes round-trip through the palette: dst index →
+ * palette RGB → blend → quantize. Verify ADDITIVE (dst+src clamped) and
+ * MULTIPLY (dst*src/255) produce the expected indices.
+ *---------------------------------------------------------------------*/
+void test_draw_sw_blend_image_to_i4_additive(void)
+{
+    /* Pre-fill destination with index 4 in both nibbles of byte[0]. */
+    uint8_t dest[1] = {nib_pair(0x4, 0x4)};
+
+    /* Source: ARGB8888, R=G=B=0x40, alpha=0xFF.
+     * Additive: dst(0x40) + src(0x40) = 0x80 → idx 8. */
+    static const lv_color32_t src[2] = {
+        {.blue = 0x40, .green = 0x40, .red = 0x40, .alpha = 0xFF},
+        {.blue = 0x40, .green = 0x40, .red = 0x40, .alpha = 0xFF},
+    };
+
+    lv_draw_sw_blend_image_dsc_t dsc = {0};
+    dsc.dest_buf = dest;
+    dsc.dest_w = 2;
+    dsc.dest_h = 1;
+    dsc.dest_stride = 1;
+    dsc.src_buf = src;
+    dsc.src_stride = sizeof(src);
+    dsc.src_color_format = LV_COLOR_FORMAT_ARGB8888;
+    dsc.opa = LV_OPA_COVER;
+    dsc.blend_mode = LV_BLEND_MODE_ADDITIVE;
+    dsc.relative_area.x1 = 0;
+    dsc.relative_area.y1 = 0;
+    dsc.relative_area.x2 = 1;
+    dsc.relative_area.y2 = 0;
+    dsc.src_area.x1 = 0;
+    dsc.src_area.y1 = 0;
+    dsc.src_area.x2 = 1;
+    dsc.src_area.y2 = 0;
+
+    lv_draw_sw_blend_image_to_i4(&dsc);
+
+    TEST_ASSERT_EQUAL_HEX8(nib_pair(0x8, 0x8), dest[0]);
+}
+
+void test_draw_sw_blend_image_to_i4_multiply(void)
+{
+    /* Pre-fill destination with index 8 (R=G=B=0x80) in both nibbles. */
+    uint8_t dest[1] = {nib_pair(0x8, 0x8)};
+
+    /* Source: R=G=B=0x80. Multiply: (0x80 * 0x80) >> 8 = 0x40 → idx 4. */
+    static const lv_color32_t src[2] = {
+        {.blue = 0x80, .green = 0x80, .red = 0x80, .alpha = 0xFF},
+        {.blue = 0x80, .green = 0x80, .red = 0x80, .alpha = 0xFF},
+    };
+
+    lv_draw_sw_blend_image_dsc_t dsc = {0};
+    dsc.dest_buf = dest;
+    dsc.dest_w = 2;
+    dsc.dest_h = 1;
+    dsc.dest_stride = 1;
+    dsc.src_buf = src;
+    dsc.src_stride = sizeof(src);
+    dsc.src_color_format = LV_COLOR_FORMAT_ARGB8888;
+    dsc.opa = LV_OPA_COVER;
+    dsc.blend_mode = LV_BLEND_MODE_MULTIPLY;
+    dsc.relative_area.x1 = 0;
+    dsc.relative_area.y1 = 0;
+    dsc.relative_area.x2 = 1;
+    dsc.relative_area.y2 = 0;
+    dsc.src_area.x1 = 0;
+    dsc.src_area.y1 = 0;
+    dsc.src_area.x2 = 1;
+    dsc.src_area.y2 = 0;
+
+    lv_draw_sw_blend_image_to_i4(&dsc);
+
+    TEST_ASSERT_EQUAL_HEX8(nib_pair(0x4, 0x4), dest[0]);
+}
+
+/*-----------------------------------------------------------------------
+ * Source ARGB8888 with non-cover alpha mixes into the underlying I4 dst
+ * via palette quantization. Pre-fill dst index 0 (black, RGB 0x00) and
+ * blend src white (RGB 0xFF) at alpha 128 → expected midgray ~ idx 7..8.
+ *---------------------------------------------------------------------*/
+void test_draw_sw_blend_image_to_i4_argb_with_alpha(void)
+{
+    uint8_t dest[1] = {nib_pair(0x0, 0x0)};
+
+    static const lv_color32_t src[2] = {
+        {.blue = 0xFF, .green = 0xFF, .red = 0xFF, .alpha = 0x80},
+        {.blue = 0xFF, .green = 0xFF, .red = 0xFF, .alpha = 0x80},
+    };
+
+    lv_draw_sw_blend_image_dsc_t dsc = {0};
+    dsc.dest_buf = dest;
+    dsc.dest_w = 2;
+    dsc.dest_h = 1;
+    dsc.dest_stride = 1;
+    dsc.src_buf = src;
+    dsc.src_stride = sizeof(src);
+    dsc.src_color_format = LV_COLOR_FORMAT_ARGB8888;
+    dsc.opa = LV_OPA_COVER;
+    dsc.blend_mode = LV_BLEND_MODE_NORMAL;
+    dsc.relative_area.x1 = 0;
+    dsc.relative_area.y1 = 0;
+    dsc.relative_area.x2 = 1;
+    dsc.relative_area.y2 = 0;
+    dsc.src_area.x1 = 0;
+    dsc.src_area.y1 = 0;
+    dsc.src_area.x2 = 1;
+    dsc.src_area.y2 = 0;
+
+    lv_draw_sw_blend_image_to_i4(&dsc);
+
+    /* (0 * (255-128) + 255 * 128) / 256 = 0x7F → quantized to idx 7. */
+    uint8_t lo = dest[0] & 0x0F;
+    uint8_t hi = dest[0] >> 4;
+    TEST_ASSERT_TRUE_MESSAGE(hi == 0x7 || hi == 0x8, "high nibble must be ~midgray");
+    TEST_ASSERT_TRUE_MESSAGE(lo == 0x7 || lo == 0x8, "low nibble must be ~midgray");
+    TEST_ASSERT_EQUAL_MESSAGE(hi, lo, "both nibbles must agree");
+}
+
+#endif /*LV_DRAW_SW_SUPPORT_I4*/
+
+#endif


### PR DESCRIPTION
## Summary

Adds `LV_COLOR_FORMAT_I4` as a render target for the software rasterizer, mirroring the existing I1 / L8 destination handlers. LVGL 9.5 already defines `LV_COLOR_FORMAT_I4 = 0x09` as an *image-asset* format, but `src/draw/sw/blend/lv_draw_sw_blend.c` has no `case LV_COLOR_FORMAT_I4` in either `lv_draw_sw_blend_color()` or `lv_draw_sw_blend_image()`, and there is no `lv_draw_sw_blend_to_i4.c` alongside `lv_draw_sw_blend_to_i1.c` / `lv_draw_sw_blend_to_l8.c`. This PR fills that gap.

## Motivation

Indexed-color AMOLED controllers (e.g. CO5300, several Sitronix and Solomon Systech parts) accept a 4-bit-per-pixel framebuffer with a 16-entry user-defined palette loaded into the panel's `COLSET` registers. At typical sizes (e.g. 410x502) a full I4 framebuffer is ~25% the size of the equivalent RGB565 buffer — small enough to fit a single full-frame buffer in the SRAM of MCUs that cannot hold an RGB565 framebuffer (e.g. ESP32-C6, 512 KB SRAM, no PSRAM controller). That unlocks a single-FB tear-free render path on these targets.

The downstream consumer of this PR is a watch firmware on an ESP32-C6 + CO5300 (Waveshare 2.06" AMOLED). CO5300 datasheet §7.5.32 / §7.5.50 / §7.5.51 describe the panel side: `COLMOD 0x3A=0x33`, `COLOPT 0x80` with `RGB4bit_en=1`, palette loaded via `COLSET 0x70..0x7F`.

## Pixel packing

Two pixels per byte, lower-x pixel in the upper nibble (D[7:4]), higher-x pixel in the lower nibble (D[3:0]) — matching the wire format these panels expect. Stride is rounded up to whole bytes (`(width + 1) / 2`); the existing `lv_draw_buf` stride math already handles 4 bpp via `lv_color_format_get_bpp` and needed no changes.

## Palette-binding API

I4 has 16 freely defined entries (rather than I1's fixed black/white), so the blender needs to know the palette to quantize incoming RGB / RGB565 / ARGB8888 / etc. pixels.

```c
void                 lv_display_set_palette(lv_display_t * disp,
                                            const lv_color32_t * palette, uint32_t size);
const lv_color32_t * lv_display_get_palette(lv_display_t * disp);
uint32_t             lv_display_get_palette_size(lv_display_t * disp);
```

The palette is *not* copied — the caller owns it. The blender pulls it from `lv_refr_get_disp_refreshing()` at render time. If no palette is registered, a default 16-entry grayscale ramp is used so canvas / test code can render without configuration.

Quantization is a 16-entry linear search over squared RGB distance (48 multiplies per pixel). On RV32 / Cortex-M this is well under a microsecond per pixel; not the bottleneck for typical refresh rates. A 32K-entry RGB565→index lookup table is a possible future optimization but adds 32 KB of static data and isn't worth the cost for the first cut.

## Coverage

`lv_draw_sw_blend_image_to_i4` implements all source-format inner loops mirrored from `lv_draw_sw_blend_to_i1.c`:

- I1, L8, AL88, RGB565, RGB565_SWAPPED, RGB888, XRGB8888, ARGB8888, I4

Blend modes: NORMAL, plus ADDITIVE / SUBTRACTIVE / MULTIPLY / DIFFERENCE via palette round-trip (index → palette RGB → blend in RGB → quantize back).

## Configuration

- `LV_DRAW_SW_SUPPORT_I4` added to `lv_conf_template.h` (default on, consistent with `LV_DRAW_SW_SUPPORT_I1`)
- matching Kconfig entry in `Kconfig`
- matching fallback in `src/lv_conf_internal.h`

## Edge cases covered by tests

`tests/src/test_cases/draw/test_draw_sw_blend_to_i4.c`:

- [x] Solid fill of all 16 indices on a byte-aligned destination.
- [x] Odd `dest_x` start — first byte's upper nibble must be untouched.
- [x] Odd width — last byte's lower nibble must be untouched.
- [x] Odd start AND odd width — both ends partial.
- [x] RGB565 image source quantizing to known palette entries.
- [x] ADDITIVE blend mode via palette round-trip.
- [x] MULTIPLY blend mode via palette round-trip.
- [x] ARGB8888 source with non-cover alpha mixing into I4 destination.

## Known limitations / follow-ups (not part of this PR)

- I4-to-I4 image blend assumes the source and destination share a palette (fast-path nibble copy). This matches I1's behavior, but for I4 image *assets* whose own palette is carried in `lv_image_dsc_t` it's not generally correct. A follow-up can plumb a source-side palette through `lv_draw_sw_blend_image_dsc_t`. Not blocking for the display-framebuffer use case.
- No assembly hooks. I1 / L8 carry ~80 `LV_DRAW_SW_*_TO_I1`-style stub macros for accelerated backends. I omitted them to keep this PR focused on the C path; they can be added incrementally if backends grow I4 support.

## Test plan

- [x] Local build (host gcc, `cmake -B build && cmake --build build`) of the LVGL library + examples + demos is green.
- [x] Strict compile of new files with `-Wall -Wextra -Werror -pedantic -Wshadow -Wundef -Wmissing-prototypes -Wsign-compare -Wfloat-conversion`: clean.
- [ ] Full `tests/main.py test` — needs CI (Ruby + several apt-only libs unavailable in my local env).
- [ ] I1 / L8 / RGB565 destination tests still pass — needs CI.
- [ ] On-hardware sanity check on ESP32-C6 + CO5300 — will follow once this is merged and the firmware is switched over to the new path.