### PR TITLE
fix(nuttx): guard declarations inside LV_USE_NUTTX

### DIFF
--- a/src/drivers/nuttx/lv_nuttx_cache.h
+++ b/src/drivers/nuttx/lv_nuttx_cache.h
@@ -14,6 +14,10 @@ extern "C" {
  *      INCLUDES
  *********************/
 
+#include "../../lvgl_public.h"
+
+#if LV_USE_NUTTX
+
 /*********************
  *      DEFINES
  *********************/
@@ -33,6 +37,8 @@ void lv_nuttx_cache_deinit(void);
 /**********************
  *      MACROS
  **********************/
+
+#endif /*LV_USE_NUTTX*/
 
 #ifdef __cplusplus
 } /*extern "C"*/

--- a/src/drivers/nuttx/lv_nuttx_image_cache.h
+++ b/src/drivers/nuttx/lv_nuttx_image_cache.h
@@ -15,6 +15,9 @@ extern "C" {
  *********************/
 
 #include "../../lvgl_public.h"
+
+#if LV_USE_NUTTX
+
 #include LV_STDBOOL_INCLUDE
 
 /*********************
@@ -36,6 +39,8 @@ void lv_nuttx_image_cache_deinit(void);
 /**********************
  *      MACROS
  **********************/
+
+#endif /*LV_USE_NUTTX*/
 
 #ifdef __cplusplus
 } /*extern "C"*/


### PR DESCRIPTION
Micropython build was failing for https://github.com/lvgl/lvgl/pull/10066 when I added the nuttx internal headers to `lvgl_private.h` because it would find the declaration of the nuttx_cache functions but not the definition because LV_USE_NUTTX is not enabled

This guards against that issue