### PR TITLE
refactor(include): pass through lvgl_public.h to include public api from src

### DIFF
--- a/src/lvgl.h
+++ b/src/lvgl.h
@@ -14,7 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 
-#include "../include/lvgl/lvgl.h"
+#include "lvgl_public.h"
 
 /*********************
  *      DEFINES


### PR DESCRIPTION
No file inside `src` should include a file outside it except for `lvgl_public.h` for two reasons:

1. Having a single entry point makes it very easy for contributors to know what to do "always include lvgl_public.h"
2. For the private api installation, paths that include something outside src all need to be changed so if there's only one place where the public api is included from `src`
 
CI check for this is coming in another PR