### PR TITLE
docs(api): split public/private API pages

### DIFF
--- a/.github/workflows/compile_docs.yml
+++ b/.github/workflows/compile_docs.yml
@@ -90,19 +90,24 @@ jobs:
       # Tool used to convert Doxygen XML to .mdx API pages
       - name: Install doxymark 
         run: |
-          npm install github:mutahharmkhan/doxymark
+          npm install github:mutahharmkhan/doxymark#multi-root-prefix
 
       # Generate Documentation API pages 
       - name: Generate API pages
         run: |
             npx doxymark \
-               --input docs/doxygen/xml \
-               --output docs/src/api \
-               --index docs/src/api-index.json \
-               --preset fumadocs \
-               --auto-group \
-               --source-url https://github.com/lvgl/lvgl/tree/${{ github.sha }}/src 
-            rm -rf docs/doxygen
+            --input docs/doxygen/xml \
+            --output docs/src \
+            --index docs/src/api-index.json \
+            --preset fumadocs \
+            --auto-group \
+            --root api=./include/lvgl \
+            --root 'api-private=./src#*_private.h' \
+            --source-url-for api=https://github.com/lvgl/lvgl/tree/${{ github.sha }}/include/lvgl \
+            --source-url-for api-private=https://github.com/lvgl/lvgl/tree/${{ github.sha }}/src \
+            --root-title api=API \
+            --root-title 'api-private=API Private'
+            rm -rf docs/doxygen 
 
       - name: Install Example Documentation
         run: npm i @lvgl/examples-generator

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -790,7 +790,7 @@ WARN_LOGFILE           = doxygen_warnings.txt
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../include/lvgl
+INPUT                  = ../include/lvgl ../src
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/docs/src/meta.json
+++ b/docs/src/meta.json
@@ -13,7 +13,9 @@
     "debugging",
     "guides",
     "contributing",
+    "api",
+    "api-private",
     "CHANGELOG",
-    "api"
+    "deprecated"
   ]
 }


### PR DESCRIPTION
- `docs/Doxyfile`: add `../src` to `INPUT` so private headers are emitted in the XML.
- `compile_docs.yml`: switch doxymark to multi-root mode — `api/` from `include/lvgl`, `api-private/` from `src/*_private.h`, each with its own `--source-url-for`.
- `docs/src/meta.json`: list `api-private` and `deprecated` in the docs nav.

The new flags require the `multi-root-prefix` branch of doxymark (installed from a fork for now). Should land in the canonical doxymark before this is merged.