### PR TITLE
feat(nanovg): add blur and dropshadow support

### DIFF
--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -558,6 +558,11 @@ void lv_draw_layer_finish_drop_shadow(lv_layer_t * drop_shadow_layer, const lv_d
     lv_draw_blur_dsc_init(&blur_dsc);
     blur_dsc.blur_radius = base->drop_shadow_blur_radius;
     blur_dsc.quality = base->drop_shadow_quality;
+    /* Forward the shadow color so backends that bake the recolor into the
+     * blur pass (e.g. NanoVG, where the subsequent layer composite cannot
+     * easily apply recolor to a pre-existing FBO image) can pick it up. */
+    blur_dsc.base.drop_shadow_color = base->drop_shadow_color;
+    blur_dsc.base.drop_shadow_opa   = base->drop_shadow_opa;
     lv_draw_blur(drop_shadow_layer, &blur_dsc, &drop_shadow_layer->buf_area);
 
     lv_area_move(&drop_shadow_area, base->drop_shadow_ofs_x, base->drop_shadow_ofs_y);

--- a/src/draw/nanovg/lv_draw_nanovg.c
+++ b/src/draw/nanovg/lv_draw_nanovg.c
@@ -123,12 +123,6 @@ int lv_nanovg_fb_get_image_handle(struct NVGLUframebuffer * fb)
     return fb->image;
 }
 
-unsigned int lv_nanovg_fb_get_texture_id(struct NVGLUframebuffer * fb)
-{
-    if(fb == NULL) return 0;
-    return (unsigned int)fb->texture;
-}
-
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/src/draw/nanovg/lv_draw_nanovg.c
+++ b/src/draw/nanovg/lv_draw_nanovg.c
@@ -114,12 +114,19 @@ void lv_draw_nanovg_init(void)
     lv_nanovg_image_cache_init(unit);
     lv_nanovg_fbo_cache_init(unit);
     lv_draw_nanovg_label_init(unit);
+    lv_draw_nanovg_blur_init(unit);
 }
 
 int lv_nanovg_fb_get_image_handle(struct NVGLUframebuffer * fb)
 {
     LV_ASSERT_NULL(fb);
     return fb->image;
+}
+
+unsigned int lv_nanovg_fb_get_texture_id(struct NVGLUframebuffer * fb)
+{
+    if(fb == NULL) return 0;
+    return (unsigned int)fb->texture;
 }
 
 /**********************
@@ -209,6 +216,11 @@ static void draw_execute(lv_draw_nanovg_unit_t * u, lv_draw_task_t * t)
             lv_draw_nanovg_3d(t, t->draw_dsc, &t->area);
             break;
 #endif
+
+        case LV_DRAW_TASK_TYPE_BLUR:
+            lv_draw_nanovg_blur(t, t->draw_dsc, &t->area);
+            break;
+
         default:
             LV_LOG_ERROR("unknown draw task type: %d", t->type);
             break;
@@ -341,6 +353,11 @@ static int32_t draw_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
     }
 
     if(u->current_layer != layer) {
+        /* Flush any draws still queued for the previous layer before
+         * rebinding to the new layer's FBO. Otherwise those queued draws
+         * get rerouted to the new FBO when nvgEndFrame is eventually
+         * called (and the previous layer ends up missing them). */
+        lv_nanovg_end_frame(u);
         on_layer_changed(layer);
         u->current_layer = layer;
     }
@@ -390,6 +407,7 @@ static int32_t draw_evaluate(lv_draw_unit_t * draw_unit, lv_draw_task_t * task)
 #if LV_USE_3DTEXTURE
         case LV_DRAW_TASK_TYPE_3D:
 #endif
+        case LV_DRAW_TASK_TYPE_BLUR:
             break;
 
         default:
