### PR TITLE
feat(nema_gfx): add cache management

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -579,6 +579,16 @@ menu "LVGL configuration"
 			bool "Use NemaGFX acceleration"
 			default n
 
+		config LV_NEMA_USE_CACHE
+			bool "Cache handling of NemaGFX"
+			depends on LV_USE_NEMA_GFX
+			default n
+
+		config LV_NEMA_CACHE_HAL_INCLUDE
+			string "NemaGFX Cache HAL include"
+			default "stm32u5xx_hal.h"
+			depends on LV_USE_NEMA_GFX && LV_NEMA_USE_CACHE
+
 		choice LV_USE_NEMA_LIB
 			prompt "NemaGFX static library"
 			depends on LV_USE_NEMA_GFX
@@ -689,7 +699,6 @@ menu "LVGL configuration"
 			int "Draw letter cache count"
 			default 512
 			depends on LV_USE_DRAW_NANOVG
-
 	endmenu
 
 	menu "Feature Configuration"

--- a/docs/src/integration/chip_vendors/stm32/neochrom.mdx
+++ b/docs/src/integration/chip_vendors/stm32/neochrom.mdx
@@ -80,6 +80,11 @@ that will place the memory shared between the CPU and the GPU in a region of mem
 not cached. This requires coordination from the linker script and memory protection unit
 configuration. See [lv_port_stm32h7s78-dk](https://github.com/lvgl/lv_port_stm32h7s78-dk)
 as a reference.
+Alternatively, <ApiLink name="LV_NEMA_USE_CACHE" /> can be set to 1 to perform necessary
+cache management on the buffers, avoiding the need to place buffers in non-cached area.
+For that purpose, the <ApiLink name="LV_NEMA_CACHE_HAL_INCLUDE" /> must also be set to
+a HAL include file exposing the CMSIS cache handling functions and SCB pointer,
+such as for example "stm32u5xx_hal.h".
 
 ## Vector Graphics
 

--- a/include/lvgl/config/lv_conf_internal.h
+++ b/include/lvgl/config/lv_conf_internal.h
@@ -696,6 +696,22 @@
         #endif
     #endif
 
+    /** Control of the cache support within NEMA GFX */
+    #ifndef LV_NEMA_USE_CACHE
+        #ifdef CONFIG_LV_NEMA_USE_CACHE
+            #define LV_NEMA_USE_CACHE CONFIG_LV_NEMA_USE_CACHE
+        #else
+            #define LV_NEMA_USE_CACHE 0
+        #endif
+    #endif
+    #ifndef LV_NEMA_CACHE_HAL_INCLUDE
+        #ifdef CONFIG_LV_NEMA_CACHE_HAL_INCLUDE
+            #define LV_NEMA_CACHE_HAL_INCLUDE CONFIG_LV_NEMA_CACHE_HAL_INCLUDE
+        #else
+            #define LV_NEMA_CACHE_HAL_INCLUDE <stm32u5xx_hal.h>
+        #endif
+    #endif
+
     /** Select which NemaGFX HAL to use. Possible options:
      * - LV_NEMA_HAL_CUSTOM
      * - LV_NEMA_HAL_STM32 */
@@ -4961,6 +4977,10 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
 
 #ifndef LV_USE_VG_LITE_THORVG
     #define LV_USE_VG_LITE_THORVG 0
+#endif
+
+#ifndef LV_NEMA_USE_CACHE
+    #define LV_NEMA_USE_CACHE 0
 #endif
 
 /* Set some defines if a dependency is disabled. */

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -247,6 +247,10 @@
      */
     #define LV_USE_NEMA_LIB LV_NEMA_LIB_NONE
 
+    /** Control of the cache support within NEMA GFX */
+    #define LV_NEMA_USE_CACHE 0
+    #define LV_NEMA_CACHE_HAL_INCLUDE <stm32u5xx_hal.h>
+
     /** Select which NemaGFX HAL to use. Possible options:
      * - LV_NEMA_HAL_CUSTOM
      * - LV_NEMA_HAL_STM32 */

--- a/scripts/lv_conf_internal_gen.py
+++ b/scripts/lv_conf_internal_gen.py
@@ -221,6 +221,10 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
     #define LV_USE_VG_LITE_THORVG 0
 #endif
 
+#ifndef LV_NEMA_USE_CACHE
+    #define LV_NEMA_USE_CACHE 0
+#endif
+
 /* Set some defines if a dependency is disabled. */
 #if LV_USE_LOG == 0
     #define LV_LOG_LEVEL            LV_LOG_LEVEL_NONE

--- a/src/draw/nema_gfx/lv_draw_nema_gfx.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx.c
@@ -32,7 +32,6 @@
 /*********************
  *      INCLUDES
  *********************/
-
 #include "lv_draw_nema_gfx.h"
 
 #if LV_USE_NEMA_GFX
@@ -75,6 +74,10 @@ static int32_t nema_gfx_delete(lv_draw_unit_t * draw_unit);
 
 static int32_t nema_gfx_wait_for_finish(lv_draw_unit_t * draw_unit);
 
+static void nema_gfx_init_handlers(lv_draw_buf_handlers_t * handlers);
+
+static void lv_draw_buf_nema_gfx_init_handlers(void);
+
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -92,6 +95,8 @@ void lv_draw_nema_gfx_init(void)
     lv_draw_nema_gfx_unit_t * draw_nema_gfx_unit = lv_draw_create_unit(sizeof(lv_draw_nema_gfx_unit_t));
     /*Initialize NemaGFX*/
     nema_init();
+
+    lv_draw_buf_nema_gfx_init_handlers();
 
     draw_nema_gfx_unit->base_unit.dispatch_cb = nema_gfx_dispatch;
     draw_nema_gfx_unit->base_unit.evaluate_cb = nema_gfx_evaluate;
@@ -129,6 +134,20 @@ void lv_draw_nema_gfx_deinit(void)
 /**********************
  *   STATIC FUNCTIONS
  **********************/
+static void nema_gfx_init_handlers(lv_draw_buf_handlers_t * handlers)
+{
+#if LV_NEMA_USE_CACHE
+    handlers->invalidate_cache_cb = lv_draw_nema_gfx_invalidate_cache;
+    handlers->flush_cache_cb = lv_draw_nema_gfx_flush_cache;
+#endif
+}
+
+static void lv_draw_buf_nema_gfx_init_handlers(void)
+{
+    nema_gfx_init_handlers(lv_draw_buf_get_handlers());
+    nema_gfx_init_handlers(lv_draw_buf_get_font_handlers());
+    nema_gfx_init_handlers(lv_draw_buf_get_image_handlers());
+}
 
 static int32_t nema_gfx_wait_for_finish(lv_draw_unit_t * draw_unit)
 {
@@ -304,6 +323,24 @@ static void nema_gfx_execute_drawing(lv_draw_nema_gfx_unit_t * u)
     /* remember draw unit for access to unit's context */
     t->draw_unit = (lv_draw_unit_t *)u;
 
+    lv_layer_t * layer = t->target_layer;
+    lv_area_t clipped_area;
+    int32_t x;
+    int32_t y;
+
+    if(!lv_area_intersect(&clipped_area,  &t->area, &t->clip_area)) {
+        /* Nothing to do */
+        return;
+    }
+
+    x = 0 - t->target_layer->buf_area.x1;
+    y = 0 - t->target_layer->buf_area.y1;
+
+    lv_area_move(&clipped_area, x, y);
+
+    /* Clean cache */
+    lv_draw_buf_flush_cache(layer->draw_buf, &clipped_area);
+
     switch(t->type) {
         case LV_DRAW_TASK_TYPE_FILL:
             lv_draw_nema_gfx_fill(t, t->draw_dsc, &t->area);
@@ -343,6 +380,9 @@ static void nema_gfx_execute_drawing(lv_draw_nema_gfx_unit_t * u)
 #if !LV_USE_OS
     nema_cl_wait(&(u->cl));
 #endif
+
+    /* Invalidate cache */
+    lv_draw_buf_invalidate_cache(layer->draw_buf, &clipped_area);
 }
 
 static int32_t nema_gfx_delete(lv_draw_unit_t * draw_unit)

--- a/src/draw/nema_gfx/lv_draw_nema_gfx.h
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx.h
@@ -44,6 +44,7 @@ extern "C" {
 #if LV_USE_NEMA_GFX
 
 #include "lv_draw_nema_gfx_utils.h"
+#include "lv_draw_nema_gfx_cache.h"
 
 #include "../lv_draw_private.h"
 #include "../lv_draw_buf_private.h"

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_cache.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_cache.c
@@ -1,0 +1,93 @@
+/**
+ * @file lv_draw_nema_gfx_cache.c
+ * Copyright (c) 2026 STMicroelectronics.
+ */
+
+#include "lv_draw_nema_gfx.h"
+
+#if LV_NEMA_USE_CACHE
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include LV_NEMA_CACHE_HAL_INCLUDE
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+static void __invalidate_flush_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area,
+                                     bool flush);
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void lv_draw_nema_gfx_invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area)
+{
+    __invalidate_flush_cache(draw_buf, area, false);
+}
+
+void lv_draw_nema_gfx_flush_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area)
+{
+    __invalidate_flush_cache(draw_buf, area, true);
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+static void __invalidate_flush_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area,
+                                     bool flush)
+{
+    const lv_image_header_t * header = &draw_buf->header;
+    uint32_t stride = header->stride;
+    lv_color_format_t cf = header->cf;
+
+    uint32_t bpp = lv_color_format_get_bpp(cf);
+    int32_t lines = lv_area_get_height(area);
+
+    if(lines <= 0 || bpp == 0U || stride == 0U) {
+        return;
+    }
+
+    uint64_t start_bit = (uint64_t)(uint32_t)area->x1 * (uint64_t)bpp;
+    uint64_t end_bit = (uint64_t)((uint32_t)area->x2 + 1U) * (uint64_t)bpp;
+    uint32_t start_byte = (uint32_t)(start_bit >> 3);
+    uint32_t end_byte = (uint32_t)((end_bit + 7U) >> 3);
+    int32_t bytes_to_flush_per_line = (int32_t)(end_byte - start_byte);
+    uint8_t * address = draw_buf->data + start_byte + (stride * (uint32_t)area->y1);
+    int32_t i = 0;
+
+    if(bytes_to_flush_per_line <= 0) {
+        return;
+    }
+
+    for(i = 0; i < lines; i++) {
+        if(SCB->CCR & SCB_CCR_DC_Msk) {
+            if(flush) {
+                SCB_CleanDCache_by_Addr(address, bytes_to_flush_per_line);
+            }
+            else {
+                SCB_InvalidateDCache_by_Addr(address, bytes_to_flush_per_line);
+            }
+        }
+        address += stride;
+    }
+}
+
+#endif

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_cache.h
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_cache.h
@@ -1,0 +1,41 @@
+/**
+ * @file lv_draw_nema_gfx_cache.h
+ * Copyright (c) 2026 STMicroelectronics.
+ */
+
+#ifndef LV_DRAW_NEMA_GFX_CACHE_H
+#define LV_DRAW_NEMA_GFX_CACHE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../../lvgl_public.h"
+
+#if LV_NEMA_USE_CACHE
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+void lv_draw_nema_gfx_invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
+void lv_draw_nema_gfx_flush_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
+
+/**********************
+ *      MACROS
+ **********************/
+
+#endif /*LV_NEMA_USE_CACHE*/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_DRAW_NEMA_GFX_CACHE_H*/

