### PR TITLE
docs(cache): include unit in prompt

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -812,7 +812,7 @@ menu "LVGL configuration"
 				default "lv_global.h"
 
 			config LV_CACHE_DEF_SIZE
-				int "Default image cache size. 0 to disable caching"
+				int "Default image cache size in bytes. 0 to disable caching"
 				default 0
 				depends on LV_USE_DRAW_SW
 				help


### PR DESCRIPTION
Include bytes in the prompt for cache size.