### PR TITLE
feat(dma2d): enable ASYNC/INTERRUPT with ZephyrOS

### DIFF
--- a/src/draw/dma2d/lv_draw_dma2d.c
+++ b/src/draw/dma2d/lv_draw_dma2d.c
@@ -13,6 +13,11 @@
 #include "../sw/lv_draw_sw.h"
 #include "../../misc/lv_area_private.h"
 
+#if defined(__ZEPHYR__) && LV_USE_DRAW_DMA2D_INTERRUPT
+    #include <zephyr/kernel.h>
+    #include <zephyr/irq.h>
+#endif
+
 #if !LV_DRAW_DMA2D_ASYNC && LV_USE_DRAW_DMA2D_INTERRUPT
     #warning LV_USE_DRAW_DMA2D_INTERRUPT is 1 but has no effect because LV_USE_OS is LV_OS_NONE
 #endif
@@ -38,6 +43,9 @@ static int32_t delete_cb(lv_draw_unit_t * draw_unit);
     static int32_t wait_finish_cb(lv_draw_unit_t * u);
 #endif
 static void post_transfer_tasks(lv_draw_dma2d_unit_t * u);
+#if defined(__ZEPHYR__) && LV_USE_DRAW_DMA2D_INTERRUPT
+    static void zephyr_dma2d_irq_handler(void *);
+#endif
 
 /**********************
  *  STATIC VARIABLES
@@ -90,8 +98,13 @@ void lv_draw_dma2d_init(void)
     /* disable dead time */
     DMA2D->AMTCR = 0;
 
+#if defined(__ZEPHYR__) && LV_USE_DRAW_DMA2D_INTERRUPT
+    IRQ_CONNECT(DT_IRQN(DT_NODELABEL(dma2d)), DT_IRQ(DT_NODELABEL(dma2d), priority), zephyr_dma2d_irq_handler, NULL, 0);
+    irq_enable(DT_IRQN(DT_NODELABEL(dma2d)));
+#else
     /* enable the interrupt */
     NVIC_EnableIRQ(DMA2D_IRQn);
+#endif
 }
 
 void lv_draw_dma2d_deinit(void)
@@ -263,6 +276,15 @@ void lv_draw_dma2d_clean_cache(const lv_draw_dma2d_cache_area_t * mem_area)
 /**********************
  *   STATIC FUNCTIONS
  **********************/
+#if defined(__ZEPHYR__) && LV_USE_DRAW_DMA2D_INTERRUPT
+static void zephyr_dma2d_irq_handler(void *)
+{
+    /* Clear Transfer Complete flag */
+    DMA2D->IFCR = DMA2D_IFCR_CTCIF;
+
+    lv_draw_dma2d_transfer_complete_interrupt_handler();
+}
+#endif
 
 static int32_t evaluate_cb(lv_draw_unit_t * draw_unit, lv_draw_task_t * task)
 {


### PR DESCRIPTION
Add support for the DMA2D ASYNC mode when running DMA2D on top of ZephyrOS. For that purpose, get the IRQ information from the ZephyrOS dma2d device-tree node.

Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
