### PR TITLE
fix(obj): fix segfault when obj_remove_flag is called for screen

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -300,15 +300,20 @@ void lv_obj_remove_flag(lv_obj_t * obj, lv_obj_flag_t f)
     }
 
     obj->flags &= (~f);
+    lv_obj_t * parent = lv_obj_get_parent(obj);
 
     if(f & LV_OBJ_FLAG_HIDDEN) {
         lv_obj_invalidate(obj);
-        lv_obj_mark_layout_as_dirty(lv_obj_get_parent(obj));
+        if(parent) {
+            lv_obj_mark_layout_as_dirty(parent);
+        }
         lv_obj_mark_layout_as_dirty(obj);
     }
 
     if((was_on_layout != lv_obj_is_layout_positioned(obj)) || (f & (LV_OBJ_FLAG_LAYOUT_1 |  LV_OBJ_FLAG_LAYOUT_2))) {
-        lv_obj_mark_layout_as_dirty(lv_obj_get_parent(obj));
+        if(parent) {
+            lv_obj_mark_layout_as_dirty(parent);
+        }
     }
 
 }

--- a/tests/src/test_cases/widgets/test_obj_flags.c
+++ b/tests/src/test_cases/widgets/test_obj_flags.c
@@ -237,4 +237,14 @@ void test_obj_flag_radio_button(void)
 
 }
 
+void test_obj_flag_parent_hidden(void)
+{
+    /* #10083: Ensure that adding and removing screen flags don't make lvgl crash*/
+    lv_obj_add_flag(lv_screen_active(), LV_OBJ_FLAG_HIDDEN);
+    TEST_ASSERT_TRUE(lv_obj_has_flag(lv_screen_active(), LV_OBJ_FLAG_HIDDEN));
+    lv_obj_remove_flag(lv_screen_active(), LV_OBJ_FLAG_HIDDEN);
+    TEST_ASSERT_FALSE(lv_obj_has_flag(lv_screen_active(), LV_OBJ_FLAG_HIDDEN));
+    TEST_PASS();
+}
+
 #endif


### PR DESCRIPTION
Fixes #10083  <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
