### PR TITLE
refactor(external_includes): use angle brackets for external includes

### DIFF
--- a/include/lvgl/fs/lv_fsdrv.h
+++ b/include/lvgl/fs/lv_fsdrv.h
@@ -50,7 +50,7 @@ void lv_fs_memfs_init(void);
 #endif
 
 #if LV_USE_FS_LITTLEFS
-#include "lfs.h"
+#include <lfs.h>
 struct lfs;
 /**
  * Set the default LittleFS handler to be used by LVGL

--- a/src/draw/espressif/ppa/lv_draw_ppa_private.h
+++ b/src/draw/espressif/ppa/lv_draw_ppa_private.h
@@ -29,7 +29,7 @@ extern "C" {
 #include "../../../misc/lv_area_private.h"
 
 /* The ppa driver depends heavily on the esp-idf headers*/
-#include "sdkconfig.h"
+#include <sdkconfig.h>
 
 #if (CONFIG_LV_DRAW_BUF_ALIGN != CONFIG_CACHE_L2_CACHE_LINE_SIZE)
 #error "CONFIG_LV_DRAW_BUF_ALIGN must be equal to CONFIG_CACHE_L2_CACHE_LINE_SIZE!"
@@ -40,12 +40,12 @@ extern "C" {
 #error "This SoC does not support PPA"
 #endif
 
-#include "driver/ppa.h"
-#include "esp_heap_caps.h"
-#include "esp_err.h"
-#include "hal/color_hal.h"
-#include "esp_cache.h"
-#include "esp_log.h"
+#include <driver/ppa.h>
+#include <esp_heap_caps.h>
+#include <esp_err.h>
+#include <hal/color_hal.h>
+#include <esp_cache.h>
+#include <esp_log.h>
 /*********************
 *      DEFINES
 *********************/

--- a/src/draw/nxp/g2d/lv_draw_buf_g2d.c
+++ b/src/draw/nxp/g2d/lv_draw_buf_g2d.c
@@ -18,7 +18,7 @@
 #if LV_USE_G2D
 #if LV_USE_DRAW_G2D
 #include "../../lv_draw_buf_private.h"
-#include "g2d.h"
+#include <g2d.h>
 #include "lv_g2d_buf_map.h"
 #include "lv_g2d_utils.h"
 

--- a/src/draw/nxp/g2d/lv_draw_g2d.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d.c
@@ -13,7 +13,7 @@
 
 #if LV_USE_G2D
 #include "../../../misc/lv_area_private.h"
-#include "g2d.h"
+#include <g2d.h>
 #include "lv_g2d_buf_map.h"
 #include "lv_g2d_utils.h"
 

--- a/src/draw/nxp/g2d/lv_draw_g2d_fill.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d_fill.c
@@ -18,7 +18,7 @@
 #if LV_USE_G2D
 #if LV_USE_DRAW_G2D
 #include <stdlib.h>
-#include "g2d.h"
+#include <g2d.h>
 #include "../../../misc/lv_area_private.h"
 #include "lv_g2d_buf_map.h"
 #include "lv_g2d_utils.h"

--- a/src/draw/nxp/g2d/lv_draw_g2d_img.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d_img.c
@@ -18,7 +18,7 @@
 #if LV_USE_G2D
 #if LV_USE_DRAW_G2D
 #include <math.h>
-#include "g2d.h"
+#include <g2d.h>
 #include "../../../misc/lv_area_private.h"
 #include "../../lv_draw_image_private.h"
 #include "../../lv_image_decoder_private.h"

--- a/src/draw/nxp/g2d/lv_g2d_buf_map.c
+++ b/src/draw/nxp/g2d/lv_g2d_buf_map.c
@@ -15,7 +15,7 @@
 #if LV_USE_DRAW_G2D
 #include <stdio.h>
 #include "lv_g2d_utils.h"
-#include "g2d.h"
+#include <g2d.h>
 
 /*********************
  *      DEFINES

--- a/src/draw/nxp/g2d/lv_g2d_utils.h
+++ b/src/draw/nxp/g2d/lv_g2d_utils.h
@@ -24,8 +24,8 @@ extern "C" {
 #if LV_USE_G2D
 #if LV_USE_DRAW_G2D
 #include "../../sw/lv_draw_sw_private.h"
-#include "g2d.h"
-#include "g2dExt.h"
+#include <g2d.h>
+#include <g2dExt.h>
 
 /*********************
  *      DEFINES

--- a/src/draw/nxp/pxp/lv_draw_buf_pxp.c
+++ b/src/draw/nxp/pxp/lv_draw_buf_pxp.c
@@ -21,7 +21,7 @@
 #include "lv_pxp_cfg.h"
 #include "lv_pxp_utils.h"
 
-#include "lvgl_support.h"
+#include <lvgl_support.h>
 
 /*********************
  *      DEFINES

--- a/src/draw/nxp/pxp/lv_pxp_cfg.h
+++ b/src/draw/nxp/pxp/lv_pxp_cfg.h
@@ -24,8 +24,8 @@ extern "C" {
 
 #if LV_USE_PXP
 #if LV_USE_DRAW_PXP || LV_USE_ROTATE_PXP
-#include "fsl_cache.h"
-#include "fsl_pxp.h"
+#include <fsl_cache.h>
+#include <fsl_pxp.h>
 
 #if ((LV_DRAW_BUF_ALIGN % 32) != 0)
 #error "If PXP is enabled the draw buffers should be aligned to 32-byte boundary, please set LV_DRAW_BUF_ALIGN to a multiple of 32 in lv_conf.h"

--- a/src/draw/nxp/pxp/lv_pxp_osa.c
+++ b/src/draw/nxp/pxp/lv_pxp_osa.c
@@ -19,10 +19,10 @@
 #if LV_USE_DRAW_PXP || LV_USE_ROTATE_PXP
 #include "lv_pxp_utils.h"
 #include "../../../osal/lv_os_private.h"
-#include "fsl_pxp.h"
+#include <fsl_pxp.h>
 
 #if defined(SDK_OS_FREE_RTOS)
-    #include "FreeRTOS.h"
+    #include <FreeRTOS.h>
 #endif
 
 #if defined(__ZEPHYR__)

--- a/src/draw/nxp/pxp/lv_pxp_utils.h
+++ b/src/draw/nxp/pxp/lv_pxp_utils.h
@@ -23,7 +23,7 @@ extern "C" {
 
 #if LV_USE_PXP
 #if LV_USE_DRAW_PXP || LV_USE_ROTATE_PXP
-#include "fsl_pxp.h"
+#include <fsl_pxp.h>
 
 /*********************
  *      DEFINES

--- a/src/draw/renesas/dave2d/lv_draw_dave2d.h
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d.h
@@ -16,8 +16,8 @@ extern "C" {
 #include "../../../lvgl_public.h"
 #if LV_USE_DRAW_DAVE2D
 #include "../../lv_draw_private.h"
-#include "bsp_api.h"
-#include "dave_driver.h"
+#include <bsp_api.h>
+#include <dave_driver.h>
 
 #if LV_USE_FLOAT
 

--- a/src/draw/sw/arm2d/lv_draw_sw_arm2d.h
+++ b/src/draw/sw/arm2d/lv_draw_sw_arm2d.h
@@ -24,8 +24,8 @@ extern "C" {
 #if LV_USE_DRAW_ARM2D_SYNC
 
 #define __ARM_2D_IMPL__
-#include "arm_2d.h"
-#include "__arm_2d_impl.h"
+#include <arm_2d.h>
+#include <__arm_2d_impl.h>
 
 #if defined(__IS_COMPILER_ARM_COMPILER_5__)
 #pragma diag_suppress 174,177,188,68,513,144,1296

--- a/src/draw/sw/blend/arm2d/lv_blend_arm2d.h
+++ b/src/draw/sw/blend/arm2d/lv_blend_arm2d.h
@@ -19,8 +19,8 @@ extern "C" {
 #if LV_USE_DRAW_ARM2D_SYNC
 
 #define __ARM_2D_IMPL__
-#include "arm_2d.h"
-#include "__arm_2d_impl.h"
+#include <arm_2d.h>
+#include <__arm_2d_impl.h>
 
 #if defined(__IS_COMPILER_ARM_COMPILER_5__)
 #pragma diag_suppress 174,177,188,68,513,144,1296

--- a/src/draw/sw/blend/helium/lv_blend_helium.h
+++ b/src/draw/sw/blend/helium/lv_blend_helium.h
@@ -15,8 +15,8 @@ extern "C" {
  *********************/
 
 #if defined(_RTE_)
-#include "Pre_Include_Global.h"
-#include "lv_conf_cmsis.h"
+#include <Pre_Include_Global.h>
+#include <lv_conf_cmsis.h>
 #endif
 
 #include "../../../../lvgl_public.h"

--- a/src/drivers/display/nxp_elcdif/lv_nxp_elcdif.c
+++ b/src/drivers/display/nxp_elcdif/lv_nxp_elcdif.c
@@ -11,9 +11,9 @@
  *      INCLUDES
  *********************/
 #include "../../../display/lv_display_private.h"
-#include "fsl_video_common.h"
-#include "fsl_elcdif.h"
-#include "fsl_cache.h"
+#include <fsl_video_common.h>
+#include <fsl_elcdif.h>
+#include <fsl_cache.h>
 
 /*********************
  *      DEFINES

--- a/src/drivers/display/renesas_glcdc/lv_renesas_glcdc.c
+++ b/src/drivers/display/renesas_glcdc/lv_renesas_glcdc.c
@@ -27,12 +27,12 @@
 #endif /*_RENESAS_RA_*/
 
 #ifdef _RENESAS_RA_
-    #include "LVGL_thread.h"
+    #include <LVGL_thread.h>
 #else /* RX */
-    #include "hal_data.h"
-    #include "platform.h"
-    #include "r_glcdc_rx_if.h"
-    #include "r_glcdc_rx_pinset.h"
+    #include <hal_data.h>
+    #include <platform.h>
+    #include <r_glcdc_rx_if.h>
+    #include <r_glcdc_rx_pinset.h>
 #endif /*_RENESAS_RA_*/
 
 #include <stdbool.h>

--- a/src/drivers/display/st_ltdc/lv_st_ltdc.c
+++ b/src/drivers/display/st_ltdc/lv_st_ltdc.c
@@ -13,7 +13,7 @@
 #include "../../../display/lv_display_private.h"
 #include "../../../draw/sw/lv_draw_sw.h"
 #include "../../../osal/lv_os_private.h"
-#include "main.h"
+#include <main.h>
 
 #if LV_ST_LTDC_USE_DMA2D_FLUSH
     #if LV_USE_DRAW_DMA2D

--- a/src/libs/freetype/lv_freetype_private.h
+++ b/src/libs/freetype/lv_freetype_private.h
@@ -19,7 +19,7 @@ extern "C" {
 #if LV_USE_FREETYPE
 
 #include "../../misc/cache/lv_cache.h"
-#include "ft2build.h"
+#include <ft2build.h>
 #include FT_FREETYPE_H
 #include FT_GLYPH_H
 #include FT_CACHE_H

--- a/src/libs/fsdrv/lv_fs_arduino_esp_littlefs.cpp
+++ b/src/libs/fsdrv/lv_fs_arduino_esp_littlefs.cpp
@@ -2,7 +2,7 @@
 #if LV_USE_FS_ARDUINO_ESP_LITTLEFS
 
 #include "../../core/lv_global.h"
-#include "LittleFS.h"
+#include <LittleFS.h>
 
 #if !LV_FS_IS_VALID_LETTER(LV_FS_ARDUINO_ESP_LITTLEFS_LETTER)
     #error "Invalid drive letter"

--- a/src/libs/fsdrv/lv_fs_arduino_sd.cpp
+++ b/src/libs/fsdrv/lv_fs_arduino_sd.cpp
@@ -3,7 +3,7 @@
 
 #include "../../core/lv_global.h"
 #include <SPI.h>
-#include "SD.h"
+#include <SD.h>
 
 #if !LV_FS_IS_VALID_LETTER(LV_FS_ARDUINO_SD_LETTER)
     #error "Invalid drive letter"

--- a/src/libs/fsdrv/lv_fs_fatfs.c
+++ b/src/libs/fsdrv/lv_fs_fatfs.c
@@ -9,7 +9,7 @@
 #include "../../../lvgl.h"
 
 #if LV_USE_FS_FATFS
-#include "ff.h"
+#include <ff.h>
 
 #include "../../core/lv_global.h"
 /*********************

--- a/src/libs/fsdrv/lv_fs_littlefs.c
+++ b/src/libs/fsdrv/lv_fs_littlefs.c
@@ -1,7 +1,7 @@
 #include "../../../lvgl.h"
 #if LV_USE_FS_LITTLEFS
 
-#include "lfs.h"
+#include <lfs.h>
 #include "../../core/lv_global.h"
 
 #if !LV_FS_IS_VALID_LETTER(LV_FS_LITTLEFS_LETTER)

--- a/src/libs/gltf/gltf_data/lv_gltf_data_animations.cpp
+++ b/src/libs/gltf/gltf_data/lv_gltf_data_animations.cpp
@@ -11,6 +11,8 @@
 
 #if LV_USE_GLTF
 #include <fastgltf/tools.hpp>
+#include <fastgltf/math.hpp>
+#include "lv_gltf_data_internal.hpp"
 
 /*********************
  *      DEFINES
@@ -26,8 +28,6 @@
  *  STATIC PROTOTYPES
  **********************/
 
-#include "fastgltf/math.hpp"
-#include "lv_gltf_data_internal.hpp"
 static fastgltf::math::fvec3 animation_get_vec3_at_timestamp(lv_gltf_model_t * data,
                                                              fastgltf::AnimationSampler * sampler,
                                                              float seconds);

--- a/src/libs/gltf/gltf_data/lv_gltf_model_node.cpp
+++ b/src/libs/gltf/gltf_data/lv_gltf_model_node.cpp
@@ -11,7 +11,7 @@
 #if LV_USE_GLTF
 
 #include <float.h>
-#include "fastgltf/types.hpp"
+#include <fastgltf/types.hpp>
 #include "../../../misc/lv_event_private.h"
 
 /*********************

--- a/src/libs/gltf/gltf_view/lv_gltf_view_shader.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_shader.cpp
@@ -9,7 +9,7 @@
 #include "lv_gltf_view_internal.h"
 #if LV_USE_GLTF
 
-#include "fastgltf/types.hpp"
+#include <fastgltf/types.hpp>
 #include "../gltf_data/lv_gltf_data_internal.hpp"
 #include "../gltf_data/lv_gltf_data_internal.h"
 #include "../../../drivers/opengles/opengl_shader/lv_opengl_shader_internal.h"

--- a/src/osal/lv_cmsis_rtos2.h
+++ b/src/osal/lv_cmsis_rtos2.h
@@ -21,7 +21,7 @@ extern "C" {
  *********************/
 #if LV_USE_OS == LV_OS_CMSIS_RTOS2
 
-#include "cmsis_os2.h"
+#include <cmsis_os2.h>
 
 /*********************
  *      DEFINES

--- a/src/osal/lv_freertos.c
+++ b/src/osal/lv_freertos.c
@@ -16,9 +16,9 @@
 #if LV_USE_OS == LV_OS_FREERTOS
 
 #ifdef ESP_PLATFORM
-    #include "freertos/atomic.h"
+    #include <freertos/atomic.h>
 #else
-    #include "atomic.h"
+    #include <atomic.h>
 #endif
 
 #include "../core/lv_global.h"

--- a/src/osal/lv_freertos.h
+++ b/src/osal/lv_freertos.h
@@ -24,13 +24,13 @@ extern "C" {
 #if LV_USE_OS == LV_OS_FREERTOS
 
 #ifdef ESP_PLATFORM
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-#include "freertos/semphr.h"
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <freertos/semphr.h>
 #else
-#include "FreeRTOS.h"
-#include "task.h"
-#include "semphr.h"
+#include <FreeRTOS.h>
+#include <task.h>
+#include <semphr.h>
 #endif
 
 /*********************

--- a/src/osal/lv_mqx.h
+++ b/src/osal/lv_mqx.h
@@ -17,8 +17,8 @@ extern "C" {
 
 #if LV_USE_OS == LV_OS_MQX
 
-#include "mqx.h"
-#include "mutex.h"
+#include <mqx.h>
+#include <mutex.h>
 
 /*********************
  *      DEFINES


### PR DESCRIPTION
This way, we can easily know if the include is supposed to be part of lvgl or if it's part of an external dependency

CI check for this is coming in another PR