### PR TITLE
feat(event): add arg checks to public functions

### DIFF
--- a/src/misc/lv_event.c
+++ b/src/misc/lv_event.c
@@ -54,10 +54,7 @@ static lv_event_dsc_t ** event_array_at(lv_event_list_t * list, uint32_t index);
 #if LV_USE_EXT_DATA
 void lv_event_desc_set_external_data(lv_event_dsc_t * dsc, void * data, void (* free_cb)(void * data))
 {
-    if(!dsc) {
-        LV_LOG_WARN("Can't attach external user data and destructor callback to a NULL event descriptor");
-        return;
-    }
+    LV_CHECK_ARG(dsc != NULL, return);
 
     dsc->ext_data.data = data;
     dsc->ext_data.free_cb = free_cb;
@@ -105,6 +102,7 @@ ret:
 lv_result_t lv_event_send(lv_event_list_t * list, lv_event_t * e, bool preprocess)
 {
     if(list == NULL) return LV_RESULT_OK;
+    LV_CHECK_ARG(e != NULL, return LV_RESULT_INVALID);
     if(e->deleted) return LV_RESULT_INVALID;
 
     /* When obj is deleted in its own event, it will cause the `list->array` header to be released,
@@ -156,6 +154,7 @@ lv_result_t lv_event_send(lv_event_list_t * list, lv_event_t * e, bool preproces
 lv_event_dsc_t * lv_event_add(lv_event_list_t * list, lv_event_cb_t cb, lv_event_code_t filter,
                               void * user_data)
 {
+    LV_CHECK_ARG(list != NULL, return NULL);
     lv_event_dsc_t * dsc = lv_malloc(sizeof(lv_event_dsc_t));
     LV_ASSERT_NULL(dsc);
 
@@ -178,8 +177,8 @@ lv_event_dsc_t * lv_event_add(lv_event_list_t * list, lv_event_cb_t cb, lv_event
 
 bool lv_event_remove_dsc(lv_event_list_t * list, lv_event_dsc_t * dsc)
 {
-    LV_ASSERT_NULL(list);
-    LV_ASSERT_NULL(dsc);
+    LV_CHECK_ARG(list != NULL, return false);
+    LV_CHECK_ARG(dsc != NULL, return false);
 
     const uint32_t size = event_array_size(list);
     for(uint32_t i = 0; i < size; i++) {
@@ -202,33 +201,33 @@ bool lv_event_remove_dsc(lv_event_list_t * list, lv_event_dsc_t * dsc)
 
 uint32_t lv_event_get_count(lv_event_list_t * list)
 {
-    LV_ASSERT_NULL(list);
+    LV_CHECK_ARG(list != NULL, return 0);
     return event_array_size(list);
 }
 
 lv_event_dsc_t * lv_event_get_dsc(lv_event_list_t * list, uint32_t index)
 {
-    LV_ASSERT_NULL(list);
+    LV_CHECK_ARG(list != NULL, return NULL);
     lv_event_dsc_t ** dsc = event_array_at(list, index);
     return dsc ? *dsc : NULL;
 }
 
 lv_event_cb_t lv_event_dsc_get_cb(lv_event_dsc_t * dsc)
 {
-    LV_ASSERT_NULL(dsc);
+    LV_CHECK_ARG(dsc != NULL, return NULL);
     return dsc->cb;
 }
 
 void * lv_event_dsc_get_user_data(lv_event_dsc_t * dsc)
 {
-    LV_ASSERT_NULL(dsc);
+    LV_CHECK_ARG(dsc != NULL, return NULL);
     return dsc->user_data;
 
 }
 
 bool lv_event_remove(lv_event_list_t * list, uint32_t index)
 {
-    LV_ASSERT_NULL(list);
+    LV_CHECK_ARG(list != NULL, return false);
     lv_event_dsc_t * dsc = lv_event_get_dsc(list, index);
     if(dsc == NULL) return false;
 #if LV_USE_EXT_DATA
@@ -244,7 +243,7 @@ bool lv_event_remove(lv_event_list_t * list, uint32_t index)
 
 void lv_event_remove_all(lv_event_list_t * list)
 {
-    LV_ASSERT_NULL(list);
+    LV_CHECK_ARG(list != NULL, return);
     const uint32_t size = event_array_size(list);
     for(uint32_t i = 0; i < size; i++) {
 #if LV_USE_EXT_DATA
@@ -262,46 +261,55 @@ void lv_event_remove_all(lv_event_list_t * list)
 
 void * lv_event_get_current_target(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return NULL);
     return e->current_target;
 }
 
 void * lv_event_get_target(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return NULL);
     return e->original_target;
 }
 
 lv_event_code_t lv_event_get_code(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return 0);
     return e->code & ~LV_EVENT_PREPROCESS;
 }
 
 void * lv_event_get_param(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return NULL);
     return e->param;
 }
 
 void * lv_event_get_user_data(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return NULL);
     return e->user_data;
 }
 
 void lv_event_stop_bubbling(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return);
     e->stop_bubbling = 1;
 }
 
 void lv_event_stop_trickling(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return);
     e->stop_trickling = 1;
 }
 
 void lv_event_stop_processing(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return);
     e->stop_processing = 1;
 }
 
 void lv_event_free_user_data_cb(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return);
     void * p = lv_event_get_user_data(e);
     lv_free(p);
 }


### PR DESCRIPTION
## Summary
Add `LV_CHECK_ARG` to all public API functions in `lv_event.c`, replacing hard asserts with graceful returns.

## Public API audit

| Function | Parameter | Action | Reason |
|---|---|---|---|
| `lv_result_t lv_event_send(lv_event_list_t * list, lv_event_t * e, bool preprocess)` | `list` | Pre-existing | `if(list == NULL) return LV_RESULT_OK` was already on master — NULL list is a documented valid use case that returns OK |
| | `e` | Added | No prior guard; dereferencing NULL `e` would crash |
| | `preprocess` | No check needed | `bool` value, not a pointer |
| `lv_event_dsc_t * lv_event_add(lv_event_list_t * list, lv_event_cb_t cb, lv_event_code_t filter, void * user_data)` | `list` | Added | No prior guard; dereferencing NULL `list` would crash |
| | `cb` | NULL is valid — no check | NULL callback is tolerated by design; `lv_event_send` skips entries where `dsc->cb == NULL` |
| | `filter` | No check needed | Enum value, not a pointer |
| | `user_data` | NULL is valid — no check | `void *` user data; NULL is a valid value |
| `bool lv_event_remove_dsc(lv_event_list_t * list, lv_event_dsc_t * dsc)` | `list` | Pre-existing | Replaced `LV_ASSERT_NULL(list)` with `LV_CHECK_ARG` — check existed on master |
| | `dsc` | Pre-existing | Replaced `LV_ASSERT_NULL(dsc)` with `LV_CHECK_ARG` — check existed on master |
| `uint32_t lv_event_get_count(lv_event_list_t * list)` | `list` | Pre-existing | Replaced `LV_ASSERT_NULL(list)` with `LV_CHECK_ARG` — check existed on master |
| `lv_event_dsc_t * lv_event_get_dsc(lv_event_list_t * list, uint32_t index)` | `list` | Pre-existing | Replaced `LV_ASSERT_NULL(list)` with `LV_CHECK_ARG` — check existed on master |
| | `index` | No check needed | `uint32_t`; `lv_array_at` returns NULL on out-of-range, handled by caller |
| `lv_event_cb_t lv_event_dsc_get_cb(lv_event_dsc_t * dsc)` | `dsc` | Pre-existing | Replaced `LV_ASSERT_NULL(dsc)` with `LV_CHECK_ARG` — check existed on master |
| `void * lv_event_dsc_get_user_data(lv_event_dsc_t * dsc)` | `dsc` | Pre-existing | Replaced `LV_ASSERT_NULL(dsc)` with `LV_CHECK_ARG` — check existed on master |
| `bool lv_event_remove(lv_event_list_t * list, uint32_t index)` | `list` | Pre-existing | Replaced `LV_ASSERT_NULL(list)` with `LV_CHECK_ARG` — check existed on master |
| | `index` | No check needed | `uint32_t`; `lv_event_get_dsc` returns NULL for out-of-range, handled |
| `void lv_event_remove_all(lv_event_list_t * list)` | `list` | Pre-existing | Replaced `LV_ASSERT_NULL(list)` with `LV_CHECK_ARG` — check existed on master |
| `void * lv_event_get_target(lv_event_t * e)` | `e` | Added | No prior guard; dereferencing NULL `e` would crash |
| `void * lv_event_get_current_target(lv_event_t * e)` | `e` | Added | No prior guard; dereferencing NULL `e` would crash |
| `lv_event_code_t lv_event_get_code(lv_event_t * e)` | `e` | Added | No prior guard; dereferencing NULL `e` would crash |
| `void * lv_event_get_param(lv_event_t * e)` | `e` | Added | No prior guard; dereferencing NULL `e` would crash |
| `void * lv_event_get_user_data(lv_event_t * e)` | `e` | Added | No prior guard; dereferencing NULL `e` would crash |
| `void lv_event_stop_bubbling(lv_event_t * e)` | `e` | Added | No prior guard; dereferencing NULL `e` would crash |
| `void lv_event_stop_trickling(lv_event_t * e)` | `e` | Added | No prior guard; dereferencing NULL `e` would crash |
| `void lv_event_stop_processing(lv_event_t * e)` | `e` | Added | No prior guard; dereferencing NULL `e` would crash |
| `void lv_event_free_user_data_cb(lv_event_t * e)` | `e` | Added | No prior guard; dereferencing NULL `e` would crash |
| `uint32_t lv_event_register_id(void)` | — | — | No parameters |
| `const char * lv_event_code_get_name(lv_event_code_t code)` | `code` | No check needed | `lv_event_code_t` enum/integer, not a pointer |
| `void lv_event_desc_set_external_data(lv_event_dsc_t * dsc, void * data, void (* free_cb)(void * data))` | `dsc` | Pre-existing | Replaced manual `if(!dsc) { LV_LOG_WARN... return; }` with `LV_CHECK_ARG` — check existed on master |
| | `data` | NULL is valid — no check | `void *`; NULL is valid to clear external data |
| | `free_cb` | NULL is valid — no check | Function pointer; NULL means no destructor — valid by design |

Generated with [Claude Code](https://claude.com/claude-code)