### PR TITLE
fix(bar): properly closing the #if

### DIFF
--- a/src/widgets/bar/lv_bar.c
+++ b/src/widgets/bar/lv_bar.c
@@ -803,6 +803,8 @@ static void bar_value_observer_cb(lv_observer_t * observer, lv_subject_t * subje
 #endif
 }
 
+#endif /*LV_USE_OBSERVER*/
+
 #if LV_USE_OBJ_PROPERTY
 static void lv_bar_set_value_helper(lv_obj_t * obj, int32_t value)
 {
@@ -814,7 +816,5 @@ static void lv_bar_set_start_value_helper(lv_obj_t * obj, int32_t value)
     lv_bar_set_start_value(obj, value, LV_ANIM_OFF);
 }
 #endif
-
-#endif /*LV_USE_OBSERVER*/
 
 #endif


### PR DESCRIPTION
Those two functions related to `property` should not be included in the observer.

If you enable the property but disable the observer, a compilation error will occur. However, this is a reasonable requirement.

```
/home/joseph/work/ingenic/ad102/tools/toolchains/mips-xburst2-gcc1210-glibc238/bin/../lib/gcc/mips-linux-gnu/12.1.0/../../../../mips-linux-gnu/bin/ld: deps/lvgl/lib/liblvgl.so.9.5.0: undefined reference to `lv_bar_set_start_value_helper'
/home/joseph/work/ingenic/ad102/tools/toolchains/mips-xburst2-gcc1210-glibc238/bin/../lib/gcc/mips-linux-gnu/12.1.0/../../../../mips-linux-gnu/bin/ld: deps/lvgl/lib/liblvgl.so.9.5.0: undefined reference to `lv_bar_set_value_helper'
```
