### PR TITLE
feat(types): add IAR support for compiler attributes

### DIFF
--- a/include/lvgl/lv_types.h
+++ b/include/lvgl/lv_types.h
@@ -420,7 +420,7 @@ typedef struct _lv_draw_eve_unit_t lv_draw_eve_unit_t;
 #ifndef LV_NORETURN
 #if defined(PYCPARSER)
 #define LV_NORETURN
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__IAR_SYSTEMS_ICC__)
 #define LV_NORETURN __attribute__((noreturn))
 #elif defined(_MSC_VER)
 #define LV_NORETURN __declspec(noreturn)
@@ -430,7 +430,7 @@ typedef struct _lv_draw_eve_unit_t lv_draw_eve_unit_t;
 #endif /* LV_NORETURN not defined */
 
 #ifndef LV_UNREACHABLE
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__IAR_SYSTEMS_ICC__)
 #define LV_UNREACHABLE() __builtin_unreachable()
 #elif defined(_MSC_VER)
 #define LV_UNREACHABLE() __assume(0)
@@ -461,7 +461,7 @@ typedef struct _lv_draw_eve_unit_t lv_draw_eve_unit_t;
 #ifndef LV_DEPRECATED
 #if defined(PYCPARSER)
 #define LV_DEPRECATED(msg)
-#elif defined(__GNUC__) || defined(__clang__)
+#elif defined(__GNUC__) || defined(__clang__) || defined(__IAR_SYSTEMS_ICC__)
 #define LV_DEPRECATED(msg) __attribute__((deprecated(msg)))
 #elif defined(_MSC_VER)
 #define LV_DEPRECATED(msg) __declspec(deprecated(msg))
@@ -486,7 +486,7 @@ typedef struct _lv_draw_eve_unit_t lv_draw_eve_unit_t;
  */
 #if defined(PYCPARSER)
 #define LV_DEPRECATED_MACRO_WARN(msg) ((void)0)
-#elif defined(__GNUC__) || defined(__clang__)
+#elif defined(__GNUC__) || defined(__clang__) || defined(__IAR_SYSTEMS_ICC__)
 #define LV_DEPRECATED_MACRO_WARN(msg) \
 do { \
 typedef int __attribute__((deprecated(msg))) __lv_deprecated_t; \


### PR DESCRIPTION
This change extends `LV_NORETURN`, `LV_UNREACHABLE`, `LV_DEPRECATED`, and `LV_DEPRECATED_MACRO_WARN` to recognize `__IAR_SYSTEMS_ICC__`, improving compatibility with IAR Embedded Workbench builds.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
