### PR TITLE
refactor(system_includes): replace system includes with LV_XXX_INCLUDE macros

### DIFF
--- a/src/debugging/test/lv_test_screenshot_compare.c
+++ b/src/debugging/test/lv_test_screenshot_compare.c
@@ -22,7 +22,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <stdarg.h>
+#include LV_STDARG_INCLUDE
 #include <errno.h>
 #include "../../libs/lodepng/lodepng.h"
 

--- a/src/draw/nanovg/lv_nanovg_math.h
+++ b/src/draw/nanovg/lv_nanovg_math.h
@@ -19,7 +19,7 @@ extern "C" {
 #if LV_USE_DRAW_NANOVG
 
 #include <math.h>
-#include <stdbool.h>
+#include LV_STDBOOL_INCLUDE
 #include <float.h>
 
 /*********************

--- a/src/draw/snapshot/lv_snapshot.c
+++ b/src/draw/snapshot/lv_snapshot.c
@@ -12,7 +12,7 @@
 
 #include "../../draw/lv_draw_private.h"
 #include "../../core/lv_obj_draw_private.h"
-#include <stdbool.h>
+#include LV_STDBOOL_INCLUDE
 #include "../../core/lv_refr_private.h"
 #include "../../display/lv_display_private.h"
 #include "../../core/lv_obj_private.h"

--- a/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb888.c
+++ b/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb888.c
@@ -10,7 +10,7 @@
 #if LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_NEON
 
 #include "../lv_draw_sw_blend_private.h"
-#include <stdint.h>
+#include LV_STDINT_INCLUDE
 #include <arm_neon.h>
 
 /*********************

--- a/src/draw/sw/blend/riscv_v/lv_blend_riscv_vector_emulation.h
+++ b/src/draw/sw/blend/riscv_v/lv_blend_riscv_vector_emulation.h
@@ -28,9 +28,9 @@ extern "C" {
 #include "../../../../lvgl_public.h"
 #if LV_USE_DRAW_SW_ASM == LV_DRAW_SW_ASM_RISCV_V
 
-#include <stdint.h>
+#include LV_STDINT_INCLUDE
 #include <string.h>
-#include <stddef.h>
+#include LV_STDDEF_INCLUDE
 
 /* ============================================================================
  * Vector Type Definitions

--- a/src/draw/vg_lite/lv_vg_lite_math.c
+++ b/src/draw/vg_lite/lv_vg_lite_math.c
@@ -11,7 +11,7 @@
 
 #if LV_USE_DRAW_VG_LITE
 
-#include <stdint.h>
+#include LV_STDINT_INCLUDE
 
 /*********************
  *      DEFINES

--- a/src/draw/vg_lite/lv_vg_lite_math.h
+++ b/src/draw/vg_lite/lv_vg_lite_math.h
@@ -19,7 +19,7 @@ extern "C" {
 #if LV_USE_DRAW_VG_LITE
 
 #include <math.h>
-#include <stdbool.h>
+#include LV_STDBOOL_INCLUDE
 #include <float.h>
 
 /*********************

--- a/src/drivers/display/drm/lv_linux_drm.c
+++ b/src/drivers/display/drm/lv_linux_drm.c
@@ -12,7 +12,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <poll.h>
-#include <stdint.h>
+#include LV_STDINT_INCLUDE
 #include <sys/mman.h>
 #include <time.h>
 #include <unistd.h>

--- a/src/drivers/display/drm/lv_linux_drm_egl.c
+++ b/src/drivers/display/drm/lv_linux_drm_egl.c
@@ -14,7 +14,7 @@
 #include <string.h>
 #include <xf86drmMode.h>
 #include <stdlib.h>
-#include <stdint.h>
+#include LV_STDINT_INCLUDE
 #include <gbm.h>
 #include <drm_fourcc.h>
 #include <xf86drm.h>

--- a/src/drivers/display/fb/lv_linux_fbdev.c
+++ b/src/drivers/display/fb/lv_linux_fbdev.c
@@ -11,7 +11,7 @@
 
 #include <stdlib.h>
 #include <unistd.h>
-#include <stddef.h>
+#include LV_STDDEF_INCLUDE
 #include <stdio.h>
 #include <fcntl.h>
 #include <sys/mman.h>

--- a/src/drivers/display/renesas_glcdc/lv_renesas_glcdc.c
+++ b/src/drivers/display/renesas_glcdc/lv_renesas_glcdc.c
@@ -35,7 +35,7 @@
     #include "r_glcdc_rx_pinset.h"
 #endif /*_RENESAS_RA_*/
 
-#include <stdbool.h>
+#include LV_STDBOOL_INCLUDE
 #include "../../../display/lv_display_private.h"
 #include "../../../draw/sw/lv_draw_sw.h"
 

--- a/src/drivers/libinput/lv_libinput.c
+++ b/src/drivers/libinput/lv_libinput.c
@@ -19,7 +19,7 @@
 #include <linux/limits.h>
 #include <fcntl.h>
 #include <errno.h>
-#include <stdbool.h>
+#include LV_STDBOOL_INCLUDE
 #include <dirent.h>
 #include <libinput.h>
 #include <pthread.h>

--- a/src/drivers/libinput/lv_xkb.c
+++ b/src/drivers/libinput/lv_xkb.c
@@ -12,7 +12,7 @@
 #if defined(LV_LIBINPUT_XKB) && LV_LIBINPUT_XKB
 
 #include <errno.h>
-#include <stdbool.h>
+#include LV_STDBOOL_INCLUDE
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/drivers/nuttx/lv_nuttx_fbdev.c
+++ b/src/drivers/nuttx/lv_nuttx_fbdev.c
@@ -11,7 +11,7 @@
 
 #include <stdlib.h>
 #include <unistd.h>
-#include <stddef.h>
+#include LV_STDDEF_INCLUDE
 #include <stdio.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/drivers/nuttx/mock/nuttx_arch.h
+++ b/src/drivers/nuttx/mock/nuttx_arch.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include <stdint.h>
+#include LV_STDINT_INCLUDE
 
 /*********************
  *      DEFINES

--- a/src/drivers/nuttx/mock/nuttx_cache.h
+++ b/src/drivers/nuttx/mock/nuttx_cache.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include <stdint.h>
+#include LV_STDINT_INCLUDE
 
 /*********************
  *      DEFINES

--- a/src/drivers/nuttx/mock/nuttx_clock.h
+++ b/src/drivers/nuttx/mock/nuttx_clock.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include <stdint.h>
+#include LV_STDINT_INCLUDE
 
 /*********************
  *      DEFINES

--- a/src/drivers/nuttx/mock/nuttx_input_mouse.h
+++ b/src/drivers/nuttx/mock/nuttx_input_mouse.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include <stdint.h>
+#include LV_STDINT_INCLUDE
 
 /*********************
  *      DEFINES

--- a/src/drivers/nuttx/mock/nuttx_input_touchscreen.h
+++ b/src/drivers/nuttx/mock/nuttx_input_touchscreen.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include <stdint.h>
+#include LV_STDINT_INCLUDE
 
 /*********************
  *      DEFINES

--- a/src/drivers/nuttx/mock/nuttx_mm.h
+++ b/src/drivers/nuttx/mock/nuttx_mm.h
@@ -14,8 +14,8 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include <stddef.h>
-#include <stdbool.h>
+#include LV_STDDEF_INCLUDE
+#include LV_STDBOOL_INCLUDE
 
 /*********************
  *      DEFINES

--- a/src/drivers/nuttx/mock/nuttx_video_fb.h
+++ b/src/drivers/nuttx/mock/nuttx_video_fb.h
@@ -14,8 +14,8 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include <stdint.h>
-#include <stddef.h>
+#include LV_STDINT_INCLUDE
+#include LV_STDDEF_INCLUDE
 
 /*********************
  *      DEFINES

--- a/src/drivers/opengles/lv_opengles_egl.c
+++ b/src/drivers/opengles/lv_opengles_egl.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 #include "lv_opengles_egl.h"
-#include <stdint.h>
+#include LV_STDBOOL_INCLUDE
 
 #if LV_USE_EGL
 

--- a/src/drivers/qnx/lv_qnx.c
+++ b/src/drivers/qnx/lv_qnx.c
@@ -8,7 +8,7 @@
  *********************/
 #include "../../lvgl_public.h"
 #if LV_USE_QNX
-#include <stdbool.h>
+#include LV_STDBOOL_INCLUDE
 #include "../../core/lv_global.h"
 #include "../../display/lv_display_private.h"
 #include <stdlib.h>

--- a/src/drivers/sdl/lv_sdl_window.c
+++ b/src/drivers/sdl/lv_sdl_window.c
@@ -13,7 +13,7 @@
 #include "../../lvgl_public.h"
 
 #if LV_USE_SDL
-#include <stdbool.h>
+#include LV_STDBOOL_INCLUDE
 #include "../../core/lv_global.h"
 #include "../../display/lv_display_private.h"
 

--- a/src/drivers/wayland/lv_wayland.c
+++ b/src/drivers/wayland/lv_wayland.c
@@ -21,9 +21,9 @@
     #endif
 #endif
 
-#include <stddef.h>
-#include <stdbool.h>
-#include <stdint.h>
+#include LV_STDDEF_INCLUDE
+#include LV_STDINT_INCLUDE
+#include LV_STDBOOL_INCLUDE
 #include <unistd.h>
 #include <fcntl.h>
 #include <string.h>

--- a/src/drivers/windows/lv_windows_input_private.h
+++ b/src/drivers/windows/lv_windows_input_private.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #if LV_USE_WINDOWS
 
-#include <stdbool.h>
+#include LV_STDBOOL_INCLUDE
 #include <windows.h>
 
 /*********************

--- a/src/drivers/x11/lv_x11_display.c
+++ b/src/drivers/x11/lv_x11_display.c
@@ -10,7 +10,7 @@
 
 #if LV_USE_X11
 
-#include <stdbool.h>
+#include LV_STDBOOL_INCLUDE
 #include <unistd.h>
 #include <stdlib.h>
 #include <pthread.h>

--- a/src/drivers/x11/lv_x11_input.c
+++ b/src/drivers/x11/lv_x11_input.c
@@ -11,7 +11,7 @@
 #if LV_USE_X11
 
 #include <string.h>
-#include <stdbool.h>
+#include LV_STDBOOL_INCLUDE
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 

--- a/src/libs/fsdrv/lv_fs_win32.c
+++ b/src/libs/fsdrv/lv_fs_win32.c
@@ -11,7 +11,7 @@
 
 #include <windows.h>
 #include <stdio.h>
-#include <limits.h>
+#include LV_LIMITS_INCLUDE
 
 #include "../../core/lv_global.h"
 /*********************

--- a/src/libs/qrcode/qrcodegen.c
+++ b/src/libs/qrcode/qrcodegen.c
@@ -25,7 +25,7 @@
 #include "../../lvgl_public.h"
 
 #if LV_USE_QRCODE
-#include <limits.h>
+#include LV_LIMITS_INCLUDE
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/libs/tjpgd/tjpgd.h
+++ b/src/libs/tjpgd/tjpgd.h
@@ -14,7 +14,7 @@ extern "C" {
 #if LV_USE_TJPGD
 
 #include <string.h>
-#include <stdint.h>
+#include LV_STDINT_INCLUDE
 
 #if JD_FASTDECODE >= 1
 typedef int16_t jd_yuv_t;

--- a/src/libs/vg_lite_driver/VGLite/vg_lite_context.h
+++ b/src/libs/vg_lite_driver/VGLite/vg_lite_context.h
@@ -31,8 +31,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdint.h>
-#include <stddef.h>
+#include LV_STDINT_INCLUDE
+#include LV_STDDEF_INCLUDE
 #include <math.h>
 #include "../inc/vg_lite.h"
 #include "../VGLiteKernel/vg_lite_kernel.h"

--- a/src/libs/vg_lite_driver/inc/vg_lite.h
+++ b/src/libs/vg_lite_driver/inc/vg_lite.h
@@ -39,8 +39,8 @@ extern "C" {
 #include "../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
-#include <stddef.h>
-#include <stdint.h>
+#include LV_STDDEF_INCLUDE
+#include LV_STDINT_INCLUDE
 
 /*  VGLite API Constants *******************************************************************************************************************/
 

--- a/src/libs/vg_lite_driver/lv_vg_lite_hal/lv_vg_lite_hal.c
+++ b/src/libs/vg_lite_driver/lv_vg_lite_hal/lv_vg_lite_hal.c
@@ -13,7 +13,7 @@
 #include "../VGLiteKernel/vg_lite_hal.h"
 #include "../VGLiteKernel/vg_lite_hw.h"
 
-#include <stdarg.h>
+#include LV_STDARG_INCLUDE
 
 static void sleep(uint32_t msec)
 {

--- a/src/libs/vg_lite_driver/lv_vg_lite_hal/vg_lite_platform.h
+++ b/src/libs/vg_lite_driver/lv_vg_lite_hal/vg_lite_platform.h
@@ -4,7 +4,7 @@
 #include "../../../lvgl_public.h"
 #if LV_USE_VG_LITE_DRIVER
 
-#include <stdint.h>
+#include LV_STDINT_INCLUDE
 #include <stdlib.h>
 #include <stdio.h>
 #include "../VGLiteKernel/vg_lite_debug.h"

--- a/src/osal/lv_pthread.h
+++ b/src/osal/lv_pthread.h
@@ -18,7 +18,7 @@ extern "C" {
 #include <unistd.h>
 #include <pthread.h>
 #include <semaphore.h>
-#include <stdbool.h>
+#include LV_STDBOOL_INCLUDE
 
 /*********************
  *      DEFINES

--- a/src/osal/lv_rtthread.h
+++ b/src/osal/lv_rtthread.h
@@ -16,7 +16,7 @@ extern "C" {
 #if LV_USE_OS == LV_OS_RTTHREAD
 
 #include <rtthread.h>
-#include <stdbool.h>
+#include LV_STDBOOL_INCLUDE
 
 /*********************
  *      DEFINES

--- a/src/osal/lv_sdl2.h
+++ b/src/osal/lv_sdl2.h
@@ -15,7 +15,7 @@ extern "C" {
  *********************/
 #if LV_USE_OS == LV_OS_SDL2
 #include <SDL2/SDL.h>
-#include <stdbool.h>
+#include LV_STDBOOL_INCLUDE
 
 /*********************
  *      DEFINES

--- a/src/osal/lv_windows.h
+++ b/src/osal/lv_windows.h
@@ -17,7 +17,7 @@ extern "C" {
 #if LV_USE_OS == LV_OS_WINDOWS
 
 #include <windows.h>
-#include <stdbool.h>
+#include LV_STDBOOL_INCLUDE
 
 /*********************
  *      DEFINES

--- a/src/stdlib/clib/lv_sprintf_clib.c
+++ b/src/stdlib/clib/lv_sprintf_clib.c
@@ -12,7 +12,7 @@
 #if LV_USE_STDLIB_SPRINTF == LV_STDLIB_CLIB
 
 #include <stdio.h>
-#include <stdarg.h>
+#include LV_STDARG_INCLUDE
 
 /*********************
  *      DEFINES

--- a/src/stdlib/rtthread/lv_sprintf_rtthread.c
+++ b/src/stdlib/rtthread/lv_sprintf_rtthread.c
@@ -12,7 +12,7 @@
 #if LV_USE_STDLIB_SPRINTF == LV_STDLIB_RTTHREAD
 
 #include <rtthread.h>
-#include <stdarg.h>
+#include LV_STDARG_INCLUDE
 
 #if LV_USE_FLOAT == 1
     #warning "lv_sprintf_rtthread: rtthread not support float in sprintf"


### PR DESCRIPTION
LVGL has LV_XXX_INCLUDE for these use-cases, this replaces all files that were including things like <stdint.h> instead of LV_STDINT_INCLUDE

CI check for this is coming in another PR