--- a/src/lvgl_private.h
+++ b/src/lvgl_private.h
@@ -50,6 +50,7 @@
 #include "draw/nanovg/lv_nanovg_math.h"
 #include "draw/nanovg/lv_nanovg_utils.h"
 #include "draw/nema_gfx/lv_draw_nema_gfx.h"
+#include "draw/nema_gfx/lv_draw_nema_gfx_cache.h"
 #include "draw/nema_gfx/lv_draw_nema_gfx_utils.h"
 #include "draw/nema_gfx/lv_nema_gfx_path.h"
 #include "draw/nxp/g2d/lv_draw_g2d.h"


### PR DESCRIPTION
This series adds cache handling within the nema_gfx code by adding handlers invalidate/flush ops and also in case of LVGL is use without OS defined, ensure to have the nema_cl_wait called after submitting a command.
Indeed, nema_gfx is usually performing the nema_cl_wait within the wait_for_finish callback however it is never called by the LVGL draw FW if LV_USE_OS is != 1.

For the time being the cache handling addition commit is including stm32n6xx.h which is wrong. I thought about doing it same as for the DMA2D with a LV_ config indicating the HAL_INCLUDE file to be included however for nema_gfx it is done differently and there are also actually very few / none NEMA_GFX Kconfig entries to base it on. Is that on purpose ?

For other engines, there are usually LV_DRAW_xxx accessible via KConfig but that is not the case of NEMA_GFX. Is there a reason for that ?

Those modifications are done in the context of LVGL usage within Zephyr and as part of debugging the PR https://github.com/zephyrproject-rtos/zephyr/pull/105970.