### PR TITLE
feat(stdlib/micropython): use tracked allocations for LVGL memory

### DIFF
--- a/src/stdlib/micropython/lv_mem_core_micropython.c
+++ b/src/stdlib/micropython/lv_mem_core_micropython.c
@@ -12,6 +12,10 @@
 
 #include <include/lv_mp_mem_custom_include.h>
 
+#if !MICROPY_TRACKED_ALLOC
+    #error "LV_STDLIB_MICROPYTHON requires MICROPY_TRACKED_ALLOC=1 in mpconfigport.h"
+#endif
+
 /*********************
  *      DEFINES
  *********************/
@@ -64,32 +68,17 @@ void lv_mem_remove_pool(lv_mem_pool_t pool)
 
 void * lv_malloc_core(size_t size)
 {
-#if MICROPY_MALLOC_USES_ALLOCATED_SIZE
-    return gc_alloc(size, true);
-#else
-    return m_malloc(size);
-#endif
+    return m_tracked_calloc(1, size);
 }
 
 void * lv_realloc_core(void * p, size_t new_size)
 {
-
-#if MICROPY_MALLOC_USES_ALLOCATED_SIZE
-    return gc_realloc(p, new_size, true);
-#else
-    return m_realloc(p, new_size);
-#endif
+    return m_tracked_realloc(p, new_size);
 }
 
 void lv_free_core(void * p)
 {
-
-#if MICROPY_MALLOC_USES_ALLOCATED_SIZE
-    gc_free(p);
-
-#else
-    m_free(p);
-#endif
+    m_tracked_free(p);
 }
 
 void lv_mem_monitor_core(lv_mem_monitor_t * mon_p)


### PR DESCRIPTION
## Summary

Switch the MicroPython stdlib backend (`LV_USE_STDLIB_MALLOC == LV_STDLIB_MICROPYTHON`) to use MicroPython's tracked-allocation API for every LVGL allocation. Tracked allocations are GC-heap blocks that MicroPython explicitly registers in a separate linked list — they give LVGL several properties the previous direct-`gc_alloc` approach didn't:

**Reliable cleanup on VM teardown and soft-reset.** When the MicroPython runtime shuts down or soft-resets, the tracked-alloc subsystem walks its registry and frees every block. LVGL's internal state — display lists, font caches, widget pools, anything that came through `lv_malloc` — goes with it. That makes a soft-reset cycle (REPL `Ctrl-D`, harness reload, embedded "restart Python without rebooting the chip") leave LVGL in a clean state on the way back up. Previously these blocks survived as orphaned GC memory that the runtime had no safe way to reclaim, leaking across every reset.

**No spurious finaliser sweeps over LVGL data.** Tracked allocations are not flagged with `GC_ALLOC_FLAG_HAS_FINALISER`, so MicroPython's `gc_sweep_run_finalisers` doesn't try to dispatch `__del__` on raw LVGL bytes. The previous shim passed `true` as the second argument to `gc_alloc` — that arg is `unsigned int alloc_flags`, not a boolean, and `true == 1 == GC_ALLOC_FLAG_HAS_FINALISER`. The result was that every LVGL allocation had the finaliser bit set, and GC sweeps would walk into font glyph tables / widget pool entries and try to interpret the first bytes as `mp_obj_type_t *`. That's a SIGSEGV class the unix-port harness has been hitting reliably under load.

**Honest accounting in MicroPython's heap stats.** Tracked blocks participate in normal GC scanning and `gc.mem_info()` totals correctly include LVGL's footprint.

## API used

`m_tracked_calloc`, `m_tracked_realloc`, `m_tracked_free` from `py/misc.h`. `m_tracked_realloc` was added in [micropython/micropython#16023](https://github.com/micropython/micropython/pull/16023) (merged 2026-04-08), so LVGL builds need a MicroPython version that includes it.

Also drops the `MICROPY_MALLOC_USES_ALLOCATED_SIZE` branch — the tracked-alloc API handles both configurations internally.

## Requirements

`MICROPY_TRACKED_ALLOC=1` must be set in the consumer's `mpconfigport.h`. The default is 0, but the unix port already enables it. An `#error` guard makes the build fail clearly if the flag is missing.

## Testing

Built `lv_binding_micropython` against this branch on the unix port and exercised the reload cycle that previously SIGSEGV'd:

- Repeated `lv.init() → allocate widgets/fonts/buffers → lv.deinit() → GC cycle` no longer crashes
- Soft-reset (with the binding's `lvgl_mod___del__` invoking `lv_deinit()`) leaves no orphaned LVGL blocks
- `gc.mem_info()` post-deinit shows reclaimed memory matching expected LVGL footprint
