### PR TITLE
fix(obj/pos): stop tranform point recursion after reaching screen

### DIFF
--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -1050,13 +1050,14 @@ void lv_obj_transform_point_array(const lv_obj_t * obj, lv_point_t points[], siz
     bool do_tranf = layer_type == LV_LAYER_TYPE_TRANSFORM;
     bool recursive = flags & LV_OBJ_POINT_TRANSFORM_FLAG_RECURSIVE;
     bool inverse = flags & LV_OBJ_POINT_TRANSFORM_FLAG_INVERSE;
+    lv_obj_t * parent = lv_obj_get_parent(obj);
     if(inverse) {
-        if(recursive) lv_obj_transform_point_array(lv_obj_get_parent(obj), points, count, flags);
+        if(recursive && parent) lv_obj_transform_point_array(parent, points, count, flags);
         if(do_tranf) transform_point_array(obj, points, count, inverse);
     }
     else {
         if(do_tranf) transform_point_array(obj, points, count, inverse);
-        if(recursive) lv_obj_transform_point_array(lv_obj_get_parent(obj), points, count, flags);
+        if(recursive && parent) lv_obj_transform_point_array(parent, points, count, flags);
     }
 }
 


### PR DESCRIPTION
Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
