### PR TITLE
feat(wayland): buffer keyboard input events to avoid dropping key presses

### DIFF
--- a/src/drivers/wayland/lv_wayland_keyboard.c
+++ b/src/drivers/wayland/lv_wayland_keyboard.c
@@ -146,11 +146,16 @@ void lv_wayland_seat_keyboard_delete(lv_wl_seat_keyboard_t * seat_keyboard)
 static void keyboard_read(lv_indev_t * indev, lv_indev_data_t * data)
 {
     lv_wl_seat_keyboard_t * kbdata = lv_indev_get_driver_data(indev);
-    if(!kbdata) {
+    LV_ASSERT(kbdata != NULL);
+
+    if(kbdata->event_count == 0) {
         return;
     }
-    data->key = kbdata->key;
-    data->state = kbdata->state;
+
+    data->key = kbdata->events[0].key;
+    data->state = kbdata->events[0].state;
+    kbdata->event_count--;
+    data->continue_reading = kbdata->event_count > 0;
 }
 
 static void keyboard_handle_keymap(void * data, struct wl_keyboard * keyboard, uint32_t format, int fd, uint32_t size)
@@ -229,6 +234,11 @@ static void keyboard_handle_key(void * data, struct wl_keyboard * keyboard, uint
     if(!kbdata->xkb_state) {
         return;
     }
+    if(kbdata->event_count == LV_WAYLAND_KEY_EVENT_MAX_COUNT) {
+        LV_LOG_WARN("Dropping event as LV_WAYLAND_KEY_EVENT_MAX_COUNT (%d) was reached. Increase it this causes issues",
+                    LV_WAYLAND_KEY_EVENT_MAX_COUNT);
+        return;
+    }
 
     const xkb_keysym_t * syms = XKB_KEY_NoSymbol;
     if(xkb_state_key_get_syms(kbdata->xkb_state, code, &syms) != 1) {
@@ -240,8 +250,9 @@ static void keyboard_handle_key(void * data, struct wl_keyboard * keyboard, uint
         (state == WL_KEYBOARD_KEY_STATE_PRESSED) ? LV_INDEV_STATE_PRESSED : LV_INDEV_STATE_RELEASED;
 
     if(lv_key != 0) {
-        kbdata->key = lv_key;
-        kbdata->state = lv_state;
+        kbdata->events[kbdata->event_count].key = lv_key;
+        kbdata->events[kbdata->event_count].state = lv_state;
+        kbdata->event_count++;
     }
 }
 

--- a/src/drivers/wayland/lv_wayland_keyboard.c
+++ b/src/drivers/wayland/lv_wayland_keyboard.c
@@ -146,7 +146,9 @@ void lv_wayland_seat_keyboard_delete(lv_wl_seat_keyboard_t * seat_keyboard)
 static void keyboard_read(lv_indev_t * indev, lv_indev_data_t * data)
 {
     lv_wl_seat_keyboard_t * kbdata = lv_indev_get_driver_data(indev);
-    LV_ASSERT(kbdata != NULL);
+    if(!kbdata) {
+        return;
+    }
 
     if(kbdata->event_count == 0) {
         return;

--- a/src/drivers/wayland/lv_wayland_keyboard.c
+++ b/src/drivers/wayland/lv_wayland_keyboard.c
@@ -152,7 +152,7 @@ static void keyboard_read(lv_indev_t * indev, lv_indev_data_t * data)
         return;
     }
 
-    if(kbdata->event_read_index == kbdata->event_write_index) {
+    if(kbdata->event_count == 0) {
         return;
     }
 
@@ -160,7 +160,8 @@ static void keyboard_read(lv_indev_t * indev, lv_indev_data_t * data)
     data->key = kbdata->events[index].key;
     data->state = kbdata->events[index].state;
     kbdata->event_read_index = (index + 1) % LV_WAYLAND_KEY_EVENT_MAX_COUNT;
-    data->continue_reading = kbdata->event_read_index != kbdata->event_write_index;
+    kbdata->event_count--;
+    data->continue_reading = kbdata->event_count > 0;
 }
 
 static void keyboard_handle_keymap(void * data, struct wl_keyboard * keyboard, uint32_t format, int fd, uint32_t size)
@@ -240,6 +241,11 @@ static void keyboard_handle_key(void * data, struct wl_keyboard * keyboard, uint
         return;
     }
 
+    if(kbdata->event_count == LV_WAYLAND_KEY_EVENT_MAX_COUNT) {
+        LV_LOG_WARN("Dropping event as LV_WAYLAND_KEY_EVENT_MAX_COUNT was reached.");
+        return;
+    }
+
     const xkb_keysym_t * syms = XKB_KEY_NoSymbol;
     if(xkb_state_key_get_syms(kbdata->xkb_state, code, &syms) != 1) {
         return;
@@ -253,6 +259,7 @@ static void keyboard_handle_key(void * data, struct wl_keyboard * keyboard, uint
         kbdata->events[kbdata->event_write_index].key = lv_key;
         kbdata->events[kbdata->event_write_index].state = lv_state;
         kbdata->event_write_index = (kbdata->event_write_index + 1) % LV_WAYLAND_KEY_EVENT_MAX_COUNT;
+        kbdata->event_count++;
     }
 }
 

--- a/src/drivers/wayland/lv_wayland_keyboard.c
+++ b/src/drivers/wayland/lv_wayland_keyboard.c
@@ -152,14 +152,15 @@ static void keyboard_read(lv_indev_t * indev, lv_indev_data_t * data)
         return;
     }
 
-    if(kbdata->event_count == 0) {
+    if(kbdata->event_read_index == kbdata->event_write_index) {
         return;
     }
 
-    data->key = kbdata->events[0].key;
-    data->state = kbdata->events[0].state;
-    kbdata->event_count--;
-    data->continue_reading = kbdata->event_count > 0;
+    uint8_t index = kbdata->event_read_index;
+    data->key = kbdata->events[index].key;
+    data->state = kbdata->events[index].state;
+    kbdata->event_read_index = (index + 1) % LV_WAYLAND_KEY_EVENT_MAX_COUNT;
+    data->continue_reading = kbdata->event_read_index != kbdata->event_write_index;
 }
 
 static void keyboard_handle_keymap(void * data, struct wl_keyboard * keyboard, uint32_t format, int fd, uint32_t size)
@@ -238,11 +239,6 @@ static void keyboard_handle_key(void * data, struct wl_keyboard * keyboard, uint
     if(!kbdata->xkb_state) {
         return;
     }
-    if(kbdata->event_count == LV_WAYLAND_KEY_EVENT_MAX_COUNT) {
-        LV_LOG_WARN("Dropping event as LV_WAYLAND_KEY_EVENT_MAX_COUNT (%d) was reached. Increase it this causes issues",
-                    LV_WAYLAND_KEY_EVENT_MAX_COUNT);
-        return;
-    }
 
     const xkb_keysym_t * syms = XKB_KEY_NoSymbol;
     if(xkb_state_key_get_syms(kbdata->xkb_state, code, &syms) != 1) {
@@ -254,9 +250,9 @@ static void keyboard_handle_key(void * data, struct wl_keyboard * keyboard, uint
         (state == WL_KEYBOARD_KEY_STATE_PRESSED) ? LV_INDEV_STATE_PRESSED : LV_INDEV_STATE_RELEASED;
 
     if(lv_key != 0) {
-        kbdata->events[kbdata->event_count].key = lv_key;
-        kbdata->events[kbdata->event_count].state = lv_state;
-        kbdata->event_count++;
+        kbdata->events[kbdata->event_write_index].key = lv_key;
+        kbdata->events[kbdata->event_write_index].state = lv_state;
+        kbdata->event_write_index = (kbdata->event_write_index + 1) % LV_WAYLAND_KEY_EVENT_MAX_COUNT;
     }
 }
 

--- a/src/drivers/wayland/lv_wayland_keyboard.c
+++ b/src/drivers/wayland/lv_wayland_keyboard.c
@@ -148,11 +148,16 @@ static void keyboard_read(lv_indev_t * indev, lv_indev_data_t * data)
     LV_ASSERT(indev != NULL);
     LV_ASSERT(data != NULL);
     lv_wl_seat_keyboard_t * kbdata = lv_indev_get_driver_data(indev);
-    if(!kbdata) {
+    LV_ASSERT(kbdata != NULL);
+
+    if(kbdata->event_count == 0) {
         return;
     }
-    data->key = kbdata->key;
-    data->state = kbdata->state;
+
+    data->key = kbdata->events[0].key;
+    data->state = kbdata->events[0].state;
+    kbdata->event_count--;
+    data->continue_reading = kbdata->event_count > 0;
 }
 
 static void keyboard_handle_keymap(void * data, struct wl_keyboard * keyboard, uint32_t format, int fd, uint32_t size)
@@ -231,6 +236,11 @@ static void keyboard_handle_key(void * data, struct wl_keyboard * keyboard, uint
     if(!kbdata->xkb_state) {
         return;
     }
+    if(kbdata->event_count == LV_WAYLAND_KEY_EVENT_MAX_COUNT) {
+        LV_LOG_WARN("Dropping event as LV_WAYLAND_KEY_EVENT_MAX_COUNT (%d) was reached. Increase it this causes issues",
+                    LV_WAYLAND_KEY_EVENT_MAX_COUNT);
+        return;
+    }
 
     const xkb_keysym_t * syms = XKB_KEY_NoSymbol;
     if(xkb_state_key_get_syms(kbdata->xkb_state, code, &syms) != 1) {
@@ -242,8 +252,9 @@ static void keyboard_handle_key(void * data, struct wl_keyboard * keyboard, uint
         (state == WL_KEYBOARD_KEY_STATE_PRESSED) ? LV_INDEV_STATE_PRESSED : LV_INDEV_STATE_RELEASED;
 
     if(lv_key != 0) {
-        kbdata->key = lv_key;
-        kbdata->state = lv_state;
+        kbdata->events[kbdata->event_count].key = lv_key;
+        kbdata->events[kbdata->event_count].state = lv_state;
+        kbdata->event_count++;
     }
 }
 

--- a/src/drivers/wayland/lv_wayland_keyboard.c
+++ b/src/drivers/wayland/lv_wayland_keyboard.c
@@ -148,7 +148,9 @@ static void keyboard_read(lv_indev_t * indev, lv_indev_data_t * data)
     LV_ASSERT(indev != NULL);
     LV_ASSERT(data != NULL);
     lv_wl_seat_keyboard_t * kbdata = lv_indev_get_driver_data(indev);
-    LV_ASSERT(kbdata != NULL);
+    if(!kbdata) {
+        return;
+    }
 
     if(kbdata->event_count == 0) {
         return;

--- a/src/drivers/wayland/lv_wayland_private.h
+++ b/src/drivers/wayland/lv_wayland_private.h
@@ -31,6 +31,10 @@ extern "C" {
 #define LV_WAYLAND_DEFAULT_CURSOR_NAME "left_ptr"
 #define LV_WAYLAND_MAX_OUTPUTS 8
 
+#ifndef LV_WAYLAND_KEY_EVENT_MAX_COUNT
+#define LV_WAYLAND_KEY_EVENT_MAX_COUNT (64)
+#endif
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -67,9 +71,11 @@ typedef struct {
     struct xkb_keymap * xkb_keymap;
     struct xkb_state * xkb_state;
 
-    lv_key_t key;
-    lv_indev_state_t state;
-    bool is_pressed;
+    struct {
+        lv_key_t key;
+        lv_indev_state_t state;
+    } events[LV_WAYLAND_KEY_EVENT_MAX_COUNT];
+    uint8_t event_count;
 } lv_wl_seat_keyboard_t;
 
 

--- a/src/drivers/wayland/lv_wayland_private.h
+++ b/src/drivers/wayland/lv_wayland_private.h
@@ -32,6 +32,10 @@ extern "C" {
 #define LV_WAYLAND_DEFAULT_CURSOR_NAME "left_ptr"
 #define LV_WAYLAND_MAX_OUTPUTS 8
 
+#ifndef LV_WAYLAND_KEY_EVENT_MAX_COUNT
+#define LV_WAYLAND_KEY_EVENT_MAX_COUNT (64)
+#endif
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -68,9 +72,11 @@ typedef struct {
     struct xkb_keymap * xkb_keymap;
     struct xkb_state * xkb_state;
 
-    lv_key_t key;
-    lv_indev_state_t state;
-    bool is_pressed;
+    struct {
+        lv_key_t key;
+        lv_indev_state_t state;
+    } events[LV_WAYLAND_KEY_EVENT_MAX_COUNT];
+    uint8_t event_count;
 } lv_wl_seat_keyboard_t;
 
 

--- a/src/drivers/wayland/lv_wayland_private.h
+++ b/src/drivers/wayland/lv_wayland_private.h
@@ -78,6 +78,7 @@ typedef struct {
     } events[LV_WAYLAND_KEY_EVENT_MAX_COUNT];
     uint8_t event_read_index;
     uint8_t event_write_index;
+    uint8_t event_count;
 } lv_wl_seat_keyboard_t;
 
 

--- a/src/drivers/wayland/lv_wayland_private.h
+++ b/src/drivers/wayland/lv_wayland_private.h
@@ -76,7 +76,8 @@ typedef struct {
         lv_key_t key;
         lv_indev_state_t state;
     } events[LV_WAYLAND_KEY_EVENT_MAX_COUNT];
-    uint8_t event_count;
+    uint8_t event_read_index;
+    uint8_t event_write_index;
 } lv_wl_seat_keyboard_t;
 
 

--- a/src/drivers/wayland/lv_wayland_window.c
+++ b/src/drivers/wayland/lv_wayland_window.c
@@ -302,10 +302,17 @@ static void delete_event(lv_event_t * e)
     wl_backend_ops.deinit_display(window->backend_display_data, window->lv_disp);
     window->backend_display_data = NULL;
 
-    if(LV_WAYLAND_DIRECT_EXIT) {
-        lv_display_set_driver_data(window->lv_disp, NULL);
+    lv_indev_t * indevs[] = { window->lv_indev_keyboard,
+                              window->lv_indev_pointer,
+                              window->lv_indev_pointeraxis,
+                              window->lv_indev_touch
+                            };
+
+    for(size_t i = 0; i < sizeof(indevs) / sizeof(indevs[0]); ++i) {
+        lv_indev_delete(indevs[i]);
     }
 
+    lv_display_set_driver_data(window->lv_disp, NULL);
     lv_ll_remove(&lv_wl_ctx.window_ll, window);
     lv_free(window);
 

--- a/src/drivers/wayland/lv_wayland_window.c
+++ b/src/drivers/wayland/lv_wayland_window.c
@@ -299,10 +299,17 @@ static void delete_event(lv_event_t * e)
     wl_display_roundtrip(lv_wl_ctx.wl_display);
     lv_wayland_backend_deinit_display(&window->backend_ddata, window->lv_disp);
 
-    if(LV_WAYLAND_DIRECT_EXIT) {
-        lv_display_set_driver_data(window->lv_disp, NULL);
+    lv_indev_t * indevs[] = { window->lv_indev_keyboard,
+                              window->lv_indev_pointer,
+                              window->lv_indev_pointeraxis,
+                              window->lv_indev_touch
+                            };
+
+    for(size_t i = 0; i < sizeof(indevs) / sizeof(indevs[0]); ++i) {
+        lv_indev_delete(indevs[i]);
     }
 
+    lv_display_set_driver_data(window->lv_disp, NULL);
     lv_ll_remove(&lv_wl_ctx.window_ll, window);
     lv_free(window);
 


### PR DESCRIPTION
Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
