### PR TITLE
chore(Kconfig): add missing Kconfig symbols

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -106,7 +106,6 @@ menu "LVGL configuration"
 			hex "Address for the memory pool instead of allocating it as a normal array"
 			default 0x0
 			depends on LV_USE_BUILTIN_MALLOC
-
 	endmenu
 
 	menu "HAL Settings"
@@ -519,6 +518,26 @@ menu "LVGL configuration"
 			default 1000
 			depends on LV_USE_DRAW_VG_LITE
 
+		config LV_USE_VG_LITE_DRIVER
+			bool "Use LVGL's built-in vg_lite driver"
+			default n
+			depends on LV_USE_DRAW_VG_LITE
+
+		config LV_VG_LITE_HAL_GPU_SERIES
+			string "VG-Lite GPU series"
+			default "gc255"
+			depends on LV_USE_VG_LITE_DRIVER
+
+		config LV_VG_LITE_HAL_GPU_REVISION
+			hex "VG-Lite GPU revision"
+			default 0x40
+			depends on LV_USE_VG_LITE_DRIVER
+
+		config LV_VG_LITE_HAL_GPU_BASE_ADDRESS
+			hex "VG-Lite GPU base address"
+			default 0x40240000
+			depends on LV_USE_VG_LITE_DRIVER
+
 		config LV_USE_VECTOR_GRAPHIC
 			bool "Use Vector Graphic APIs"
 			default n
@@ -550,6 +569,63 @@ menu "LVGL configuration"
 			bool "Draw using cached OpenGLES textures"
 			default n
 			depends on LV_USE_OPENGLES
+
+		config LV_DRAW_OPENGLES_TEXTURE_CACHE_COUNT
+			int "OpenGLES texture cache count"
+			default 64
+			depends on LV_USE_DRAW_OPENGLES
+
+		config LV_USE_NEMA_GFX
+			bool "Use NemaGFX acceleration"
+			default n
+
+		choice LV_USE_NEMA_LIB
+			prompt "NemaGFX static library"
+			depends on LV_USE_NEMA_GFX
+			default LV_NEMA_LIB_NONE
+
+			config LV_NEMA_LIB_NONE
+				bool "LV_NEMA_LIB_NONE"
+			config LV_NEMA_LIB_M33_REVC
+				bool "LV_NEMA_LIB_M33_REVC"
+			config LV_NEMA_LIB_M33_NEMAPVG
+				bool "LV_NEMA_LIB_M33_NEMAPVG"
+			config LV_NEMA_LIB_M55
+				bool "LV_NEMA_LIB_M55"
+			config LV_NEMA_LIB_M7
+				bool "LV_NEMA_LIB_M7"
+		endchoice
+
+		choice LV_USE_NEMA_HAL
+			prompt "NemaGFX HAL"
+			depends on LV_USE_NEMA_GFX
+			default LV_NEMA_HAL_CUSTOM
+
+			config LV_NEMA_HAL_CUSTOM
+				bool "LV_NEMA_HAL_CUSTOM"
+			config LV_NEMA_HAL_STM32
+				bool "LV_NEMA_HAL_STM32"
+		endchoice
+
+		config LV_NEMA_STM32_HAL_INCLUDE
+			string "NemaGFX STM32 HAL include"
+			default "stm32u5xx_hal.h"
+			depends on LV_USE_NEMA_GFX && LV_NEMA_HAL_STM32
+
+		config LV_USE_NEMA_VG
+			bool "Enable NemaVG operations"
+			default n
+			depends on LV_USE_NEMA_GFX
+
+		config LV_NEMA_GFX_MAX_RESX
+			int "NemaVG max horizontal resolution"
+			default 800
+			depends on LV_USE_NEMA_VG
+
+		config LV_NEMA_GFX_MAX_RESY
+			int "NemaVG max vertical resolution"
+			default 600
+			depends on LV_USE_NEMA_VG
 
 		config LV_USE_PPA
 		bool "Use Espressif's PPA accelerator for ESP SoCs"
@@ -1205,6 +1281,19 @@ menu "LVGL configuration"
 				The direction will be processed according to the Unicode Bidirectional Algorithm:
 				https://www.w3.org/International/articles/inline-bidi-markup/uba-basics
 
+		choice LV_BIDI_BASE_DIR_DEF
+			prompt "Set the default BIDI base direction"
+			depends on LV_USE_BIDI
+			default LV_BASE_DIR_AUTO
+
+			config LV_BASE_DIR_LTR
+				bool "Left-to-Right"
+			config LV_BASE_DIR_RTL
+				bool "Right-to-Left"
+			config LV_BASE_DIR_AUTO
+				bool "Auto detect"
+		endchoice
+
 		choice
 			prompt "Set the default BIDI direction"
 			default LV_BIDI_DIR_AUTO
@@ -1545,6 +1634,10 @@ menu "LVGL configuration"
 			int "Set an upper-cased driver-identifier letter for this driver (e.g. 65 for 'A')"
 			default 0
 			depends on LV_USE_FS_UEFI
+		config LV_FS_UEFI_LETTER
+			int "UEFI driver-identifier letter alias"
+			default LV_USE_FS_UEFI_LETTER
+			depends on LV_USE_FS_UEFI
 
 		config LV_USE_FS_FROGFS
 			bool "FrogFS read-only filesystem"
@@ -1590,8 +1683,17 @@ menu "LVGL configuration"
 			bool "SVG animation"
 			depends on LV_USE_SVG
 