@@ -409,6 +427,7 @@ static int32_t draw_evaluate(lv_draw_unit_t * draw_unit, lv_draw_task_t * task)
 static int32_t draw_delete(lv_draw_unit_t * draw_unit)
 {
     lv_draw_nanovg_unit_t * unit = (lv_draw_nanovg_unit_t *)draw_unit;
+    lv_draw_nanovg_blur_deinit(unit);
     lv_draw_nanovg_label_deinit(unit);
     lv_nanovg_fbo_cache_deinit(unit);
     lv_nanovg_image_cache_deinit(unit);

--- a/src/draw/nanovg/lv_draw_nanovg.c
+++ b/src/draw/nanovg/lv_draw_nanovg.c
@@ -387,7 +387,7 @@ static int32_t draw_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 
 static int32_t draw_evaluate(lv_draw_unit_t * draw_unit, lv_draw_task_t * task)
 {
-    LV_UNUSED(draw_unit);
+    lv_draw_nanovg_unit_t * u = (lv_draw_nanovg_unit_t *)draw_unit;
 
     switch(task->type) {
         case LV_DRAW_TASK_TYPE_FILL:
@@ -407,7 +407,11 @@ static int32_t draw_evaluate(lv_draw_unit_t * draw_unit, lv_draw_task_t * task)
 #if LV_USE_3DTEXTURE
         case LV_DRAW_TASK_TYPE_3D:
 #endif
+            break;
+
         case LV_DRAW_TASK_TYPE_BLUR:
+            /* Only accept blur if FBO support is available (blur_state was created) */
+            if(u->blur_state == NULL) return 0;
             break;
 
         default:

--- a/src/draw/nanovg/lv_draw_nanovg_blur.c
+++ b/src/draw/nanovg/lv_draw_nanovg_blur.c
@@ -70,7 +70,7 @@ void lv_draw_nanovg_blur(lv_draw_task_t * t, const lv_draw_blur_dsc_t * dsc, con
 
     lv_draw_nanovg_unit_t * u = (lv_draw_nanovg_unit_t *)t->draw_unit;
     lv_layer_t * layer = t->target_layer;
-    NVGLUblurState * state = (NVGLUblurState *)u->blur_state;
+    NVGLUblurState * state = u->blur_state;
 
     if(state == NULL) {
         LV_LOG_WARN("nanovg blur: state not initialized (FBO not supported?), skipping");
@@ -134,7 +134,10 @@ void lv_draw_nanovg_blur(lv_draw_task_t * t, const lv_draw_blur_dsc_t * dsc, con
     }
 
     /* Call the NanoVG blur utility */
-    nvgluBlurRegion(state, u->vg, src_fb, rel_x, gl_y, blur_w, blur_h, &params);
+    int ret = nvgluBlurRegion(state, u->vg, src_fb, rel_x, gl_y, blur_w, blur_h, &params);
+    if(ret != 0) {
+        LV_LOG_WARN("nanovg blur: nvgluBlurRegion failed (ret=%d)", ret);
+    }
 
     LV_PROFILER_DRAW_END;
 }

--- a/src/draw/nanovg/lv_draw_nanovg_blur.c
+++ b/src/draw/nanovg/lv_draw_nanovg_blur.c
@@ -1,9 +1,9 @@
 /**
  * @file lv_draw_nanovg_blur.c
  *
- * Separable gaussian blur for the NanoVG draw unit, implemented with a
- * fragment shader. Two passes: horizontal then vertical, ping-ponging
- * between the layer's FBO and a scratch FBO.
+ * NanoVG blur draw task handler. Translates LVGL blur tasks into
+ * nvgluBlurRegion() calls — the actual shader/FBO logic lives in
+ * nanovg_gl_utils.h for backend portability.
  */
 
 /*********************
@@ -16,168 +16,23 @@
 
 #include "lv_nanovg_utils.h"
 #include "lv_nanovg_fbo_cache.h"
-
-#if LV_USE_OPENGLES && LV_USE_EGL
-    #include "../../drivers/opengles/lv_opengles_private.h"
-#else
-    #define NANOVG_GL_STATIC_LINK
-#endif
-
-#if defined(NANOVG_GL2_IMPLEMENTATION) || defined(NANOVG_GL3_IMPLEMENTATION)
-    #ifdef NANOVG_GL_STATIC_LINK
-        #include <GL/glew.h>
-    #endif
-#elif defined(NANOVG_GLES2_IMPLEMENTATION)
-    #ifdef NANOVG_GL_STATIC_LINK
-        #include <GLES2/gl2.h>
-    #endif
-#elif defined(NANOVG_GLES3_IMPLEMENTATION)
-    #ifdef NANOVG_GL_STATIC_LINK
-        #include <GLES3/gl3.h>
-    #endif
-#endif
-
 #include "../../libs/nanovg/nanovg_gl_utils.h"
-
-#include <math.h>
 
 /*********************
  *      DEFINES
  *********************/
 
-#define BLUR_MAX_TAPS      16
-#define BLUR_MAX_RADIUS    256
-
-/* GL3 / GLES3 core profile require a Vertex Array Object to be bound
- * before any vertex-attribute setup. GL2 and GLES2 don't have VAOs. */
-#if LV_NANOVG_BACKEND == LV_NANOVG_BACKEND_GL3 || LV_NANOVG_BACKEND == LV_NANOVG_BACKEND_GLES3
-    #define BLUR_NEEDS_VAO 1
-#else
-    #define BLUR_NEEDS_VAO 0
-#endif
-
-/* Per-backend GLSL prologue. The shader body uses legacy GLES2/GL2 syntax
- * (attribute / varying / texture2D / gl_FragColor) and is remapped to GL3
- * / GLES3 modern equivalents via #define when needed. */
-#if LV_NANOVG_BACKEND == LV_NANOVG_BACKEND_GL3
-#define BLUR_VS_HEADER \
-    "#version 130\n" \
-    "#define attribute in\n" \
-    "#define varying out\n"
-#define BLUR_FS_HEADER \
-    "#version 130\n" \
-    "#define varying in\n" \
-    "#define texture2D texture\n" \
-    "out vec4 blur_frag_out;\n" \
-    "#define gl_FragColor blur_frag_out\n"
-#elif LV_NANOVG_BACKEND == LV_NANOVG_BACKEND_GLES3
-#define BLUR_VS_HEADER \
-    "#version 300 es\n" \
-    "#define attribute in\n" \
-    "#define varying out\n"
-#define BLUR_FS_HEADER \
-    "#version 300 es\n" \
-    "precision mediump float;\n" \
-    "#define varying in\n" \
-    "#define texture2D texture\n" \
-    "out vec4 blur_frag_out;\n" \
-    "#define gl_FragColor blur_frag_out\n"
-#elif LV_NANOVG_BACKEND == LV_NANOVG_BACKEND_GLES2
-#define BLUR_VS_HEADER ""
-#define BLUR_FS_HEADER "precision mediump float;\n"
-#else /* GL2 */
-#define BLUR_VS_HEADER ""
-#define BLUR_FS_HEADER ""
-#endif
-
 /**********************
  *      TYPEDEFS
  **********************/
-
-typedef struct {
-    GLuint program;
-    GLuint vbo;
-#if BLUR_NEEDS_VAO
-    GLuint vao;
-#endif
-    GLint  loc_tex;
-    GLint  loc_step;
-    GLint  loc_tap_count;
-    GLint  loc_weights;
-    GLint  loc_src_uv;
-    GLint  loc_recolor;
-    GLint  attr_pos;
-    GLint  attr_uv;
-    bool   program_ok;
-
-    /* Scratch FBO sized to the current blur area; ping-pong target. */
-    NVGLUframebuffer * scratch_fb;
-    int                scratch_w;
-    int                scratch_h;
-
-    /* Capture texture used when blurring the screen layer (no FBO).
-     * Holds a copy of the screen region we're about to blur. */
-    GLuint             capture_tex;
-    int                capture_w;
-    int                capture_h;
-} blur_state_t;
 
 /**********************
  *  STATIC PROTOTYPES
  **********************/
 
-static bool ensure_program(blur_state_t * s);
-static void ensure_scratch_fb(blur_state_t * s, NVGcontext * vg, int w, int h);
-static void ensure_capture_tex(blur_state_t * s, int w, int h);
-static GLuint compile_shader(GLenum type, const char * src);
-static void compute_weights(int radius, int tap_count, int step_px, float * weights);
-static void set_tex_params(void);
-
 /**********************
  *  STATIC VARIABLES
  **********************/
-
-static const char * VS_SRC =
-    BLUR_VS_HEADER
-    "attribute vec2 a_pos;\n"
-    "attribute vec2 a_uv;\n"
-    "varying vec2 v_uv;\n"
-    "void main() {\n"
-    "    v_uv = a_uv;\n"
-    "    gl_Position = vec4(a_pos, 0.0, 1.0);\n"
-    "}\n";
-
-static const char * FS_SRC =
-    BLUR_FS_HEADER
-    "uniform sampler2D u_tex;\n"
-    "uniform vec2 u_step;\n"
-    "uniform vec4 u_src_uv;\n"   /* xy = sub-region UV offset, zw = sub-region UV scale */
-    "uniform vec4 u_recolor;\n"  /* rgb = recolor, a > 0.5 enables alpha-masked recolor */
-    "uniform int u_tap_count;\n"
-    "uniform float u_weights[17];\n"
-    "varying vec2 v_uv;\n"
-    "void main() {\n"
-    "    vec2 base = u_src_uv.xy + v_uv * u_src_uv.zw;\n"
-    "    vec4 sum = texture2D(u_tex, base) * u_weights[0];\n"
-    "    for(int i = 1; i <= 16; i++) {\n"
-    "        if(i > u_tap_count) break;\n"
-    "        vec2 off = u_step * float(i);\n"
-    "        sum += texture2D(u_tex, base + off) * u_weights[i];\n"
-    "        sum += texture2D(u_tex, base - off) * u_weights[i];\n"
-    "    }\n"
-    "    if(u_recolor.a > 0.5) {\n"
-    "        sum = vec4(u_recolor.rgb * sum.a, sum.a);\n"
-    "    }\n"
-    "    gl_FragColor = sum;\n"
-    "}\n";
-
-/* Fullscreen triangle strip: x, y, u, v */
-static const float QUAD_VERTS[] = {
-    -1.0f, -1.0f, 0.0f, 0.0f,
-    1.0f, -1.0f, 1.0f, 0.0f,
-    -1.0f,  1.0f, 0.0f, 1.0f,
-    1.0f,  1.0f, 1.0f, 1.0f,
-};
 
 /**********************
  *   GLOBAL FUNCTIONS
@@ -186,68 +41,38 @@ static const float QUAD_VERTS[] = {
 void lv_draw_nanovg_blur_init(lv_draw_nanovg_unit_t * u)
 {
     LV_ASSERT_NULL(u);
-    blur_state_t * s = lv_malloc_zeroed(sizeof(blur_state_t));
-    if(s == NULL) {
-        LV_LOG_ERROR("nanovg blur: failed to allocate blur state");
-        return;
+    u->blur_state = nvgluCreateBlurState();
+    if(u->blur_state == NULL) {
+        LV_LOG_WARN("nanovg blur: failed to create blur state (FBO not supported?)");
     }
-    u->blur_state = s;
 }
 
 void lv_draw_nanovg_blur_deinit(lv_draw_nanovg_unit_t * u)
 {
     LV_ASSERT_NULL(u);
-    blur_state_t * s = u->blur_state;
-    if(s == NULL) return;
-
-    if(s->scratch_fb) {
-        nvgluDeleteFramebuffer(s->scratch_fb);
-        s->scratch_fb = NULL;
+    if(u->blur_state) {
+        nvgluDeleteBlurState(u->blur_state, u->vg);
+        u->blur_state = NULL;
     }
-    if(s->capture_tex) {
-        glDeleteTextures(1, &s->capture_tex);
-        s->capture_tex = 0;
-    }
-    if(s->program) {
-        glDeleteProgram(s->program);
-        s->program = 0;
-    }
-    if(s->vbo) {
-        glDeleteBuffers(1, &s->vbo);
-        s->vbo = 0;
-    }
-#if BLUR_NEEDS_VAO
-    if(s->vao) {
-        glDeleteVertexArrays(1, &s->vao);
-        s->vao = 0;
-    }
-#endif
-
-    lv_free(s);
-    u->blur_state = NULL;
 }
 
 void lv_draw_nanovg_blur(lv_draw_task_t * t, const lv_draw_blur_dsc_t * dsc, const lv_area_t * coords)
 {
-    int radius = dsc->blur_radius;
-    if(radius <= 0) return;
-    if(radius > BLUR_MAX_RADIUS) radius = BLUR_MAX_RADIUS;
+    if(dsc->blur_radius <= 0) return;
 
     LV_PROFILER_DRAW_BEGIN;
 
     lv_draw_nanovg_unit_t * u = (lv_draw_nanovg_unit_t *)t->draw_unit;
     lv_layer_t * layer = t->target_layer;
-    blur_state_t * s = u->blur_state;
+    NVGLUblurState * state = (NVGLUblurState *)u->blur_state;
 
-    if(s == NULL) {
+    if(state == NULL) {
         LV_LOG_ERROR("nanovg blur: state not initialized");
         LV_PROFILER_DRAW_END;
         return;
     }
 
-    /* Determine the blur area: requested coords clipped to clip_area and
-     * the layer's own extent, expressed in layer-relative coordinates with
-     * the layer's top-left at (0, 0). LVGL coordinates are top-down. */
+    /* Clip the blur area to clip_area and layer extent */
     lv_area_t clip;
     if(!lv_area_intersect(&clip, coords, &t->clip_area)) {
         LV_PROFILER_DRAW_END;
@@ -257,6 +82,7 @@ void lv_draw_nanovg_blur(lv_draw_task_t * t, const lv_draw_blur_dsc_t * dsc, con
         LV_PROFILER_DRAW_END;
         return;
     }
+
     const int blur_w = lv_area_get_width(&clip);
     const int blur_h = lv_area_get_height(&clip);
     if(blur_w <= 0 || blur_h <= 0) {
@@ -264,15 +90,14 @@ void lv_draw_nanovg_blur(lv_draw_task_t * t, const lv_draw_blur_dsc_t * dsc, con
         return;
     }
 
-    const int layer_h    = lv_area_get_height(&layer->buf_area);
-    const int rel_x      = clip.x1 - layer->buf_area.x1;
-    const int rel_y_top  = clip.y1 - layer->buf_area.y1;
-    /* GL viewport / glCopyTex* take Y measured from the bottom of the
-     * framebuffer; LVGL gives Y from the top. */
-    const int gl_y       = layer_h - rel_y_top - blur_h;
+    /* Convert LVGL top-down coords to GL bottom-up coords */
+    const int layer_h   = lv_area_get_height(&layer->buf_area);
+    const int rel_x     = clip.x1 - layer->buf_area.x1;
+    const int rel_y_top = clip.y1 - layer->buf_area.y1;
+    const int gl_y      = layer_h - rel_y_top - blur_h;
 
+    /* Determine source FBO */
     const bool is_root = (layer->user_data == NULL);
-
     NVGLUframebuffer * src_fb = NULL;
     if(!is_root) {
         src_fb = lv_nanovg_fbo_cache_entry_to_fb(layer->user_data);
@@ -282,292 +107,30 @@ void lv_draw_nanovg_blur(lv_draw_task_t * t, const lv_draw_blur_dsc_t * dsc, con
         }
     }
 
-    /* --- Allocate resources BEFORE mutating any GL state, so an early
-     * failure simply returns without leaving the driver in a partially
-     * configured state for the next nanovg draws. */
-    if(!ensure_program(s)) {
-        LV_PROFILER_DRAW_END;
-        return;
-    }
-    ensure_scratch_fb(s, u->vg, blur_w, blur_h);
-    if(s->scratch_fb == NULL) {
-        LV_PROFILER_DRAW_END;
-        return;
-    }
-    if(is_root) {
-        ensure_capture_tex(s, blur_w, blur_h);
-        if(s->capture_tex == 0) {
-            LV_PROFILER_DRAW_END;
-            return;
-        }
-    }
-
-    /* Flush nanovg's pending batched draws before we touch raw GL state.
-     * The next dispatch will call nvgBeginFrame again. */
+    /* Flush pending NanoVG draws before raw GL operations */
     lv_nanovg_end_frame(u);
 
-    /* Map (radius, quality) -> (tap_count, step_px). For BLUR_QUALITY_SPEED
-     * we use half the taps; the per-tap step grows so the same radius is
-     * still covered, at the cost of coarser sampling. */
-    const int max_taps  = (dsc->quality == LV_BLUR_QUALITY_SPEED) ? 8 : BLUR_MAX_TAPS;
-    int       tap_count = radius < max_taps ? radius : max_taps;
-    if(tap_count < 1) tap_count = 1;
-    int step_px = (radius + tap_count - 1) / tap_count; /* ceil(radius / taps) */
-    if(step_px < 1) step_px = 1;
+    /* Build blur params */
+    NVGLUblurParams params;
+    params.radius  = dsc->blur_radius;
+    params.quality = (dsc->quality == LV_BLUR_QUALITY_SPEED)
+                     ? NVGLU_BLUR_QUALITY_SPEED : NVGLU_BLUR_QUALITY_NORMAL;
 
-    float weights[BLUR_MAX_TAPS + 1];
-    compute_weights(radius, tap_count, step_px, weights);
-
-    /* --- Set up shared GL state for both passes --- */
-#if BLUR_NEEDS_VAO
-    glBindVertexArray(s->vao);
-#endif
-    glUseProgram(s->program);
-    glBindBuffer(GL_ARRAY_BUFFER, s->vbo);
-    glEnableVertexAttribArray((GLuint)s->attr_pos);
-    glVertexAttribPointer((GLuint)s->attr_pos, 2, GL_FLOAT, GL_FALSE,
-                          sizeof(float) * 4, (const void *)0);
-    glEnableVertexAttribArray((GLuint)s->attr_uv);
-    glVertexAttribPointer((GLuint)s->attr_uv, 2, GL_FLOAT, GL_FALSE,
-                          sizeof(float) * 4, (const void *)(sizeof(float) * 2));
-
-    glActiveTexture(GL_TEXTURE0);
-    glUniform1i(s->loc_tex, 0);
-    glUniform1i(s->loc_tap_count, tap_count);
-    glUniform1fv(s->loc_weights, BLUR_MAX_TAPS + 1, weights);
-
-    glDisable(GL_BLEND);
-    glDisable(GL_STENCIL_TEST);
-    glDisable(GL_DEPTH_TEST);
-    glDisable(GL_CULL_FACE);
-    glDisable(GL_SCISSOR_TEST);
-    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-
-    /* --- Pick the source texture and compute its sampling sub-region. */
-    GLuint src_tex;
-    int    src_tex_w, src_tex_h;
-    float  src_uv_off_x, src_uv_off_y, src_uv_scl_x, src_uv_scl_y;
-    if(is_root) {
-        glBindTexture(GL_TEXTURE_2D, s->capture_tex);
-        glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, rel_x, gl_y, blur_w, blur_h);
-        src_tex      = s->capture_tex;
-        src_tex_w    = s->capture_w;
-        src_tex_h    = s->capture_h;
-        src_uv_off_x = 0.0f;
-        src_uv_off_y = 0.0f;
-        src_uv_scl_x = (float)blur_w / (float)src_tex_w;
-        src_uv_scl_y = (float)blur_h / (float)src_tex_h;
-    }
-    else {
-        src_tex      = (GLuint)lv_nanovg_fb_get_texture_id(src_fb);
-        src_tex_w    = lv_area_get_width(&layer->buf_area);
-        src_tex_h    = layer_h;
-        src_uv_off_x = (float)rel_x / (float)src_tex_w;
-        src_uv_off_y = (float)gl_y  / (float)src_tex_h;
-        src_uv_scl_x = (float)blur_w / (float)src_tex_w;
-        src_uv_scl_y = (float)blur_h / (float)src_tex_h;
-    }
-    const GLuint scratch_tex = (GLuint)lv_nanovg_fb_get_texture_id(s->scratch_fb);
-
-    /* --- Pass 1: source -> scratch, horizontal blur --- */
-    LV_PROFILER_DRAW_BEGIN_TAG("blur_h");
-    nvgluBindFramebuffer(s->scratch_fb);
-    glViewport(0, 0, blur_w, blur_h);
-    glBindTexture(GL_TEXTURE_2D, src_tex);
-    set_tex_params();
-    glUniform4f(s->loc_src_uv, src_uv_off_x, src_uv_off_y, src_uv_scl_x, src_uv_scl_y);
-    glUniform4f(s->loc_recolor, 0.0f, 0.0f, 0.0f, 0.0f);
-    glUniform2f(s->loc_step, (float)step_px / (float)src_tex_w, 0.0f);
-    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-    LV_PROFILER_DRAW_END_TAG("blur_h");
-
-    /* --- Pass 2: scratch -> destination, vertical blur --- */
-    LV_PROFILER_DRAW_BEGIN_TAG("blur_v");
-    if(is_root) {
-        nvgluBindFramebuffer(NULL);
-    }
-    else {
-        nvgluBindFramebuffer(src_fb);
-    }
-    glViewport(rel_x, gl_y, blur_w, blur_h);
-    glBindTexture(GL_TEXTURE_2D, scratch_tex);
-    set_tex_params();
-    glUniform4f(s->loc_src_uv,
-                0.0f, 0.0f,
-                (float)blur_w / (float)s->scratch_w,
-                (float)blur_h / (float)s->scratch_h);
+    /* Recolor for drop shadows */
     if(dsc->base.drop_shadow_opa > 0) {
-        glUniform4f(s->loc_recolor,
-                    (float)dsc->base.drop_shadow_color.red   / 255.0f,
-                    (float)dsc->base.drop_shadow_color.green / 255.0f,
-                    (float)dsc->base.drop_shadow_color.blue  / 255.0f,
-                    1.0f);
+        params.recolor = nvgRGBA(dsc->base.drop_shadow_color.red,
+                                 dsc->base.drop_shadow_color.green,
+                                 dsc->base.drop_shadow_color.blue,
+                                 255);
     }
     else {
-        glUniform4f(s->loc_recolor, 0.0f, 0.0f, 0.0f, 0.0f);
+        params.recolor = nvgRGBA(0, 0, 0, 0);
     }
-    glUniform2f(s->loc_step, 0.0f, (float)step_px / (float)s->scratch_h);
-    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-    LV_PROFILER_DRAW_END_TAG("blur_v");
 
-    /* --- Restore minimal state --- */
-    glDisableVertexAttribArray((GLuint)s->attr_pos);
-    glDisableVertexAttribArray((GLuint)s->attr_uv);
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-    glBindTexture(GL_TEXTURE_2D, 0);
-    glUseProgram(0);
-#if BLUR_NEEDS_VAO
-    glBindVertexArray(0);
-#endif
+    /* Call the NanoVG blur utility */
+    nvgluBlurRegion(state, u->vg, src_fb, rel_x, gl_y, blur_w, blur_h, &params);
 
     LV_PROFILER_DRAW_END;
-}
-
-/**********************
- *   STATIC FUNCTIONS
- **********************/
-
-static bool ensure_program(blur_state_t * s)
-{
-    if(s->program_ok) return true;
-    if(s->program != 0) return false; /* previously failed */
-
-    GLuint vs = compile_shader(GL_VERTEX_SHADER, VS_SRC);
-    GLuint fs = compile_shader(GL_FRAGMENT_SHADER, FS_SRC);
-    if(vs == 0 || fs == 0) {
-        if(vs) glDeleteShader(vs);
-        if(fs) glDeleteShader(fs);
-        return false;
-    }
-
-    GLuint prog = glCreateProgram();
-    glAttachShader(prog, vs);
-    glAttachShader(prog, fs);
-    glLinkProgram(prog);
-    glDeleteShader(vs);
-    glDeleteShader(fs);
-
-    GLint linked = 0;
-    glGetProgramiv(prog, GL_LINK_STATUS, &linked);
-    if(!linked) {
-        char log[512];
-        GLsizei len = 0;
-        glGetProgramInfoLog(prog, sizeof(log), &len, log);
-        LV_LOG_ERROR("nanovg blur: program link failed: %.*s", (int)len, log);
-        glDeleteProgram(prog);
-        return false;
-    }
-
-    s->program       = prog;
-    s->loc_tex       = glGetUniformLocation(prog, "u_tex");
-    s->loc_step      = glGetUniformLocation(prog, "u_step");
-    s->loc_src_uv    = glGetUniformLocation(prog, "u_src_uv");
-    s->loc_recolor   = glGetUniformLocation(prog, "u_recolor");
-    s->loc_tap_count = glGetUniformLocation(prog, "u_tap_count");
-    s->loc_weights   = glGetUniformLocation(prog, "u_weights[0]");
-    if(s->loc_weights < 0) s->loc_weights = glGetUniformLocation(prog, "u_weights");
-    s->attr_pos      = glGetAttribLocation(prog, "a_pos");
-    s->attr_uv       = glGetAttribLocation(prog, "a_uv");
-
-    glGenBuffers(1, &s->vbo);
-    glBindBuffer(GL_ARRAY_BUFFER, s->vbo);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(QUAD_VERTS), QUAD_VERTS, GL_STATIC_DRAW);
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-
-#if BLUR_NEEDS_VAO
-    glGenVertexArrays(1, &s->vao);
-#endif
-
-    s->program_ok = true;
-    return true;
-}
-
-static void ensure_scratch_fb(blur_state_t * s, NVGcontext * vg, int w, int h)
-{
-    if(s->scratch_fb != NULL && s->scratch_w == w && s->scratch_h == h) return;
-
-    if(s->scratch_fb) {
-        nvgluDeleteFramebuffer(s->scratch_fb);
-        s->scratch_fb = NULL;
-        s->scratch_w = 0;
-        s->scratch_h = 0;
-    }
-    s->scratch_fb = nvgluCreateFramebuffer(vg, w, h, 0, NVG_TEXTURE_RGBA);
-    if(s->scratch_fb == NULL) {
-        LV_LOG_ERROR("nanovg blur: failed to allocate %dx%d scratch FBO", w, h);
-        return;
-    }
-    s->scratch_w = w;
-    s->scratch_h = h;
-}
-
-static void ensure_capture_tex(blur_state_t * s, int w, int h)
-{
-    if(s->capture_tex != 0 && s->capture_w == w && s->capture_h == h) return;
-
-    if(s->capture_tex == 0) {
-        glGenTextures(1, &s->capture_tex);
-    }
-    glBindTexture(GL_TEXTURE_2D, s->capture_tex);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    s->capture_w = w;
-    s->capture_h = h;
-}
-
-static GLuint compile_shader(GLenum type, const char * src)
-{
-    GLuint sh = glCreateShader(type);
-    glShaderSource(sh, 1, &src, NULL);
-    glCompileShader(sh);
-
-    GLint compiled = 0;
-    glGetShaderiv(sh, GL_COMPILE_STATUS, &compiled);
-    if(!compiled) {
-        char log[512];
-        GLsizei len = 0;
-        glGetShaderInfoLog(sh, sizeof(log), &len, log);
-        LV_LOG_ERROR("nanovg blur: %s shader compile failed: %.*s",
-                     type == GL_VERTEX_SHADER ? "vertex" : "fragment",
-                     (int)len, log);
-        glDeleteShader(sh);
-        return 0;
-    }
-    return sh;
-}
-
-static void compute_weights(int radius, int tap_count, int step_px, float * weights)
-{
-    /* Gaussian with sigma = radius / 3 -- the usual "3-sigma covers radius"
-     * convention. Sample positions: 0, step_px, 2*step_px, ... */
-    float sigma = (float)radius / 3.0f;
-    if(sigma < 1.0f) sigma = 1.0f;
-    const float inv_two_sigma_sq = 1.0f / (2.0f * sigma * sigma);
-
-    float total = 0.0f;
-    for(int i = 0; i <= BLUR_MAX_TAPS; i++) {
-        if(i > tap_count) {
-            weights[i] = 0.0f;
-            continue;
-        }
-        float x = (float)(i * step_px);
-        float w = expf(-x * x * inv_two_sigma_sq);
-        weights[i] = w;
-        total += (i == 0) ? w : (2.0f * w);
-    }
-    if(total > 0.0f) {
-        float inv = 1.0f / total;
-        for(int i = 0; i <= BLUR_MAX_TAPS; i++) weights[i] *= inv;
-    }
-}
-
-static void set_tex_params(void)
-{
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 }
 
 #endif /* LV_USE_DRAW_NANOVG */

--- a/src/draw/nanovg/lv_draw_nanovg_blur.c
+++ b/src/draw/nanovg/lv_draw_nanovg_blur.c
@@ -60,6 +60,12 @@ void lv_draw_nanovg_blur(lv_draw_task_t * t, const lv_draw_blur_dsc_t * dsc, con
 {
     if(dsc->blur_radius <= 0) return;
 
+    if(dsc->blur_radius > 256) {
+        LV_LOG_WARN("nanovg blur: radius %d exceeds backend limit (256), skipping",
+                    (int)dsc->blur_radius);
+        return;
+    }
+
     LV_PROFILER_DRAW_BEGIN;
 
     lv_draw_nanovg_unit_t * u = (lv_draw_nanovg_unit_t *)t->draw_unit;
@@ -67,7 +73,7 @@ void lv_draw_nanovg_blur(lv_draw_task_t * t, const lv_draw_blur_dsc_t * dsc, con
     NVGLUblurState * state = (NVGLUblurState *)u->blur_state;
 
     if(state == NULL) {
-        LV_LOG_ERROR("nanovg blur: state not initialized");
+        LV_LOG_WARN("nanovg blur: state not initialized (FBO not supported?), skipping");
         LV_PROFILER_DRAW_END;
         return;
     }

--- a/src/draw/nanovg/lv_draw_nanovg_blur.c
+++ b/src/draw/nanovg/lv_draw_nanovg_blur.c
@@ -1,0 +1,573 @@
+/**
+ * @file lv_draw_nanovg_blur.c
+ *
+ * Separable gaussian blur for the NanoVG draw unit, implemented with a
+ * fragment shader. Two passes: horizontal then vertical, ping-ponging
+ * between the layer's FBO and a scratch FBO.
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "lv_draw_nanovg_private.h"
+
+#if LV_USE_DRAW_NANOVG
+
+#include "lv_nanovg_utils.h"
+#include "lv_nanovg_fbo_cache.h"
+
+#if LV_USE_OPENGLES && LV_USE_EGL
+    #include "../../drivers/opengles/lv_opengles_private.h"
+#else
+    #define NANOVG_GL_STATIC_LINK
+#endif
+
+#if defined(NANOVG_GL2_IMPLEMENTATION) || defined(NANOVG_GL3_IMPLEMENTATION)
+    #ifdef NANOVG_GL_STATIC_LINK
+        #include <GL/glew.h>
+    #endif
+#elif defined(NANOVG_GLES2_IMPLEMENTATION)
+    #ifdef NANOVG_GL_STATIC_LINK
+        #include <GLES2/gl2.h>
+    #endif
+#elif defined(NANOVG_GLES3_IMPLEMENTATION)
+    #ifdef NANOVG_GL_STATIC_LINK
+        #include <GLES3/gl3.h>
+    #endif
+#endif
+
+#include "../../libs/nanovg/nanovg_gl_utils.h"
+
+#include <math.h>
+
+/*********************
+ *      DEFINES
+ *********************/
+
+#define BLUR_MAX_TAPS      16
+#define BLUR_MAX_RADIUS    256
+
+/* GL3 / GLES3 core profile require a Vertex Array Object to be bound
+ * before any vertex-attribute setup. GL2 and GLES2 don't have VAOs. */
+#if LV_NANOVG_BACKEND == LV_NANOVG_BACKEND_GL3 || LV_NANOVG_BACKEND == LV_NANOVG_BACKEND_GLES3
+    #define BLUR_NEEDS_VAO 1
+#else
+    #define BLUR_NEEDS_VAO 0
+#endif
+
+/* Per-backend GLSL prologue. The shader body uses legacy GLES2/GL2 syntax
+ * (attribute / varying / texture2D / gl_FragColor) and is remapped to GL3
+ * / GLES3 modern equivalents via #define when needed. */
+#if LV_NANOVG_BACKEND == LV_NANOVG_BACKEND_GL3
+#define BLUR_VS_HEADER \
+    "#version 130\n" \
+    "#define attribute in\n" \
+    "#define varying out\n"
+#define BLUR_FS_HEADER \
+    "#version 130\n" \
+    "#define varying in\n" \
+    "#define texture2D texture\n" \
+    "out vec4 blur_frag_out;\n" \
+    "#define gl_FragColor blur_frag_out\n"
+#elif LV_NANOVG_BACKEND == LV_NANOVG_BACKEND_GLES3
+#define BLUR_VS_HEADER \
+    "#version 300 es\n" \
+    "#define attribute in\n" \
+    "#define varying out\n"
+#define BLUR_FS_HEADER \
+    "#version 300 es\n" \
+    "precision mediump float;\n" \
+    "#define varying in\n" \
+    "#define texture2D texture\n" \
+    "out vec4 blur_frag_out;\n" \
+    "#define gl_FragColor blur_frag_out\n"
+#elif LV_NANOVG_BACKEND == LV_NANOVG_BACKEND_GLES2
+#define BLUR_VS_HEADER ""
+#define BLUR_FS_HEADER "precision mediump float;\n"
+#else /* GL2 */
+#define BLUR_VS_HEADER ""
+#define BLUR_FS_HEADER ""
+#endif
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+typedef struct {
+    GLuint program;
+    GLuint vbo;
+#if BLUR_NEEDS_VAO
+    GLuint vao;
+#endif
+    GLint  loc_tex;
+    GLint  loc_step;
+    GLint  loc_tap_count;
+    GLint  loc_weights;
+    GLint  loc_src_uv;
+    GLint  loc_recolor;
+    GLint  attr_pos;
+    GLint  attr_uv;
+    bool   program_ok;
+
+    /* Scratch FBO sized to the current blur area; ping-pong target. */
+    NVGLUframebuffer * scratch_fb;
+    int                scratch_w;
+    int                scratch_h;
+
+    /* Capture texture used when blurring the screen layer (no FBO).
+     * Holds a copy of the screen region we're about to blur. */
+    GLuint             capture_tex;
+    int                capture_w;
+    int                capture_h;
+} blur_state_t;
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+static bool ensure_program(blur_state_t * s);
+static void ensure_scratch_fb(blur_state_t * s, NVGcontext * vg, int w, int h);
+static void ensure_capture_tex(blur_state_t * s, int w, int h);
+static GLuint compile_shader(GLenum type, const char * src);
+static void compute_weights(int radius, int tap_count, int step_px, float * weights);
+static void set_tex_params(void);
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+static const char * VS_SRC =
+    BLUR_VS_HEADER
+    "attribute vec2 a_pos;\n"
+    "attribute vec2 a_uv;\n"
+    "varying vec2 v_uv;\n"
+    "void main() {\n"
+    "    v_uv = a_uv;\n"
+    "    gl_Position = vec4(a_pos, 0.0, 1.0);\n"
+    "}\n";
+
+static const char * FS_SRC =
+    BLUR_FS_HEADER
+    "uniform sampler2D u_tex;\n"
+    "uniform vec2 u_step;\n"
+    "uniform vec4 u_src_uv;\n"   /* xy = sub-region UV offset, zw = sub-region UV scale */
+    "uniform vec4 u_recolor;\n"  /* rgb = recolor, a > 0.5 enables alpha-masked recolor */
+    "uniform int u_tap_count;\n"
+    "uniform float u_weights[17];\n"
+    "varying vec2 v_uv;\n"
+    "void main() {\n"
+    "    vec2 base = u_src_uv.xy + v_uv * u_src_uv.zw;\n"
+    "    vec4 sum = texture2D(u_tex, base) * u_weights[0];\n"
+    "    for(int i = 1; i <= 16; i++) {\n"
+    "        if(i > u_tap_count) break;\n"
+    "        vec2 off = u_step * float(i);\n"
+    "        sum += texture2D(u_tex, base + off) * u_weights[i];\n"
+    "        sum += texture2D(u_tex, base - off) * u_weights[i];\n"
+    "    }\n"
+    "    if(u_recolor.a > 0.5) {\n"
+    "        sum = vec4(u_recolor.rgb * sum.a, sum.a);\n"
+    "    }\n"
+    "    gl_FragColor = sum;\n"
+    "}\n";
+
+/* Fullscreen triangle strip: x, y, u, v */
+static const float QUAD_VERTS[] = {
+    -1.0f, -1.0f, 0.0f, 0.0f,
+    1.0f, -1.0f, 1.0f, 0.0f,
+    -1.0f,  1.0f, 0.0f, 1.0f,
+    1.0f,  1.0f, 1.0f, 1.0f,
+};
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void lv_draw_nanovg_blur_init(lv_draw_nanovg_unit_t * u)
+{
+    LV_ASSERT_NULL(u);
+    blur_state_t * s = lv_malloc_zeroed(sizeof(blur_state_t));
+    if(s == NULL) {
+        LV_LOG_ERROR("nanovg blur: failed to allocate blur state");
+        return;
+    }
+    u->blur_state = s;
+}
+
+void lv_draw_nanovg_blur_deinit(lv_draw_nanovg_unit_t * u)
+{
+    LV_ASSERT_NULL(u);
+    blur_state_t * s = u->blur_state;
+    if(s == NULL) return;
+
+    if(s->scratch_fb) {
+        nvgluDeleteFramebuffer(s->scratch_fb);
+        s->scratch_fb = NULL;
+    }
+    if(s->capture_tex) {
+        glDeleteTextures(1, &s->capture_tex);
+        s->capture_tex = 0;
+    }
+    if(s->program) {
+        glDeleteProgram(s->program);
+        s->program = 0;
+    }
+    if(s->vbo) {
+        glDeleteBuffers(1, &s->vbo);
+        s->vbo = 0;
+    }
+#if BLUR_NEEDS_VAO
+    if(s->vao) {
+        glDeleteVertexArrays(1, &s->vao);
+        s->vao = 0;
+    }
+#endif
+
+    lv_free(s);
+    u->blur_state = NULL;
+}
+
+void lv_draw_nanovg_blur(lv_draw_task_t * t, const lv_draw_blur_dsc_t * dsc, const lv_area_t * coords)
+{
+    int radius = dsc->blur_radius;
+    if(radius <= 0) return;
+    if(radius > BLUR_MAX_RADIUS) radius = BLUR_MAX_RADIUS;
+
+    LV_PROFILER_DRAW_BEGIN;
+
+    lv_draw_nanovg_unit_t * u = (lv_draw_nanovg_unit_t *)t->draw_unit;
+    lv_layer_t * layer = t->target_layer;
+    blur_state_t * s = u->blur_state;
+
+    if(s == NULL) {
+        LV_LOG_ERROR("nanovg blur: state not initialized");
+        LV_PROFILER_DRAW_END;
+        return;
+    }
+
+    /* Determine the blur area: requested coords clipped to clip_area and
+     * the layer's own extent, expressed in layer-relative coordinates with
+     * the layer's top-left at (0, 0). LVGL coordinates are top-down. */
+    lv_area_t clip;
+    if(!lv_area_intersect(&clip, coords, &t->clip_area)) {
+        LV_PROFILER_DRAW_END;
+        return;
+    }
+    if(!lv_area_intersect(&clip, &clip, &layer->buf_area)) {
+        LV_PROFILER_DRAW_END;
+        return;
+    }
+    const int blur_w = lv_area_get_width(&clip);
+    const int blur_h = lv_area_get_height(&clip);
+    if(blur_w <= 0 || blur_h <= 0) {
+        LV_PROFILER_DRAW_END;
+        return;
+    }
+
+    const int layer_h    = lv_area_get_height(&layer->buf_area);
+    const int rel_x      = clip.x1 - layer->buf_area.x1;
+    const int rel_y_top  = clip.y1 - layer->buf_area.y1;
+    /* GL viewport / glCopyTex* take Y measured from the bottom of the
+     * framebuffer; LVGL gives Y from the top. */
+    const int gl_y       = layer_h - rel_y_top - blur_h;
+
+    const bool is_root = (layer->user_data == NULL);
+
+    NVGLUframebuffer * src_fb = NULL;
+    if(!is_root) {
+        src_fb = lv_nanovg_fbo_cache_entry_to_fb(layer->user_data);
+        if(src_fb == NULL) {
+            LV_PROFILER_DRAW_END;
+            return;
+        }
+    }
+
+    /* --- Allocate resources BEFORE mutating any GL state, so an early
+     * failure simply returns without leaving the driver in a partially
+     * configured state for the next nanovg draws. */
+    if(!ensure_program(s)) {
+        LV_PROFILER_DRAW_END;
+        return;
+    }
+    ensure_scratch_fb(s, u->vg, blur_w, blur_h);
+    if(s->scratch_fb == NULL) {
+        LV_PROFILER_DRAW_END;
+        return;
+    }
+    if(is_root) {
+        ensure_capture_tex(s, blur_w, blur_h);
+        if(s->capture_tex == 0) {
+            LV_PROFILER_DRAW_END;
+            return;
+        }
+    }
+
+    /* Flush nanovg's pending batched draws before we touch raw GL state.
+     * The next dispatch will call nvgBeginFrame again. */
+    lv_nanovg_end_frame(u);
+
+    /* Map (radius, quality) -> (tap_count, step_px). For BLUR_QUALITY_SPEED
+     * we use half the taps; the per-tap step grows so the same radius is
+     * still covered, at the cost of coarser sampling. */
+    const int max_taps  = (dsc->quality == LV_BLUR_QUALITY_SPEED) ? 8 : BLUR_MAX_TAPS;
+    int       tap_count = radius < max_taps ? radius : max_taps;
+    if(tap_count < 1) tap_count = 1;
+    int step_px = (radius + tap_count - 1) / tap_count; /* ceil(radius / taps) */
+    if(step_px < 1) step_px = 1;
+
+    float weights[BLUR_MAX_TAPS + 1];
+    compute_weights(radius, tap_count, step_px, weights);
+
+    /* --- Set up shared GL state for both passes --- */
+#if BLUR_NEEDS_VAO
+    glBindVertexArray(s->vao);
+#endif
+    glUseProgram(s->program);
+    glBindBuffer(GL_ARRAY_BUFFER, s->vbo);
+    glEnableVertexAttribArray((GLuint)s->attr_pos);
+    glVertexAttribPointer((GLuint)s->attr_pos, 2, GL_FLOAT, GL_FALSE,
+                          sizeof(float) * 4, (const void *)0);
+    glEnableVertexAttribArray((GLuint)s->attr_uv);
+    glVertexAttribPointer((GLuint)s->attr_uv, 2, GL_FLOAT, GL_FALSE,
+                          sizeof(float) * 4, (const void *)(sizeof(float) * 2));
+
+    glActiveTexture(GL_TEXTURE0);
+    glUniform1i(s->loc_tex, 0);
+    glUniform1i(s->loc_tap_count, tap_count);
+    glUniform1fv(s->loc_weights, BLUR_MAX_TAPS + 1, weights);
+
+    glDisable(GL_BLEND);
+    glDisable(GL_STENCIL_TEST);
+    glDisable(GL_DEPTH_TEST);
+    glDisable(GL_CULL_FACE);
+    glDisable(GL_SCISSOR_TEST);
+    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+
+    /* --- Pick the source texture and compute its sampling sub-region. */
+    GLuint src_tex;
+    int    src_tex_w, src_tex_h;
+    float  src_uv_off_x, src_uv_off_y, src_uv_scl_x, src_uv_scl_y;
+    if(is_root) {
+        glBindTexture(GL_TEXTURE_2D, s->capture_tex);
+        glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, rel_x, gl_y, blur_w, blur_h);
+        src_tex      = s->capture_tex;
+        src_tex_w    = s->capture_w;
+        src_tex_h    = s->capture_h;
+        src_uv_off_x = 0.0f;
+        src_uv_off_y = 0.0f;
+        src_uv_scl_x = (float)blur_w / (float)src_tex_w;
+        src_uv_scl_y = (float)blur_h / (float)src_tex_h;
+    }
+    else {
+        src_tex      = (GLuint)lv_nanovg_fb_get_texture_id(src_fb);
+        src_tex_w    = lv_area_get_width(&layer->buf_area);
+        src_tex_h    = layer_h;
+        src_uv_off_x = (float)rel_x / (float)src_tex_w;
+        src_uv_off_y = (float)gl_y  / (float)src_tex_h;
+        src_uv_scl_x = (float)blur_w / (float)src_tex_w;
+        src_uv_scl_y = (float)blur_h / (float)src_tex_h;
+    }
+    const GLuint scratch_tex = (GLuint)lv_nanovg_fb_get_texture_id(s->scratch_fb);
+
+    /* --- Pass 1: source -> scratch, horizontal blur --- */
+    LV_PROFILER_DRAW_BEGIN_TAG("blur_h");
+    nvgluBindFramebuffer(s->scratch_fb);
+    glViewport(0, 0, blur_w, blur_h);
+    glBindTexture(GL_TEXTURE_2D, src_tex);
+    set_tex_params();
+    glUniform4f(s->loc_src_uv, src_uv_off_x, src_uv_off_y, src_uv_scl_x, src_uv_scl_y);
+    glUniform4f(s->loc_recolor, 0.0f, 0.0f, 0.0f, 0.0f);
+    glUniform2f(s->loc_step, (float)step_px / (float)src_tex_w, 0.0f);
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+    LV_PROFILER_DRAW_END_TAG("blur_h");
+
+    /* --- Pass 2: scratch -> destination, vertical blur --- */
+    LV_PROFILER_DRAW_BEGIN_TAG("blur_v");
+    if(is_root) {
+        nvgluBindFramebuffer(NULL);
+    }
+    else {
+        nvgluBindFramebuffer(src_fb);
+    }
+    glViewport(rel_x, gl_y, blur_w, blur_h);
+    glBindTexture(GL_TEXTURE_2D, scratch_tex);
+    set_tex_params();
+    glUniform4f(s->loc_src_uv,
+                0.0f, 0.0f,
+                (float)blur_w / (float)s->scratch_w,
+                (float)blur_h / (float)s->scratch_h);
+    if(dsc->base.drop_shadow_opa > 0) {
+        glUniform4f(s->loc_recolor,
+                    (float)dsc->base.drop_shadow_color.red   / 255.0f,
+                    (float)dsc->base.drop_shadow_color.green / 255.0f,
+                    (float)dsc->base.drop_shadow_color.blue  / 255.0f,
+                    1.0f);
+    }
+    else {
+        glUniform4f(s->loc_recolor, 0.0f, 0.0f, 0.0f, 0.0f);
+    }
+    glUniform2f(s->loc_step, 0.0f, (float)step_px / (float)s->scratch_h);
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+    LV_PROFILER_DRAW_END_TAG("blur_v");
+
+    /* --- Restore minimal state --- */
+    glDisableVertexAttribArray((GLuint)s->attr_pos);
+    glDisableVertexAttribArray((GLuint)s->attr_uv);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    glUseProgram(0);
+#if BLUR_NEEDS_VAO
+    glBindVertexArray(0);
+#endif
+
+    LV_PROFILER_DRAW_END;
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static bool ensure_program(blur_state_t * s)
+{
+    if(s->program_ok) return true;
+    if(s->program != 0) return false; /* previously failed */
+
+    GLuint vs = compile_shader(GL_VERTEX_SHADER, VS_SRC);
+    GLuint fs = compile_shader(GL_FRAGMENT_SHADER, FS_SRC);
+    if(vs == 0 || fs == 0) {
+        if(vs) glDeleteShader(vs);
+        if(fs) glDeleteShader(fs);
+        return false;
+    }
+
+    GLuint prog = glCreateProgram();
+    glAttachShader(prog, vs);
+    glAttachShader(prog, fs);
+    glLinkProgram(prog);
+    glDeleteShader(vs);
+    glDeleteShader(fs);
+
+    GLint linked = 0;
+    glGetProgramiv(prog, GL_LINK_STATUS, &linked);
+    if(!linked) {
+        char log[512];
+        GLsizei len = 0;
+        glGetProgramInfoLog(prog, sizeof(log), &len, log);
+        LV_LOG_ERROR("nanovg blur: program link failed: %.*s", (int)len, log);
+        glDeleteProgram(prog);
+        return false;
+    }
+
+    s->program       = prog;
+    s->loc_tex       = glGetUniformLocation(prog, "u_tex");
+    s->loc_step      = glGetUniformLocation(prog, "u_step");
+    s->loc_src_uv    = glGetUniformLocation(prog, "u_src_uv");
+    s->loc_recolor   = glGetUniformLocation(prog, "u_recolor");
+    s->loc_tap_count = glGetUniformLocation(prog, "u_tap_count");
+    s->loc_weights   = glGetUniformLocation(prog, "u_weights[0]");
+    if(s->loc_weights < 0) s->loc_weights = glGetUniformLocation(prog, "u_weights");
+    s->attr_pos      = glGetAttribLocation(prog, "a_pos");
+    s->attr_uv       = glGetAttribLocation(prog, "a_uv");
+
+    glGenBuffers(1, &s->vbo);
+    glBindBuffer(GL_ARRAY_BUFFER, s->vbo);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(QUAD_VERTS), QUAD_VERTS, GL_STATIC_DRAW);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+#if BLUR_NEEDS_VAO
+    glGenVertexArrays(1, &s->vao);
+#endif
+
+    s->program_ok = true;
+    return true;
+}
+
+static void ensure_scratch_fb(blur_state_t * s, NVGcontext * vg, int w, int h)
+{
+    if(s->scratch_fb != NULL && s->scratch_w == w && s->scratch_h == h) return;
+
+    if(s->scratch_fb) {
+        nvgluDeleteFramebuffer(s->scratch_fb);
+        s->scratch_fb = NULL;
+        s->scratch_w = 0;
+        s->scratch_h = 0;
+    }
+    s->scratch_fb = nvgluCreateFramebuffer(vg, w, h, 0, NVG_TEXTURE_RGBA);
+    if(s->scratch_fb == NULL) {
+        LV_LOG_ERROR("nanovg blur: failed to allocate %dx%d scratch FBO", w, h);
+        return;
+    }
+    s->scratch_w = w;
+    s->scratch_h = h;
+}
+
+static void ensure_capture_tex(blur_state_t * s, int w, int h)
+{
+    if(s->capture_tex != 0 && s->capture_w == w && s->capture_h == h) return;
+
+    if(s->capture_tex == 0) {
+        glGenTextures(1, &s->capture_tex);
+    }
+    glBindTexture(GL_TEXTURE_2D, s->capture_tex);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    s->capture_w = w;
+    s->capture_h = h;
+}
+
+static GLuint compile_shader(GLenum type, const char * src)
+{
+    GLuint sh = glCreateShader(type);
+    glShaderSource(sh, 1, &src, NULL);
+    glCompileShader(sh);
+
+    GLint compiled = 0;
+    glGetShaderiv(sh, GL_COMPILE_STATUS, &compiled);
+    if(!compiled) {
+        char log[512];
+        GLsizei len = 0;
+        glGetShaderInfoLog(sh, sizeof(log), &len, log);
+        LV_LOG_ERROR("nanovg blur: %s shader compile failed: %.*s",
+                     type == GL_VERTEX_SHADER ? "vertex" : "fragment",
+                     (int)len, log);
+        glDeleteShader(sh);
+        return 0;
+    }
+    return sh;
+}
+
+static void compute_weights(int radius, int tap_count, int step_px, float * weights)
+{
+    /* Gaussian with sigma = radius / 3 -- the usual "3-sigma covers radius"
+     * convention. Sample positions: 0, step_px, 2*step_px, ... */
+    float sigma = (float)radius / 3.0f;
+    if(sigma < 1.0f) sigma = 1.0f;
+    const float inv_two_sigma_sq = 1.0f / (2.0f * sigma * sigma);
+
+    float total = 0.0f;
+    for(int i = 0; i <= BLUR_MAX_TAPS; i++) {
+        if(i > tap_count) {
+            weights[i] = 0.0f;
+            continue;
+        }
+        float x = (float)(i * step_px);
+        float w = expf(-x * x * inv_two_sigma_sq);
+        weights[i] = w;
+        total += (i == 0) ? w : (2.0f * w);
+    }
+    if(total > 0.0f) {
+        float inv = 1.0f / total;
+        for(int i = 0; i <= BLUR_MAX_TAPS; i++) weights[i] *= inv;
+    }
+}
+
+static void set_tex_params(void)
+{
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+}
+
+#endif /* LV_USE_DRAW_NANOVG */

--- a/src/draw/nanovg/lv_draw_nanovg_private.h
+++ b/src/draw/nanovg/lv_draw_nanovg_private.h
@@ -71,6 +71,8 @@ typedef struct _lv_draw_nanovg_unit_t {
     struct _lv_pending_t * letter_pending;
 
     lv_cache_t * fbo_cache;
+
+    void * blur_state;
 } lv_draw_nanovg_unit_t;
 
 /**********************
@@ -192,6 +194,33 @@ void lv_draw_nanovg_mask_rect(lv_draw_task_t * t, const lv_draw_mask_rect_dsc_t 
  * @return the image handle
  */
 int lv_nanovg_fb_get_image_handle(struct NVGLUframebuffer * fb);
+
+/**
+ * Get the raw GL texture id backing a NanoVG framebuffer
+ * @param fb the framebuffer
+ * @return the GL texture id (GLuint), or 0 if fb is NULL
+ */
+unsigned int lv_nanovg_fb_get_texture_id(struct NVGLUframebuffer * fb);
+
+/**
+ * Initialize the blur draw unit state on the given nanovg unit
+ * @param u pointer to the nanovg unit
+ */
+void lv_draw_nanovg_blur_init(lv_draw_nanovg_unit_t * u);
+
+/**
+ * Deinitialize the blur draw unit state on the given nanovg unit
+ * @param u pointer to the nanovg unit
+ */
+void lv_draw_nanovg_blur_deinit(lv_draw_nanovg_unit_t * u);
+
+/**
+ * Apply a separable gaussian blur to the current layer using a fragment shader
+ * @param t pointer to a drawing task
+ * @param dsc pointer to a blur descriptor
+ * @param coords the coordinates of the area to blur
+ */
+void lv_draw_nanovg_blur(lv_draw_task_t * t, const lv_draw_blur_dsc_t * dsc, const lv_area_t * coords);
 
 #if LV_USE_VECTOR_GRAPHIC
 /**

--- a/src/draw/nanovg/lv_draw_nanovg_private.h
+++ b/src/draw/nanovg/lv_draw_nanovg_private.h
@@ -54,6 +54,7 @@ extern "C" {
 
 struct _lv_pending_t;
 struct NVGLUframebuffer;
+struct NVGLUblurState;
 
 typedef struct _lv_draw_nanovg_unit_t {
     lv_draw_unit_t base_unit;
@@ -72,7 +73,7 @@ typedef struct _lv_draw_nanovg_unit_t {
 
     lv_cache_t * fbo_cache;
 
-    void * blur_state;
+    struct NVGLUblurState * blur_state;
 } lv_draw_nanovg_unit_t;
 
 /**********************
@@ -194,13 +195,6 @@ void lv_draw_nanovg_mask_rect(lv_draw_task_t * t, const lv_draw_mask_rect_dsc_t 
  * @return the image handle
  */
 int lv_nanovg_fb_get_image_handle(struct NVGLUframebuffer * fb);
-
-/**
- * Get the raw GL texture id backing a NanoVG framebuffer
- * @param fb the framebuffer
- * @return the GL texture id (GLuint), or 0 if fb is NULL
- */
-unsigned int lv_nanovg_fb_get_texture_id(struct NVGLUframebuffer * fb);
 
 /**
  * Initialize the blur draw unit state on the given nanovg unit

--- a/src/libs/nanovg/nanovg_gl_utils.h
+++ b/src/libs/nanovg/nanovg_gl_utils.h
@@ -244,6 +244,7 @@ struct NVGLUblurState {
     GLint loc_step;
     GLint loc_tap_count;
     GLint loc_weights;
+    GLint loc_offsets;
     GLint loc_src_uv;
     GLint loc_recolor;
     GLint attr_pos;
@@ -269,6 +270,11 @@ static const char * nvglu__blur_vs_src =
     "    gl_Position = vec4(a_pos, 0.0, 1.0);\n"
     "}\n";
 
+/* Bilinear-optimized fragment shader: each texture fetch samples between
+ * two texels, merging two discrete taps into one HW-filtered read.
+ * u_offsets[i] = bilinear offset in texels (pre-divided by tex size on CPU)
+ * u_weights[i] = combined weight for that bilinear sample
+ * u_weights[0] = center tap weight (sampled at base) */
 static const char * nvglu__blur_fs_src =
     NVGLU_BLUR_FS_HEADER
     "uniform sampler2D u_tex;\n"
@@ -276,14 +282,15 @@ static const char * nvglu__blur_fs_src =
     "uniform vec4 u_src_uv;\n"
     "uniform vec4 u_recolor;\n"
     "uniform int u_tap_count;\n"
-    "uniform float u_weights[17];\n"
+    "uniform float u_weights[9];\n"
+    "uniform float u_offsets[9];\n"
     "varying vec2 v_uv;\n"
     "void main() {\n"
     "    vec2 base = u_src_uv.xy + v_uv * u_src_uv.zw;\n"
     "    vec4 sum = texture2D(u_tex, base) * u_weights[0];\n"
-    "    for(int i = 1; i <= 16; i++) {\n"
+    "    for(int i = 1; i <= 8; i++) {\n"
     "        if(i > u_tap_count) break;\n"
-    "        vec2 off = u_step * float(i);\n"
+    "        vec2 off = u_step * u_offsets[i];\n"
     "        sum += texture2D(u_tex, base + off) * u_weights[i];\n"
     "        sum += texture2D(u_tex, base - off) * u_weights[i];\n"
     "    }\n"
@@ -349,6 +356,8 @@ static int nvglu__ensure_program(NVGLUblurState * s)
     s->loc_tap_count = glGetUniformLocation(prog, "u_tap_count");
     s->loc_weights   = glGetUniformLocation(prog, "u_weights[0]");
     if(s->loc_weights < 0) s->loc_weights = glGetUniformLocation(prog, "u_weights");
+    s->loc_offsets   = glGetUniformLocation(prog, "u_offsets[0]");
+    if(s->loc_offsets < 0) s->loc_offsets = glGetUniformLocation(prog, "u_offsets");
     s->attr_pos      = glGetAttribLocation(prog, "a_pos");
     s->attr_uv       = glGetAttribLocation(prog, "a_uv");
 
@@ -365,16 +374,21 @@ static int nvglu__ensure_program(NVGLUblurState * s)
     return 1;
 }
 
+/* Grow-only scratch FBO: only reallocate when a larger size is needed.
+ * The shader uses u_src_uv to address the sub-region, so a larger FBO is fine. */
 static void nvglu__ensure_scratch(NVGLUblurState * s, NVGcontext * ctx, int w, int h)
 {
-    if(s->scratch_fb && s->scratch_w == w && s->scratch_h == h) return;
+    if(s->scratch_fb && s->scratch_w >= w && s->scratch_h >= h) return;
     if(s->scratch_fb) {
         nvgluDeleteFramebuffer(s->scratch_fb);
         s->scratch_fb = NULL;
     }
-    s->scratch_fb = nvgluCreateFramebuffer(ctx, w, h, 0, NVG_TEXTURE_RGBA);
-    s->scratch_w = s->scratch_fb ? w : 0;
-    s->scratch_h = s->scratch_fb ? h : 0;
+    /* Allocate with some headroom to reduce future reallocations */
+    int alloc_w = w > s->scratch_w ? w : s->scratch_w;
+    int alloc_h = h > s->scratch_h ? h : s->scratch_h;
+    s->scratch_fb = nvgluCreateFramebuffer(ctx, alloc_w, alloc_h, 0, NVG_TEXTURE_RGBA);
+    s->scratch_w = s->scratch_fb ? alloc_w : 0;
+    s->scratch_h = s->scratch_fb ? alloc_h : 0;
 }
 
 static void nvglu__ensure_capture(NVGLUblurState * s, int w, int h)
@@ -391,27 +405,66 @@ static void nvglu__ensure_capture(NVGLUblurState * s, int w, int h)
     s->capture_h = h;
 }
 
-static void nvglu__compute_weights(int radius, int tap_count, int step_px, float * weights)
+/* Compute bilinear-optimized weights and offsets.
+ * Takes N discrete Gaussian taps and merges adjacent pairs into
+ * bilinear samples: offset = (pos_a * w_a + pos_b * w_b) / (w_a + w_b)
+ * This halves the number of texture fetches with identical results.
+ *
+ * Output: bilinear_weights[0] = center weight
+ *         bilinear_weights[1..tap_count_out] = merged pair weights
+ *         bilinear_offsets[1..tap_count_out] = merged pair offsets (in texels * step_px)
+ * Returns the number of bilinear taps (excluding center). */
+static int nvglu__compute_bilinear_kernel(int radius, int discrete_taps, int step_px,
+                                          float * bilinear_weights, float * bilinear_offsets)
 {
     float sigma = (float)radius / 3.0f;
     if(sigma < 1.0f) sigma = 1.0f;
     float inv2s2 = 1.0f / (2.0f * sigma * sigma);
+
+    /* First compute discrete weights */
+    float dw[NVGLU_BLUR_MAX_TAPS * 2 + 1]; /* max discrete taps */
     float total = 0.0f;
     int i;
-    for(i = 0; i <= NVGLU_BLUR_MAX_TAPS; i++) {
-        if(i > tap_count) {
-            weights[i] = 0.0f;
-            continue;
-        }
+    int n = discrete_taps;
+    if(n > NVGLU_BLUR_MAX_TAPS * 2) n = NVGLU_BLUR_MAX_TAPS * 2;
+
+    for(i = 0; i <= n; i++) {
         float x = (float)(i * step_px);
-        float w = expf(-x * x * inv2s2);
-        weights[i] = w;
-        total += (i == 0) ? w : (2.0f * w);
+        dw[i] = expf(-x * x * inv2s2);
+        total += (i == 0) ? dw[i] : (2.0f * dw[i]);
     }
+    /* Normalize */
     if(total > 0.0f) {
         float inv = 1.0f / total;
-        for(i = 0; i <= NVGLU_BLUR_MAX_TAPS; i++) weights[i] *= inv;
+        for(i = 0; i <= n; i++) dw[i] *= inv;
     }
+
+    /* Center tap */
+    bilinear_weights[0] = dw[0];
+    bilinear_offsets[0] = 0.0f;
+
+    /* Merge pairs: (1,2), (3,4), (5,6), ... */
+    int bi = 0;
+    for(i = 1; i <= n; i += 2) {
+        float w1 = dw[i];
+        float w2 = (i + 1 <= n) ? dw[i + 1] : 0.0f;
+        float wsum = w1 + w2;
+        if(wsum < 1e-10f) break;
+        bi++;
+        bilinear_weights[bi] = wsum;
+        /* Bilinear offset: weighted average of the two tap positions */
+        float pos1 = (float)(i * step_px);
+        float pos2 = (float)((i + 1) * step_px);
+        bilinear_offsets[bi] = (pos1 * w1 + pos2 * w2) / wsum;
+    }
+
+    /* Zero remaining slots */
+    for(i = bi + 1; i <= 8; i++) {
+        bilinear_weights[i] = 0.0f;
+        bilinear_offsets[i] = 0.0f;
+    }
+
+    return bi;
 }
 
 NVGLUblurState * nvgluCreateBlurState(void)
@@ -464,15 +517,17 @@ int nvgluBlurRegion(NVGLUblurState * state, NVGcontext * ctx, NVGLUframebuffer *
         if(!state->capture_tex) return -1;
     }
 
-    // Compute kernel
-    int max_taps = (params->quality == NVGLU_BLUR_QUALITY_SPEED) ? 8 : NVGLU_BLUR_MAX_TAPS;
-    int tap_count = radius < max_taps ? radius : max_taps;
-    if(tap_count < 1) tap_count = 1;
-    int step_px = (radius + tap_count - 1) / tap_count;
+    // Compute bilinear kernel
+    // Use more discrete taps for quality, fewer for speed
+    int discrete_taps = (params->quality == NVGLU_BLUR_QUALITY_SPEED) ? 8 : NVGLU_BLUR_MAX_TAPS;
+    if(radius < discrete_taps) discrete_taps = radius;
+    if(discrete_taps < 1) discrete_taps = 1;
+    int step_px = (radius + discrete_taps - 1) / discrete_taps;
     if(step_px < 1) step_px = 1;
 
-    float weights[NVGLU_BLUR_MAX_TAPS + 1];
-    nvglu__compute_weights(radius, tap_count, step_px, weights);
+    float weights[9];
+    float offsets[9];
+    int tap_count = nvglu__compute_bilinear_kernel(radius, discrete_taps, step_px, weights, offsets);
 
     // Setup GL state
 #if NVGLU_BLUR_NEEDS_VAO
@@ -489,7 +544,8 @@ int nvgluBlurRegion(NVGLUblurState * state, NVGcontext * ctx, NVGLUframebuffer *
     glActiveTexture(GL_TEXTURE0);
     glUniform1i(state->loc_tex, 0);
     glUniform1i(state->loc_tap_count, tap_count);
-    glUniform1fv(state->loc_weights, NVGLU_BLUR_MAX_TAPS + 1, weights);
+    glUniform1fv(state->loc_weights, 9, weights);
+    glUniform1fv(state->loc_offsets, 9, offsets);
 
     glDisable(GL_BLEND);
     glDisable(GL_STENCIL_TEST);
@@ -541,7 +597,7 @@ int nvgluBlurRegion(NVGLUblurState * state, NVGcontext * ctx, NVGLUframebuffer *
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glUniform4f(state->loc_src_uv, uv_ox, uv_oy, uv_sx, uv_sy);
     glUniform4f(state->loc_recolor, 0.0f, 0.0f, 0.0f, 0.0f);
-    glUniform2f(state->loc_step, (float)step_px / (float)src_tex_w, 0.0f);
+    glUniform2f(state->loc_step, 1.0f / (float)src_tex_w, 0.0f);
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
     // Pass 2: scratch -> dst (vertical)
@@ -564,7 +620,7 @@ int nvgluBlurRegion(NVGLUblurState * state, NVGcontext * ctx, NVGLUframebuffer *
     else {
         glUniform4f(state->loc_recolor, 0.0f, 0.0f, 0.0f, 0.0f);
     }
-    glUniform2f(state->loc_step, 0.0f, (float)step_px / (float)state->scratch_h);
+    glUniform2f(state->loc_step, 0.0f, 1.0f / (float)state->scratch_h);
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
     // Restore

--- a/src/libs/nanovg/nanovg_gl_utils.h
+++ b/src/libs/nanovg/nanovg_gl_utils.h
@@ -270,11 +270,10 @@ static const char * nvglu__blur_vs_src =
     "    gl_Position = vec4(a_pos, 0.0, 1.0);\n"
     "}\n";
 
-/* Bilinear-optimized fragment shader: each texture fetch samples between
- * two texels, merging two discrete taps into one HW-filtered read.
- * u_offsets[i] = bilinear offset in texels (pre-divided by tex size on CPU)
- * u_weights[i] = combined weight for that bilinear sample
- * u_weights[0] = center tap weight (sampled at base) */
+/* Fragment shader with per-tap offsets.
+ * u_offsets[i] = sample offset in texels (multiplied by u_step on GPU)
+ * u_weights[i] = weight for that sample
+ * u_weights[0] / u_offsets[0] = center tap */
 static const char * nvglu__blur_fs_src =
     NVGLU_BLUR_FS_HEADER
     "uniform sampler2D u_tex;\n"
@@ -282,13 +281,13 @@ static const char * nvglu__blur_fs_src =
     "uniform vec4 u_src_uv;\n"
     "uniform vec4 u_recolor;\n"
     "uniform int u_tap_count;\n"
-    "uniform float u_weights[9];\n"
-    "uniform float u_offsets[9];\n"
+    "uniform float u_weights[17];\n"
+    "uniform float u_offsets[17];\n"
     "varying vec2 v_uv;\n"
     "void main() {\n"
     "    vec2 base = u_src_uv.xy + v_uv * u_src_uv.zw;\n"
     "    vec4 sum = texture2D(u_tex, base) * u_weights[0];\n"
-    "    for(int i = 1; i <= 8; i++) {\n"
+    "    for(int i = 1; i <= 16; i++) {\n"
     "        if(i > u_tap_count) break;\n"
     "        vec2 off = u_step * u_offsets[i];\n"
     "        sum += texture2D(u_tex, base + off) * u_weights[i];\n"
@@ -405,66 +404,40 @@ static void nvglu__ensure_capture(NVGLUblurState * s, int w, int h)
     s->capture_h = h;
 }
 
-/* Compute bilinear-optimized weights and offsets.
- * Takes N discrete Gaussian taps and merges adjacent pairs into
- * bilinear samples: offset = (pos_a * w_a + pos_b * w_b) / (w_a + w_b)
- * This halves the number of texture fetches with identical results.
- *
- * Output: bilinear_weights[0] = center weight
- *         bilinear_weights[1..tap_count_out] = merged pair weights
- *         bilinear_offsets[1..tap_count_out] = merged pair offsets (in texels * step_px)
- * Returns the number of bilinear taps (excluding center). */
-static int nvglu__compute_bilinear_kernel(int radius, int discrete_taps, int step_px,
-                                          float * bilinear_weights, float * bilinear_offsets)
+/* Compute discrete Gaussian kernel weights and offsets.
+ * Output: weights[0] = center, weights[1..tap_count] = symmetric taps
+ *         offsets[i] = sample position in texels (i * step_px)
+ * Returns tap_count. */
+static int nvglu__compute_kernel(int radius, int max_taps, int step_px,
+                                 float * weights, float * offsets)
 {
     float sigma = (float)radius / 3.0f;
     if(sigma < 1.0f) sigma = 1.0f;
     float inv2s2 = 1.0f / (2.0f * sigma * sigma);
 
-    /* First compute discrete weights */
-    float dw[NVGLU_BLUR_MAX_TAPS * 2 + 1]; /* max discrete taps */
+    int tap_count = radius < max_taps ? radius : max_taps;
+    if(tap_count < 1) tap_count = 1;
+
     float total = 0.0f;
     int i;
-    int n = discrete_taps;
-    if(n > NVGLU_BLUR_MAX_TAPS * 2) n = NVGLU_BLUR_MAX_TAPS * 2;
-
-    for(i = 0; i <= n; i++) {
+    for(i = 0; i <= tap_count; i++) {
         float x = (float)(i * step_px);
-        dw[i] = expf(-x * x * inv2s2);
-        total += (i == 0) ? dw[i] : (2.0f * dw[i]);
+        float w = expf(-x * x * inv2s2);
+        weights[i] = w;
+        offsets[i] = x;
+        total += (i == 0) ? w : (2.0f * w);
     }
     /* Normalize */
     if(total > 0.0f) {
         float inv = 1.0f / total;
-        for(i = 0; i <= n; i++) dw[i] *= inv;
+        for(i = 0; i <= tap_count; i++) weights[i] *= inv;
     }
-
-    /* Center tap */
-    bilinear_weights[0] = dw[0];
-    bilinear_offsets[0] = 0.0f;
-
-    /* Merge pairs: (1,2), (3,4), (5,6), ... */
-    int bi = 0;
-    for(i = 1; i <= n; i += 2) {
-        float w1 = dw[i];
-        float w2 = (i + 1 <= n) ? dw[i + 1] : 0.0f;
-        float wsum = w1 + w2;
-        if(wsum < 1e-10f) break;
-        bi++;
-        bilinear_weights[bi] = wsum;
-        /* Bilinear offset: weighted average of the two tap positions */
-        float pos1 = (float)(i * step_px);
-        float pos2 = (float)((i + 1) * step_px);
-        bilinear_offsets[bi] = (pos1 * w1 + pos2 * w2) / wsum;
+    /* Zero remaining */
+    for(i = tap_count + 1; i <= NVGLU_BLUR_MAX_TAPS; i++) {
+        weights[i] = 0.0f;
+        offsets[i] = 0.0f;
     }
-
-    /* Zero remaining slots */
-    for(i = bi + 1; i <= 8; i++) {
-        bilinear_weights[i] = 0.0f;
-        bilinear_offsets[i] = 0.0f;
-    }
-
-    return bi;
+    return tap_count;
 }
 
 NVGLUblurState * nvgluCreateBlurState(void)
@@ -517,17 +490,14 @@ int nvgluBlurRegion(NVGLUblurState * state, NVGcontext * ctx, NVGLUframebuffer *
         if(!state->capture_tex) return -1;
     }
 
-    // Compute bilinear kernel
-    // Use more discrete taps for quality, fewer for speed
-    int discrete_taps = (params->quality == NVGLU_BLUR_QUALITY_SPEED) ? 8 : NVGLU_BLUR_MAX_TAPS;
-    if(radius < discrete_taps) discrete_taps = radius;
-    if(discrete_taps < 1) discrete_taps = 1;
-    int step_px = (radius + discrete_taps - 1) / discrete_taps;
+    // Compute kernel
+    int max_taps = (params->quality == NVGLU_BLUR_QUALITY_SPEED) ? 8 : NVGLU_BLUR_MAX_TAPS;
+    int step_px = (radius + max_taps - 1) / max_taps;
     if(step_px < 1) step_px = 1;
 
-    float weights[9];
-    float offsets[9];
-    int tap_count = nvglu__compute_bilinear_kernel(radius, discrete_taps, step_px, weights, offsets);
+    float weights[NVGLU_BLUR_MAX_TAPS + 1];
+    float offsets[NVGLU_BLUR_MAX_TAPS + 1];
+    int tap_count = nvglu__compute_kernel(radius, max_taps, step_px, weights, offsets);
 
     // Setup GL state
 #if NVGLU_BLUR_NEEDS_VAO
@@ -544,8 +514,8 @@ int nvgluBlurRegion(NVGLUblurState * state, NVGcontext * ctx, NVGLUframebuffer *
     glActiveTexture(GL_TEXTURE0);
     glUniform1i(state->loc_tex, 0);
     glUniform1i(state->loc_tap_count, tap_count);
-    glUniform1fv(state->loc_weights, 9, weights);
-    glUniform1fv(state->loc_offsets, 9, offsets);
+    glUniform1fv(state->loc_weights, NVGLU_BLUR_MAX_TAPS + 1, weights);
+    glUniform1fv(state->loc_offsets, NVGLU_BLUR_MAX_TAPS + 1, offsets);
 
     glDisable(GL_BLEND);
     glDisable(GL_STENCIL_TEST);

--- a/src/libs/nanovg/nanovg_gl_utils.h
+++ b/src/libs/nanovg/nanovg_gl_utils.h
@@ -440,6 +440,57 @@ static int nvglu__compute_kernel(int radius, int max_taps, int step_px,
     return tap_count;
 }
 
+/* Bilinear-optimized kernel: merge adjacent discrete tap pairs into single
+ * HW-filtered fetches. Halves texture bandwidth at slight quality cost.
+ * Returns bilinear tap count (excluding center). */
+static int nvglu__compute_kernel_bilinear(int radius, int step_px,
+                                          float * weights, float * offsets)
+{
+    float sigma = (float)radius / 3.0f;
+    if(sigma < 1.0f) sigma = 1.0f;
+    float inv2s2 = 1.0f / (2.0f * sigma * sigma);
+
+    /* Compute discrete weights for up to 16 taps */
+    int n = radius < NVGLU_BLUR_MAX_TAPS ? radius : NVGLU_BLUR_MAX_TAPS;
+    float dw[NVGLU_BLUR_MAX_TAPS + 1];
+    float total = 0.0f;
+    int i;
+    for(i = 0; i <= n; i++) {
+        float x = (float)(i * step_px);
+        dw[i] = expf(-x * x * inv2s2);
+        total += (i == 0) ? dw[i] : (2.0f * dw[i]);
+    }
+    if(total > 0.0f) {
+        float inv = 1.0f / total;
+        for(i = 0; i <= n; i++) dw[i] *= inv;
+    }
+
+    /* Center tap */
+    weights[0] = dw[0];
+    offsets[0] = 0.0f;
+
+    /* Merge pairs: (1,2), (3,4), ... */
+    int bi = 0;
+    for(i = 1; i <= n; i += 2) {
+        float w1 = dw[i];
+        float w2 = (i + 1 <= n) ? dw[i + 1] : 0.0f;
+        float wsum = w1 + w2;
+        if(wsum < 1e-10f) break;
+        bi++;
+        weights[bi] = wsum;
+        float p1 = (float)(i * step_px);
+        float p2 = (float)((i + 1) * step_px);
+        offsets[bi] = (p1 * w1 + p2 * w2) / wsum;
+    }
+
+    /* Zero remaining */
+    for(i = bi + 1; i <= NVGLU_BLUR_MAX_TAPS; i++) {
+        weights[i] = 0.0f;
+        offsets[i] = 0.0f;
+    }
+    return bi;
+}
+
 NVGLUblurState * nvgluCreateBlurState(void)
 {
 #ifdef NANOVG_FBO_VALID
@@ -490,14 +541,22 @@ int nvgluBlurRegion(NVGLUblurState * state, NVGcontext * ctx, NVGLUframebuffer *
         if(!state->capture_tex) return -1;
     }
 
-    // Compute kernel
-    int max_taps = (params->quality == NVGLU_BLUR_QUALITY_SPEED) ? 8 : NVGLU_BLUR_MAX_TAPS;
-    int step_px = (radius + max_taps - 1) / max_taps;
-    if(step_px < 1) step_px = 1;
-
+    // Compute kernel — speed mode uses bilinear merging (half the fetches)
     float weights[NVGLU_BLUR_MAX_TAPS + 1];
     float offsets[NVGLU_BLUR_MAX_TAPS + 1];
-    int tap_count = nvglu__compute_kernel(radius, max_taps, step_px, weights, offsets);
+    int tap_count;
+
+    if(params->quality == NVGLU_BLUR_QUALITY_SPEED) {
+        int step_px = (radius + 8 - 1) / 8;
+        if(step_px < 1) step_px = 1;
+        tap_count = nvglu__compute_kernel_bilinear(radius, step_px, weights, offsets);
+    }
+    else {
+        int max_taps = NVGLU_BLUR_MAX_TAPS;
+        int step_px = (radius + max_taps - 1) / max_taps;
+        if(step_px < 1) step_px = 1;
+        tap_count = nvglu__compute_kernel(radius, max_taps, step_px, weights, offsets);
+    }
 
     // Setup GL state
 #if NVGLU_BLUR_NEEDS_VAO

--- a/src/libs/nanovg/nanovg_gl_utils.h
+++ b/src/libs/nanovg/nanovg_gl_utils.h
@@ -562,12 +562,18 @@ int nvgluBlurRegion(NVGLUblurState * state, NVGcontext * ctx, NVGLUframebuffer *
 
     // Save GL state that we modify
     GLint prev_program = 0, prev_fbo = 0, prev_vbo = 0, prev_tex = 0;
+    GLint prev_active_tex = 0;
     GLint prev_viewport[4] = {0};
     GLboolean prev_blend, prev_scissor, prev_depth, prev_stencil, prev_cull;
     GLboolean prev_colormask[4];
+#if NVGLU_BLUR_NEEDS_VAO
+    GLint prev_vao = 0;
+    glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &prev_vao);
+#endif
     glGetIntegerv(GL_CURRENT_PROGRAM, &prev_program);
     glGetIntegerv(GL_FRAMEBUFFER_BINDING, &prev_fbo);
     glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &prev_vbo);
+    glGetIntegerv(GL_ACTIVE_TEXTURE, &prev_active_tex);
     glGetIntegerv(GL_TEXTURE_BINDING_2D, &prev_tex);
     glGetIntegerv(GL_VIEWPORT, prev_viewport);
     prev_blend = glIsEnabled(GL_BLEND);
@@ -675,10 +681,11 @@ int nvgluBlurRegion(NVGLUblurState * state, NVGcontext * ctx, NVGLUframebuffer *
     glDisableVertexAttribArray((GLuint)state->attr_pos);
     glDisableVertexAttribArray((GLuint)state->attr_uv);
 #if NVGLU_BLUR_NEEDS_VAO
-    glBindVertexArray(0);
+    glBindVertexArray((GLuint)prev_vao);
 #endif
     glUseProgram((GLuint)prev_program);
     glBindBuffer(GL_ARRAY_BUFFER, (GLuint)prev_vbo);
+    glActiveTexture((GLenum)prev_active_tex);
     glBindTexture(GL_TEXTURE_2D, (GLuint)prev_tex);
     glBindFramebuffer(GL_FRAMEBUFFER, (GLuint)prev_fbo);
     glViewport(prev_viewport[0], prev_viewport[1], prev_viewport[2], prev_viewport[3]);

--- a/src/libs/nanovg/nanovg_gl_utils.h
+++ b/src/libs/nanovg/nanovg_gl_utils.h
@@ -40,6 +40,36 @@ void nvgluBindFramebuffer(NVGLUframebuffer * fb);
 NVGLUframebuffer * nvgluCreateFramebuffer(NVGcontext * ctx, int w, int h, int imageFlags, int format);
 void nvgluDeleteFramebuffer(NVGLUframebuffer * fb);
 
+// ---- Blur utilities ----
+
+// Quality hint for blur operations
+enum NVGLUblurQuality {
+    NVGLU_BLUR_QUALITY_SPEED  = 0,  // Fewer taps, faster
+    NVGLU_BLUR_QUALITY_NORMAL = 1,  // Full taps, better quality
+};
+
+// Parameters for nvgluBlurRegion
+typedef struct NVGLUblurParams {
+    int radius;                     // Blur radius in pixels (clamped to internal max)
+    int quality;                    // NVGLUblurQuality
+    NVGcolor recolor;               // If recolor.a > 0, apply as tint (for drop shadows)
+} NVGLUblurParams;
+
+// Opaque blur state handle (created/destroyed per draw unit lifetime)
+typedef struct NVGLUblurState NVGLUblurState;
+
+// Create/destroy blur state (shader program, VBO, scratch resources)
+NVGLUblurState * nvgluCreateBlurState(void);
+void nvgluDeleteBlurState(NVGLUblurState * state, NVGcontext * ctx);
+
+// Blur a rectangular region of the given framebuffer in-place.
+// If fb is NULL, operates on the default (screen) framebuffer via texture copy.
+// The region (x, y, w, h) is in GL coordinates (origin at bottom-left).
+// Returns 0 on success, -1 on failure.
+int nvgluBlurRegion(NVGLUblurState * state, NVGcontext * ctx, NVGLUframebuffer * fb,
+                    int x, int y, int w, int h,
+                    const NVGLUblurParams * params);
+
 #endif // NANOVG_GL_UTILS_H
 
 #ifdef NANOVG_GL_IMPLEMENTATION
@@ -157,6 +187,407 @@ void nvgluDeleteFramebuffer(NVGLUframebuffer * fb)
     lv_free(fb);
 #else
     NVG_NOTUSED(fb);
+#endif
+}
+
+// ---- Blur implementation ----
+
+#define NVGLU_BLUR_MAX_TAPS   16
+#define NVGLU_BLUR_MAX_RADIUS 256
+
+// GL3/GLES3 need VAO
+#if defined(NANOVG_GL3) || defined(NANOVG_GLES3)
+    #define NVGLU_BLUR_NEEDS_VAO 1
+#else
+    #define NVGLU_BLUR_NEEDS_VAO 0
+#endif
+
+// GLSL version prologues
+#if defined(NANOVG_GL3)
+#define NVGLU_BLUR_VS_HEADER \
+    "#version 130\n" \
+    "#define attribute in\n" \
+    "#define varying out\n"
+#define NVGLU_BLUR_FS_HEADER \
+    "#version 130\n" \
+    "#define varying in\n" \
+    "#define texture2D texture\n" \
+    "out vec4 nvglu_frag_out;\n" \
+    "#define gl_FragColor nvglu_frag_out\n"
+#elif defined(NANOVG_GLES3)
+#define NVGLU_BLUR_VS_HEADER \
+    "#version 300 es\n" \
+    "#define attribute in\n" \
+    "#define varying out\n"
+#define NVGLU_BLUR_FS_HEADER \
+    "#version 300 es\n" \
+    "precision mediump float;\n" \
+    "#define varying in\n" \
+    "#define texture2D texture\n" \
+    "out vec4 nvglu_frag_out;\n" \
+    "#define gl_FragColor nvglu_frag_out\n"
+#elif defined(NANOVG_GLES2)
+#define NVGLU_BLUR_VS_HEADER ""
+#define NVGLU_BLUR_FS_HEADER "precision mediump float;\n"
+#else // GL2
+#define NVGLU_BLUR_VS_HEADER ""
+#define NVGLU_BLUR_FS_HEADER ""
+#endif
+
+struct NVGLUblurState {
+    GLuint program;
+    GLuint vbo;
+#if NVGLU_BLUR_NEEDS_VAO
+    GLuint vao;
+#endif
+    GLint loc_tex;
+    GLint loc_step;
+    GLint loc_tap_count;
+    GLint loc_weights;
+    GLint loc_src_uv;
+    GLint loc_recolor;
+    GLint attr_pos;
+    GLint attr_uv;
+    int   program_ok;
+
+    NVGLUframebuffer * scratch_fb;
+    int scratch_w;
+    int scratch_h;
+
+    GLuint capture_tex;
+    int capture_w;
+    int capture_h;
+};
+
+static const char * nvglu__blur_vs_src =
+    NVGLU_BLUR_VS_HEADER
+    "attribute vec2 a_pos;\n"
+    "attribute vec2 a_uv;\n"
+    "varying vec2 v_uv;\n"
+    "void main() {\n"
+    "    v_uv = a_uv;\n"
+    "    gl_Position = vec4(a_pos, 0.0, 1.0);\n"
+    "}\n";
+
+static const char * nvglu__blur_fs_src =
+    NVGLU_BLUR_FS_HEADER
+    "uniform sampler2D u_tex;\n"
+    "uniform vec2 u_step;\n"
+    "uniform vec4 u_src_uv;\n"
+    "uniform vec4 u_recolor;\n"
+    "uniform int u_tap_count;\n"
+    "uniform float u_weights[17];\n"
+    "varying vec2 v_uv;\n"
+    "void main() {\n"
+    "    vec2 base = u_src_uv.xy + v_uv * u_src_uv.zw;\n"
+    "    vec4 sum = texture2D(u_tex, base) * u_weights[0];\n"
+    "    for(int i = 1; i <= 16; i++) {\n"
+    "        if(i > u_tap_count) break;\n"
+    "        vec2 off = u_step * float(i);\n"
+    "        sum += texture2D(u_tex, base + off) * u_weights[i];\n"
+    "        sum += texture2D(u_tex, base - off) * u_weights[i];\n"
+    "    }\n"
+    "    if(u_recolor.a > 0.5) {\n"
+    "        sum = vec4(u_recolor.rgb * sum.a, sum.a);\n"
+    "    }\n"
+    "    gl_FragColor = sum;\n"
+    "}\n";
+
+static const float nvglu__blur_quad[] = {
+    -1.0f, -1.0f, 0.0f, 0.0f,
+    1.0f, -1.0f, 1.0f, 0.0f,
+    -1.0f,  1.0f, 0.0f, 1.0f,
+    1.0f,  1.0f, 1.0f, 1.0f,
+};
+
+static GLuint nvglu__compile_shader(GLenum type, const char * src)
+{
+    GLuint sh = glCreateShader(type);
+    glShaderSource(sh, 1, &src, NULL);
+    glCompileShader(sh);
+    GLint compiled = 0;
+    glGetShaderiv(sh, GL_COMPILE_STATUS, &compiled);
+    if(!compiled) {
+        glDeleteShader(sh);
+        return 0;
+    }
+    return sh;
+}
+
+static int nvglu__ensure_program(NVGLUblurState * s)
+{
+    if(s->program_ok) return 1;
+    if(s->program != 0) return 0;
+
+    GLuint vs = nvglu__compile_shader(GL_VERTEX_SHADER, nvglu__blur_vs_src);
+    GLuint fs = nvglu__compile_shader(GL_FRAGMENT_SHADER, nvglu__blur_fs_src);
+    if(vs == 0 || fs == 0) {
+        if(vs) glDeleteShader(vs);
+        if(fs) glDeleteShader(fs);
+        return 0;
+    }
+
+    GLuint prog = glCreateProgram();
+    glAttachShader(prog, vs);
+    glAttachShader(prog, fs);
+    glLinkProgram(prog);
+    glDeleteShader(vs);
+    glDeleteShader(fs);
+
+    GLint linked = 0;
+    glGetProgramiv(prog, GL_LINK_STATUS, &linked);
+    if(!linked) {
+        glDeleteProgram(prog);
+        return 0;
+    }
+
+    s->program       = prog;
+    s->loc_tex       = glGetUniformLocation(prog, "u_tex");
+    s->loc_step      = glGetUniformLocation(prog, "u_step");
+    s->loc_src_uv    = glGetUniformLocation(prog, "u_src_uv");
+    s->loc_recolor   = glGetUniformLocation(prog, "u_recolor");
+    s->loc_tap_count = glGetUniformLocation(prog, "u_tap_count");
+    s->loc_weights   = glGetUniformLocation(prog, "u_weights[0]");
+    if(s->loc_weights < 0) s->loc_weights = glGetUniformLocation(prog, "u_weights");
+    s->attr_pos      = glGetAttribLocation(prog, "a_pos");
+    s->attr_uv       = glGetAttribLocation(prog, "a_uv");
+
+    glGenBuffers(1, &s->vbo);
+    glBindBuffer(GL_ARRAY_BUFFER, s->vbo);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(nvglu__blur_quad), nvglu__blur_quad, GL_STATIC_DRAW);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+#if NVGLU_BLUR_NEEDS_VAO
+    glGenVertexArrays(1, &s->vao);
+#endif
+
+    s->program_ok = 1;
+    return 1;
+}
+
+static void nvglu__ensure_scratch(NVGLUblurState * s, NVGcontext * ctx, int w, int h)
+{
+    if(s->scratch_fb && s->scratch_w == w && s->scratch_h == h) return;
+    if(s->scratch_fb) {
+        nvgluDeleteFramebuffer(s->scratch_fb);
+        s->scratch_fb = NULL;
+    }
+    s->scratch_fb = nvgluCreateFramebuffer(ctx, w, h, 0, NVG_TEXTURE_RGBA);
+    s->scratch_w = s->scratch_fb ? w : 0;
+    s->scratch_h = s->scratch_fb ? h : 0;
+}
+
+static void nvglu__ensure_capture(NVGLUblurState * s, int w, int h)
+{
+    if(s->capture_tex && s->capture_w == w && s->capture_h == h) return;
+    if(!s->capture_tex) glGenTextures(1, &s->capture_tex);
+    glBindTexture(GL_TEXTURE_2D, s->capture_tex);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    s->capture_w = w;
+    s->capture_h = h;
+}
+
+static void nvglu__compute_weights(int radius, int tap_count, int step_px, float * weights)
+{
+    float sigma = (float)radius / 3.0f;
+    if(sigma < 1.0f) sigma = 1.0f;
+    float inv2s2 = 1.0f / (2.0f * sigma * sigma);
+    float total = 0.0f;
+    int i;
+    for(i = 0; i <= NVGLU_BLUR_MAX_TAPS; i++) {
+        if(i > tap_count) {
+            weights[i] = 0.0f;
+            continue;
+        }
+        float x = (float)(i * step_px);
+        float w = expf(-x * x * inv2s2);
+        weights[i] = w;
+        total += (i == 0) ? w : (2.0f * w);
+    }
+    if(total > 0.0f) {
+        float inv = 1.0f / total;
+        for(i = 0; i <= NVGLU_BLUR_MAX_TAPS; i++) weights[i] *= inv;
+    }
+}
+
+NVGLUblurState * nvgluCreateBlurState(void)
+{
+#ifdef NANOVG_FBO_VALID
+    NVGLUblurState * s = (NVGLUblurState *)lv_malloc_zeroed(sizeof(NVGLUblurState));
+    return s;
+#else
+    return NULL;
+#endif
+}
+
+void nvgluDeleteBlurState(NVGLUblurState * state, NVGcontext * ctx)
+{
+#ifdef NANOVG_FBO_VALID
+    NVG_NOTUSED(ctx);
+    if(!state) return;
+    if(state->scratch_fb) nvgluDeleteFramebuffer(state->scratch_fb);
+    if(state->capture_tex) glDeleteTextures(1, &state->capture_tex);
+    if(state->program) glDeleteProgram(state->program);
+    if(state->vbo) glDeleteBuffers(1, &state->vbo);
+#if NVGLU_BLUR_NEEDS_VAO
+    if(state->vao) glDeleteVertexArrays(1, &state->vao);
+#endif
+    lv_free(state);
+#else
+    NVG_NOTUSED(state);
+    NVG_NOTUSED(ctx);
+#endif
+}
+
+int nvgluBlurRegion(NVGLUblurState * state, NVGcontext * ctx, NVGLUframebuffer * fb,
+                    int x, int y, int w, int h,
+                    const NVGLUblurParams * params)
+{
+#ifdef NANOVG_FBO_VALID
+    if(!state || !ctx || w <= 0 || h <= 0) return -1;
+
+    int radius = params->radius;
+    if(radius <= 0) return 0;
+    if(radius > NVGLU_BLUR_MAX_RADIUS) radius = NVGLU_BLUR_MAX_RADIUS;
+
+    if(!nvglu__ensure_program(state)) return -1;
+    nvglu__ensure_scratch(state, ctx, w, h);
+    if(!state->scratch_fb) return -1;
+
+    int is_root = (fb == NULL);
+    if(is_root) {
+        nvglu__ensure_capture(state, w, h);
+        if(!state->capture_tex) return -1;
+    }
+
+    // Compute kernel
+    int max_taps = (params->quality == NVGLU_BLUR_QUALITY_SPEED) ? 8 : NVGLU_BLUR_MAX_TAPS;
+    int tap_count = radius < max_taps ? radius : max_taps;
+    if(tap_count < 1) tap_count = 1;
+    int step_px = (radius + tap_count - 1) / tap_count;
+    if(step_px < 1) step_px = 1;
+
+    float weights[NVGLU_BLUR_MAX_TAPS + 1];
+    nvglu__compute_weights(radius, tap_count, step_px, weights);
+
+    // Setup GL state
+#if NVGLU_BLUR_NEEDS_VAO
+    glBindVertexArray(state->vao);
+#endif
+    glUseProgram(state->program);
+    glBindBuffer(GL_ARRAY_BUFFER, state->vbo);
+    glEnableVertexAttribArray((GLuint)state->attr_pos);
+    glVertexAttribPointer((GLuint)state->attr_pos, 2, GL_FLOAT, GL_FALSE, sizeof(float) * 4, (const void *)0);
+    glEnableVertexAttribArray((GLuint)state->attr_uv);
+    glVertexAttribPointer((GLuint)state->attr_uv, 2, GL_FLOAT, GL_FALSE, sizeof(float) * 4,
+                          (const void *)(sizeof(float) * 2));
+
+    glActiveTexture(GL_TEXTURE0);
+    glUniform1i(state->loc_tex, 0);
+    glUniform1i(state->loc_tap_count, tap_count);
+    glUniform1fv(state->loc_weights, NVGLU_BLUR_MAX_TAPS + 1, weights);
+
+    glDisable(GL_BLEND);
+    glDisable(GL_STENCIL_TEST);
+    glDisable(GL_DEPTH_TEST);
+    glDisable(GL_CULL_FACE);
+    glDisable(GL_SCISSOR_TEST);
+    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+
+    // Determine source texture
+    GLuint src_tex;
+    int src_tex_w, src_tex_h;
+    float uv_ox, uv_oy, uv_sx, uv_sy;
+
+    if(is_root) {
+        glBindTexture(GL_TEXTURE_2D, state->capture_tex);
+        glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, x, y, w, h);
+        src_tex = state->capture_tex;
+        src_tex_w = state->capture_w;
+        src_tex_h = state->capture_h;
+        uv_ox = 0.0f;
+        uv_oy = 0.0f;
+        uv_sx = (float)w / (float)src_tex_w;
+        uv_sy = (float)h / (float)src_tex_h;
+    }
+    else {
+        src_tex = fb->texture;
+        src_tex_w = w; // caller provides region size
+        src_tex_h = h;
+        // fb may be larger; compute UV from full FBO size via image query
+        int iw = 0, ih = 0;
+        nvgImageSize(ctx, fb->image, &iw, &ih);
+        if(iw <= 0) iw = w;
+        if(ih <= 0) ih = h;
+        src_tex_w = iw;
+        src_tex_h = ih;
+        uv_ox = (float)x / (float)src_tex_w;
+        uv_oy = (float)y / (float)src_tex_h;
+        uv_sx = (float)w / (float)src_tex_w;
+        uv_sy = (float)h / (float)src_tex_h;
+    }
+
+    GLuint scratch_tex = state->scratch_fb->texture;
+
+    // Pass 1: src -> scratch (horizontal)
+    nvgluBindFramebuffer(state->scratch_fb);
+    glViewport(0, 0, w, h);
+    glBindTexture(GL_TEXTURE_2D, src_tex);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glUniform4f(state->loc_src_uv, uv_ox, uv_oy, uv_sx, uv_sy);
+    glUniform4f(state->loc_recolor, 0.0f, 0.0f, 0.0f, 0.0f);
+    glUniform2f(state->loc_step, (float)step_px / (float)src_tex_w, 0.0f);
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+    // Pass 2: scratch -> dst (vertical)
+    if(is_root) {
+        nvgluBindFramebuffer(NULL);
+    }
+    else {
+        nvgluBindFramebuffer(fb);
+    }
+    glViewport(x, y, w, h);
+    glBindTexture(GL_TEXTURE_2D, scratch_tex);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glUniform4f(state->loc_src_uv, 0.0f, 0.0f,
+                (float)w / (float)state->scratch_w,
+                (float)h / (float)state->scratch_h);
+    if(params->recolor.ch.a > 0.0f) {
+        glUniform4f(state->loc_recolor, params->recolor.ch.r, params->recolor.ch.g, params->recolor.ch.b, 1.0f);
+    }
+    else {
+        glUniform4f(state->loc_recolor, 0.0f, 0.0f, 0.0f, 0.0f);
+    }
+    glUniform2f(state->loc_step, 0.0f, (float)step_px / (float)state->scratch_h);
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+    // Restore
+    glDisableVertexAttribArray((GLuint)state->attr_pos);
+    glDisableVertexAttribArray((GLuint)state->attr_uv);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    glUseProgram(0);
+#if NVGLU_BLUR_NEEDS_VAO
+    glBindVertexArray(0);
+#endif
+
+    return 0;
+#else
+    NVG_NOTUSED(state);
+    NVG_NOTUSED(ctx);
+    NVG_NOTUSED(fb);
+    NVG_NOTUSED(x);
+    NVG_NOTUSED(y);
+    NVG_NOTUSED(w);
+    NVG_NOTUSED(h);
+    NVG_NOTUSED(params);
+    return -1;
 #endif
 }
 

--- a/src/libs/nanovg/nanovg_gl_utils.h
+++ b/src/libs/nanovg/nanovg_gl_utils.h
@@ -192,6 +192,8 @@ void nvgluDeleteFramebuffer(NVGLUframebuffer * fb)
 
 // ---- Blur implementation ----
 
+#include <math.h>
+
 #define NVGLU_BLUR_MAX_TAPS   16
 #define NVGLU_BLUR_MAX_RADIUS 256
 
@@ -525,7 +527,7 @@ int nvgluBlurRegion(NVGLUblurState * state, NVGcontext * ctx, NVGLUframebuffer *
                     const NVGLUblurParams * params)
 {
 #ifdef NANOVG_FBO_VALID
-    if(!state || !ctx || w <= 0 || h <= 0) return -1;
+    if(!state || !ctx || !params || w <= 0 || h <= 0) return -1;
 
     int radius = params->radius;
     if(radius <= 0) return 0;
@@ -557,6 +559,23 @@ int nvgluBlurRegion(NVGLUblurState * state, NVGcontext * ctx, NVGLUframebuffer *
         if(step_px < 1) step_px = 1;
         tap_count = nvglu__compute_kernel(radius, max_taps, step_px, weights, offsets);
     }
+
+    // Save GL state that we modify
+    GLint prev_program = 0, prev_fbo = 0, prev_vbo = 0, prev_tex = 0;
+    GLint prev_viewport[4] = {0};
+    GLboolean prev_blend, prev_scissor, prev_depth, prev_stencil, prev_cull;
+    GLboolean prev_colormask[4];
+    glGetIntegerv(GL_CURRENT_PROGRAM, &prev_program);
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &prev_fbo);
+    glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &prev_vbo);
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &prev_tex);
+    glGetIntegerv(GL_VIEWPORT, prev_viewport);
+    prev_blend = glIsEnabled(GL_BLEND);
+    prev_scissor = glIsEnabled(GL_SCISSOR_TEST);
+    prev_depth = glIsEnabled(GL_DEPTH_TEST);
+    prev_stencil = glIsEnabled(GL_STENCIL_TEST);
+    prev_cull = glIsEnabled(GL_CULL_FACE);
+    glGetBooleanv(GL_COLOR_WRITEMASK, prev_colormask);
 
     // Setup GL state
 #if NVGLU_BLUR_NEEDS_VAO
@@ -652,15 +671,28 @@ int nvgluBlurRegion(NVGLUblurState * state, NVGcontext * ctx, NVGLUframebuffer *
     glUniform2f(state->loc_step, 0.0f, 1.0f / (float)state->scratch_h);
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
-    // Restore
+    // Restore GL state
     glDisableVertexAttribArray((GLuint)state->attr_pos);
     glDisableVertexAttribArray((GLuint)state->attr_uv);
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-    glBindTexture(GL_TEXTURE_2D, 0);
-    glUseProgram(0);
 #if NVGLU_BLUR_NEEDS_VAO
     glBindVertexArray(0);
 #endif
+    glUseProgram((GLuint)prev_program);
+    glBindBuffer(GL_ARRAY_BUFFER, (GLuint)prev_vbo);
+    glBindTexture(GL_TEXTURE_2D, (GLuint)prev_tex);
+    glBindFramebuffer(GL_FRAMEBUFFER, (GLuint)prev_fbo);
+    glViewport(prev_viewport[0], prev_viewport[1], prev_viewport[2], prev_viewport[3]);
+    if(prev_blend) glEnable(GL_BLEND);
+    else glDisable(GL_BLEND);
+    if(prev_scissor) glEnable(GL_SCISSOR_TEST);
+    else glDisable(GL_SCISSOR_TEST);
+    if(prev_depth) glEnable(GL_DEPTH_TEST);
+    else glDisable(GL_DEPTH_TEST);
+    if(prev_stencil) glEnable(GL_STENCIL_TEST);
+    else glDisable(GL_STENCIL_TEST);
+    if(prev_cull) glEnable(GL_CULL_FACE);
+    else glDisable(GL_CULL_FACE);
+    glColorMask(prev_colormask[0], prev_colormask[1], prev_colormask[2], prev_colormask[3]);
 
     return 0;
 #else


### PR DESCRIPTION
## Summary

Add GPU-accelerated blur and drop-shadow rendering to the NanoVG draw backend using a two-pass separable Gaussian shader with FBO ping-pong.

This continues the work started in #10129 by @kisvegabor, reworked based on my architectural review in that PR. The key change is that the blur shader logic has been **pushed down into `nanovg_gl_utils.h`** as a reusable `nvgluBlurRegion()` API, keeping the LVGL porting layer thin and backend-portable.

## Motivation

- Widgets using `blur_backdrop`, `blur_radius`, and `drop_shadow_*` styles had no NanoVG backend support — they were either skipped or fell through to the software renderer (which cannot operate on FBO-backed layers).
- This PR enables frosted-glass effects and shape-accurate drop shadows on GPU-rendered UIs.

## Architecture

```mermaid
flowchart TD
    A["LVGL Draw Task<br/>(LV_DRAW_TASK_TYPE_BLUR)"] --> B
    B["lv_draw_nanovg_blur.c (~140 lines)<br/>• Clip area calculation<br/>• LVGL→GL coord conversion<br/>• Build NVGLUblurParams"] --> C
    C["nvgluBlurRegion() — nanovg_gl_utils.h<br/>• Shader compilation & caching<br/>• Gaussian kernel computation<br/>• FBO ping-pong (grow-only scratch)<br/>• GL state isolation"] --> D
    D["GL/GLES Backend<br/>(GL2 / GL3 / GLES2 / GLES3)"]

    style A fill:#e3f2fd,stroke:#1565c0
    style B fill:#e8f5e9,stroke:#2e7d32
    style C fill:#fff3e0,stroke:#e65100
    style D fill:#f3e5f5,stroke:#6a1b9a
```

### Before vs After (compared to #10129)

```mermaid
flowchart LR
    subgraph "#10129 (original)"
        direction TB
        X1["LVGL blur task"] --> X2["lv_draw_nanovg_blur.c<br/>~600 lines of raw GL"]
        X2 --> X3["glCreateShader / glUseProgram<br/>FBO mgmt / glDrawArrays"]
    end

    subgraph "This PR"
        direction TB
        Y1["LVGL blur task"] --> Y2["lv_draw_nanovg_blur.c<br/>~140 lines (adapter)"]
        Y2 --> Y3["nvgluBlurRegion()<br/>(NanoVG library API)"]
        Y3 --> Y4["GL backend internals"]
    end

    style X2 fill:#ffcdd2
    style Y2 fill:#c8e6c9
    style Y3 fill:#c8e6c9
```

## Changes

| File | Description |
|------|-------------|
| `src/libs/nanovg/nanovg_gl_utils.h` | New `nvgluBlurRegion()` API with shader, FBO management, kernel computation |
| `src/draw/nanovg/lv_draw_nanovg_blur.c` | New file — thin LVGL adapter translating blur tasks to `nvgluBlurRegion()` |
| `src/draw/nanovg/lv_draw_nanovg_private.h` | Add `blur_state` field and blur function declarations |
| `src/draw/nanovg/lv_draw_nanovg.c` | Register blur init/deinit/execute/evaluate, flush draws before layer switch |
| `src/draw/lv_draw.c` | Forward `drop_shadow_color`/`opa` through `blur_dsc` for NanoVG recolor |

## Key Design Decisions

### 1. Blur lives in NanoVG library layer (not LVGL)

As proposed in my review of #10129: raw GL code should not live in the LVGL porting layer. The blur shader, FBO management, and GL state transitions are encapsulated in `nanovg_gl_utils.h`, making future backend ports (Vulkan, Metal) straightforward.

### 2. Two quality modes

| Mode | Taps | Texture Fetches | Use Case |
|------|------|-----------------|----------|
| `NVGLU_BLUR_QUALITY_NORMAL` | 16 discrete | 32 per pass | Default, best visual quality |
| `NVGLU_BLUR_QUALITY_SPEED` | 8 bilinear | 16 per pass | Mobile/embedded, ~2× faster |

Speed mode uses [bilinear tap merging](http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/) — adjacent Gaussian samples are combined into single HW-filtered texture reads.

### 3. Grow-only scratch FBO

The scratch FBO used for ping-pong is only reallocated when a larger size is needed, eliminating per-frame allocation churn when multiple blur regions of varying sizes exist.

### 4. No fallback to SW renderer

The software renderer cannot operate on FBO-backed layers. When blur cannot be performed (no FBO support, radius exceeds 256px limit), the task is skipped with `LV_LOG_WARN` rather than falling back.

### 5. Drop shadow recolor baked into blur pass

NanoVG's image draw path cannot easily recolor a pre-existing FBO. The shadow color is forwarded through `blur_dsc.base.drop_shadow_color` and applied as a tint in the blur shader's final output (premultiplied alpha).

## Testing

### Test case: Backdrop blur

The `lv_example_style_blur` example creates a translucent card with `blur_backdrop=true` and `blur_radius=18` over a gradient background with text. Expected result:
- Text under the card is visibly blurred (unreadable)
- Text outside the card remains sharp
- Card has a frosted-glass appearance with white tint

### Test case: Drop shadow

The `lv_example_style_drop_shadow` example applies a red drop shadow to an arc's indicator part with `drop_shadow_radius=16` and offset `(5, 10)`. Expected result:
- A soft red glow follows the arc's curved shape
- Shadow is offset from the arc indicator
- Shadow color matches `lv_color_hex(0xf44336)`

### Test case: Edge conditions

| Condition | Expected Behavior |
|-----------|-------------------|
| `blur_radius = 0` | No-op, returns immediately |
| `blur_radius > 256` | `LV_LOG_WARN`, task skipped |
| GL2 without FBO extension | `blur_state = NULL`, evaluate rejects task |
| Blur area fully clipped | No-op after intersection check |
| Multiple blur sizes per frame | Grow-only FBO handles without reallocation |

## Commits

1. `feat(draw/nanovg): add blur and dropshadow support` — Base implementation
2. `refactor(draw/nanovg): move blur shader into nanovg_gl_utils` — Architecture cleanup
3. `perf(draw/nanovg): optimize blur with bilinear tap reduction` — Initial bilinear attempt
4. `fix(draw/nanovg): add blur robustness checks` — Edge case handling
5. `fix(draw/nanovg): use discrete kernel for correct blur quality` — Fix visual artifacts
6. `perf(draw/nanovg): add bilinear blur for speed quality mode` — Bilinear as opt-in speed mode

## Related

- #10129 — Original PR by @kisvegabor (this PR supersedes it with architectural improvements)
- [Efficient Gaussian Blur with Linear Sampling](http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/) — Bilinear optimization reference

## Checklist

- [x] Code formatted with `scripts/code-format.py`
- [x] Builds clean with `-Wall -Wextra` (no new warnings)
- [x] Tested on GLES2 backend (PC simulator with SDL + EGL)
- [x] `lv_example_style_blur` renders correctly
- [x] `lv_example_style_drop_shadow` renders correctly
- [x] `lv_demo_widgets` renders without regressions
- [ ] Tested on GLES3 / GL3 backend
- [ ] Tested on actual embedded hardware
- [ ] Screenshot comparison tests (requires test infrastructure)


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
