### PR TITLE
feat(lvgl_private): include lvgl private api when config is set

### DIFF
--- a/lvgl.h
+++ b/lvgl.h
@@ -1,1 +1,6 @@
 #include "include/lvgl/lvgl.h"
+
+#if LV_USE_PRIVATE_API
+    /* To keep backward compatibility with v9.5 */
+    #include "lvgl_private.h"
+#endif


### PR DESCRIPTION
Closes #10065 

This was previously removed in #10041, adding it back to keep backwards compatibility with lvgl v9.5

See discussion in #10065 about the future plans around this