### PR TITLE
fix(draw/ppa): tolerate unaligned cache regions in invalidate_cache_cb

### DIFF
--- a/src/draw/espressif/ppa/lv_draw_ppa_buf.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa_buf.c
@@ -41,6 +41,24 @@ void lv_draw_buf_ppa_init_handlers(void)
 
 static void invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area)
 {
-    esp_cache_msync(draw_buf->data, draw_buf->data_size, ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
+    LV_UNUSED(area);
+    /* draw_buf->data is not guaranteed to be aligned to the ESP32-P4 L2
+     * cache line size (64 B). Without ESP_CACHE_MSYNC_FLAG_UNALIGNED the
+     * kernel rejects the call with:
+     *
+     *   E cache: esp_cache_msync(122): start address: 0x... or the size:
+     *           0x... is(are) not aligned with cache line size (0x40)B
+     *
+     * Failed flushes leave stale PSRAM bytes that the PPA's DMA reads
+     * as garbage, producing visible corruption when rendering through
+     * buffer-backed canvases. The UNALIGNED flag lets esp_cache_msync
+     * internally handle partial leading/trailing cache lines.
+     *
+     * Cast the const-pointer to void * — esp_cache_msync's signature
+     * takes a non-const buffer pointer. */
+    esp_cache_msync((void *)(uintptr_t)draw_buf->data, draw_buf->data_size,
+                    ESP_CACHE_MSYNC_FLAG_DIR_C2M
+                    | ESP_CACHE_MSYNC_FLAG_TYPE_DATA
+                    | ESP_CACHE_MSYNC_FLAG_UNALIGNED);
 }
 #endif /* LV_USE_PPA */


### PR DESCRIPTION
## Summary

`invalidate_cache_cb` in `lv_draw_ppa_buf.c` calls `esp_cache_msync` with `draw_buf->data` and `draw_buf->data_size` straight through. PR #9869 fixed `data_size` alignment via `_calculate_draw_buf_size`, but `data` itself isn't guaranteed to be aligned to the ESP32-P4 L2 cache line size (64 B) — draw buffers can come from code paths that produce only a 4-byte-aligned pointer (regular `malloc`, `heap_caps_malloc` without explicit alignment, user-supplied buffers handed to `lv_canvas_set_buffer`, …).

Without `ESP_CACHE_MSYNC_FLAG_UNALIGNED` the kernel rejects the call:

```
E cache: esp_cache_msync(122): start address: 0x... or the size: 0x... is(are) not aligned with cache line size (0x40)B
```

Failed flushes leave stale PSRAM bytes that the PPA's DMA then reads as garbage, producing visible corruption (banded rows / wrong colors) when rendering through buffer-backed canvases on PSRAM.

The `ESP_CACHE_MSYNC_FLAG_UNALIGNED` flag asks `esp_cache_msync` to internally handle partial leading/trailing cache lines instead of refusing the call. This is the same root cause as #9868 / #9869 but on the *invalidate* path rather than the size-calculation path.

## Reproduction

* Hardware: Waveshare ESP32-P4-WIFI6-Touch-LCD-7B (EK79007 panel, 1024×600 RGB565)
* LVGL 9.5.0 with `LV_USE_PPA=y`
* PSRAM-backed `lv_canvas` (~2 MB) used as a tile mosaic for map rendering
* `heap_caps_aligned_alloc(64, ...)` for the canvas buffer — but the same callback also fires for LVGL-allocated draw buffers whose start address is not 64-byte aligned

Errors stream continuously during render, accompanied by row-wise color corruption that disappears once `UNALIGNED` is added.

## Notes

- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/tree/master/tests) if applicable.