### PR TITLE
feat(dma2d): add warning if buffers are not well aligned

### DIFF
--- a/src/draw/dma2d/lv_draw_dma2d.c
+++ b/src/draw/dma2d/lv_draw_dma2d.c
@@ -157,6 +157,41 @@ uint32_t lv_draw_dma2d_color_to_dma2d_color(lv_draw_dma2d_output_cf_t cf, lv_col
 
 void lv_draw_dma2d_configure_and_start_transfer(const lv_draw_dma2d_configuration_t * conf)
 {
+    /* Check that addresses are valid regarding to alignment constraints */
+    if(((conf->output_cf == LV_DRAW_DMA2D_OUTPUT_CF_ARGB8888) &&
+        (((uint32_t)(lv_uintptr_t) conf->output_address) & 0x03)) ||
+       ((conf->output_cf == LV_DRAW_DMA2D_OUTPUT_CF_RGB888) &&
+        (((uint32_t)(lv_uintptr_t) conf->output_address) & 0x03)) ||
+       ((conf->output_cf == LV_DRAW_DMA2D_OUTPUT_CF_RGB565) &&
+        (((uint32_t)(lv_uintptr_t) conf->output_address) & 0x01)) ||
+       ((conf->output_cf == LV_DRAW_DMA2D_OUTPUT_CF_ARGB1555) &&
+        (((uint32_t)(lv_uintptr_t) conf->output_address) & 0x01))) {
+        LV_LOG_WARN("Incompatible output address %p and format 0x%x",
+                    conf->output_address, conf->output_cf);
+    }
+    if(((conf->fg_cf == LV_DRAW_DMA2D_FGBG_CF_ARGB8888) &&
+        (((uint32_t)(lv_uintptr_t) conf->fg_address) & 0x03)) ||
+       ((conf->fg_cf == LV_DRAW_DMA2D_FGBG_CF_RGB888) &&
+        (((uint32_t)(lv_uintptr_t) conf->fg_address) & 0x03)) ||
+       ((conf->fg_cf == LV_DRAW_DMA2D_FGBG_CF_RGB565) &&
+        (((uint32_t)(lv_uintptr_t) conf->fg_address) & 0x01)) ||
+       ((conf->fg_cf == LV_DRAW_DMA2D_FGBG_CF_ARGB1555) &&
+        (((uint32_t)(lv_uintptr_t) conf->fg_address) & 0x01))) {
+        LV_LOG_WARN("Incompatible foreground address %p and format 0x%x",
+                    conf->fg_address, conf->fg_cf);
+    }
+    if(((conf->bg_cf == LV_DRAW_DMA2D_FGBG_CF_ARGB8888) &&
+        (((uint32_t)(lv_uintptr_t) conf->bg_address) & 0x03)) ||
+       ((conf->bg_cf == LV_DRAW_DMA2D_FGBG_CF_RGB888) &&
+        (((uint32_t)(lv_uintptr_t) conf->bg_address) & 0x03)) ||
+       ((conf->bg_cf == LV_DRAW_DMA2D_FGBG_CF_RGB565) &&
+        (((uint32_t)(lv_uintptr_t) conf->bg_address) & 0x01)) ||
+       ((conf->bg_cf == LV_DRAW_DMA2D_FGBG_CF_ARGB1555) &&
+        (((uint32_t)(lv_uintptr_t) conf->bg_address) & 0x01))) {
+        LV_LOG_WARN("Incompatible background address %p and format 0x%x",
+                    conf->bg_address, conf->bg_cf);
+    }
+
     /* number of lines register */
     DMA2D->NLR = (conf->w << DMA2D_NLR_PL_Pos) | (conf->h << DMA2D_NLR_NL_Pos);
 


### PR DESCRIPTION
Add runtime warning message if a buffer is not well aligned in order to be rendered by the DMA2D.

Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
