### PR TITLE
fix(group): never get defocused event

### DIFF
--- a/src/core/lv_group.c
+++ b/src/core/lv_group.c
@@ -191,20 +191,16 @@ void lv_group_remove_obj(lv_obj_t * obj)
     if(g->obj_focus && *g->obj_focus == obj) {
         if(g->frozen) g->frozen = 0;
 
-        /*If this is the only object in the group then focus to nothing.*/
-        if(lv_ll_get_head(&g->obj_ll) == g->obj_focus && lv_ll_get_tail(&g->obj_ll) == g->obj_focus) {
-            lv_obj_send_event(*g->obj_focus, LV_EVENT_DEFOCUSED, get_indev(g));
-        }
-        /*If there more objects in the group then focus to the next/prev object*/
-        else {
+        /*If there are more objects in the group, try to move focus to the next/prev object*/
+        if(lv_ll_get_head(&g->obj_ll) != g->obj_focus || lv_ll_get_tail(&g->obj_ll) != g->obj_focus) {
             lv_group_refocus(g);
         }
     }
 
-    /*If the focuses object is still the same then it was the only object in the group but it will
-     *be deleted. Set the `obj_focus` to NULL to get back to the initial state of the group with
-     *zero objects*/
+    /*If the focused object is still the one being removed (either it was the only object,
+     *or refocus couldn't find a focusable candidate), defocus it and clear the focus.*/
     if(g->obj_focus && *g->obj_focus == obj) {
+        lv_obj_send_event(*g->obj_focus, LV_EVENT_DEFOCUSED, get_indev(g));
         g->obj_focus = NULL;
     }
 

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -485,13 +485,13 @@ lv_obj_spec_attr_t * lv_obj_allocate_spec_attr(lv_obj_t * obj)
 
 bool lv_obj_check_type(const lv_obj_t * obj, const lv_obj_class_t * class_p)
 {
-    if(obj == NULL) return false;
+    LV_CHECK_ARG(obj != NULL, return false);
     return obj->class_p == class_p;
 }
 
 bool lv_obj_has_class(const lv_obj_t * obj, const lv_obj_class_t * class_p)
 {
-    if(obj == NULL) return false;
+    LV_CHECK_ARG(obj != NULL, return false);
 
     const lv_obj_class_t * obj_class = obj->class_p;
     while(obj_class) {

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -485,13 +485,13 @@ lv_obj_spec_attr_t * lv_obj_allocate_spec_attr(lv_obj_t * obj)
 
 bool lv_obj_check_type(const lv_obj_t * obj, const lv_obj_class_t * class_p)
 {
-    LV_CHECK_ARG(obj != NULL, return false);
+    if(obj == NULL) return false;
     return obj->class_p == class_p;
 }
 
 bool lv_obj_has_class(const lv_obj_t * obj, const lv_obj_class_t * class_p)
 {
-    LV_CHECK_ARG(obj != NULL, return false);
+    if(obj == NULL) return false;
 
     const lv_obj_class_t * obj_class = obj->class_p;
     while(obj_class) {

--- a/tests/src/test_cases/test_group.c
+++ b/tests/src/test_cases/test_group.c
@@ -152,4 +152,39 @@ void test_group_focus_obj_that_was_previously_unfocused(void)
     TEST_ASSERT_EQUAL_UINT32(1U, final_focused_a);
 }
 
+void test_group_remove_focused_obj_sends_defocused_when_others_unfocusable(void)
+{
+    lv_obj_t * screen = lv_screen_active();
+    lv_group_t * group = lv_group_create();
+
+    lv_obj_t * obj_hidden  = lv_obj_create(screen);
+    lv_obj_t * obj_disabled = lv_obj_create(screen);
+    lv_obj_t * obj_focused = lv_obj_create(screen);
+
+    lv_group_add_obj(group, obj_hidden);
+    lv_group_add_obj(group, obj_disabled);
+    lv_group_add_obj(group, obj_focused);
+
+    lv_obj_add_flag(obj_hidden, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_state(obj_disabled, LV_STATE_DISABLED);
+
+    lv_group_focus_obj(obj_focused);
+    TEST_ASSERT_EQUAL_PTR(lv_group_get_focused(group), obj_focused);
+
+    uint32_t defocused_count = 0;
+    lv_obj_add_event_cb(obj_focused, count_defocused_cb, LV_EVENT_DEFOCUSED, &defocused_count);
+
+    lv_group_remove_obj(obj_focused);
+
+    uint32_t final_count = defocused_count;
+
+    lv_obj_delete(obj_hidden);
+    lv_obj_delete(obj_disabled);
+    lv_obj_delete(obj_focused);
+    lv_group_delete(group);
+
+    TEST_ASSERT_EQUAL_UINT32(1U, final_count);
+}
+
+
 #endif

--- a/tests/src/test_cases/test_group.c
+++ b/tests/src/test_cases/test_group.c
@@ -58,13 +58,7 @@ void test_group_obj_by_index(void)
     TEST_ASSERT_EQUAL_PTR(lv_group_get_obj_by_index(group, 1), NULL);
 }
 
-static void count_defocused_cb(lv_event_t * e)
-{
-    uint32_t * counter = lv_event_get_user_data(e);
-    (*counter)++;
-}
-
-static void count_focused_cb(lv_event_t * e)
+static void count_event_cb(lv_event_t * e)
 {
     uint32_t * counter = lv_event_get_user_data(e);
     (*counter)++;
@@ -80,8 +74,8 @@ void test_group_focus_already_focused_obj_sends_no_events(void)
 
     uint32_t focused_count   = 0;
     uint32_t defocused_count = 0;
-    lv_obj_add_event_cb(obj, count_focused_cb,   LV_EVENT_FOCUSED,   &focused_count);
-    lv_obj_add_event_cb(obj, count_defocused_cb, LV_EVENT_DEFOCUSED, &defocused_count);
+    lv_obj_add_event_cb(obj, count_event_cb,   LV_EVENT_FOCUSED,   &focused_count);
+    lv_obj_add_event_cb(obj, count_event_cb, LV_EVENT_DEFOCUSED, &defocused_count);
 
     lv_group_focus_obj(obj);
 
@@ -109,8 +103,8 @@ void test_group_focus_different_obj_sends_correct_events(void)
 
     uint32_t defocused_a = 0;
     uint32_t focused_b   = 0;
-    lv_obj_add_event_cb(obj_a, count_defocused_cb, LV_EVENT_DEFOCUSED, &defocused_a);
-    lv_obj_add_event_cb(obj_b, count_focused_cb,   LV_EVENT_FOCUSED,   &focused_b);
+    lv_obj_add_event_cb(obj_a, count_event_cb, LV_EVENT_DEFOCUSED, &defocused_a);
+    lv_obj_add_event_cb(obj_b, count_event_cb,   LV_EVENT_FOCUSED,   &focused_b);
 
     lv_group_focus_obj(obj_b);
 
@@ -139,7 +133,7 @@ void test_group_focus_obj_that_was_previously_unfocused(void)
     lv_group_focus_obj(obj_b); /* obj_a defocused, obj_b focused */
 
     uint32_t focused_a = 0;
-    lv_obj_add_event_cb(obj_a, count_focused_cb, LV_EVENT_FOCUSED, &focused_a);
+    lv_obj_add_event_cb(obj_a, count_event_cb, LV_EVENT_FOCUSED, &focused_a);
 
     lv_group_focus_obj(obj_a);
 
@@ -172,7 +166,7 @@ void test_group_remove_focused_obj_sends_defocused_when_others_unfocusable(void)
     TEST_ASSERT_EQUAL_PTR(lv_group_get_focused(group), obj_focused);
 
     uint32_t defocused_count = 0;
-    lv_obj_add_event_cb(obj_focused, count_defocused_cb, LV_EVENT_DEFOCUSED, &defocused_count);
+    lv_obj_add_event_cb(obj_focused, count_event_cb, LV_EVENT_DEFOCUSED, &defocused_count);
 
     lv_group_remove_obj(obj_focused);
 
@@ -194,7 +188,7 @@ void test_group_remove_only_focused_obj_sends_defocused(void)
     lv_group_add_obj(group, obj);
 
     uint32_t defocused_count = 0;
-    lv_obj_add_event_cb(obj, count_defocused_cb, LV_EVENT_DEFOCUSED, &defocused_count);
+    lv_obj_add_event_cb(obj, count_event_cb, LV_EVENT_DEFOCUSED, &defocused_count);
 
     lv_group_remove_obj(obj);
 
@@ -222,8 +216,8 @@ void test_group_remove_focused_obj_focuses_previous(void)
 
     uint32_t defocused_count = 0;
     uint32_t prev_focused_count = 0;
-    lv_obj_add_event_cb(obj_focused, count_defocused_cb, LV_EVENT_DEFOCUSED, &defocused_count);
-    lv_obj_add_event_cb(obj_prev,    count_focused_cb,   LV_EVENT_FOCUSED,   &prev_focused_count);
+    lv_obj_add_event_cb(obj_focused, count_event_cb, LV_EVENT_DEFOCUSED, &defocused_count);
+    lv_obj_add_event_cb(obj_prev,    count_event_cb,   LV_EVENT_FOCUSED,   &prev_focused_count);
 
     lv_group_remove_obj(obj_focused);
 
@@ -253,8 +247,8 @@ void test_group_remove_focused_first_obj_focuses_next(void)
 
     uint32_t defocused_count = 0;
     uint32_t next_focused_count = 0;
-    lv_obj_add_event_cb(obj_focused, count_defocused_cb, LV_EVENT_DEFOCUSED, &defocused_count);
-    lv_obj_add_event_cb(obj_next,    count_focused_cb,   LV_EVENT_FOCUSED,   &next_focused_count);
+    lv_obj_add_event_cb(obj_focused, count_event_cb, LV_EVENT_DEFOCUSED, &defocused_count);
+    lv_obj_add_event_cb(obj_next,    count_event_cb,   LV_EVENT_FOCUSED,   &next_focused_count);
 
     lv_group_remove_obj(obj_focused);
 
@@ -283,7 +277,7 @@ void test_group_remove_non_focused_obj_no_focus_events(void)
     lv_group_add_obj(group, obj_other);
 
     uint32_t defocused_count = 0;
-    lv_obj_add_event_cb(obj_focused, count_defocused_cb, LV_EVENT_DEFOCUSED, &defocused_count);
+    lv_obj_add_event_cb(obj_focused, count_event_cb, LV_EVENT_DEFOCUSED, &defocused_count);
 
     lv_group_remove_obj(obj_other);
 

--- a/tests/src/test_cases/test_group.c
+++ b/tests/src/test_cases/test_group.c
@@ -186,5 +186,117 @@ void test_group_remove_focused_obj_sends_defocused_when_others_unfocusable(void)
     TEST_ASSERT_EQUAL_UINT32(1U, final_count);
 }
 
+void test_group_remove_only_focused_obj_sends_defocused(void)
+{
+    lv_group_t * group = lv_group_create();
+    lv_obj_t * obj = lv_obj_create(lv_screen_active());
+
+    lv_group_add_obj(group, obj);
+
+    uint32_t defocused_count = 0;
+    lv_obj_add_event_cb(obj, count_defocused_cb, LV_EVENT_DEFOCUSED, &defocused_count);
+
+    lv_group_remove_obj(obj);
+
+    uint32_t final_defocused = defocused_count;
+    lv_obj_t * focused_after = lv_group_get_focused(group);
+
+    lv_obj_delete(obj);
+    lv_group_delete(group);
+
+    TEST_ASSERT_EQUAL_UINT32(1U, final_defocused);
+    TEST_ASSERT_NULL(focused_after);
+}
+
+void test_group_remove_focused_obj_focuses_previous(void)
+{
+    lv_obj_t * screen = lv_screen_active();
+    lv_group_t * group = lv_group_create();
+
+    lv_obj_t * obj_prev    = lv_obj_create(screen);
+    lv_obj_t * obj_focused = lv_obj_create(screen);
+
+    lv_group_add_obj(group, obj_prev);
+    lv_group_add_obj(group, obj_focused);
+    lv_group_focus_obj(obj_focused);
+
+    uint32_t defocused_count = 0;
+    uint32_t prev_focused_count = 0;
+    lv_obj_add_event_cb(obj_focused, count_defocused_cb, LV_EVENT_DEFOCUSED, &defocused_count);
+    lv_obj_add_event_cb(obj_prev,    count_focused_cb,   LV_EVENT_FOCUSED,   &prev_focused_count);
+
+    lv_group_remove_obj(obj_focused);
+
+    uint32_t final_defocused    = defocused_count;
+    uint32_t final_prev_focused = prev_focused_count;
+    lv_obj_t * focused_after    = lv_group_get_focused(group);
+
+    lv_obj_delete(obj_prev);
+    lv_obj_delete(obj_focused);
+    lv_group_delete(group);
+
+    TEST_ASSERT_EQUAL_UINT32(1U, final_defocused);
+    TEST_ASSERT_EQUAL_UINT32(1U, final_prev_focused);
+    TEST_ASSERT_EQUAL_PTR(obj_prev, focused_after);
+}
+
+void test_group_remove_focused_first_obj_focuses_next(void)
+{
+    lv_obj_t * screen = lv_screen_active();
+    lv_group_t * group = lv_group_create();
+
+    lv_obj_t * obj_focused = lv_obj_create(screen);
+    lv_obj_t * obj_next    = lv_obj_create(screen);
+
+    lv_group_add_obj(group, obj_focused); /* auto-focused as the first object */
+    lv_group_add_obj(group, obj_next);
+
+    uint32_t defocused_count = 0;
+    uint32_t next_focused_count = 0;
+    lv_obj_add_event_cb(obj_focused, count_defocused_cb, LV_EVENT_DEFOCUSED, &defocused_count);
+    lv_obj_add_event_cb(obj_next,    count_focused_cb,   LV_EVENT_FOCUSED,   &next_focused_count);
+
+    lv_group_remove_obj(obj_focused);
+
+    uint32_t final_defocused    = defocused_count;
+    uint32_t final_next_focused = next_focused_count;
+    lv_obj_t * focused_after    = lv_group_get_focused(group);
+
+    lv_obj_delete(obj_focused);
+    lv_obj_delete(obj_next);
+    lv_group_delete(group);
+
+    TEST_ASSERT_EQUAL_UINT32(1U, final_defocused);
+    TEST_ASSERT_EQUAL_UINT32(1U, final_next_focused);
+    TEST_ASSERT_EQUAL_PTR(obj_next, focused_after);
+}
+
+void test_group_remove_non_focused_obj_no_focus_events(void)
+{
+    lv_obj_t * screen = lv_screen_active();
+    lv_group_t * group = lv_group_create();
+
+    lv_obj_t * obj_focused = lv_obj_create(screen);
+    lv_obj_t * obj_other   = lv_obj_create(screen);
+
+    lv_group_add_obj(group, obj_focused); /* auto-focused as the first object */
+    lv_group_add_obj(group, obj_other);
+
+    uint32_t defocused_count = 0;
+    lv_obj_add_event_cb(obj_focused, count_defocused_cb, LV_EVENT_DEFOCUSED, &defocused_count);
+
+    lv_group_remove_obj(obj_other);
+
+    uint32_t final_defocused = defocused_count;
+    lv_obj_t * focused_after = lv_group_get_focused(group);
+
+    lv_obj_delete(obj_focused);
+    lv_obj_delete(obj_other);
+    lv_group_delete(group);
+
+    TEST_ASSERT_EQUAL_UINT32(0U, final_defocused);
+    TEST_ASSERT_EQUAL_PTR(obj_focused, focused_after);
+}
+
 
 #endif


### PR DESCRIPTION
Fixes an edge case when removing an already focused event that is the only focusable in the group, it never gets the defocused event