### PR TITLE
fix(theme): prevent reentrancy in resolution_change_event_cb

### DIFF
--- a/scripts/gdb/scripts/generators/widget_specs.json
+++ b/scripts/gdb/scripts/generators/widget_specs.json
@@ -380,6 +380,7 @@
         "text": "string",
         "translation_tag": "string",
         "dot_begin": "int",
+        "max_lines": "int",
         "sel_start": "int",
         "sel_end": "int",
         "size_cache": "point",

--- a/src/themes/default/lv_theme_default.c
+++ b/src/themes/default/lv_theme_default.c
@@ -671,17 +671,19 @@ lv_theme_t * lv_theme_default_init(lv_display_t * disp, lv_color_t color_primary
     theme->base.ext_data.data = NULL;
 #endif
 
+    /*Remove the callback before triggering style refresh to prevent
+     *resolution_change_event_cb from re-entering lv_theme_default_init
+     *during lv_obj_report_style_change. Re-added below.*/
+    lv_display_remove_event_cb_with_user_data(new_disp, resolution_change_event_cb, theme);
+
     style_init(theme);
+
+    theme->inited = true;
 
     if(disp == NULL || lv_display_get_theme(disp) == (lv_theme_t *)theme) {
         lv_obj_report_style_change(NULL);
     }
 
-    theme->inited = true;
-
-    /*Re-initialize the styles if the resolution changes as a different display size might
-     *result in different paddings */
-    lv_display_remove_event_cb_with_user_data(new_disp, resolution_change_event_cb, theme);
     lv_display_add_event_cb(new_disp, resolution_change_event_cb, LV_EVENT_RESOLUTION_CHANGED, theme);
 
     return (lv_theme_t *) theme;
@@ -1239,9 +1241,8 @@ static void resolution_change_event_cb(lv_event_t * e)
     lv_display_t * disp = lv_event_get_target(e);
     my_theme_t * theme = lv_event_get_user_data(e);
 
-    lv_theme_default_init(disp, theme->base.color_primary, theme->base.color_secondary, theme->base.flags,
-                          theme->base.font_normal);
-
+    lv_theme_default_init(disp, theme->base.color_primary, theme->base.color_secondary,
+                          theme->base.flags & MODE_DARK, theme->base.font_normal);
 }
 
 #endif

--- a/tests/src/test_cases/test_theme.c
+++ b/tests/src/test_cases/test_theme.c
@@ -148,6 +148,31 @@ static void test_widgets(const char * img_name)
     lv_obj_clean(scr_act);
 }
 
+void test_theme_default_resolution_change_no_recursion(void)
+{
+    lv_theme_t * theme = lv_theme_default_init(NULL,
+                                               lv_palette_main(LV_PALETTE_BLUE),
+                                               lv_palette_main(LV_PALETTE_RED),
+                                               true, LV_FONT_DEFAULT);
+    lv_display_set_theme(NULL, theme);
+
+    lv_obj_t * label = lv_label_create(lv_screen_active());
+    lv_label_set_text(label, "Resolution change test");
+    lv_button_create(lv_screen_active());
+
+    lv_display_set_resolution(NULL, 320, 240);
+
+    TEST_ASSERT_NOT_NULL(lv_screen_active());
+    TEST_ASSERT_TRUE(lv_theme_default_is_inited());
+
+    lv_display_set_resolution(NULL, 800, 480);
+
+    TEST_ASSERT_NOT_NULL(lv_screen_active());
+    TEST_ASSERT_TRUE(lv_theme_default_is_inited());
+
+    lv_obj_clean(lv_screen_active());
+}
+
 void test_theme_default(void)
 {
     TEST_ASSERT_TRUE(lv_theme_default_is_inited());


### PR DESCRIPTION
## Summary

Reorder operations in `lv_theme_default_init()` to prevent infinite recursion when `resolution_change_event_cb` triggers theme re-init.

The fix (per @FASTSHIFT's suggestion):
1. **Remove** `resolution_change_event_cb` before `style_init()` and **re-add** it after `lv_obj_report_style_change()` -- this is the primary reentrancy prevention, no shared state needed
2. Set `theme->inited = true` after `style_init()` but **before** `lv_obj_report_style_change()` -- styles must be initialized first (sentinel check), but the early-return guard must be effective before the style change notification

This approach works correctly with multiple displays and is thread-safe by design.

Also passes only the `MODE_DARK` bit (not raw `flags`) from the callback to `lv_theme_default_init()` so future flag additions cannot be misinterpreted as `dark=true`.

Includes a regression test that calls `lv_display_set_resolution()` with the default theme active and a non-trivial widget tree.

Closes https://github.com/lvgl/lvgl/issues/9982