### PR TITLE
docs(index): add <DirectoryIndex /> to section index pages

### DIFF
--- a/docs/src/auxiliary-modules/index.mdx
+++ b/docs/src/auxiliary-modules/index.mdx
@@ -3,3 +3,4 @@ title: Auxiliary Modules
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/common-widget-features/index.mdx
+++ b/docs/src/common-widget-features/index.mdx
@@ -4,3 +4,4 @@ description: The following details apply to all types of Widgets.
 ---
 
 The following details apply to all types of Widgets.
+<DirectoryIndex />

--- a/docs/src/common-widget-features/layouts/index.mdx
+++ b/docs/src/common-widget-features/layouts/index.mdx
@@ -3,3 +3,4 @@ title: Layouts
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/common-widget-features/styles/index.mdx
+++ b/docs/src/common-widget-features/styles/index.mdx
@@ -3,3 +3,4 @@ title: Styles
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/contributing/index.mdx
+++ b/docs/src/contributing/index.mdx
@@ -3,3 +3,4 @@ title: Contributing
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/debugging/index.mdx
+++ b/docs/src/debugging/index.mdx
@@ -5,3 +5,4 @@ description: LVGL comes packaged with various tools that can help you debug prob
 
 LVGL comes packaged with various tools that can help you debug problems you may
 encounter during development and testing.
+<DirectoryIndex />

--- a/docs/src/getting_started/index.mdx
+++ b/docs/src/getting_started/index.mdx
@@ -3,3 +3,4 @@ title: Getting started
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/guides/index.mdx
+++ b/docs/src/guides/index.mdx
@@ -3,3 +3,4 @@ title: Guides
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/integration/bindings/index.mdx
+++ b/docs/src/integration/bindings/index.mdx
@@ -3,3 +3,4 @@ title: Bindings
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/integration/boards/index.mdx
+++ b/docs/src/integration/boards/index.mdx
@@ -3,3 +3,4 @@ title: Board Support
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/integration/boards/manufacturers/index.mdx
+++ b/docs/src/integration/boards/manufacturers/index.mdx
@@ -3,3 +3,4 @@ title: Boards
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/integration/building/index.mdx
+++ b/docs/src/integration/building/index.mdx
@@ -3,3 +3,4 @@ title: Build System Support
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/integration/chip_vendors/alif/index.mdx
+++ b/docs/src/integration/chip_vendors/alif/index.mdx
@@ -3,3 +3,4 @@ title: Alif
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/integration/chip_vendors/arm/index.mdx
+++ b/docs/src/integration/chip_vendors/arm/index.mdx
@@ -3,3 +3,4 @@ title: Arm
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/integration/chip_vendors/espressif/index.mdx
+++ b/docs/src/integration/chip_vendors/espressif/index.mdx
@@ -3,3 +3,4 @@ title: Espressif
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/integration/chip_vendors/index.mdx
+++ b/docs/src/integration/chip_vendors/index.mdx
@@ -3,3 +3,4 @@ title: Chip Vendor Support
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/integration/chip_vendors/nxp/index.mdx
+++ b/docs/src/integration/chip_vendors/nxp/index.mdx
@@ -3,3 +3,4 @@ title: NXP
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/integration/chip_vendors/renesas/index.mdx
+++ b/docs/src/integration/chip_vendors/renesas/index.mdx
@@ -3,3 +3,4 @@ title: Renesas
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/integration/chip_vendors/stm32/index.mdx
+++ b/docs/src/integration/chip_vendors/stm32/index.mdx
@@ -3,3 +3,4 @@ title: STM32
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/integration/embedded_linux/drivers/index.mdx
+++ b/docs/src/integration/embedded_linux/drivers/index.mdx
@@ -3,3 +3,4 @@ title: Drivers
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/integration/embedded_linux/index.mdx
+++ b/docs/src/integration/embedded_linux/index.mdx
@@ -3,3 +3,4 @@ title: Embedded Linux Support
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/integration/embedded_linux/os/buildroot/index.mdx
+++ b/docs/src/integration/embedded_linux/os/buildroot/index.mdx
@@ -10,3 +10,4 @@ Buildroot is a set of Makefiles and patches that simplifies and automates the
 process of building a complete and bootable Linux environment for an embedded
 system, while using cross-compilation to allow building for multiple target
 platforms on a single Linux-based development system.
+<DirectoryIndex />

--- a/docs/src/integration/embedded_linux/os/index.mdx
+++ b/docs/src/integration/embedded_linux/os/index.mdx
@@ -3,3 +3,4 @@ title: OS Support
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/integration/embedded_linux/os/yocto/index.mdx
+++ b/docs/src/integration/embedded_linux/os/yocto/index.mdx
@@ -14,3 +14,4 @@ embedded and IOT devices, or anywhere a customized Linux OS is needed.
 
 This section objective is to ease to process of understanding the basic
 concepts of Yocto and to help beginners to start with Yocto.
+<DirectoryIndex />

