### PR TITLE
fix(indev): check for NULL last and hovered objects before sending event

### DIFF
--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -1456,15 +1456,20 @@ static void indev_proc_release(lv_indev_t * indev)
         lv_obj_t ** last = &indev->pointer.last_hovered;
         lv_obj_t * hovered = pointer_search_obj(lv_display_get_default(), &indev->pointer.act_point);
         if(*last != hovered) {
-            lv_obj_send_event(hovered, LV_EVENT_HOVER_OVER, indev);
-            if(indev_reset_check(indev)) return;
-            lv_indev_send_event(indev, LV_EVENT_HOVER_OVER, hovered);
-            if(indev_reset_check(indev)) return;
 
-            lv_obj_send_event(*last, LV_EVENT_HOVER_LEAVE, indev);
-            if(indev_reset_check(indev)) return;
-            lv_indev_send_event(indev, LV_EVENT_HOVER_LEAVE, *last);
-            if(indev_reset_check(indev)) return;
+            if(hovered) {
+                lv_obj_send_event(hovered, LV_EVENT_HOVER_OVER, indev);
+                if(indev_reset_check(indev)) return;
+                lv_indev_send_event(indev, LV_EVENT_HOVER_OVER, hovered);
+                if(indev_reset_check(indev)) return;
+            }
+
+            if(*last) {
+                lv_obj_send_event(*last, LV_EVENT_HOVER_LEAVE, indev);
+                if(indev_reset_check(indev)) return;
+                lv_indev_send_event(indev, LV_EVENT_HOVER_LEAVE, *last);
+                if(indev_reset_check(indev)) return;
+            }
             *last = hovered;
         }
     }
@@ -1728,8 +1733,10 @@ static void indev_click_focus(lv_indev_t * indev)
         /*The object are not in group*/
         else {
             if(indev->pointer.last_pressed != indev_obj_act) {
-                lv_obj_send_event(indev->pointer.last_pressed, LV_EVENT_DEFOCUSED, indev_act);
-                if(indev_reset_check(indev)) return;
+                if(indev->pointer.last_pressed) {
+                    lv_obj_send_event(indev->pointer.last_pressed, LV_EVENT_DEFOCUSED, indev_act);
+                    if(indev_reset_check(indev)) return;
+                }
 
                 lv_obj_send_event(indev_obj_act, LV_EVENT_FOCUSED, indev_act);
                 if(indev_reset_check(indev)) return;


### PR DESCRIPTION
Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
