### PR TITLE
fix(anim): ensure end value is applied on last frame even if value unchanged

### DIFF
--- a/src/misc/lv_anim.c
+++ b/src/misc/lv_anim.c
@@ -385,7 +385,7 @@ static void anim_timer(lv_timer_t * param)
                 int32_t new_value;
                 new_value = a->path_cb(a);
 
-                if(new_value != a->current_value) {
+                if(new_value != a->current_value || a->act_time >= a->time) {
                     a->current_value = new_value;
                     /*Apply the calculated value*/
                     if(a->exec_cb) a->exec_cb(a->var, new_value);


### PR DESCRIPTION
fix(anim): ensure end value is applied on last frame even if value unchanged

## Description
This PR fixes a bug where the animation's final value and `exec_cb` are **not applied** when:
1. The animation start value == end value (e.g., 0 → 0)
2. The animation skips frames and only runs the last step
3. The computed value is the same as the current value on the last frame

The root cause was the check `if(new_value != a->current_value)` which skipped execution even on the final frame.

The fix adds `|| a->act_time >= a->time` to ensure the last frame always runs, while keeping performance optimizations for intermediate frames.

## Changes
- Modified the value update condition in `anim.c` to force execution on the last frame
- No breaking changes
- No performance regression
- Preserves all existing behavior

### Notes
- No documentation update needed
- No new examples required
- No new tests needed
- Code follows LVGL coding conventions