### PR TITLE
fix(obj): use clz instead of obj

### DIFF
--- a/src/core/lv_obj_property.c
+++ b/src/core/lv_obj_property.c
@@ -210,7 +210,7 @@ lv_prop_id_t lv_obj_class_property_get_id(const lv_obj_class_t * clz, const char
     found = lv_utils_bsearch(name, names, clz->names_count, sizeof(lv_property_name_t), property_name_compare);
     if(found) return found->id;
 #else
-    LV_UNUSED(obj);
+    LV_UNUSED(clz);
     LV_UNUSED(name);
     LV_UNUSED(property_name_compare);
 #endif


### PR DESCRIPTION
There's no obj here at all, only clz.