### PR TITLE
refactor(lvgl_public): rename lv_public_api to lvgl_public

### DIFF
--- a/docs/src/common-widget-features/styles/style-properties.mdx
+++ b/docs/src/common-widget-features/styles/style-properties.mdx
@@ -822,7 +822,7 @@ Set opacity of lines.
 
 ## Arc
 
-TODO
+Properties to describe the Arc Widget
 
 <StyleProperty
   name="arc_width"

--- a/scripts/properties.py
+++ b/scripts/properties.py
@@ -144,7 +144,7 @@ def write_widget_properties(root_folder, properties_by_widget):
             else:
                 guard = None
 
-            include = "../../lv_public_api.h"
+            include = "../../lvgl_public.h"
 
             with open(output_file, 'w') as f:
                 f.write(f'''

--- a/scripts/style_api_gen.py
+++ b/scripts/style_api_gen.py
@@ -989,7 +989,7 @@ print('#endif /* LV_OBJ_STYLE_GEN_H */')
 sys.stdout = open(base_dir + '/../src/core/lv_obj_style_gen.c', 'w')
 
 print(HEADING)
-print('#include "../lv_public_api.h"')
+print('#include "../lvgl_public.h"')
 print()
 
 for prop in props:
@@ -1003,7 +1003,7 @@ guard_close()
 sys.stdout = open(base_dir + '/../src/misc/lv_style_gen.c', 'w')
 
 print(HEADING)
-print('#include "../lv_public_api.h"')
+print('#include "../lvgl_public.h"')
 print()
 
 for prop in props:

--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 #if LV_USE_DRAW_SW
 #include "../draw/sw/lv_draw_sw.h"

--- a/src/core/lv_group.c
+++ b/src/core/lv_group.c
@@ -9,7 +9,7 @@
 #include "lv_group_private.h"
 #include "../core/lv_obj_private.h"
 #include "../core/lv_global.h"
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/core/lv_group_private.h
+++ b/src/core/lv_group_private.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 #include "lv_obj_private.h"
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 #include "../misc/lv_event_private.h"
 #include "../misc/lv_area_private.h"
 #include "lv_obj_style_private.h"

--- a/src/core/lv_obj_class.c
+++ b/src/core/lv_obj_class.c
@@ -9,7 +9,7 @@
 #include "lv_obj_class_private.h"
 #include "lv_obj_private.h"
 #include "../display/lv_display_private.h"
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/core/lv_obj_class_private.h
+++ b/src/core/lv_obj_class_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/core/lv_obj_draw.c
+++ b/src/core/lv_obj_draw.c
@@ -8,7 +8,7 @@
  *********************/
 #include "lv_obj_draw_private.h"
 #include "lv_obj_private.h"
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/core/lv_obj_draw_private.h
+++ b/src/core/lv_obj_draw_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/core/lv_obj_event.c
+++ b/src/core/lv_obj_event.c
@@ -11,7 +11,7 @@
 #include "lv_obj_class_private.h"
 #include "lv_obj_private.h"
 #include "../indev/lv_indev_private.h"
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/core/lv_obj_event_private.h
+++ b/src/core/lv_obj_event_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/core/lv_obj_id_builtin.c
+++ b/src/core/lv_obj_id_builtin.c
@@ -9,7 +9,7 @@
 #include "lv_obj_class_private.h"
 #include "lv_obj_private.h"
 #include "lv_global.h"
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 #include "../osal/lv_os_private.h"
 
 /*********************

--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -15,7 +15,7 @@
 #include "../display/lv_display_private.h"
 #include "lv_refr_private.h"
 #include "../core/lv_global.h"
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/core/lv_obj_private.h
+++ b/src/core/lv_obj_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/core/lv_obj_property.c
+++ b/src/core/lv_obj_property.c
@@ -9,7 +9,7 @@
 #include "lv_obj_private.h"
 #include "../misc/lv_utils.h"
 #include "lv_obj_class_private.h"
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY
 

--- a/src/core/lv_obj_scroll.c
+++ b/src/core/lv_obj_scroll.c
@@ -10,7 +10,7 @@
 #include "../misc/lv_anim_private.h"
 #include "lv_obj_private.h"
 #include "../indev/lv_indev_scroll.h"
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/core/lv_obj_scroll_private.h
+++ b/src/core/lv_obj_scroll_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -13,7 +13,7 @@
 #include "../display/lv_display_private.h"
 #include "../core/lv_global.h"
 #include "lv_observer_private.h"
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/core/lv_obj_style_gen.c
+++ b/src/core/lv_obj_style_gen.c
@@ -8,7 +8,7 @@
  */
 
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 
 void lv_obj_set_style_width(lv_obj_t * obj, int32_t value, lv_style_selector_t selector)

--- a/src/core/lv_obj_style_private.h
+++ b/src/core/lv_obj_style_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -12,7 +12,7 @@
 #include "../display/lv_display_private.h"
 #include "../misc/lv_anim_private.h"
 #include "../core/lv_global.h"
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/core/lv_observer.c
+++ b/src/core/lv_observer.c
@@ -10,7 +10,7 @@
 #include "lv_observer_private.h"
 #if LV_USE_OBSERVER
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 #include "../core/lv_obj_private.h"
 #include "../misc/lv_event_private.h"
 /*********************

--- a/src/core/lv_observer_private.h
+++ b/src/core/lv_observer_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 #if LV_USE_OBSERVER
 

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -17,7 +17,7 @@
 #include "../draw/lv_draw_private.h"
 #include "../draw/opengles/lv_draw_opengles.h"
 #include "lv_global.h"
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/core/lv_refr_private.h
+++ b/src/core/lv_refr_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/debugging/monkey/lv_monkey_private.h
+++ b/src/debugging/monkey/lv_monkey_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_MONKEY
 

--- a/src/debugging/sysmon/lv_sysmon_private.h
+++ b/src/debugging/sysmon/lv_sysmon_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_SYSMON
 

--- a/src/debugging/test/lv_test_display.c
+++ b/src/debugging/test/lv_test_display.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_TEST
 
 #include "../../core/lv_global.h"

--- a/src/debugging/test/lv_test_fs.c
+++ b/src/debugging/test/lv_test_fs.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_TEST
 

--- a/src/debugging/test/lv_test_helpers.c
+++ b/src/debugging/test/lv_test_helpers.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_TEST
 

--- a/src/debugging/test/lv_test_indev.c
+++ b/src/debugging/test/lv_test_indev.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_TEST
 
 #include "../../core/lv_global.h"

--- a/src/debugging/test/lv_test_indev_gesture.c
+++ b/src/debugging/test/lv_test_indev_gesture.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_TEST && LV_USE_GESTURE_RECOGNITION
 
 #include "../../core/lv_global.h"

--- a/src/debugging/test/lv_test_private.h
+++ b/src/debugging/test/lv_test_private.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_TEST
 

--- a/src/debugging/test/lv_test_screenshot_compare.c
+++ b/src/debugging/test/lv_test_screenshot_compare.c
@@ -11,7 +11,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_TEST && defined(LV_USE_TEST_SCREENSHOT_COMPARE) && LV_USE_TEST_SCREENSHOT_COMPARE
 

--- a/src/debugging/vg_lite_tvg/vg_lite_matrix.c
+++ b/src/debugging/vg_lite_tvg/vg_lite_matrix.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_DRAW_VG_LITE && LV_USE_VG_LITE_THORVG
 

--- a/src/debugging/vg_lite_tvg/vg_lite_tvg.cpp
+++ b/src/debugging/vg_lite_tvg/vg_lite_tvg.cpp
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_DRAW_VG_LITE && LV_USE_VG_LITE_THORVG
 
 #include "vg_lite.h"

--- a/src/display/lv_display_private.h
+++ b/src/display/lv_display_private.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 #if LV_USE_SYSMON
 #include "../debugging/sysmon/lv_sysmon_private.h"

--- a/src/draw/convert/helium/lv_draw_buf_convert_helium.c
+++ b/src/draw/convert/helium/lv_draw_buf_convert_helium.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_HELIUM
 #include "lv_draw_buf_convert_helium.h"

--- a/src/draw/convert/helium/lv_draw_buf_convert_helium.h
+++ b/src/draw/convert/helium/lv_draw_buf_convert_helium.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_HELIUM
 

--- a/src/draw/convert/lv_draw_buf_convert.c
+++ b/src/draw/convert/lv_draw_buf_convert.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #include "lv_draw_buf_convert.h"
 
 #if LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_NEON

--- a/src/draw/convert/lv_draw_buf_convert.h
+++ b/src/draw/convert/lv_draw_buf_convert.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/draw/convert/neon/lv_draw_buf_convert_neon.c
+++ b/src/draw/convert/neon/lv_draw_buf_convert_neon.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_NEON
 

--- a/src/draw/convert/neon/lv_draw_buf_convert_neon.h
+++ b/src/draw/convert/neon/lv_draw_buf_convert_neon.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_NEON
 

--- a/src/draw/dma2d/lv_draw_dma2d.h
+++ b/src/draw/dma2d/lv_draw_dma2d.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_DRAW_DMA2D
 
 /*********************

--- a/src/draw/dma2d/lv_draw_dma2d_private.h
+++ b/src/draw/dma2d/lv_draw_dma2d_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_DRAW_DMA2D
 
 #include "../lv_draw_private.h"

--- a/src/draw/espressif/ppa/lv_draw_ppa.h
+++ b/src/draw/espressif/ppa/lv_draw_ppa.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_PPA
 

--- a/src/draw/espressif/ppa/lv_draw_ppa_private.h
+++ b/src/draw/espressif/ppa/lv_draw_ppa_private.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
 *      INCLUDES
 *********************/
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_PPA
 #if LV_PPA_NONBLOCKING_OPS

--- a/src/draw/eve/lv_draw_eve.c
+++ b/src/draw/eve/lv_draw_eve.c
@@ -13,7 +13,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_DRAW_EVE
 
 #include "../../display/lv_display_private.h"

--- a/src/draw/eve/lv_draw_eve.h
+++ b/src/draw/eve/lv_draw_eve.h
@@ -21,7 +21,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_DRAW_EVE
 
 /*********************

--- a/src/draw/eve/lv_draw_eve_private.h
+++ b/src/draw/eve/lv_draw_eve_private.h
@@ -19,7 +19,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_DRAW_EVE
 
 #include "lv_draw_eve_ram_g.h"

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -10,7 +10,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 #include "../misc/lv_area_private.h"
 #include "../misc/lv_event_private.h"
 #include "lv_draw_private.h"

--- a/src/draw/lv_draw_buf_private.h
+++ b/src/draw/lv_draw_buf_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/draw/lv_draw_image_private.h
+++ b/src/draw/lv_draw_image_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/draw/lv_draw_label_private.h
+++ b/src/draw/lv_draw_label_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/draw/lv_draw_private.h
+++ b/src/draw/lv_draw_private.h
@@ -18,7 +18,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 #include "../osal/lv_os_private.h"
 #include "../misc/cache/lv_cache.h"
 #include "../misc/cache/lv_cache_entry.h"

--- a/src/draw/nanovg/lv_draw_nanovg.h
+++ b/src/draw/nanovg/lv_draw_nanovg.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_DRAW_NANOVG
 

--- a/src/draw/nanovg/lv_draw_nanovg_private.h
+++ b/src/draw/nanovg/lv_draw_nanovg_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_DRAW_NANOVG
 

--- a/src/draw/nanovg/lv_nanovg_fbo_cache.h
+++ b/src/draw/nanovg/lv_nanovg_fbo_cache.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_DRAW_NANOVG
 

--- a/src/draw/nanovg/lv_nanovg_image_cache.h
+++ b/src/draw/nanovg/lv_nanovg_image_cache.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_DRAW_NANOVG
 

--- a/src/draw/nanovg/lv_nanovg_math.h
+++ b/src/draw/nanovg/lv_nanovg_math.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_DRAW_NANOVG
 

--- a/src/draw/nanovg/lv_nanovg_utils.h
+++ b/src/draw/nanovg/lv_nanovg_utils.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_DRAW_NANOVG
 

--- a/src/draw/nema_gfx/lv_draw_nema_gfx.h
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx.h
@@ -39,7 +39,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_NEMA_GFX
 

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_stm32_hal.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_stm32_hal.c
@@ -9,7 +9,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_NEMA_GFX
 
 #if LV_USE_NEMA_HAL == LV_NEMA_HAL_STM32

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_utils.h
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_utils.h
@@ -39,7 +39,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_NEMA_GFX
 #include "../sw/lv_draw_sw.h"

--- a/src/draw/nema_gfx/lv_nema_gfx_path.c
+++ b/src/draw/nema_gfx/lv_nema_gfx_path.c
@@ -32,7 +32,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_NEMA_GFX
 #if LV_USE_NEMA_VG

--- a/src/draw/nxp/g2d/lv_draw_g2d.h
+++ b/src/draw/nxp/g2d/lv_draw_g2d.h
@@ -20,7 +20,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_G2D
 #if LV_USE_DRAW_G2D

--- a/src/draw/nxp/g2d/lv_g2d_buf_map.h
+++ b/src/draw/nxp/g2d/lv_g2d_buf_map.h
@@ -21,7 +21,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_G2D
 #if LV_USE_DRAW_G2D

--- a/src/draw/nxp/g2d/lv_g2d_utils.h
+++ b/src/draw/nxp/g2d/lv_g2d_utils.h
@@ -19,7 +19,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_G2D
 #if LV_USE_DRAW_G2D

--- a/src/draw/nxp/pxp/lv_draw_pxp.h
+++ b/src/draw/nxp/pxp/lv_draw_pxp.h
@@ -20,7 +20,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_PXP
 #if LV_USE_DRAW_PXP || LV_USE_ROTATE_PXP

--- a/src/draw/nxp/pxp/lv_pxp_cfg.h
+++ b/src/draw/nxp/pxp/lv_pxp_cfg.h
@@ -20,7 +20,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_PXP
 #if LV_USE_DRAW_PXP || LV_USE_ROTATE_PXP

--- a/src/draw/nxp/pxp/lv_pxp_osa.h
+++ b/src/draw/nxp/pxp/lv_pxp_osa.h
@@ -20,7 +20,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_PXP
 #if LV_USE_DRAW_PXP || LV_USE_ROTATE_PXP

--- a/src/draw/nxp/pxp/lv_pxp_utils.h
+++ b/src/draw/nxp/pxp/lv_pxp_utils.h
@@ -19,7 +19,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_PXP
 #if LV_USE_DRAW_PXP || LV_USE_ROTATE_PXP

--- a/src/draw/opengles/lv_draw_opengles.h
+++ b/src/draw/opengles/lv_draw_opengles.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_DRAW_OPENGLES
 
 

--- a/src/draw/renesas/dave2d/lv_draw_dave2d.h
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_DRAW_DAVE2D
 #include "../../lv_draw_private.h"
 #include "bsp_api.h"

--- a/src/draw/sdl/lv_draw_sdl.h
+++ b/src/draw/sdl/lv_draw_sdl.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_DRAW_SDL
 

--- a/src/draw/snapshot/lv_snapshot.c
+++ b/src/draw/snapshot/lv_snapshot.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_SNAPSHOT
 
 #include "../../draw/lv_draw_private.h"

--- a/src/draw/sw/arm2d/lv_draw_sw_arm2d.h
+++ b/src/draw/sw/arm2d/lv_draw_sw_arm2d.h
@@ -16,7 +16,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #include "../../../misc/lv_area_private.h"
 #include "../../../draw/lv_draw_private.h"
 #include "../../../draw/lv_draw_image_private.h"

--- a/src/draw/sw/arm2d/lv_draw_sw_helium.h
+++ b/src/draw/sw/arm2d/lv_draw_sw_helium.h
@@ -16,7 +16,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 /* detect whether helium is available based on arm compilers' standard */
 #if defined(__ARM_FEATURE_MVE) && __ARM_FEATURE_MVE

--- a/src/draw/sw/blend/arm2d/lv_blend_arm2d.h
+++ b/src/draw/sw/blend/arm2d/lv_blend_arm2d.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../../../lv_public_api.h"
+#include "../../../../lvgl_public.h"
 
 #if LV_USE_DRAW_ARM2D_SYNC
 

--- a/src/draw/sw/blend/helium/lv_blend_helium.S
+++ b/src/draw/sw/blend/helium/lv_blend_helium.S
@@ -9,7 +9,7 @@
 #define __ASSEMBLY__
 #endif
 
-#include "../../../../lv_public_api.h"
+#include "../../../../lvgl_public.h"
 
 #if LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_HELIUM && LV_USE_NATIVE_HELIUM_ASM
 

--- a/src/draw/sw/blend/helium/lv_blend_helium.h
+++ b/src/draw/sw/blend/helium/lv_blend_helium.h
@@ -19,7 +19,7 @@ extern "C" {
 #include "lv_conf_cmsis.h"
 #endif
 
-#include "../../../../lv_public_api.h"
+#include "../../../../lvgl_public.h"
 
 /* detect whether helium is available based on arm compilers' standard */
 #if defined(__ARM_FEATURE_MVE) && __ARM_FEATURE_MVE

--- a/src/draw/sw/blend/lv_draw_sw_blend.h
+++ b/src/draw/sw/blend/lv_draw_sw_blend.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_DRAW_SW
 

--- a/src/draw/sw/blend/neon/lv_blend_neon.h
+++ b/src/draw/sw/blend/neon/lv_blend_neon.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../../../lv_public_api.h"
+#include "../../../../lvgl_public.h"
 
 #if LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_NEON
 

--- a/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.h
+++ b/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../../../lv_public_api.h"
+#include "../../../../lvgl_public.h"
 #if LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_NEON
 
 /*********************

--- a/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb888.h
+++ b/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb888.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../../../lv_public_api.h"
+#include "../../../../lvgl_public.h"
 #if LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_NEON
 
 /*********************

--- a/src/draw/sw/blend/riscv_v/lv_blend_riscv_v_private.h
+++ b/src/draw/sw/blend/riscv_v/lv_blend_riscv_v_private.h
@@ -20,7 +20,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../../../lv_public_api.h"
+#include "../../../../lvgl_public.h"
 #if LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_RISCV_V
 
 /* Try to use real RVV, fall back to emulation if not available */

--- a/src/draw/sw/blend/riscv_v/lv_blend_riscv_vector_emulation.h
+++ b/src/draw/sw/blend/riscv_v/lv_blend_riscv_vector_emulation.h
@@ -25,7 +25,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#include "../../../../lv_public_api.h"
+#include "../../../../lvgl_public.h"
 #if LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_RISCV_V
 
 #include <stdint.h>

--- a/src/draw/sw/blend/riscv_v/lv_draw_sw_blend_riscv_v_to_rgb888.h
+++ b/src/draw/sw/blend/riscv_v/lv_draw_sw_blend_riscv_v_to_rgb888.h
@@ -13,7 +13,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../../../lv_public_api.h"
+#include "../../../../lvgl_public.h"
 #if LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_RISCV_V
 
 /*********************

--- a/src/draw/vg_lite/lv_draw_vg_lite.h
+++ b/src/draw/vg_lite/lv_draw_vg_lite.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_DRAW_VG_LITE
 

--- a/src/draw/vg_lite/lv_draw_vg_lite_type.h
+++ b/src/draw/vg_lite/lv_draw_vg_lite_type.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_DRAW_VG_LITE
 

--- a/src/draw/vg_lite/lv_vg_lite_bitmap_font_cache.h
+++ b/src/draw/vg_lite/lv_vg_lite_bitmap_font_cache.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_DRAW_VG_LITE
 

--- a/src/draw/vg_lite/lv_vg_lite_decoder.h
+++ b/src/draw/vg_lite/lv_vg_lite_decoder.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_DRAW_VG_LITE
 

--- a/src/draw/vg_lite/lv_vg_lite_grad.h
+++ b/src/draw/vg_lite/lv_vg_lite_grad.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_DRAW_VG_LITE && LV_USE_VECTOR_GRAPHIC
 

--- a/src/draw/vg_lite/lv_vg_lite_math.h
+++ b/src/draw/vg_lite/lv_vg_lite_math.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_DRAW_VG_LITE
 

--- a/src/draw/vg_lite/lv_vg_lite_pending.h
+++ b/src/draw/vg_lite/lv_vg_lite_pending.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_DRAW_VG_LITE
 

--- a/src/draw/vg_lite/lv_vg_lite_utils.h
+++ b/src/draw/vg_lite/lv_vg_lite_utils.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_DRAW_VG_LITE
 

--- a/src/drivers/display/drm/lv_linux_drm.c
+++ b/src/drivers/display/drm/lv_linux_drm.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_LINUX_DRM && !LV_LINUX_DRM_USE_EGL
 
 #include <errno.h>

--- a/src/drivers/display/drm/lv_linux_drm_common.c
+++ b/src/drivers/display/drm/lv_linux_drm_common.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_LINUX_DRM
 

--- a/src/drivers/display/drm/lv_linux_drm_egl.c
+++ b/src/drivers/display/drm/lv_linux_drm_egl.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_LINUX_DRM && LV_LINUX_DRM_USE_EGL
 

--- a/src/drivers/display/drm/lv_linux_drm_egl_private.h
+++ b/src/drivers/display/drm/lv_linux_drm_egl_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_LINUX_DRM && LV_LINUX_DRM_USE_EGL
 

--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_LINUX_FBDEV
 
 #include <stdlib.h>

--- a/src/drivers/display/ft81x/lv_ft81x.c
+++ b/src/drivers/display/ft81x/lv_ft81x.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_FT81X
 
 #include "lv_ft81x_defines.h"

--- a/src/drivers/display/ili9341/lv_ili9341.c
+++ b/src/drivers/display/ili9341/lv_ili9341.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_ILI9341
 

--- a/src/drivers/display/lcd/lv_lcd_generic_mipi.c
+++ b/src/drivers/display/lcd/lv_lcd_generic_mipi.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_GENERIC_MIPI
 

--- a/src/drivers/display/lovyan_gfx/lv_lgfx_user.hpp
+++ b/src/drivers/display/lovyan_gfx/lv_lgfx_user.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_LOVYAN_GFX
 

--- a/src/drivers/display/lovyan_gfx/lv_lovyan_gfx.cpp
+++ b/src/drivers/display/lovyan_gfx/lv_lovyan_gfx.cpp
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_LOVYAN_GFX
 
 #include LV_LGFX_USER_INCLUDE

--- a/src/drivers/display/nv3007/lv_nv3007.c
+++ b/src/drivers/display/nv3007/lv_nv3007.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_NV3007
 

--- a/src/drivers/display/nxp_elcdif/lv_nxp_elcdif.c
+++ b/src/drivers/display/nxp_elcdif/lv_nxp_elcdif.c
@@ -4,7 +4,7 @@
  * Driver for NXP's ELCD
  */
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_NXP_ELCDIF
 /*********************

--- a/src/drivers/display/renesas_glcdc/lv_renesas_glcdc.c
+++ b/src/drivers/display/renesas_glcdc/lv_renesas_glcdc.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_RENESAS_GLCDC
 

--- a/src/drivers/display/st7735/lv_st7735.c
+++ b/src/drivers/display/st7735/lv_st7735.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_ST7735
 

--- a/src/drivers/display/st7789/lv_st7789.c
+++ b/src/drivers/display/st7789/lv_st7789.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_ST7789
 

--- a/src/drivers/display/st7796/lv_st7796.c
+++ b/src/drivers/display/st7796/lv_st7796.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_ST7796
 

--- a/src/drivers/display/st_ltdc/lv_st_ltdc.c
+++ b/src/drivers/display/st_ltdc/lv_st_ltdc.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_ST_LTDC
 
 #include "../../../display/lv_display_private.h"

--- a/src/drivers/display/tft_espi/lv_tft_espi.cpp
+++ b/src/drivers/display/tft_espi/lv_tft_espi.cpp
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_TFT_ESPI
 
 #include <TFT_eSPI.h>

--- a/src/drivers/draw/eve/lv_draw_eve_display.c
+++ b/src/drivers/draw/eve/lv_draw_eve_display.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_DRAW_EVE
 
 #include "../../../draw/eve/lv_eve.h"

--- a/src/drivers/evdev/lv_evdev_private.h
+++ b/src/drivers/evdev/lv_evdev_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_EVDEV
 

--- a/src/drivers/libinput/lv_libinput_private.h
+++ b/src/drivers/libinput/lv_libinput_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_LIBINPUT
 

--- a/src/drivers/libinput/lv_xkb_private.h
+++ b/src/drivers/libinput/lv_xkb_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if defined(LV_LIBINPUT_XKB) && LV_LIBINPUT_XKB
 

--- a/src/drivers/nuttx/lv_nuttx_cache.c
+++ b/src/drivers/nuttx/lv_nuttx_cache.c
@@ -8,7 +8,7 @@
  *********************/
 
 #include "lv_nuttx_cache.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_NUTTX
 

--- a/src/drivers/nuttx/lv_nuttx_entry.c
+++ b/src/drivers/nuttx/lv_nuttx_entry.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_NUTTX
 
@@ -19,7 +19,6 @@
 #include "../../core/lv_global.h"
 #include "lv_nuttx_profiler.h"
 #include "lv_nuttx_mouse.h"
-#include "../../lv_public_api.h"
 
 #if LV_USE_NUTTX_LIBUV
     #include <uv.h>

--- a/src/drivers/nuttx/lv_nuttx_fbdev.c
+++ b/src/drivers/nuttx/lv_nuttx_fbdev.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_NUTTX
 
 #include <stdlib.h>

--- a/src/drivers/nuttx/lv_nuttx_image_cache.c
+++ b/src/drivers/nuttx/lv_nuttx_image_cache.c
@@ -9,7 +9,7 @@
 
 #include "lv_nuttx_image_cache.h"
 #include "../../core/lv_global.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_NUTTX
 

--- a/src/drivers/nuttx/lv_nuttx_image_cache.h
+++ b/src/drivers/nuttx/lv_nuttx_image_cache.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #include LV_STDBOOL_INCLUDE
 
 /*********************

--- a/src/drivers/nuttx/lv_nuttx_lcd.c
+++ b/src/drivers/nuttx/lv_nuttx_lcd.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_NUTTX
 

--- a/src/drivers/nuttx/lv_nuttx_libuv.c
+++ b/src/drivers/nuttx/lv_nuttx_libuv.c
@@ -5,7 +5,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_NUTTX
 #include "../../lvgl_private.h"

--- a/src/drivers/nuttx/lv_nuttx_mouse.c
+++ b/src/drivers/nuttx/lv_nuttx_mouse.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_NUTTX
 

--- a/src/drivers/nuttx/lv_nuttx_mouse.h
+++ b/src/drivers/nuttx/lv_nuttx_mouse.h
@@ -18,7 +18,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_NUTTX
 

--- a/src/drivers/nuttx/lv_nuttx_profiler.c
+++ b/src/drivers/nuttx/lv_nuttx_profiler.c
@@ -11,7 +11,7 @@
 
 #if LV_USE_NUTTX && LV_USE_PROFILER && LV_USE_PROFILER_BUILTIN
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #include "../../misc/lv_profiler_builtin_private.h"
 #include "../../core/lv_global.h"
 #include <fcntl.h>

--- a/src/drivers/nuttx/lv_nuttx_profiler.h
+++ b/src/drivers/nuttx/lv_nuttx_profiler.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_NUTTX && LV_USE_PROFILER && LV_USE_PROFILER_BUILTIN
 

--- a/src/drivers/nuttx/lv_nuttx_touchscreen.c
+++ b/src/drivers/nuttx/lv_nuttx_touchscreen.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_NUTTX
 

--- a/src/drivers/opengles/glad/include/EGL/eglplatform.h
+++ b/src/drivers/opengles/glad/include/EGL/eglplatform.h
@@ -1,7 +1,7 @@
 #ifndef __eglplatform_h_
 #define __eglplatform_h_
 
-#include "../../../../../lv_public_api.h"
+#include "../../../../../lvgl_public.h"
 #if LV_USE_OPENGLES
 
 /*

--- a/src/drivers/opengles/glad/include/KHR/khrplatform.h
+++ b/src/drivers/opengles/glad/include/KHR/khrplatform.h
@@ -1,7 +1,7 @@
 #ifndef __khrplatform_h_
 #define __khrplatform_h_
 
-#include "../../../../../lv_public_api.h"
+#include "../../../../../lvgl_public.h"
 #if LV_USE_OPENGLES
 /*
 ** Copyright (c) 2008-2018 The Khronos Group Inc.

--- a/src/drivers/opengles/glad/include/glad/egl.h
+++ b/src/drivers/opengles/glad/include/glad/egl.h
@@ -30,7 +30,7 @@
 #define GLAD_EGL_H_
 
 
-#include "../../../../../lv_public_api.h"
+#include "../../../../../lvgl_public.h"
 #if LV_USE_EGL
 
 #define GLAD_EGL

--- a/src/drivers/opengles/glad/include/glad/gl.h
+++ b/src/drivers/opengles/glad/include/glad/gl.h
@@ -29,7 +29,7 @@
 #ifndef GLAD_GL_H_
 #define GLAD_GL_H_
 
-#include "../../../../../lv_public_api.h"
+#include "../../../../../lvgl_public.h"
 
 #if LV_USE_OPENGLES && !LV_USE_EGL
 

--- a/src/drivers/opengles/glad/include/glad/gles2.h
+++ b/src/drivers/opengles/glad/include/glad/gles2.h
@@ -29,7 +29,7 @@
 #ifndef GLAD_GLES2_H_
 #define GLAD_GLES2_H_
 
-#include "../../../../../lv_public_api.h"
+#include "../../../../../lvgl_public.h"
 #if LV_USE_EGL
 
 #ifdef __clang__

--- a/src/drivers/opengles/lv_opengles_debug.h
+++ b/src/drivers/opengles/lv_opengles_debug.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_OPENGLES
 
 /*********************

--- a/src/drivers/opengles/lv_opengles_egl.c
+++ b/src/drivers/opengles/lv_opengles_egl.c
@@ -16,7 +16,7 @@
 #include <string.h>
 #include "lv_opengles_debug.h"
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #include "glad/include/glad/egl.h"
 #include "lv_opengles_private.h"
 #include "lv_opengles_egl_private.h"

--- a/src/drivers/opengles/lv_opengles_egl.h
+++ b/src/drivers/opengles/lv_opengles_egl.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_EGL
 

--- a/src/drivers/opengles/lv_opengles_egl_private.h
+++ b/src/drivers/opengles/lv_opengles_egl_private.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_EGL
 

--- a/src/drivers/opengles/lv_opengles_glfw.c
+++ b/src/drivers/opengles/lv_opengles_glfw.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_GLFW
 

--- a/src/drivers/opengles/lv_opengles_private.h
+++ b/src/drivers/opengles/lv_opengles_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OPENGLES
 

--- a/src/drivers/opengles/lv_opengles_texture.c
+++ b/src/drivers/opengles/lv_opengles_texture.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OPENGLES
 

--- a/src/drivers/opengles/lv_opengles_texture_private.h
+++ b/src/drivers/opengles/lv_opengles_texture_private.h
@@ -14,7 +14,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OPENGLES
 

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_internal.h
@@ -6,7 +6,7 @@
 #ifndef LV_OPENGL_SHADER_INTERNAL_H
 #define LV_OPENGL_SHADER_INTERNAL_H
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_OPENGLES
 

--- a/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
+++ b/src/drivers/opengles/opengl_shader/lv_opengl_shader_manager.c
@@ -8,7 +8,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_OPENGLES
 

--- a/src/drivers/qnx/lv_qnx.c
+++ b/src/drivers/qnx/lv_qnx.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_QNX
 #include <stdbool.h>
 #include "../../core/lv_global.h"

--- a/src/drivers/sdl/lv_sdl_egl.c
+++ b/src/drivers/sdl/lv_sdl_egl.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_SDL_USE_EGL
 

--- a/src/drivers/sdl/lv_sdl_private.h
+++ b/src/drivers/sdl/lv_sdl_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_SDL
 

--- a/src/drivers/sdl/lv_sdl_window.c
+++ b/src/drivers/sdl/lv_sdl_window.c
@@ -10,7 +10,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_SDL
 #include <stdbool.h>

--- a/src/drivers/uefi/lv_uefi_private.h
+++ b/src/drivers/uefi/lv_uefi_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_UEFI
 

--- a/src/drivers/wayland/lv_wayland_private.h
+++ b/src/drivers/wayland/lv_wayland_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_WAYLAND
 

--- a/src/drivers/wayland/lv_wayland_seat.c
+++ b/src/drivers/wayland/lv_wayland_seat.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_WAYLAND
 

--- a/src/drivers/windows/lv_windows_context.h
+++ b/src/drivers/windows/lv_windows_context.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_WINDOWS
 

--- a/src/drivers/windows/lv_windows_display.c
+++ b/src/drivers/windows/lv_windows_display.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_WINDOWS
 
 #include "lv_windows_context.h"

--- a/src/drivers/windows/lv_windows_input.c
+++ b/src/drivers/windows/lv_windows_input.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_WINDOWS
 

--- a/src/drivers/x11/lv_x11_display.c
+++ b/src/drivers/x11/lv_x11_display.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_X11
 

--- a/src/drivers/x11/lv_x11_input.c
+++ b/src/drivers/x11/lv_x11_input.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_X11
 

--- a/src/font/binfont_loader/lv_binfont_loader.c
+++ b/src/font/binfont_loader/lv_binfont_loader.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #include "../fmt_txt/lv_font_fmt_txt_private.h"
 #include "../../misc/lv_fs_private.h"
 

--- a/src/font/fmt_txt/lv_font_fmt_txt_private.h
+++ b/src/font/fmt_txt/lv_font_fmt_txt_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_FONT_COMPRESSED
 

--- a/src/font/font_manager/lv_font_manager.c
+++ b/src/font/font_manager/lv_font_manager.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_FONT_MANAGER
 

--- a/src/font/font_manager/lv_font_manager_recycle.h
+++ b/src/font/font_manager/lv_font_manager_recycle.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_FONT_MANAGER
 

--- a/src/font/lv_font_private.h
+++ b/src/font/lv_font_private.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/indev/lv_gridnav.c
+++ b/src/indev/lv_gridnav.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 #if LV_USE_GRIDNAV
 
 #include "../core/lv_obj_private.h"

--- a/src/indev/lv_indev_gesture_private.h
+++ b/src/indev/lv_indev_gesture_private.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 #if LV_USE_GESTURE_RECOGNITION
 

--- a/src/indev/lv_indev_private.h
+++ b/src/indev/lv_indev_private.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 #include "lv_indev_scroll.h"
 
 /*********************

--- a/src/indev/lv_indev_scroll.h
+++ b/src/indev/lv_indev_scroll.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/layouts/grid/lv_grid.c
+++ b/src/layouts/grid/lv_grid.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_GRID
 

--- a/src/layouts/lv_layout_private.h
+++ b/src/layouts/lv_layout_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/libs/FT800-FT813/EVE_commands.c
+++ b/src/libs/FT800-FT813/EVE_commands.c
@@ -1,4 +1,4 @@
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_DRAW_EVE
 /*
 @file    EVE_commands.c

--- a/src/libs/FT800-FT813/EVE_supplemental.c
+++ b/src/libs/FT800-FT813/EVE_supplemental.c
@@ -1,4 +1,4 @@
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_DRAW_EVE
 /*
 @file    EVE_supplemental.h

--- a/src/libs/FT800-FT813/EVE_target.h
+++ b/src/libs/FT800-FT813/EVE_target.h
@@ -1,7 +1,7 @@
 #ifndef EVE_TARGET_H
 #define EVE_TARGET_H
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #include "../../draw/eve/lv_draw_eve_private.h"
 #include "../../core/lv_global.h"
 

--- a/src/libs/barcode/lv_barcode_private.h
+++ b/src/libs/barcode/lv_barcode_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_BARCODE
 

--- a/src/libs/ffmpeg/lv_ffmpeg_private.h
+++ b/src/libs/ffmpeg/lv_ffmpeg_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_FFMPEG
 #include "../../widgets/image/lv_image_private.h"
 

--- a/src/libs/freetype/lv_freetype_outline.c
+++ b/src/libs/freetype/lv_freetype_outline.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #include "../../misc/lv_event_private.h"
 #include "lv_freetype_private.h"
 

--- a/src/libs/freetype/lv_freetype_private.h
+++ b/src/libs/freetype/lv_freetype_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_FREETYPE
 

--- a/src/libs/frogfs/include/frogfs/frogfs.h
+++ b/src/libs/frogfs/include/frogfs/frogfs.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#include "../../../../lv_public_api.h"
+#include "../../../../lvgl_public.h"
 #include LV_STDDEF_INCLUDE
 #include LV_STDINT_INCLUDE
 #include "frogfs_types.h"

--- a/src/libs/frogfs/include/frogfs/frogfs_types.h
+++ b/src/libs/frogfs/include/frogfs/frogfs_types.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../../../../lv_public_api.h"
+#include "../../../../lvgl_public.h"
 #include LV_STDINT_INCLUDE
 
 typedef intptr_t ssize_t;

--- a/src/libs/frogfs/src/decomp_raw.c
+++ b/src/libs/frogfs/src/decomp_raw.c
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #include LV_STDDEF_INCLUDE
 #include LV_STDINT_INCLUDE
 

--- a/src/libs/frogfs/src/frogfs.c
+++ b/src/libs/frogfs/src/frogfs.c
@@ -8,7 +8,7 @@
  * tool that comes with this source distribution.
  */
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_FS_FROGFS
 
 #include "frogfs_priv.h"

--- a/src/libs/frogfs/src/frogfs_format.h
+++ b/src/libs/frogfs/src/frogfs_format.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #include LV_STDINT_INCLUDE
 
 

--- a/src/libs/gif/AnimatedGIF.h
+++ b/src/libs/gif/AnimatedGIF.h
@@ -13,7 +13,7 @@
 #ifndef __ANIMATEDGIF__
 #define __ANIMATEDGIF__
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_GIF
 

--- a/src/libs/gltf/fastgltf/lv_fastgltf.hpp
+++ b/src/libs/gltf/fastgltf/lv_fastgltf.hpp
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_GLTF
 

--- a/src/libs/gltf/gltf_data/lv_gltf_data_internal.h
+++ b/src/libs/gltf/gltf_data/lv_gltf_data_internal.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_GLTF
 

--- a/src/libs/gltf/gltf_data/lv_gltf_data_internal.hpp
+++ b/src/libs/gltf/gltf_data/lv_gltf_data_internal.hpp
@@ -1,7 +1,7 @@
 #ifndef LV_GLTFDATA_HPP
 #define LV_GLTFDATA_HPP
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_GLTF
 

--- a/src/libs/gltf/gltf_environment/lv_gltf_environment_private.h
+++ b/src/libs/gltf/gltf_environment/lv_gltf_environment_private.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_GLTF
 
 #include "../../../drivers/opengles/opengl_shader/lv_opengl_shader_internal.h"

--- a/src/libs/gltf/gltf_view/assets/chromatic.c
+++ b/src/libs/gltf/gltf_view/assets/chromatic.c
@@ -1,4 +1,4 @@
-#include "../../../../lv_public_api.h"
+#include "../../../../lvgl_public.h"
 
 #if LV_USE_GLTF
 unsigned char chromatic_jpg[] = {

--- a/src/libs/gltf/gltf_view/lv_gltf_view_internal.h
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_internal.h
@@ -10,7 +10,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_GLTF
 

--- a/src/libs/gltf/math/lv_3dmath.c
+++ b/src/libs/gltf/math/lv_3dmath.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_GLTF
 
 /*********************

--- a/src/libs/gltf/math/lv_gltf_math.hpp
+++ b/src/libs/gltf/math/lv_gltf_math.hpp
@@ -10,7 +10,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 #if LV_USE_GLTF
 

--- a/src/libs/gstreamer/lv_gstreamer_internal.h
+++ b/src/libs/gstreamer/lv_gstreamer_internal.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_GSTREAMER
 

--- a/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
+++ b/src/libs/libjpeg_turbo/lv_libjpeg_turbo.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_LIBJPEG_TURBO
 

--- a/src/libs/libpng/lv_libpng.c
+++ b/src/libs/libpng/lv_libpng.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_LIBPNG
 

--- a/src/libs/libwebp/lv_libwebp.c
+++ b/src/libs/libwebp/lv_libwebp.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_LIBWEBP
 

--- a/src/libs/lodepng/lv_lodepng.c
+++ b/src/libs/lodepng/lv_lodepng.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_LODEPNG
 

--- a/src/libs/lz4/lz4.c
+++ b/src/libs/lz4/lz4.c
@@ -32,7 +32,7 @@
     - LZ4 source repository : https://github.com/lz4/lz4
 */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_LZ4_INTERNAL
 
 /*-************************************

--- a/src/libs/lz4/lz4.h
+++ b/src/libs/lz4/lz4.h
@@ -33,7 +33,7 @@
     - LZ4 source repository : https://github.com/lz4/lz4
 */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_LZ4_INTERNAL
 #if defined (__cplusplus)
 extern "C" {

--- a/src/libs/nanovg/nanovg.c
+++ b/src/libs/nanovg/nanovg.c
@@ -16,7 +16,7 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_NANOVG
 

--- a/src/libs/nanovg/nanovg.h
+++ b/src/libs/nanovg/nanovg.h
@@ -23,7 +23,7 @@
 extern "C" {
 #endif
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_NANOVG
 

--- a/src/libs/nanovg/nanovg_gl.h
+++ b/src/libs/nanovg/nanovg_gl.h
@@ -18,7 +18,7 @@
 #ifndef NANOVG_GL_H
 #define NANOVG_GL_H
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_NANOVG
 
@@ -116,7 +116,6 @@ enum NVGimageFlagsGL {
 
 #include <math.h>
 #include "nanovg.h"
-#include "../../lv_public_api.h"
 
 enum GLNVGuniformLoc {
     GLNVG_LOC_VIEWSIZE,

--- a/src/libs/nanovg/nanovg_gl_utils.h
+++ b/src/libs/nanovg/nanovg_gl_utils.h
@@ -18,7 +18,7 @@
 #ifndef NANOVG_GL_UTILS_H
 #define NANOVG_GL_UTILS_H
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_NANOVG
 

--- a/src/libs/qrcode/lv_qrcode_private.h
+++ b/src/libs/qrcode/lv_qrcode_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_QRCODE
 

--- a/src/libs/qrcode/qrcodegen.c
+++ b/src/libs/qrcode/qrcodegen.c
@@ -22,7 +22,7 @@
  */
 
 #include "qrcodegen.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_QRCODE
 #include <limits.h>

--- a/src/libs/rle/lv_rle_private.h
+++ b/src/libs/rle/lv_rle_private.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_RLE
 

--- a/src/libs/rlottie/lv_rlottie_private.h
+++ b/src/libs/rlottie/lv_rlottie_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_RLOTTIE
 #include "../../widgets/image/lv_image_private.h"
 #include "../../../lvgl_private.h"

--- a/src/libs/svg/lv_svg.c
+++ b/src/libs/svg/lv_svg.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_SVG
 
 #include "lv_svg_token.h"

--- a/src/libs/svg/lv_svg_decoder.c
+++ b/src/libs/svg/lv_svg_decoder.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #include "../../draw/lv_image_decoder_private.h"
 
 #if LV_USE_SVG

--- a/src/libs/svg/lv_svg_decoder.h
+++ b/src/libs/svg/lv_svg_decoder.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_SVG
 

--- a/src/libs/svg/lv_svg_parser.h
+++ b/src/libs/svg/lv_svg_parser.h
@@ -10,7 +10,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_SVG
 

--- a/src/libs/svg/lv_svg_render.h
+++ b/src/libs/svg/lv_svg_render.h
@@ -9,7 +9,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_SVG
 #if !LV_USE_VECTOR_GRAPHIC

--- a/src/libs/svg/lv_svg_token.h
+++ b/src/libs/svg/lv_svg_token.h
@@ -10,7 +10,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_SVG
 

--- a/src/libs/thorvg/add_lvgl_if.sh
+++ b/src/libs/thorvg/add_lvgl_if.sh
@@ -5,7 +5,7 @@
 #   find -name "*.cpp" | xargs ./add_lvgl_if.sh
 #   find -name "t*.h" | xargs ./add_lvgl_if.sh
 
-sed '0,/\*\/$/ {/\*\/$/ {n; s|^|\n#include "../../lv_public_api.h"\n#if LV_USE_THORVG_INTERNAL\n|}}' $@ -i
+sed '0,/\*\/$/ {/\*\/$/ {n; s|^|\n#include "../../lvgl_public.h"\n#if LV_USE_THORVG_INTERNAL\n|}}' $@ -i
 
 sed -i -e '$a\
 \

--- a/src/libs/thorvg/config.h
+++ b/src/libs/thorvg/config.h
@@ -6,7 +6,7 @@
 #ifndef TVG_CONFIG_H
 #define TVG_CONFIG_H
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #define THORVG_SW_RASTER_SUPPORT 1
 

--- a/src/libs/thorvg/rapidjson/allocators.h
+++ b/src/libs/thorvg/rapidjson/allocators.h
@@ -25,7 +25,7 @@
 #include <type_traits>
 #endif
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 RAPIDJSON_NAMESPACE_BEGIN
 

--- a/src/libs/thorvg/rapidjson/rapidjson.h
+++ b/src/libs/thorvg/rapidjson/rapidjson.h
@@ -690,7 +690,7 @@ RAPIDJSON_NAMESPACE_END
 
 ///////////////////////////////////////////////////////////////////////////////
 // malloc/realloc/free
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #ifndef RAPIDJSON_MALLOC
 ///! customization point for global \c malloc
 #define RAPIDJSON_MALLOC(size) lv_malloc(size)

--- a/src/libs/thorvg/thorvg.h
+++ b/src/libs/thorvg/thorvg.h
@@ -1,7 +1,7 @@
 #ifndef _THORVG_H_
 #define _THORVG_H_
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 /*Testing of dependencies*/
 #if LV_USE_THORVG && LV_USE_VECTOR_GRAPHIC == 0
@@ -17,7 +17,6 @@
 #include <memory>
 #include <string>
 #include <list>
-#include "../../lv_public_api.h"
 
 #ifdef TVG_API
     #undef TVG_API

--- a/src/libs/thorvg/thorvg_capi.h
+++ b/src/libs/thorvg/thorvg_capi.h
@@ -15,7 +15,7 @@
 *
 */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 #define TVG_BUILD 1
 

--- a/src/libs/thorvg/thorvg_lottie.h
+++ b/src/libs/thorvg/thorvg_lottie.h
@@ -18,7 +18,7 @@ namespace tvg
  * @since 0.15
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 class TVG_API LottieAnimation final : public Animation
 {

--- a/src/libs/thorvg/tvgAccessor.cpp
+++ b/src/libs/thorvg/tvgAccessor.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgIteratorAccessor.h"

--- a/src/libs/thorvg/tvgAnimation.cpp
+++ b/src/libs/thorvg/tvgAnimation.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgFrameModule.h"

--- a/src/libs/thorvg/tvgAnimation.h
+++ b/src/libs/thorvg/tvgAnimation.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_ANIMATION_H_

--- a/src/libs/thorvg/tvgArray.h
+++ b/src/libs/thorvg/tvgArray.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_ARRAY_H_

--- a/src/libs/thorvg/tvgBinaryDesc.h
+++ b/src/libs/thorvg/tvgBinaryDesc.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_BINARY_DESC_H_

--- a/src/libs/thorvg/tvgCanvas.cpp
+++ b/src/libs/thorvg/tvgCanvas.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgCanvas.h"

--- a/src/libs/thorvg/tvgCanvas.h
+++ b/src/libs/thorvg/tvgCanvas.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_CANVAS_H_

--- a/src/libs/thorvg/tvgCapi.cpp
+++ b/src/libs/thorvg/tvgCapi.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "config.h"

--- a/src/libs/thorvg/tvgCommon.h
+++ b/src/libs/thorvg/tvgCommon.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_COMMON_H_

--- a/src/libs/thorvg/tvgCompressor.cpp
+++ b/src/libs/thorvg/tvgCompressor.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 /*

--- a/src/libs/thorvg/tvgCompressor.h
+++ b/src/libs/thorvg/tvgCompressor.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_COMPRESSOR_H_

--- a/src/libs/thorvg/tvgFill.cpp
+++ b/src/libs/thorvg/tvgFill.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgFill.h"

--- a/src/libs/thorvg/tvgFill.h
+++ b/src/libs/thorvg/tvgFill.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_FILL_H_

--- a/src/libs/thorvg/tvgFrameModule.h
+++ b/src/libs/thorvg/tvgFrameModule.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_FRAME_MODULE_H_

--- a/src/libs/thorvg/tvgGlCanvas.cpp
+++ b/src/libs/thorvg/tvgGlCanvas.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgCanvas.h"

--- a/src/libs/thorvg/tvgInitializer.cpp
+++ b/src/libs/thorvg/tvgInitializer.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgCommon.h"

--- a/src/libs/thorvg/tvgInlist.h
+++ b/src/libs/thorvg/tvgInlist.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_INLIST_H_

--- a/src/libs/thorvg/tvgIteratorAccessor.h
+++ b/src/libs/thorvg/tvgIteratorAccessor.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_ITERATOR_ACCESSOR_H_

--- a/src/libs/thorvg/tvgLoadModule.h
+++ b/src/libs/thorvg/tvgLoadModule.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_LOAD_MODULE_H_

--- a/src/libs/thorvg/tvgLoader.cpp
+++ b/src/libs/thorvg/tvgLoader.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include <string.h>

--- a/src/libs/thorvg/tvgLoader.h
+++ b/src/libs/thorvg/tvgLoader.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_LOADER_H_

--- a/src/libs/thorvg/tvgLock.h
+++ b/src/libs/thorvg/tvgLock.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_LOCK_H_

--- a/src/libs/thorvg/tvgLottieAnimation.cpp
+++ b/src/libs/thorvg/tvgLottieAnimation.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgCommon.h"

--- a/src/libs/thorvg/tvgLottieBuilder.cpp
+++ b/src/libs/thorvg/tvgLottieBuilder.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include <cstring>

--- a/src/libs/thorvg/tvgLottieBuilder.h
+++ b/src/libs/thorvg/tvgLottieBuilder.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_LOTTIE_BUILDER_H_

--- a/src/libs/thorvg/tvgLottieCommon.h
+++ b/src/libs/thorvg/tvgLottieCommon.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_LOTTIE_COMMON_

--- a/src/libs/thorvg/tvgLottieExpressions.cpp
+++ b/src/libs/thorvg/tvgLottieExpressions.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 

--- a/src/libs/thorvg/tvgLottieExpressions.h
+++ b/src/libs/thorvg/tvgLottieExpressions.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_LOTTIE_EXPRESSIONS_H_

--- a/src/libs/thorvg/tvgLottieInterpolator.cpp
+++ b/src/libs/thorvg/tvgLottieInterpolator.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 /* This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/libs/thorvg/tvgLottieInterpolator.h
+++ b/src/libs/thorvg/tvgLottieInterpolator.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_LOTTIE_INTERPOLATOR_H_

--- a/src/libs/thorvg/tvgLottieLoader.cpp
+++ b/src/libs/thorvg/tvgLottieLoader.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgLottieLoader.h"

--- a/src/libs/thorvg/tvgLottieLoader.h
+++ b/src/libs/thorvg/tvgLottieLoader.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_LOTTIE_LOADER_H_

--- a/src/libs/thorvg/tvgLottieModel.cpp
+++ b/src/libs/thorvg/tvgLottieModel.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgMath.h"

--- a/src/libs/thorvg/tvgLottieModel.h
+++ b/src/libs/thorvg/tvgLottieModel.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_LOTTIE_MODEL_H_

--- a/src/libs/thorvg/tvgLottieModifier.cpp
+++ b/src/libs/thorvg/tvgLottieModifier.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgLottieModifier.h"

--- a/src/libs/thorvg/tvgLottieModifier.h
+++ b/src/libs/thorvg/tvgLottieModifier.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_LOTTIE_MODIFIER_H_

--- a/src/libs/thorvg/tvgLottieParser.cpp
+++ b/src/libs/thorvg/tvgLottieParser.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgStr.h"

--- a/src/libs/thorvg/tvgLottieParser.h
+++ b/src/libs/thorvg/tvgLottieParser.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_LOTTIE_PARSER_H_

--- a/src/libs/thorvg/tvgLottieParserHandler.cpp
+++ b/src/libs/thorvg/tvgLottieParserHandler.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 /*

--- a/src/libs/thorvg/tvgLottieParserHandler.h
+++ b/src/libs/thorvg/tvgLottieParserHandler.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 /*

--- a/src/libs/thorvg/tvgLottieProperty.h
+++ b/src/libs/thorvg/tvgLottieProperty.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_LOTTIE_PROPERTY_H_

--- a/src/libs/thorvg/tvgLottieRenderPooler.h
+++ b/src/libs/thorvg/tvgLottieRenderPooler.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_LOTTIE_RENDER_POOLER_H_

--- a/src/libs/thorvg/tvgMath.cpp
+++ b/src/libs/thorvg/tvgMath.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgMath.h"

--- a/src/libs/thorvg/tvgMath.h
+++ b/src/libs/thorvg/tvgMath.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_MATH_H_

--- a/src/libs/thorvg/tvgPaint.cpp
+++ b/src/libs/thorvg/tvgPaint.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgMath.h"

--- a/src/libs/thorvg/tvgPaint.h
+++ b/src/libs/thorvg/tvgPaint.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_PAINT_H_

--- a/src/libs/thorvg/tvgPicture.cpp
+++ b/src/libs/thorvg/tvgPicture.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgPaint.h"

--- a/src/libs/thorvg/tvgPicture.h
+++ b/src/libs/thorvg/tvgPicture.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_PICTURE_H_

--- a/src/libs/thorvg/tvgRawLoader.cpp
+++ b/src/libs/thorvg/tvgRawLoader.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include <fstream>

--- a/src/libs/thorvg/tvgRawLoader.h
+++ b/src/libs/thorvg/tvgRawLoader.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_RAW_LOADER_H_

--- a/src/libs/thorvg/tvgRender.cpp
+++ b/src/libs/thorvg/tvgRender.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgMath.h"

--- a/src/libs/thorvg/tvgRender.h
+++ b/src/libs/thorvg/tvgRender.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_RENDER_H_

--- a/src/libs/thorvg/tvgSaveModule.h
+++ b/src/libs/thorvg/tvgSaveModule.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_SAVE_MODULE_H_

--- a/src/libs/thorvg/tvgSaver.cpp
+++ b/src/libs/thorvg/tvgSaver.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgCommon.h"

--- a/src/libs/thorvg/tvgScene.cpp
+++ b/src/libs/thorvg/tvgScene.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include <cstdarg>

--- a/src/libs/thorvg/tvgScene.h
+++ b/src/libs/thorvg/tvgScene.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_SCENE_H_

--- a/src/libs/thorvg/tvgShape.cpp
+++ b/src/libs/thorvg/tvgShape.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgMath.h"

--- a/src/libs/thorvg/tvgShape.h
+++ b/src/libs/thorvg/tvgShape.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_SHAPE_H_

--- a/src/libs/thorvg/tvgStr.cpp
+++ b/src/libs/thorvg/tvgStr.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "config.h"

--- a/src/libs/thorvg/tvgStr.h
+++ b/src/libs/thorvg/tvgStr.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_STR_H_

--- a/src/libs/thorvg/tvgSvgCssStyle.cpp
+++ b/src/libs/thorvg/tvgSvgCssStyle.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgSvgCssStyle.h"

--- a/src/libs/thorvg/tvgSvgCssStyle.h
+++ b/src/libs/thorvg/tvgSvgCssStyle.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_SVG_CSS_STYLE_H_

--- a/src/libs/thorvg/tvgSvgLoader.cpp
+++ b/src/libs/thorvg/tvgSvgLoader.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 /*

--- a/src/libs/thorvg/tvgSvgLoader.h
+++ b/src/libs/thorvg/tvgSvgLoader.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_SVG_LOADER_H_

--- a/src/libs/thorvg/tvgSvgLoaderCommon.h
+++ b/src/libs/thorvg/tvgSvgLoaderCommon.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_SVG_LOADER_COMMON_H_

--- a/src/libs/thorvg/tvgSvgPath.cpp
+++ b/src/libs/thorvg/tvgSvgPath.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 /*

--- a/src/libs/thorvg/tvgSvgPath.h
+++ b/src/libs/thorvg/tvgSvgPath.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_SVG_PATH_H_

--- a/src/libs/thorvg/tvgSvgSceneBuilder.cpp
+++ b/src/libs/thorvg/tvgSvgSceneBuilder.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgMath.h" /* to include math.h before cstring */

--- a/src/libs/thorvg/tvgSvgSceneBuilder.h
+++ b/src/libs/thorvg/tvgSvgSceneBuilder.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_SVG_SCENE_BUILDER_H_

--- a/src/libs/thorvg/tvgSvgUtil.cpp
+++ b/src/libs/thorvg/tvgSvgUtil.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include <cstring>

--- a/src/libs/thorvg/tvgSvgUtil.h
+++ b/src/libs/thorvg/tvgSvgUtil.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_SVG_UTIL_H_

--- a/src/libs/thorvg/tvgSwCanvas.cpp
+++ b/src/libs/thorvg/tvgSwCanvas.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgCanvas.h"

--- a/src/libs/thorvg/tvgSwCommon.h
+++ b/src/libs/thorvg/tvgSwCommon.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_SW_COMMON_H_

--- a/src/libs/thorvg/tvgSwFill.cpp
+++ b/src/libs/thorvg/tvgSwFill.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgMath.h"

--- a/src/libs/thorvg/tvgSwImage.cpp
+++ b/src/libs/thorvg/tvgSwImage.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgMath.h"

--- a/src/libs/thorvg/tvgSwMath.cpp
+++ b/src/libs/thorvg/tvgSwMath.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgMath.h"

--- a/src/libs/thorvg/tvgSwMemPool.cpp
+++ b/src/libs/thorvg/tvgSwMemPool.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgSwCommon.h"

--- a/src/libs/thorvg/tvgSwPostEffect.cpp
+++ b/src/libs/thorvg/tvgSwPostEffect.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgSwCommon.h"

--- a/src/libs/thorvg/tvgSwRaster.cpp
+++ b/src/libs/thorvg/tvgSwRaster.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifdef _WIN32

--- a/src/libs/thorvg/tvgSwRasterAvx.h
+++ b/src/libs/thorvg/tvgSwRasterAvx.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifdef THORVG_AVX_VECTOR_SUPPORT

--- a/src/libs/thorvg/tvgSwRasterC.h
+++ b/src/libs/thorvg/tvgSwRasterC.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 template<typename PIXEL_T>

--- a/src/libs/thorvg/tvgSwRasterNeon.h
+++ b/src/libs/thorvg/tvgSwRasterNeon.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifdef THORVG_NEON_VECTOR_SUPPORT

--- a/src/libs/thorvg/tvgSwRasterTexmap.h
+++ b/src/libs/thorvg/tvgSwRasterTexmap.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 struct Vertex

--- a/src/libs/thorvg/tvgSwRenderer.cpp
+++ b/src/libs/thorvg/tvgSwRenderer.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifdef THORVG_SW_OPENMP_SUPPORT

--- a/src/libs/thorvg/tvgSwRenderer.h
+++ b/src/libs/thorvg/tvgSwRenderer.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_SW_RENDERER_H_

--- a/src/libs/thorvg/tvgSwRle.cpp
+++ b/src/libs/thorvg/tvgSwRle.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 /*

--- a/src/libs/thorvg/tvgSwShape.cpp
+++ b/src/libs/thorvg/tvgSwShape.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgSwCommon.h"

--- a/src/libs/thorvg/tvgSwStroke.cpp
+++ b/src/libs/thorvg/tvgSwStroke.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include <string.h>

--- a/src/libs/thorvg/tvgTaskScheduler.cpp
+++ b/src/libs/thorvg/tvgTaskScheduler.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgArray.h"

--- a/src/libs/thorvg/tvgTaskScheduler.h
+++ b/src/libs/thorvg/tvgTaskScheduler.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_TASK_SCHEDULER_H_

--- a/src/libs/thorvg/tvgText.cpp
+++ b/src/libs/thorvg/tvgText.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 

--- a/src/libs/thorvg/tvgText.h
+++ b/src/libs/thorvg/tvgText.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_TEXT_H

--- a/src/libs/thorvg/tvgWgCanvas.cpp
+++ b/src/libs/thorvg/tvgWgCanvas.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include "tvgCanvas.h"

--- a/src/libs/thorvg/tvgXmlParser.cpp
+++ b/src/libs/thorvg/tvgXmlParser.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #include <cstring>

--- a/src/libs/thorvg/tvgXmlParser.h
+++ b/src/libs/thorvg/tvgXmlParser.h
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_THORVG_INTERNAL
 
 #ifndef _TVG_SIMPLE_XML_PARSER_H_

--- a/src/libs/tjpgd/lv_tjpgd.c
+++ b/src/libs/tjpgd/lv_tjpgd.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_TJPGD
 

--- a/src/libs/tjpgd/tjpgd.h
+++ b/src/libs/tjpgd/tjpgd.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #include "tjpgdcnf.h"
 
 #if LV_USE_TJPGD

--- a/src/libs/vg_lite_driver/VGLite/Series/gc255/0x40A/vg_lite_options.h
+++ b/src/libs/vg_lite_driver/VGLite/Series/gc255/0x40A/vg_lite_options.h
@@ -28,7 +28,7 @@
 #ifndef VG_LITE_OPTIONS_H
 #define VG_LITE_OPTIONS_H
 
-#include "../../../../../../lv_public_api.h"
+#include "../../../../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
     #define CHIPID          0x255

--- a/src/libs/vg_lite_driver/VGLite/Series/gc355/0x0_1215/vg_lite_options.h
+++ b/src/libs/vg_lite_driver/VGLite/Series/gc355/0x0_1215/vg_lite_options.h
@@ -28,7 +28,7 @@
 #ifndef VG_LITE_OPTIONS_H
 #define VG_LITE_OPTIONS_H
 
-#include "../../../../../../lv_public_api.h"
+#include "../../../../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
     #define CHIPID          0x355

--- a/src/libs/vg_lite_driver/VGLite/Series/gc355/0x0_1216/vg_lite_options.h
+++ b/src/libs/vg_lite_driver/VGLite/Series/gc355/0x0_1216/vg_lite_options.h
@@ -27,7 +27,7 @@
 #ifndef VG_LITE_OPTIONS_H
 #define VG_LITE_OPTIONS_H
 
-#include "../../../../../../lv_public_api.h"
+#include "../../../../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
     #define CHIPID          0x355

--- a/src/libs/vg_lite_driver/VGLite/Series/gc555/0x423/vg_lite_options.h
+++ b/src/libs/vg_lite_driver/VGLite/Series/gc555/0x423/vg_lite_options.h
@@ -28,7 +28,7 @@
 #ifndef VG_LITE_OPTIONS_H
 #define VG_LITE_OPTIONS_H
 
-#include "../../../../../../lv_public_api.h"
+#include "../../../../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
     #define CHIPID          0x555

--- a/src/libs/vg_lite_driver/VGLite/Series/gc555/0x423_ECO/vg_lite_options.h
+++ b/src/libs/vg_lite_driver/VGLite/Series/gc555/0x423_ECO/vg_lite_options.h
@@ -28,7 +28,7 @@
 #ifndef VG_LITE_OPTIONS_H
 #define VG_LITE_OPTIONS_H
 
-#include "../../../../../../lv_public_api.h"
+#include "../../../../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
     #define CHIPID          0x555

--- a/src/libs/vg_lite_driver/VGLite/vg_lite.c
+++ b/src/libs/vg_lite_driver/VGLite/vg_lite.c
@@ -25,7 +25,7 @@
 *
 *****************************************************************************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
 #include "vg_lite_context.h"

--- a/src/libs/vg_lite_driver/VGLite/vg_lite_context.h
+++ b/src/libs/vg_lite_driver/VGLite/vg_lite_context.h
@@ -25,7 +25,7 @@
 *
 *****************************************************************************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
 #include <stdio.h>

--- a/src/libs/vg_lite_driver/VGLite/vg_lite_image.c
+++ b/src/libs/vg_lite_driver/VGLite/vg_lite_image.c
@@ -25,7 +25,7 @@
 *
 *****************************************************************************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
 #include "vg_lite_context.h"

--- a/src/libs/vg_lite_driver/VGLite/vg_lite_matrix.c
+++ b/src/libs/vg_lite_driver/VGLite/vg_lite_matrix.c
@@ -25,7 +25,7 @@
 *
 *****************************************************************************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
 #include <math.h>

--- a/src/libs/vg_lite_driver/VGLite/vg_lite_options.h
+++ b/src/libs/vg_lite_driver/VGLite/vg_lite_options.h
@@ -28,7 +28,7 @@
 #ifndef VG_LITE_OPTIONS_DISPATCH_H
 #define VG_LITE_OPTIONS_DISPATCH_H
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
     #define VG_LITE_OPTIONS VG_LITE_OPTIONS_2

--- a/src/libs/vg_lite_driver/VGLite/vg_lite_path.c
+++ b/src/libs/vg_lite_driver/VGLite/vg_lite_path.c
@@ -25,7 +25,7 @@
 *
 *****************************************************************************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
 #include "vg_lite_context.h"

--- a/src/libs/vg_lite_driver/VGLite/vg_lite_stroke.c
+++ b/src/libs/vg_lite_driver/VGLite/vg_lite_stroke.c
@@ -25,7 +25,7 @@
 *
 *****************************************************************************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
 #include "vg_lite_context.h"

--- a/src/libs/vg_lite_driver/VGLiteKernel/vg_lite_debug.h
+++ b/src/libs/vg_lite_driver/VGLiteKernel/vg_lite_debug.h
@@ -28,7 +28,7 @@
 #ifndef VG_LITE_DEBUG_H
 #define VG_LITE_DEBUG_H
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
 #include "vg_lite_kernel.h"

--- a/src/libs/vg_lite_driver/VGLiteKernel/vg_lite_hal.h
+++ b/src/libs/vg_lite_driver/VGLiteKernel/vg_lite_hal.h
@@ -55,7 +55,7 @@
 #ifndef VG_LITE_HAL_H
 #define VG_LITE_HAL_H
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
 #define VGLITE_MEM_ALIGNMENT      128

--- a/src/libs/vg_lite_driver/VGLiteKernel/vg_lite_hw.h
+++ b/src/libs/vg_lite_driver/VGLiteKernel/vg_lite_hw.h
@@ -55,7 +55,7 @@
 #ifndef VG_LITE_HW_H
 #define VG_LITE_HW_H
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
 #define VG_LITE_HW_CLOCK_CONTROL     0x000

--- a/src/libs/vg_lite_driver/VGLiteKernel/vg_lite_kernel.c
+++ b/src/libs/vg_lite_driver/VGLiteKernel/vg_lite_kernel.c
@@ -52,7 +52,7 @@
 *
 *****************************************************************************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
 #include "../lv_vg_lite_hal/vg_lite_platform.h"

--- a/src/libs/vg_lite_driver/VGLiteKernel/vg_lite_kernel.h
+++ b/src/libs/vg_lite_driver/VGLiteKernel/vg_lite_kernel.h
@@ -55,7 +55,7 @@
 #ifndef VG_LITE_KERNEL_H
 #define VG_LITE_KERNEL_H
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
 #include "../VGLite/vg_lite_options.h"

--- a/src/libs/vg_lite_driver/VGLiteKernel/vg_lite_option.h
+++ b/src/libs/vg_lite_driver/VGLiteKernel/vg_lite_option.h
@@ -55,7 +55,7 @@
 #ifndef VG_LITE_KERNEL_OPTION_H
 #define VG_LITE_KERNEL_OPTION_H
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
 #ifdef __cplusplus

--- a/src/libs/vg_lite_driver/VGLiteKernel/vg_lite_type.h
+++ b/src/libs/vg_lite_driver/VGLiteKernel/vg_lite_type.h
@@ -27,7 +27,7 @@
 #ifndef VG_LITE_TYPE_H
 #define VG_LITE_TYPE_H
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
 #if __KERNEL__

--- a/src/libs/vg_lite_driver/add_lvgl_if.sh
+++ b/src/libs/vg_lite_driver/add_lvgl_if.sh
@@ -5,7 +5,7 @@
 #   find -name "*.c" | xargs ./add_lvgl_if.sh
 #   find -name "t*.h" | xargs ./add_lvgl_if.sh
 
-sed '0,/\*\/$/ {/\*\/$/ {n; s|^|\n#include "../../lv_public_api.h"\n#if LV_USE_VG_LITE_DRIVER\n|}}' $@ -i
+sed '0,/\*\/$/ {/\*\/$/ {n; s|^|\n#include "../../lvgl_public.h"\n#if LV_USE_VG_LITE_DRIVER\n|}}' $@ -i
 
 sed -i -e '$a\
 \

--- a/src/libs/vg_lite_driver/inc/vg_lite.h
+++ b/src/libs/vg_lite_driver/inc/vg_lite.h
@@ -36,7 +36,7 @@ extern "C" {
 #define inline __inline
 #endif
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
 #include <stddef.h>

--- a/src/libs/vg_lite_driver/lv_vg_lite_hal/lv_vg_lite_hal.c
+++ b/src/libs/vg_lite_driver/lv_vg_lite_hal/lv_vg_lite_hal.c
@@ -1,5 +1,5 @@
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
 #include "../../../osal/lv_os_private.h"

--- a/src/libs/vg_lite_driver/lv_vg_lite_hal/vg_lite_os.c
+++ b/src/libs/vg_lite_driver/lv_vg_lite_hal/vg_lite_os.c
@@ -1,4 +1,4 @@
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
 #include "../../../lvgl.h"

--- a/src/libs/vg_lite_driver/lv_vg_lite_hal/vg_lite_platform.h
+++ b/src/libs/vg_lite_driver/lv_vg_lite_hal/vg_lite_platform.h
@@ -1,7 +1,7 @@
 #ifndef VG_LITE_PLATFORM_H
 #define VG_LITE_PLATFORM_H
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
 #include <stdint.h>

--- a/src/lv_init.c
+++ b/src/lv_init.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "lv_public_api.h"
+#include "lvgl_public.h"
 #include "misc/lv_timer_private.h"
 #include "misc/lv_profiler_builtin_private.h"
 #include "misc/lv_anim_private.h"

--- a/src/lv_public_api.h
+++ b/src/lv_public_api.h
@@ -1,7 +1,0 @@
-#ifndef LV_INTERNAL_H
-#define LV_INTERNAL_H
-
-/*Include every public header*/
-#include "../include/lvgl/lvgl.h"
-
-#endif /*LV_INTERNAL_H*/

--- a/src/lvgl_public.h
+++ b/src/lvgl_public.h
@@ -1,0 +1,7 @@
+#ifndef LVGL_PUBLIC_H
+#define LVGL_PUBLIC_H
+
+/*Include every public header*/
+#include "../include/lvgl/lvgl.h"
+
+#endif /*LVGL_PUBLIC_H*/

--- a/src/misc/cache/class/lv_cache_lru_rb.c
+++ b/src/misc/cache/class/lv_cache_lru_rb.c
@@ -46,7 +46,7 @@
 
 #include "lv_cache_lru_rb.h"
 #include "../lv_cache_entry.h"
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #include "../../lv_rb_private.h"
 #include "../../lv_iter_private.h"
 

--- a/src/misc/cache/class/lv_cache_sc_da.c
+++ b/src/misc/cache/class/lv_cache_sc_da.c
@@ -57,7 +57,7 @@
 #include "lv_cache_sc_da.h"
 #include "../lv_cache_entry.h"
 #include "../lv_cache_entry_private.h"
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #include "../../lv_iter_private.h"
 
 /*********************

--- a/src/misc/cache/instance/lv_image_cache.h
+++ b/src/misc/cache/instance/lv_image_cache.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 #include "../../lv_iter_private.h"
 #include "../lv_cache.h"
 

--- a/src/misc/cache/instance/lv_image_header_cache.h
+++ b/src/misc/cache/instance/lv_image_header_cache.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../../lv_public_api.h"
+#include "../../../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/cache/lv_cache.h
+++ b/src/misc/cache/lv_cache.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #include "../lv_iter_private.h"
 #include "../../osal/lv_os_private.h"
 

--- a/src/misc/lv_anim_private.h
+++ b/src/misc/lv_anim_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_anim_timeline_private.h
+++ b/src/misc/lv_anim_timeline_private.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_area.c
+++ b/src/misc/lv_area.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 #include "../core/lv_global.h"
 
 #include "lv_area_private.h"

--- a/src/misc/lv_area_private.h
+++ b/src/misc/lv_area_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_array.c
+++ b/src/misc/lv_array.c
@@ -7,7 +7,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_async.c
+++ b/src/misc/lv_async.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 #include "lv_timer_private.h"
 
 /*********************

--- a/src/misc/lv_bidi_private.h
+++ b/src/misc/lv_bidi_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 #if LV_USE_BIDI
 
 /*********************

--- a/src/misc/lv_circle_buf.c
+++ b/src/misc/lv_circle_buf.c
@@ -8,7 +8,7 @@
  *********************/
 
 #include "lv_circle_buf_private.h"
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_circle_buf_private.h
+++ b/src/misc/lv_circle_buf_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_color.c
+++ b/src/misc/lv_color.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_color_op.c
+++ b/src/misc/lv_color_op.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_event_private.h
+++ b/src/misc/lv_event_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_fs_private.h
+++ b/src/misc/lv_fs_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_grad.c
+++ b/src/misc/lv_grad.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_iter_private.h
+++ b/src/misc/lv_iter_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_ll.c
+++ b/src/misc/lv_ll.c
@@ -8,7 +8,7 @@
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_log.c
+++ b/src/misc/lv_log.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 #if LV_USE_LOG
 

--- a/src/misc/lv_lru.h
+++ b/src/misc/lv_lru.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_math.c
+++ b/src/misc/lv_math.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 #include "../core/lv_global.h"
 
 /*********************

--- a/src/misc/lv_matrix.c
+++ b/src/misc/lv_matrix.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 #if LV_USE_MATRIX
 

--- a/src/misc/lv_palette.c
+++ b/src/misc/lv_palette.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_pending.c
+++ b/src/misc/lv_pending.c
@@ -8,7 +8,7 @@
  *********************/
 
 #include "lv_pending.h"
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_pending.h
+++ b/src/misc/lv_pending.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_profiler_builtin_private.h
+++ b/src/misc/lv_profiler_builtin_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 #if LV_USE_PROFILER && LV_USE_PROFILER_BUILTIN
 

--- a/src/misc/lv_rb_private.h
+++ b/src/misc/lv_rb_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_style.c
+++ b/src/misc/lv_style.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 #include "../core/lv_global.h"
 
 /*********************

--- a/src/misc/lv_style_gen.c
+++ b/src/misc/lv_style_gen.c
@@ -8,7 +8,7 @@
  */
 
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 
 void lv_style_set_width(lv_style_t * style, int32_t value)

--- a/src/misc/lv_text_ap.h
+++ b/src/misc/lv_text_ap.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 #if LV_USE_ARABIC_PERSIAN_CHARS
 

--- a/src/misc/lv_text_private.h
+++ b/src/misc/lv_text_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_timer_private.h
+++ b/src/misc/lv_timer_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_tree.c
+++ b/src/misc/lv_tree.c
@@ -8,7 +8,7 @@
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/misc/lv_utils.h
+++ b/src/misc/lv_utils.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/osal/lv_os_none.c
+++ b/src/osal/lv_os_none.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 #if LV_USE_OS == LV_OS_NONE
 
 #include "lv_os_private.h"

--- a/src/osal/lv_os_private.h
+++ b/src/osal/lv_os_private.h
@@ -17,7 +17,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 #ifdef __linux__
 #include "lv_linux.h"

--- a/src/others/file_explorer/lv_file_explorer.c
+++ b/src/others/file_explorer/lv_file_explorer.c
@@ -12,7 +12,7 @@
 
 #include "../../misc/lv_fs_private.h"
 #include "../../core/lv_obj_class_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #include "../../core/lv_global.h"
 
 /*********************

--- a/src/others/file_explorer/lv_file_explorer_private.h
+++ b/src/others/file_explorer/lv_file_explorer_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_FILE_EXPLORER
 #include "../../core/lv_obj_private.h"

--- a/src/others/fragment/lv_fragment_private.h
+++ b/src/others/fragment/lv_fragment_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_FRAGMENT
 

--- a/src/others/translation/lv_translation_private.h
+++ b/src/others/translation/lv_translation_private.h
@@ -13,7 +13,7 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_TRANSLATION
 

--- a/src/stdlib/builtin/lv_mem_core_builtin.c
+++ b/src/stdlib/builtin/lv_mem_core_builtin.c
@@ -6,7 +6,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_STDLIB_MALLOC == LV_STDLIB_BUILTIN
 

--- a/src/stdlib/builtin/lv_sprintf_builtin.c
+++ b/src/stdlib/builtin/lv_sprintf_builtin.c
@@ -32,7 +32,7 @@
 
 /*Original repository: https://github.com/mpaland/printf*/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_STDLIB_SPRINTF == LV_STDLIB_BUILTIN
 
 #define PRINTF_DISABLE_SUPPORT_FLOAT    (!LV_USE_FLOAT)

--- a/src/stdlib/builtin/lv_string_builtin.c
+++ b/src/stdlib/builtin/lv_string_builtin.c
@@ -6,7 +6,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_STDLIB_STRING == LV_STDLIB_BUILTIN
 

--- a/src/stdlib/builtin/lv_tlsf.c
+++ b/src/stdlib/builtin/lv_tlsf.c
@@ -1,4 +1,4 @@
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_STDLIB_MALLOC == LV_STDLIB_BUILTIN
 
 #include "lv_tlsf_private.h"

--- a/src/stdlib/builtin/lv_tlsf.h
+++ b/src/stdlib/builtin/lv_tlsf.h
@@ -1,4 +1,4 @@
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_STDLIB_MALLOC == LV_STDLIB_BUILTIN
 
 #ifndef LV_TLSF_H
@@ -41,7 +41,7 @@
 ** SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if defined(__cplusplus)
 extern "C" {

--- a/src/stdlib/clib/lv_mem_core_clib.c
+++ b/src/stdlib/clib/lv_mem_core_clib.c
@@ -6,7 +6,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_STDLIB_MALLOC == LV_STDLIB_CLIB
 

--- a/src/stdlib/clib/lv_sprintf_clib.c
+++ b/src/stdlib/clib/lv_sprintf_clib.c
@@ -8,7 +8,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_STDLIB_SPRINTF == LV_STDLIB_CLIB
 
 #include <stdio.h>

--- a/src/stdlib/clib/lv_string_clib.c
+++ b/src/stdlib/clib/lv_string_clib.c
@@ -6,7 +6,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_STDLIB_STRING == LV_STDLIB_CLIB
 

--- a/src/stdlib/lv_mem.c
+++ b/src/stdlib/lv_mem.c
@@ -5,7 +5,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 #include "../core/lv_global.h"
 
 #if LV_USE_OS == LV_OS_PTHREAD

--- a/src/stdlib/micropython/lv_mem_core_micropython.c
+++ b/src/stdlib/micropython/lv_mem_core_micropython.c
@@ -6,7 +6,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_STDLIB_MALLOC == LV_STDLIB_MICROPYTHON
 

--- a/src/stdlib/rtthread/lv_mem_core_rtthread.c
+++ b/src/stdlib/rtthread/lv_mem_core_rtthread.c
@@ -6,7 +6,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_STDLIB_MALLOC == LV_STDLIB_RTTHREAD
 #include <rtthread.h>

--- a/src/stdlib/rtthread/lv_sprintf_rtthread.c
+++ b/src/stdlib/rtthread/lv_sprintf_rtthread.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_STDLIB_SPRINTF == LV_STDLIB_RTTHREAD
 

--- a/src/stdlib/rtthread/lv_string_rtthread.c
+++ b/src/stdlib/rtthread/lv_string_rtthread.c
@@ -6,7 +6,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_STDLIB_STRING == LV_STDLIB_RTTHREAD
 

--- a/src/stdlib/uefi/lv_mem_core_uefi.c
+++ b/src/stdlib/uefi/lv_mem_core_uefi.c
@@ -5,7 +5,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 #if LV_USE_UEFI
 #if LV_UEFI_USE_MEMORY_SERVICES && LV_USE_STDLIB_MALLOC == LV_STDLIB_CUSTOM
 #include "../../drivers/uefi/lv_uefi_private.h"

--- a/src/themes/default/lv_theme_default.c
+++ b/src/themes/default/lv_theme_default.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_THEME_DEFAULT
 

--- a/src/themes/lv_theme_private.h
+++ b/src/themes/lv_theme_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/themes/mono/lv_theme_mono.c
+++ b/src/themes/mono/lv_theme_mono.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_THEME_MONO
 

--- a/src/themes/simple/lv_theme_simple.c
+++ b/src/themes/simple/lv_theme_simple.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_THEME_SIMPLE
 

--- a/src/tick/lv_tick_private.h
+++ b/src/tick/lv_tick_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../lv_public_api.h"
+#include "../lvgl_public.h"
 
 /*********************
  *      DEFINES

--- a/src/widgets/3dtexture/lv_3dtexture_private.h
+++ b/src/widgets/3dtexture/lv_3dtexture_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_3DTEXTURE
 

--- a/src/widgets/animimage/lv_animimage_private.h
+++ b/src/widgets/animimage/lv_animimage_private.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #include "../image/lv_image_private.h"
 #include "../../misc/lv_anim_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_ANIMIMG
 

--- a/src/widgets/arc/lv_arc_private.h
+++ b/src/widgets/arc/lv_arc_private.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_ARC
 

--- a/src/widgets/arclabel/lv_arclabel_private.h
+++ b/src/widgets/arclabel/lv_arclabel_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_ARCLABEL
 

--- a/src/widgets/bar/lv_bar_private.h
+++ b/src/widgets/bar/lv_bar_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_BAR
 

--- a/src/widgets/button/lv_button_private.h
+++ b/src/widgets/button/lv_button_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_BUTTON
 

--- a/src/widgets/buttonmatrix/lv_buttonmatrix_private.h
+++ b/src/widgets/buttonmatrix/lv_buttonmatrix_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_BUTTONMATRIX
 

--- a/src/widgets/calendar/lv_calendar_private.h
+++ b/src/widgets/calendar/lv_calendar_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_CALENDAR
 

--- a/src/widgets/canvas/lv_canvas_private.h
+++ b/src/widgets/canvas/lv_canvas_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../image/lv_image_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_CANVAS
 

--- a/src/widgets/chart/lv_chart_private.h
+++ b/src/widgets/chart/lv_chart_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_CHART
 

--- a/src/widgets/checkbox/lv_checkbox_private.h
+++ b/src/widgets/checkbox/lv_checkbox_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_CHECKBOX
 

--- a/src/widgets/dropdown/lv_dropdown_private.h
+++ b/src/widgets/dropdown/lv_dropdown_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_DROPDOWN
 

--- a/src/widgets/gif/lv_gif.c
+++ b/src/widgets/gif/lv_gif.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_GIF
 #include "../../misc/lv_timer_private.h"

--- a/src/widgets/image/lv_image_private.h
+++ b/src/widgets/image/lv_image_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_IMAGE
 

--- a/src/widgets/imagebutton/lv_imagebutton_private.h
+++ b/src/widgets/imagebutton/lv_imagebutton_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_IMAGEBUTTON != 0
 

--- a/src/widgets/ime/lv_ime_pinyin_private.h
+++ b/src/widgets/ime/lv_ime_pinyin_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_IME_PINYIN
 

--- a/src/widgets/keyboard/lv_keyboard_private.h
+++ b/src/widgets/keyboard/lv_keyboard_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_KEYBOARD
 

--- a/src/widgets/label/lv_label_private.h
+++ b/src/widgets/label/lv_label_private.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #include "../../draw/lv_draw_label_private.h"
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_LABEL
 

--- a/src/widgets/led/lv_led_private.h
+++ b/src/widgets/led/lv_led_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_LED
 

--- a/src/widgets/line/lv_line_private.h
+++ b/src/widgets/line/lv_line_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_LINE
 

--- a/src/widgets/list/lv_list.c
+++ b/src/widgets/list/lv_list.c
@@ -8,7 +8,7 @@
  *********************/
 
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_LIST
 

--- a/src/widgets/lottie/lv_lottie_private.h
+++ b/src/widgets/lottie/lv_lottie_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_LOTTIE
 

--- a/src/widgets/menu/lv_menu_private.h
+++ b/src/widgets/menu/lv_menu_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_MENU
 

--- a/src/widgets/msgbox/lv_msgbox_private.h
+++ b/src/widgets/msgbox/lv_msgbox_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_MSGBOX
 

--- a/src/widgets/objx_templ/lv_objx_templ.h
+++ b/src/widgets/objx_templ/lv_objx_templ.h
@@ -21,7 +21,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_TEMPL
 

--- a/src/widgets/property/lv_animimage_properties.c
+++ b/src/widgets/property/lv_animimage_properties.c
@@ -4,7 +4,7 @@
  * @file lv_animimage_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_arc_properties.c
+++ b/src/widgets/property/lv_arc_properties.c
@@ -4,7 +4,7 @@
  * @file lv_arc_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_bar_properties.c
+++ b/src/widgets/property/lv_bar_properties.c
@@ -4,7 +4,7 @@
  * @file lv_bar_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_buttonmatrix_properties.c
+++ b/src/widgets/property/lv_buttonmatrix_properties.c
@@ -4,7 +4,7 @@
  * @file lv_buttonmatrix_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_chart_properties.c
+++ b/src/widgets/property/lv_chart_properties.c
@@ -4,7 +4,7 @@
  * @file lv_chart_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_checkbox_properties.c
+++ b/src/widgets/property/lv_checkbox_properties.c
@@ -4,7 +4,7 @@
  * @file lv_checkbox_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_dropdown_properties.c
+++ b/src/widgets/property/lv_dropdown_properties.c
@@ -4,7 +4,7 @@
  * @file lv_dropdown_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_image_properties.c
+++ b/src/widgets/property/lv_image_properties.c
@@ -4,7 +4,7 @@
  * @file lv_image_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_keyboard_properties.c
+++ b/src/widgets/property/lv_keyboard_properties.c
@@ -4,7 +4,7 @@
  * @file lv_keyboard_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_label_properties.c
+++ b/src/widgets/property/lv_label_properties.c
@@ -4,7 +4,7 @@
  * @file lv_label_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_led_properties.c
+++ b/src/widgets/property/lv_led_properties.c
@@ -4,7 +4,7 @@
  * @file lv_led_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_line_properties.c
+++ b/src/widgets/property/lv_line_properties.c
@@ -4,7 +4,7 @@
  * @file lv_line_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_menu_properties.c
+++ b/src/widgets/property/lv_menu_properties.c
@@ -4,7 +4,7 @@
  * @file lv_menu_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_obj_properties.c
+++ b/src/widgets/property/lv_obj_properties.c
@@ -4,7 +4,7 @@
  * @file lv_obj_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_roller_properties.c
+++ b/src/widgets/property/lv_roller_properties.c
@@ -4,7 +4,7 @@
  * @file lv_roller_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_scale_properties.c
+++ b/src/widgets/property/lv_scale_properties.c
@@ -4,7 +4,7 @@
  * @file lv_scale_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_slider_properties.c
+++ b/src/widgets/property/lv_slider_properties.c
@@ -4,7 +4,7 @@
  * @file lv_slider_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_span_properties.c
+++ b/src/widgets/property/lv_span_properties.c
@@ -4,7 +4,7 @@
  * @file lv_span_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_spinbox_properties.c
+++ b/src/widgets/property/lv_spinbox_properties.c
@@ -4,7 +4,7 @@
  * @file lv_spinbox_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_spinner_properties.c
+++ b/src/widgets/property/lv_spinner_properties.c
@@ -4,7 +4,7 @@
  * @file lv_spinner_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_style_properties.c
+++ b/src/widgets/property/lv_style_properties.c
@@ -4,7 +4,7 @@
  * @file lv_style_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_switch_properties.c
+++ b/src/widgets/property/lv_switch_properties.c
@@ -4,7 +4,7 @@
  * @file lv_switch_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_table_properties.c
+++ b/src/widgets/property/lv_table_properties.c
@@ -4,7 +4,7 @@
  * @file lv_table_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_tabview_properties.c
+++ b/src/widgets/property/lv_tabview_properties.c
@@ -4,7 +4,7 @@
  * @file lv_tabview_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/property/lv_textarea_properties.c
+++ b/src/widgets/property/lv_textarea_properties.c
@@ -4,7 +4,7 @@
  * @file lv_textarea_properties.c
  */
 
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_OBJ_PROPERTY && LV_USE_OBJ_PROPERTY_NAME
 

--- a/src/widgets/roller/lv_roller_private.h
+++ b/src/widgets/roller/lv_roller_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_ROLLER
 

--- a/src/widgets/scale/lv_scale.c
+++ b/src/widgets/scale/lv_scale.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_SCALE
 

--- a/src/widgets/scale/lv_scale.c
+++ b/src/widgets/scale/lv_scale.c
@@ -903,6 +903,9 @@ static void scale_draw_label(lv_obj_t * obj, lv_event_t * event, lv_draw_label_d
     }
     else { /* Add label with mapped values */
         lv_snprintf(text_buffer, sizeof(text_buffer), "%" LV_PRId32, tick_value);
+        /* LVGL guarantees it will copy the label text if the text is local*/
+        /* TODO: get rid of text_local and this suppression*/
+        /*cppcheck-suppress autoVariables*/
         label_dsc->text = text_buffer;
         label_dsc->text_local = 1;
     }

--- a/src/widgets/scale/lv_scale_private.h
+++ b/src/widgets/scale/lv_scale_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_SCALE
 

--- a/src/widgets/slider/lv_slider_private.h
+++ b/src/widgets/slider/lv_slider_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_SLIDER
 

--- a/src/widgets/span/lv_span_private.h
+++ b/src/widgets/span/lv_span_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_SPAN
 

--- a/src/widgets/spinbox/lv_spinbox_private.h
+++ b/src/widgets/spinbox/lv_spinbox_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_SPINBOX
 

--- a/src/widgets/spinner/lv_spinner_private.h
+++ b/src/widgets/spinner/lv_spinner_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_SPINNER
 

--- a/src/widgets/switch/lv_switch_private.h
+++ b/src/widgets/switch/lv_switch_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_SWITCH
 

--- a/src/widgets/table/lv_table_private.h
+++ b/src/widgets/table/lv_table_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_TABLE
 

--- a/src/widgets/tabview/lv_tabview_private.h
+++ b/src/widgets/tabview/lv_tabview_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_TABVIEW
 

--- a/src/widgets/textarea/lv_textarea_private.h
+++ b/src/widgets/textarea/lv_textarea_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_TEXTAREA
 

--- a/src/widgets/tileview/lv_tileview_private.h
+++ b/src/widgets/tileview/lv_tileview_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_TILEVIEW
 

--- a/src/widgets/win/lv_win_private.h
+++ b/src/widgets/win/lv_win_private.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 
 #include "../../core/lv_obj_private.h"
-#include "../../lv_public_api.h"
+#include "../../lvgl_public.h"
 
 #if LV_USE_WIN
 


### PR DESCRIPTION
Keeps a more consistent naming with `lvgl_private.h` 