### PR TITLE
fix(tjpgd): support EXIF images(#10084)

### DIFF
--- a/src/libs/tjpgd/lv_tjpgd.c
+++ b/src/libs/tjpgd/lv_tjpgd.c
@@ -319,7 +319,7 @@ static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t *
 
 static int is_jpg(const uint8_t * raw_data, size_t len)
 {
-    const uint8_t jpg_signature[] = {0xFF, 0xD8, 0xFF,  0xE0,  0x00,  0x10, 0x4A,  0x46, 0x49, 0x46};
+    const uint8_t jpg_signature[] = {0xFF, 0xD8, 0xFF};
     if(len < sizeof(jpg_signature)) return false;
     return memcmp(jpg_signature, raw_data, sizeof(jpg_signature)) == 0;
 }


### PR DESCRIPTION
Fixes #10084 by reducing JPEG magic file length to 3x bytes, which are common across all JPEGs .