### PR TITLE
feat(draw/buf): poison draw buffers before freeing to detect UAF

### DIFF
--- a/include/lvgl/draw/lv_image_dsc.h
+++ b/include/lvgl/draw/lv_image_dsc.h
@@ -25,6 +25,17 @@ extern "C" {
 #define LV_IMAGE_HEADER_MAGIC (0x19)
 LV_EXPORT_CONST_INT(LV_IMAGE_HEADER_MAGIC);
 
+/** Magic number for legacy image resources that don't set magic field (v8 compatible).
+ *  `lv_image_src_get_type` accepts this value as a valid image source.
+ */
+#define LV_IMAGE_HEADER_LEGACY (0x00)
+
+/** Magic number set after lv_draw_buf is freed, used to detect use-after-free.
+ *  If `lv_image_src_get_type` sees this value, the buffer has already been destroyed.
+ *  Must be < 0x20 and != LV_IMAGE_HEADER_MAGIC and != LV_IMAGE_HEADER_LEGACY.
+ */
+#define LV_IMAGE_HEADER_DEADBEEF (0x1D)
+
 /**
  * Flags reserved for user, lvgl won't use these bits.
  */

--- a/src/draw/lv_draw_buf.c
+++ b/src/draw/lv_draw_buf.c
@@ -347,9 +347,16 @@ void lv_draw_buf_destroy(lv_draw_buf_t * draw_buf)
     LV_PROFILER_DRAW_BEGIN;
     if(lv_draw_buf_has_flag(draw_buf, LV_IMAGE_FLAGS_ALLOCATED)) {
         LV_ASSERT_NULL(draw_buf->handlers);
+        LV_ASSERT_FORMAT_MSG(draw_buf->header.magic == LV_IMAGE_HEADER_MAGIC,
+                             "Invalid draw buf magic: 0x%02X", draw_buf->header.magic);
 
         const lv_draw_buf_handlers_t * handlers = draw_buf->handlers;
         draw_buf_free(handlers, draw_buf->unaligned_data);
+        draw_buf->unaligned_data = NULL;
+        draw_buf->data = NULL;
+
+        /*Poison the magic before freeing so UAF access can be detected*/
+        draw_buf->header.magic = LV_IMAGE_HEADER_DEADBEEF;
         lv_free(draw_buf);
     }
     else {

--- a/src/draw/lv_draw_image.c
+++ b/src/draw/lv_draw_image.c
@@ -193,19 +193,31 @@ void lv_draw_image(lv_layer_t * layer, const lv_draw_image_dsc_t * dsc, const lv
 
 lv_image_src_t lv_image_src_get_type(const void * src)
 {
-    if(src == NULL) return LV_IMAGE_SRC_UNKNOWN;
-    const uint8_t * u8_p = src;
+    if(src == NULL) {
+        return LV_IMAGE_SRC_UNKNOWN;
+    }
+
+    const uint8_t first_byte = *(const uint8_t *)src;
 
     /*The first byte shows the type of the image source*/
-    if(u8_p[0] >= 0x20 && u8_p[0] <= 0x7F) {
+    if(first_byte >= 0x20 && first_byte <= 0x7F) {
         return LV_IMAGE_SRC_FILE; /*If it's an ASCII character then it's file name*/
     }
-    else if(u8_p[0] >= 0x80) {
+
+    if(first_byte >= 0x80) {
         return LV_IMAGE_SRC_SYMBOL; /*Symbols begins after 0x7F*/
     }
-    else {
-        return LV_IMAGE_SRC_VARIABLE; /*`lv_image_dsc_t` is draw to the first byte < 0x20*/
+
+    /**
+     * Only LV_IMAGE_HEADER_MAGIC and LV_IMAGE_HEADER_LEGACY are valid.
+     * Any other value indicates a freed or corrupted buffer.
+     */
+    if(first_byte == LV_IMAGE_HEADER_MAGIC || first_byte == LV_IMAGE_HEADER_LEGACY) {
+        return LV_IMAGE_SRC_VARIABLE;
     }
+
+    LV_LOG_ERROR("image src %p invalid magic: 0x%02X", src, first_byte);
+    return LV_IMAGE_SRC_UNKNOWN;
 }
 
 void lv_draw_image_normal_helper(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,

--- a/tests/src/test_cases/test_image_src_get_type.c
+++ b/tests/src/test_cases/test_image_src_get_type.c
@@ -1,0 +1,79 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+
+#include "unity/unity.h"
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+void test_image_src_get_type_null(void)
+{
+    TEST_ASSERT_EQUAL(LV_IMAGE_SRC_UNKNOWN, lv_image_src_get_type(NULL));
+}
+
+void test_image_src_get_type_file(void)
+{
+    TEST_ASSERT_EQUAL(LV_IMAGE_SRC_FILE, lv_image_src_get_type("A:test.png"));
+    TEST_ASSERT_EQUAL(LV_IMAGE_SRC_FILE, lv_image_src_get_type("/path/to/image.bin"));
+    TEST_ASSERT_EQUAL(LV_IMAGE_SRC_FILE, lv_image_src_get_type("S:logo.bmp"));
+}
+
+void test_image_src_get_type_symbol(void)
+{
+    TEST_ASSERT_EQUAL(LV_IMAGE_SRC_SYMBOL, lv_image_src_get_type(LV_SYMBOL_OK));
+    TEST_ASSERT_EQUAL(LV_IMAGE_SRC_SYMBOL, lv_image_src_get_type(LV_SYMBOL_CLOSE));
+}
+
+void test_image_src_get_type_valid_draw_buf(void)
+{
+    lv_draw_buf_t * buf = lv_draw_buf_create(10, 10, LV_COLOR_FORMAT_ARGB8888, LV_STRIDE_AUTO);
+    TEST_ASSERT_NOT_NULL(buf);
+    TEST_ASSERT_EQUAL(LV_IMAGE_SRC_VARIABLE, lv_image_src_get_type(buf));
+    lv_draw_buf_destroy(buf);
+}
+
+void test_image_src_get_type_legacy_no_magic(void)
+{
+    /*Legacy image resources with LV_IMAGE_HEADER_LEGACY should still be accepted*/
+    lv_image_dsc_t fake_dsc;
+    lv_memzero(&fake_dsc, sizeof(fake_dsc));
+    fake_dsc.header.magic = LV_IMAGE_HEADER_LEGACY;
+    fake_dsc.header.cf = LV_COLOR_FORMAT_ARGB8888;
+    fake_dsc.header.w = 10;
+    fake_dsc.header.h = 10;
+    fake_dsc.data_size = 10 * 10 * 4;
+    TEST_ASSERT_EQUAL(LV_IMAGE_SRC_VARIABLE, lv_image_src_get_type(&fake_dsc));
+}
+
+void test_image_src_get_type_deadbeef_magic(void)
+{
+    lv_image_dsc_t fake_dsc;
+    lv_memzero(&fake_dsc, sizeof(fake_dsc));
+    fake_dsc.header.magic = LV_IMAGE_HEADER_DEADBEEF;
+    fake_dsc.header.cf = LV_COLOR_FORMAT_ARGB8888;
+    fake_dsc.header.w = 10;
+    fake_dsc.header.h = 10;
+    fake_dsc.data_size = 10 * 10 * 4;
+    TEST_ASSERT_EQUAL(LV_IMAGE_SRC_UNKNOWN, lv_image_src_get_type(&fake_dsc));
+}
+
+void test_image_src_get_type_destroyed_draw_buf(void)
+{
+    lv_draw_buf_t * buf = lv_draw_buf_create(10, 10, LV_COLOR_FORMAT_ARGB8888, LV_STRIDE_AUTO);
+    TEST_ASSERT_NOT_NULL(buf);
+    TEST_ASSERT_EQUAL(LV_IMAGE_SRC_VARIABLE, lv_image_src_get_type(buf));
+
+    /*Simulate the poisoned state*/
+    lv_draw_buf_t buf_copy = *buf;
+    lv_draw_buf_destroy(buf);
+
+    buf_copy.header.magic = LV_IMAGE_HEADER_DEADBEEF;
+    TEST_ASSERT_EQUAL(LV_IMAGE_SRC_UNKNOWN, lv_image_src_get_type(&buf_copy));
+}
+
+#endif


### PR DESCRIPTION
1. Add a magic check to `lv_image_src_get_type`.
2. Set a null pointer and poison the pointer when freeing `draw_buf`.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
