### PR TITLE
fix(dma2d): fix the way end of dispatch is being handled

### DIFF
--- a/src/draw/dma2d/lv_draw_dma2d.c
+++ b/src/draw/dma2d/lv_draw_dma2d.c
@@ -37,9 +37,6 @@ static int32_t delete_cb(lv_draw_unit_t * draw_unit);
 #if LV_DRAW_DMA2D_ASYNC
     static int32_t wait_finish_cb(lv_draw_unit_t * u);
 #endif
-#if !LV_DRAW_DMA2D_ASYNC
-    static bool check_transfer_completion(void);
-#endif
 static void post_transfer_tasks(lv_draw_dma2d_unit_t * u);
 
 /**********************
@@ -285,15 +282,8 @@ static int32_t dispatch_cb(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
     lv_draw_dma2d_unit_t * draw_dma2d_unit = (lv_draw_dma2d_unit_t *) draw_unit;
 
     if(draw_dma2d_unit->task_act) {
-#if LV_DRAW_DMA2D_ASYNC
         /*Return immediately if it's busy with draw task*/
         return LV_DRAW_UNIT_IDLE;
-#else
-        if(!check_transfer_completion()) {
-            return LV_DRAW_UNIT_IDLE;
-        }
-        post_transfer_tasks(draw_dma2d_unit);
-#endif
     }
 
     lv_draw_task_t * t = lv_draw_get_available_task(layer, NULL, DRAW_UNIT_ID_DMA2D);
@@ -353,9 +343,17 @@ static int32_t dispatch_cb(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
         }
     }
 
+#if LV_DRAW_DMA2D_ASYNC
+    return LV_DRAW_UNIT_IDLE;
+#else
+    while(DMA2D->CR & DMA2D_CR_START);
+
+    post_transfer_tasks(draw_dma2d_unit);
+
     lv_draw_dispatch_request();
 
     return 1;
+#endif
 }
 
 static int32_t delete_cb(lv_draw_unit_t * draw_unit)
@@ -376,13 +374,6 @@ static int32_t wait_finish_cb(lv_draw_unit_t * draw_unit)
     return 0;
 }
 #endif /*LV_DRAW_DMA2D_ASYNC*/
-
-#if !LV_DRAW_DMA2D_ASYNC
-static bool check_transfer_completion(void)
-{
-    return !(DMA2D->CR & DMA2D_CR_START);
-}
-#endif
 
 static void post_transfer_tasks(lv_draw_dma2d_unit_t * u)
 {

--- a/src/draw/dma2d/lv_draw_dma2d.c
+++ b/src/draw/dma2d/lv_draw_dma2d.c
@@ -366,6 +366,9 @@ static int32_t wait_finish_cb(lv_draw_unit_t * draw_unit)
 {
     lv_draw_dma2d_unit_t * u = (lv_draw_dma2d_unit_t *) draw_unit;
 
+    /* No need to wait if the DMA2D doesn't have task to complete */
+    if(u->task_act == NULL) return 0;
+
     /* If a DMA2D task has been dispatched, wait its interrupt */
     lv_thread_sync_wait(&u->interrupt_signal);
 


### PR DESCRIPTION
Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
