### PR TITLE
feat(drm): add libdrm fallback for drm device probe

### DIFF
--- a/src/drivers/display/drm/lv_linux_drm_common.c
+++ b/src/drivers/display/drm/lv_linux_drm_common.c
@@ -13,8 +13,9 @@
 
 #include <dirent.h>
 #include <xf86drmMode.h>
+#include <unistd.h>
+#include <fcntl.h>
 
-#include "lv_linux_drm.h"
 #include "../../../stdlib/lv_sprintf.h"
 
 /*********************
@@ -22,6 +23,7 @@
  *********************/
 
 #define LV_DRM_CLASS_DIR "/sys/class/drm"
+#define LV_DRM_CARD_DIR "/dev/dri"
 #define LV_DRM_CARD_PATH "/dev/dri/card"
 
 /**********************
@@ -33,6 +35,7 @@
  **********************/
 
 static char * find_by_class(void);
+static char * find_by_drm_dev(void);
 
 /**********************
  *  STATIC VARIABLES
@@ -48,12 +51,70 @@ static char * find_by_class(void);
 
 char * lv_linux_drm_find_device_path(void)
 {
-    return find_by_class();
+    char * card_path;
+    if((card_path = find_by_class()))
+        return card_path;
+    return find_by_drm_dev();
 }
 
 /**********************
  *   STATIC FUNCTIONS
  **********************/
+
+static char * find_by_drm_dev(void)
+{
+    DIR * d = opendir(LV_DRM_CARD_DIR);
+    if(!d) {
+        return NULL;
+    }
+    struct dirent * ent;
+    while((ent = readdir(d)) != NULL) {
+        if(!lv_strcmp(ent->d_name, ".")
+           || !lv_strcmp(ent->d_name, "..")
+           || lv_strncmp(ent->d_name, "card", 4))
+            continue;
+
+        const size_t buf_size = lv_strlen(LV_DRM_CARD_DIR "/") + lv_strlen(ent->d_name) + 1;
+        char * card_path = lv_zalloc(buf_size);
+        if(!card_path)
+            continue;
+        lv_snprintf(card_path, buf_size, LV_DRM_CARD_DIR "/%s", ent->d_name);
+        int fd = open(card_path, O_RDWR);
+
+        if(fd < 0)
+            goto open_fail;
+
+        if(fcntl(fd, F_SETFD, FD_CLOEXEC) < 0)
+            goto get_res_fail;
+
+        drmModeRes * res = drmModeGetResources(fd);
+        if(!res)
+            goto get_res_fail;
+
+        for(int i = 0; i < res->count_connectors; i++) {
+            drmModeConnector * conn = drmModeGetConnector(fd, res->connectors[i]);
+            if(!conn)
+                continue;
+            if(conn->connection == DRM_MODE_CONNECTED) {
+                drmModeFreeConnector(conn);
+                drmModeFreeResources(res);
+                close(fd);
+                closedir(d);
+                return card_path;
+            }
+            drmModeFreeConnector(conn);
+        }
+        drmModeFreeResources(res);
+get_res_fail:
+        close(fd);
+open_fail:
+        lv_free(card_path);
+
+    }
+
+    closedir(d);
+    return NULL;
+}
 
 static char * find_by_class(void)
 {
@@ -77,6 +138,8 @@ static char * find_by_class(void)
 
         const size_t buf_size = lv_strlen(LV_DRM_CARD_PATH) + 3;
         char * card_path = lv_zalloc(buf_size);
+        if(!card_path)
+            continue;
         if(ent->d_name[5] != '-') {
             /* Double digit card*/
             lv_snprintf(card_path, buf_size, LV_DRM_CARD_PATH "%c%c", ent->d_name[4], ent->d_name[5]);


### PR DESCRIPTION
When I try to run lvgl on Linux running on STM32F429 Discovery using DRM mode, the following error was shown.
```
[Warn]	(189.446, +45)	lv_display_refr_timer: No draw buffer lv_refr.c:391
```
I wrote my experiment detail in this note[1].

This is because the current implementation[2] relies on sysfs to find a drm device which has a connector with CONNECTED state. However, for my use case, I disable sysfs in Linux kernel to reduce image size and runtime RAM usage. This use case may also happen on some minimal Linux running on resource limited embedded platforms.

This makes lv_linux_drm_find_device_path automatically fallback to native drm device probe using libdrm API to find the available drm device if the sysfs is not available.

<!-- A clear and concise description of what the bug or new feature is.-->

[1] https://hackmd.io/@rota1001/lvgl-stm32f429-example
[2] https://github.com/lvgl/lvgl/blob/master/src/drivers/display/drm/lv_linux_drm_common.c#L49
### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
