### PR TITLE
build(cmake): remove thorvg sources from main lib sources list

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -45,4 +45,4 @@ jobs:
               return 0; 
           }" >> main.c
           # We link with `g++` as thorvg (ThorVG library) contains C++ code that requires C++ runtime symbols
-          g++ main.c -o main -I$(pwd)/lvgl-install/include -L$(pwd)/lvgl-install/lib -llvgl_thorvg -llvgl_examples -llvgl_demos -llvgl -lm
+          g++ main.c -o main -I$(pwd)/lvgl-install/include -L$(pwd)/lvgl-install/lib -llvgl_examples -llvgl_demos -llvgl -llvgl_thorvg -lm

--- a/env_support/cmake/main.cmake
+++ b/env_support/cmake/main.cmake
@@ -71,6 +71,9 @@ file(GLOB_RECURSE DEMO_SOURCES ${LVGL_ROOT_DIR}/demos/*.c)
 file(GLOB_RECURSE THORVG_SOURCES ${LVGL_ROOT_DIR}/src/libs/thorvg/*.cpp
                                  ${LVGL_ROOT_DIR}/src/others/vg_lite_tvg/*.cpp)
 
+# Remove the ThorVG sources from the main sources
+list(REMOVE_ITEM SOURCES ${THORVG_SOURCES})
+
 # Check for the case where LVGL is distributed with only its source code
 if(NOT EXAMPLE_SOURCES AND CONFIG_LV_BUILD_EXAMPLES)
     message(STATUS "No Examples found. Disabling Examples build")


### PR DESCRIPTION
Thorvg is built as a separate lib but its sources were also getting included inside the main lib because the files are getting globbed together