### PR TITLE
feat(display): add get display flush cb

### DIFF
--- a/include/lvgl/display/lv_display.h
+++ b/include/lvgl/display/lv_display.h
@@ -318,7 +318,7 @@ void lv_display_set_flush_cb(lv_display_t * disp, lv_display_flush_cb_t flush_cb
 /**
  * Get the flush callback which will be called to copy the rendered image to the display.
  * @param disp      pointer to a display
- * @return          the color format
+ * @return          the flush callback
  */
 lv_display_flush_cb_t lv_display_get_flush_cb(lv_display_t * disp);
 

--- a/include/lvgl/display/lv_display.h
+++ b/include/lvgl/display/lv_display.h
@@ -316,6 +316,13 @@ void lv_display_set_render_mode(lv_display_t * disp, lv_display_render_mode_t re
 void lv_display_set_flush_cb(lv_display_t * disp, lv_display_flush_cb_t flush_cb);
 
 /**
+ * Get the flush callback which will be called to copy the rendered image to the display.
+ * @param disp      pointer to a display
+ * @return          the color format
+ */
+lv_display_flush_cb_t lv_display_get_flush_cb(lv_display_t * disp);
+
+/**
  * Set a callback to be used while LVGL is waiting flushing to be finished.
  * It can do any complex logic to wait, including semaphores, mutexes, polling flags, etc.
  * If not set the `disp->flushing` flag is used which can be cleared with `lv_display_flush_ready()`

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -556,6 +556,14 @@ void lv_display_set_render_mode(lv_display_t * disp, lv_display_render_mode_t re
     disp->render_mode = render_mode;
 }
 
+
+lv_display_flush_cb_t lv_display_get_flush_cb(lv_display_t * disp)
+{
+    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) return NULL;
+    return disp->flush_cb;
+}
+
 void lv_display_set_flush_cb(lv_display_t * disp, lv_display_flush_cb_t flush_cb)
 {
     if(disp == NULL) disp = lv_display_get_default();

--- a/tests/src/test_cases/test_display.c
+++ b/tests/src/test_cases/test_display.c
@@ -235,7 +235,7 @@ void test_display_triple_buffer(void)
 {
     lv_display_t * disp = lv_display_create(480, 320);
     lv_display_set_flush_cb(disp, dummy_flush_cb);
-    TEST_ASSERT_EQUAL(lv_display_get_flush_cb(disp), dummy_flush_cb);
+    TEST_ASSERT_EQUAL_PTR(lv_display_get_flush_cb(disp), dummy_flush_cb);
 
     lv_draw_buf_t * buf1 = lv_draw_buf_create(480, 320, LV_COLOR_FORMAT_NATIVE, 0);
     lv_draw_buf_t * buf2 = lv_draw_buf_create(480, 320, LV_COLOR_FORMAT_NATIVE, 0);

--- a/tests/src/test_cases/test_display.c
+++ b/tests/src/test_cases/test_display.c
@@ -235,6 +235,8 @@ void test_display_triple_buffer(void)
 {
     lv_display_t * disp = lv_display_create(480, 320);
     lv_display_set_flush_cb(disp, dummy_flush_cb);
+    TEST_ASSERT_EQUAL(lv_display_get_flush_cb(disp), dummy_flush_cb);
+
     lv_draw_buf_t * buf1 = lv_draw_buf_create(480, 320, LV_COLOR_FORMAT_NATIVE, 0);
     lv_draw_buf_t * buf2 = lv_draw_buf_create(480, 320, LV_COLOR_FORMAT_NATIVE, 0);
     lv_draw_buf_t * buf3 = lv_draw_buf_create(480, 320, LV_COLOR_FORMAT_NATIVE, 0);


### PR DESCRIPTION
Add a function to get the current display flush callback.

This is useful when temporarily chaining flush callbacks between LVGL and the hardware callback.