--- a/docs/src/integration/external_display_controllers/eve/index.mdx
+++ b/docs/src/integration/external_display_controllers/eve/index.mdx
@@ -3,3 +3,4 @@ title: EVE
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/integration/external_display_controllers/index.mdx
+++ b/docs/src/integration/external_display_controllers/index.mdx
@@ -3,3 +3,4 @@ title: Display Controller Support
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/integration/frameworks/index.mdx
+++ b/docs/src/integration/frameworks/index.mdx
@@ -3,3 +3,4 @@ title: Framework Support
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/integration/index.mdx
+++ b/docs/src/integration/index.mdx
@@ -25,3 +25,4 @@ guide, you are also covered.
 
 You can also pick a [ready-to-use project](https://lvgl.io/boards) for many
 development boards.
+<DirectoryIndex />

--- a/docs/src/integration/pc/index.mdx
+++ b/docs/src/integration/pc/index.mdx
@@ -9,3 +9,4 @@ development boards).
 Many ready-to-use projects are available to get started easily on
 Windows, Linux, macOS, and in a web browser. Even developing a UEFI BIOS is
 an option.
+<DirectoryIndex />

--- a/docs/src/integration/rtos/index.mdx
+++ b/docs/src/integration/rtos/index.mdx
@@ -3,3 +3,4 @@ title: RTOS Support
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/introduction/index.mdx
+++ b/docs/src/introduction/index.mdx
@@ -45,3 +45,4 @@ these two that suits your project.
 - Documentation is available online
 - Free and open-source under MIT license
 - Free for commercial projects
+<DirectoryIndex />

--- a/docs/src/libs/font_support/index.mdx
+++ b/docs/src/libs/font_support/index.mdx
@@ -3,3 +3,4 @@ title: Font Support
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/libs/fs_support/index.mdx
+++ b/docs/src/libs/fs_support/index.mdx
@@ -3,3 +3,4 @@ title: File System Support
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/libs/image_support/index.mdx
+++ b/docs/src/libs/image_support/index.mdx
@@ -3,3 +3,4 @@ title: Image Support
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/libs/index.mdx
+++ b/docs/src/libs/index.mdx
@@ -3,3 +3,4 @@ title: "3rd-Party Libraries"
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/libs/video_support/index.mdx
+++ b/docs/src/libs/video_support/index.mdx
@@ -3,3 +3,4 @@ title: Video Support
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/main-modules/display/index.mdx
+++ b/docs/src/main-modules/display/index.mdx
@@ -3,3 +3,4 @@ title: "Display (lv_display)"
 ---
 
 ## API
+<DirectoryIndex />

--- a/docs/src/main-modules/draw/index.mdx
+++ b/docs/src/main-modules/draw/index.mdx
@@ -3,3 +3,4 @@ title: Drawing
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/main-modules/fonts/index.mdx
+++ b/docs/src/main-modules/fonts/index.mdx
@@ -3,3 +3,4 @@ title: "Fonts (lv_font)"
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/main-modules/images/index.mdx
+++ b/docs/src/main-modules/images/index.mdx
@@ -3,3 +3,4 @@ title: Images
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/main-modules/indev/index.mdx
+++ b/docs/src/main-modules/indev/index.mdx
@@ -3,3 +3,4 @@ title: "Input devices (lv_indev)"
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/main-modules/index.mdx
+++ b/docs/src/main-modules/index.mdx
@@ -3,3 +3,4 @@ title: Main Modules
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/main-modules/observer/index.mdx
+++ b/docs/src/main-modules/observer/index.mdx
@@ -3,3 +3,4 @@ title: Observer
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/widgets/index.mdx
+++ b/docs/src/widgets/index.mdx
@@ -7,3 +7,4 @@ title: All Widgets
 <hr />
 
 html
+<DirectoryIndex />

--- a/docs/src/xml/assets/index.mdx
+++ b/docs/src/xml/assets/index.mdx
@@ -3,3 +3,4 @@ title: Assets
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/xml/editor/index.mdx
+++ b/docs/src/xml/editor/index.mdx
@@ -3,3 +3,4 @@ title: Editor
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/xml/features/index.mdx
+++ b/docs/src/xml/features/index.mdx
@@ -3,3 +3,4 @@ title: Features
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/xml/index.mdx
+++ b/docs/src/xml/index.mdx
@@ -3,3 +3,4 @@ title: LVGL Pro and XML
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/xml/integration/index.mdx
+++ b/docs/src/xml/integration/index.mdx
@@ -3,3 +3,4 @@ title: Integration
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/xml/tools/index.mdx
+++ b/docs/src/xml/tools/index.mdx
@@ -3,3 +3,4 @@ title: Tools
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/xml/ui_elements/index.mdx
+++ b/docs/src/xml/ui_elements/index.mdx
@@ -3,3 +3,4 @@ title: UI Elements
 ---
 
 
+<DirectoryIndex />

--- a/docs/src/xml/xml/index.mdx
+++ b/docs/src/xml/xml/index.mdx
@@ -3,3 +3,4 @@ title: XML Overview
 ---
 
 
+<DirectoryIndex />


### PR DESCRIPTION
## Summary
- Append `<DirectoryIndex />` to every `index.mdx` under `docs/src/` whose folder contains other files, so each section landing page lists its children.
- Skipped: the root `docs/src/index.mdx` (handcrafted landing) and folders with no sibling files (`guides/internal-subsystems`, `guides/how-to-articles`).
- 52 files changed, one line added per file.