+		config LV_USE_SVG_DEBUG
+			bool "Enable SVG debug logs"
+			depends on LV_USE_SVG
+			default n
+
 		config LV_USE_RLE
 			bool "LVGL's version of RLE compression method"
+
+		config LV_USE_GSTREAMER
+			bool "GStreamer library"
+			default n
 
 		config LV_USE_QRCODE
 			bool "QR code library"
@@ -1684,6 +1786,11 @@ menu "LVGL configuration"
 
 		config LV_USE_SYSMON
 			bool "Enable system monitor component"
+			default n
+
+		config LV_SYSMON_PROC_IDLE_AVAILABLE
+			bool "Enable process idle measurement"
+			depends on LV_USE_SYSMON
 			default n
 
 		config LV_USE_PERF_MONITOR
@@ -1891,6 +1998,7 @@ menu "LVGL configuration"
 		config LV_USE_TEST_SCREENSHOT_COMPARE
 			bool "Enable `lv_test_screenshot_compare`. Requires libpng and a few MB of extra RAM."
 			depends on LV_USE_TEST
+
 		config LV_USE_TRANSLATION
 			bool "Enable text translation support"
 		config LV_USE_COLOR_FILTER
@@ -1911,6 +2019,11 @@ menu "LVGL configuration"
 		config LV_USE_SDL
 			bool "Use SDL to open window on PC and handle mouse and keyboard"
 			default n
+
+		config LV_USE_GLFW
+			bool "Use GLFW for OpenGL context handling"
+			default n
+			depends on LV_USE_OPENGLES
 		config LV_SDL_INCLUDE_PATH
 			string "SDL include path"
 			depends on LV_USE_SDL
@@ -1956,6 +2069,11 @@ menu "LVGL configuration"
 			default 0 if LV_SDL_CUSTOM_BUFFER
 			default 1 if LV_SDL_SINGLE_BUFFER
 			default 2 if LV_SDL_DOUBLE_BUFFER
+
+		config LV_SDL_BUF_COUNT
+			int
+			depends on LV_USE_SDL
+			default LV_SDL_BUFFER_COUNT
 
 		config LV_SDL_ACCELERATED
 			bool "Use hardware acceleration"
@@ -2194,6 +2312,11 @@ menu "LVGL configuration"
 			bool "Use Linux DRM device"
 			default n
 
+		config LV_USE_LINUX_DRM_GBM_BUFFERS
+			bool "Use MESA GBM for Linux DRM DMA buffers"
+			depends on LV_USE_LINUX_DRM
+			default n
+
 		config LV_USE_TFT_ESPI
 			bool "Use TFT_eSPI driver"
 			default n
@@ -2268,6 +2391,11 @@ menu "LVGL configuration"
 		config LV_USE_FT81X
 			bool "Use ft81x EVE driver"
 			default n
+
+		config LV_USE_NV3007
+			bool "Use NV3007 LCD driver"
+			default n
+			select LV_USE_GENERIC_MIPI
 
 		config LV_USE_WINDOWS
 			bool "Use LVGL Windows backend"
@@ -2386,6 +2514,10 @@ menu "LVGL configuration"
 				bool "Smartwatch demo"
 			config LV_USE_DEMO_EBIKE
 				bool "Ebike demo"
+			config LV_DEMO_EBIKE_PORTRAIT
+				bool "Ebike portrait layout"
+				depends on LV_USE_DEMO_EBIKE
+				default n
 			config LV_USE_DEMO_HIGH_RES
 			bool "High resolution demo"
 		endif

--- a/include/lvgl/config/lv_conf_kconfig.h
+++ b/include/lvgl/config/lv_conf_kconfig.h
@@ -108,6 +108,30 @@ extern "C" {
 #endif
 
 /*******************
+ * LV_USE_NEMA_LIB
+ *******************/
+#ifdef CONFIG_LV_NEMA_LIB_NONE
+#  define CONFIG_LV_USE_NEMA_LIB LV_NEMA_LIB_NONE
+#elif defined(CONFIG_LV_NEMA_LIB_M33_REVC)
+#  define CONFIG_LV_USE_NEMA_LIB LV_NEMA_LIB_M33_REVC
+#elif defined(CONFIG_LV_NANOVG_BACKEND_GLES2)
+#  define CONFIG_LV_USE_NEMA_LIB LV_NEMA_LIB_M33_NEMAPVG
+#elif defined(CONFIG_LV_NANOVG_BACKEND_GLES3)
+#  define CONFIG_LV_USE_NEMA_LIB LV_NEMA_LIB_M55
+#elif defined(CONFIG_LV_NEMA_LIB_M7)
+#  define CONFIG_LV_USE_NEMA_LIB LV_NEMA_LIB_M7
+#endif
+
+/*******************
+ * LV_USE_NEMA_HAL
+ *******************/
+#ifdef CONFIG_LV_NEMA_HAL_STM32
+#  define CONFIG_LV_USE_NEMA_HAL LV_NEMA_HAL_STM32
+#elif defined(CONFIG_LV_NEMA_HAL_CUSTOM)
+#  define CONFIG_LV_USE_NEMA_HAL LV_NEMA_HAL_CUSTOM
+#endif
+
+/*******************
  * LV_NANOVG_BACKEND
  *******************/
 


### PR DESCRIPTION
Add symbols missing for the Kconfig for lv_conf.

Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
