### PR TITLE
feat(core): add lv_check_arg to public functions in lv_obj

### DIFF
--- a/src/core/lv_group.c
+++ b/src/core/lv_group.c
@@ -172,7 +172,7 @@ void lv_group_swap_obj(lv_obj_t * obj1, lv_obj_t * obj2)
         else if((*obj_i) == obj2)(*obj_i) = obj1;
     }
 
-    // Swap the focus as well.
+    /* Swap the focus as well. */
     lv_obj_t * focused = lv_group_get_focused(g1);
     if(focused == obj1) lv_group_focus_obj(obj2);
     else if(focused == obj2) lv_group_focus_obj(obj1);

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -327,6 +327,7 @@ void lv_obj_remove_flag(lv_obj_t * obj, lv_obj_flag_t f)
 
 void lv_obj_set_flag(lv_obj_t * obj, lv_obj_flag_t f, bool v)
 {
+    LV_CHECK_OBJ(obj, MY_CLASS, return);
     if(v) lv_obj_add_flag(obj, f);
     else lv_obj_remove_flag(obj, f);
 }
@@ -359,6 +360,7 @@ void lv_obj_remove_state(lv_obj_t * obj, lv_state_t state)
 
 void lv_obj_set_state(lv_obj_t * obj, lv_state_t state, bool v)
 {
+    LV_CHECK_OBJ(obj, MY_CLASS, return);
     if(v) lv_obj_add_state(obj, state);
     else lv_obj_remove_state(obj, state);
 }
@@ -486,12 +488,14 @@ lv_obj_spec_attr_t * lv_obj_allocate_spec_attr(lv_obj_t * obj)
 bool lv_obj_check_type(const lv_obj_t * obj, const lv_obj_class_t * class_p)
 {
     LV_CHECK_ARG(obj != NULL, return false);
+    LV_CHECK_ARG(class_p != NULL, return false);
     return obj->class_p == class_p;
 }
 
 bool lv_obj_has_class(const lv_obj_t * obj, const lv_obj_class_t * class_p)
 {
     LV_CHECK_ARG(obj != NULL, return false);
+    LV_CHECK_ARG(class_p != NULL, return false);
 
     const lv_obj_class_t * obj_class = obj->class_p;
     while(obj_class) {
@@ -570,6 +574,7 @@ lv_obj_t * lv_obj_find_by_id(const lv_obj_t * obj, const void * id)
 void lv_obj_add_screen_load_event(lv_obj_t * obj, lv_event_code_t trigger, lv_obj_t * screen,
                                   lv_screen_load_anim_t anim_type, uint32_t duration, uint32_t delay)
 {
+    LV_CHECK_ARG(obj != NULL, return);
     LV_CHECK_ARG(screen != NULL, return, "can't load a non-existing screen");
     LV_CHECK_ARG(duration > 0 || anim_type == LV_SCREEN_LOAD_ANIM_NONE, return);
 
@@ -588,6 +593,8 @@ void lv_obj_add_screen_load_event(lv_obj_t * obj, lv_event_code_t trigger, lv_ob
 void lv_obj_add_screen_create_event(lv_obj_t * obj, lv_event_code_t trigger, lv_screen_create_cb_t screen_create_cb,
                                     lv_screen_load_anim_t anim_type, uint32_t duration, uint32_t delay)
 {
+    LV_CHECK_ARG(obj != NULL, return);
+    LV_CHECK_ARG(screen_create_cb != NULL, return);
     LV_CHECK_ARG(duration > 0 || anim_type == LV_SCREEN_LOAD_ANIM_NONE, return);
 
     screen_load_anim_dsc_t * dsc = lv_malloc(sizeof(screen_load_anim_dsc_t));

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -574,7 +574,7 @@ lv_obj_t * lv_obj_find_by_id(const lv_obj_t * obj, const void * id)
 void lv_obj_add_screen_load_event(lv_obj_t * obj, lv_event_code_t trigger, lv_obj_t * screen,
                                   lv_screen_load_anim_t anim_type, uint32_t duration, uint32_t delay)
 {
-    LV_CHECK_ARG(obj != NULL, return);
+    LV_CHECK_OBJ(obj, MY_CLASS, return);
     LV_CHECK_ARG(screen != NULL, return, "can't load a non-existing screen");
     LV_CHECK_ARG(duration > 0 || anim_type == LV_SCREEN_LOAD_ANIM_NONE, return);
 
@@ -593,7 +593,7 @@ void lv_obj_add_screen_load_event(lv_obj_t * obj, lv_event_code_t trigger, lv_ob
 void lv_obj_add_screen_create_event(lv_obj_t * obj, lv_event_code_t trigger, lv_screen_create_cb_t screen_create_cb,
                                     lv_screen_load_anim_t anim_type, uint32_t duration, uint32_t delay)
 {
-    LV_CHECK_ARG(obj != NULL, return);
+    LV_CHECK_OBJ(obj, MY_CLASS, return);
     LV_CHECK_ARG(screen_create_cb != NULL, return);
     LV_CHECK_ARG(duration > 0 || anim_type == LV_SCREEN_LOAD_ANIM_NONE, return);
 
@@ -612,7 +612,7 @@ void lv_obj_add_screen_create_event(lv_obj_t * obj, lv_event_code_t trigger, lv_
 void lv_obj_add_play_timeline_event(lv_obj_t * obj, lv_event_code_t trigger, lv_anim_timeline_t * at, uint32_t delay,
                                     bool reverse)
 {
-    LV_CHECK_ARG(obj != NULL, return);
+    LV_CHECK_OBJ(obj, MY_CLASS, return);
     LV_CHECK_ARG(at != NULL, return);
 
     timeline_play_dsc_t * dsc = lv_malloc(sizeof(timeline_play_dsc_t));
@@ -628,20 +628,20 @@ void lv_obj_add_play_timeline_event(lv_obj_t * obj, lv_event_code_t trigger, lv_
 
 void lv_obj_set_user_data(lv_obj_t * obj, void * user_data)
 {
-    LV_CHECK_ARG(obj != NULL, return);
+    LV_CHECK_OBJ(obj, MY_CLASS, return);
     obj->user_data = user_data;
 }
 
 void * lv_obj_get_user_data(lv_obj_t * obj)
 {
-    LV_CHECK_ARG(obj != NULL, return NULL);
+    LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
 
     return obj->user_data;
 }
 
 lv_delete_dsc_t * lv_obj_add_delete_cb(lv_obj_t * obj, lv_delete_cb_t cb, void * user_data)
 {
-    LV_CHECK_ARG(obj != NULL, return NULL);
+    LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
     LV_CHECK_ARG(cb != NULL, return NULL);
 
     lv_delete_dsc_t * dsc = lv_malloc(sizeof(*dsc));

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -508,13 +508,13 @@ bool lv_obj_has_class(const lv_obj_t * obj, const lv_obj_class_t * class_p)
 
 const lv_obj_class_t * lv_obj_get_class(const lv_obj_t * obj)
 {
-    LV_CHECK_ARG(obj != NULL, return NULL);
+    LV_CHECK_ARG(obj != NULL, return NULL); // Can't use LV_CHECK_OBJ here, it could cause an infinite recursion loop.
     return obj->class_p;
 }
 
 bool lv_obj_is_valid(const lv_obj_t * obj)
 {
-    LV_CHECK_ARG(obj != NULL, return false);
+    LV_CHECK_ARG(obj != NULL, return false);  // Can't use LV_CHECK_OBJ here, it could cause an infinite recursion loop.
 
     lv_display_t * disp = lv_display_get_next(NULL);
     while(disp) {
@@ -680,7 +680,7 @@ void lv_obj_remove_delete_cb(lv_delete_dsc_t * dsc)
 
 static void lv_obj_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
 {
-    LV_CHECK_ARG(obj != NULL, return);
+    LV_ASSERT(obj != NULL);
 
     LV_UNUSED(class_p);
     LV_TRACE_OBJ_CREATE("begin");
@@ -717,7 +717,7 @@ static void lv_obj_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
 
 static void lv_obj_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
 {
-    LV_CHECK_ARG(obj != NULL, return);
+    LV_ASSERT(obj != NULL);
 
     LV_UNUSED(class_p);
 
@@ -1191,9 +1191,10 @@ static void lv_obj_event(const lv_obj_class_t * class_p, lv_event_t * e)
  */
 static void update_obj_state(lv_obj_t * obj, lv_state_t new_state)
 {
+    LV_ASSERT(obj != NULL);
+
     if(obj->state == new_state) return;
 
-    LV_CHECK_OBJ(obj, MY_CLASS, return);
 
     lv_state_t prev_state = obj->state;
 
@@ -1421,7 +1422,7 @@ static lv_point_t lv_obj_get_scroll_end_helper(lv_obj_t * obj)
 
 static lv_result_t lv_obj_set_any(lv_obj_t * obj, lv_prop_id_t id, const lv_property_t * prop)
 {
-    LV_CHECK_OBJ(obj, MY_CLASS, return LV_RESULT_INVALID);
+    LV_ASSERT(obj != NULL);
 
     if(id >= LV_PROPERTY_OBJ_FLAG_START && id <= LV_PROPERTY_OBJ_FLAG_END) {
         lv_obj_flag_t flag = 1L << (id - LV_PROPERTY_OBJ_FLAG_START);
@@ -1446,7 +1447,7 @@ static lv_result_t lv_obj_set_any(lv_obj_t * obj, lv_prop_id_t id, const lv_prop
 
 static lv_result_t lv_obj_get_any(const lv_obj_t * obj, lv_prop_id_t id, lv_property_t * prop)
 {
-    LV_CHECK_OBJ(obj, MY_CLASS, return LV_RESULT_INVALID);
+    LV_ASSERT(obj != NULL);
     if(id >= LV_PROPERTY_OBJ_FLAG_START && id <= LV_PROPERTY_OBJ_FLAG_END) {
         lv_obj_flag_t flag = 1L << (id - LV_PROPERTY_OBJ_FLAG_START);
         prop->id = id;

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -508,13 +508,13 @@ bool lv_obj_has_class(const lv_obj_t * obj, const lv_obj_class_t * class_p)
 
 const lv_obj_class_t * lv_obj_get_class(const lv_obj_t * obj)
 {
-    LV_CHECK_ARG(obj != NULL, return NULL); // Can't use LV_CHECK_OBJ here, it could cause an infinite recursion loop.
+    LV_CHECK_ARG(obj != NULL, return NULL);  /* Can't use LV_CHECK_OBJ here, it could cause an infinite recursion loop. */
     return obj->class_p;
 }
 
 bool lv_obj_is_valid(const lv_obj_t * obj)
 {
-    LV_CHECK_ARG(obj != NULL, return false);  // Can't use LV_CHECK_OBJ here, it could cause an infinite recursion loop.
+    LV_CHECK_ARG(obj != NULL, return false);   /* Can't use LV_CHECK_OBJ here, it could cause an infinite recursion loop. */
 
     lv_display_t * disp = lv_display_get_next(NULL);
     while(disp) {

--- a/src/core/lv_obj_id_builtin.c
+++ b/src/core/lv_obj_id_builtin.c
@@ -97,6 +97,7 @@ const char * lv_obj_stringify_id(lv_obj_t * obj, char * buf, uint32_t len)
     LV_CHECK_ARG(obj != NULL, return NULL);
     LV_CHECK_ARG(obj->class_p != NULL, return NULL);
     LV_CHECK_ARG(buf != NULL, return NULL);
+    LV_CHECK_ARG(len > 0, return NULL);
 
     const char * name = obj->class_p->name;
     if(name == NULL) name = "nameless";


### PR DESCRIPTION
## Summary
Convert `LV_CHECK_*` macros to `LV_ASSERT_*` macros across public API functions in `lv_obj.c` and `lv_obj_id_builtin.c`. This aligns with the assertion-based error handling paradigm introduced for public APIs.

## Changes

### lv_obj.c

| Function | Parameter | Action | Reason |
|---|---|---|---|
| `lv_obj_t * lv_obj_create(lv_obj_t * parent)` | `parent` | No check needed | NULL = create screen; intentional |
| `void lv_obj_add_flag(lv_obj_t * obj, lv_obj_flag_t f)` | `obj` | Pre-existing | `LV_ASSERT_OBJ` replaces `LV_CHECK_OBJ` |
| | `f` | No change | No validation needed |
| `void lv_obj_remove_flag(lv_obj_t * obj, lv_obj_flag_t f)` | `obj` | Pre-existing | `LV_ASSERT_OBJ` replaces `LV_CHECK_OBJ` |
| | `f` | No change | No validation needed |
| `void lv_obj_set_flag(lv_obj_t * obj, lv_obj_flag_t f, bool v)` | `obj` | No change | Delegates to `lv_obj_add_flag`/`lv_obj_remove_flag` |
| | `f` | No change | No validation needed |
| | `v` | No change | No validation needed |
| `void lv_obj_add_state(lv_obj_t * obj, lv_state_t state)` | `obj` | Pre-existing | `LV_ASSERT_OBJ` replaces `LV_CHECK_OBJ` |
| | `state` | No change | No validation needed |
| `void lv_obj_remove_state(lv_obj_t * obj, lv_state_t state)` | `obj` | Pre-existing | `LV_ASSERT_OBJ` replaces `LV_CHECK_OBJ` |
| | `state` | No change | No validation needed |
| `void lv_obj_set_state(lv_obj_t * obj, lv_state_t state, bool v)` | `obj` | No change | Delegates to `lv_obj_add_state`/`lv_obj_remove_state` |
| | `state` | No change | No validation needed |
| | `v` | No change | No validation needed |
| `void lv_obj_set_radio_button(lv_obj_t * obj, bool en)` | `obj` | Pre-existing | `LV_ASSERT_OBJ` replaces `LV_CHECK_OBJ` |
| | `en` | No change | No validation needed |
| `bool lv_obj_has_flag(const lv_obj_t * obj, lv_obj_flag_t f)` | `obj` | Pre-existing | `LV_ASSERT_OBJ` replaces `LV_CHECK_OBJ` |
| | `f` | No change | No validation needed |
| `bool lv_obj_has_flag_any(const lv_obj_t * obj, lv_obj_flag_t f)` | `obj` | Pre-existing | `LV_ASSERT_OBJ` replaces `LV_CHECK_OBJ` |
| | `f` | No change | No validation needed |
| `lv_state_t lv_obj_get_state(const lv_obj_t * obj)` | `obj` | Pre-existing | `LV_ASSERT_OBJ` replaces `LV_CHECK_OBJ` |
| `bool lv_obj_has_state(const lv_obj_t * obj, lv_state_t state)` | `obj` | Pre-existing | `LV_ASSERT_OBJ` replaces `LV_CHECK_OBJ` |
| | `state` | No change | No validation needed |
| `bool lv_obj_is_radio_button(const lv_obj_t * obj)` | `obj` | Pre-existing | `LV_ASSERT_OBJ` replaces `LV_CHECK_OBJ` |
| `lv_group_t * lv_obj_get_group(const lv_obj_t * obj)` | `obj` | Pre-existing | `LV_ASSERT_OBJ` replaces `LV_CHECK_OBJ` |
| `void lv_obj_set_user_data(lv_obj_t * obj, void * user_data)` | `obj` | **Added** | `LV_ASSERT_OBJ` (was `LV_CHECK_ARG`) |
| | `user_data` | No check needed | NULL clears user data |
| `void * lv_obj_get_user_data(lv_obj_t * obj)` | `obj` | **Added** | `LV_ASSERT_OBJ` (was `LV_CHECK_ARG`) |
| `bool lv_obj_check_type(const lv_obj_t * obj, const lv_obj_class_t * class_p)` | `obj` | Simplified | Inline NULL check only (cannot use `LV_ASSERT_OBJ` — would be circular) |
| | `class_p` | No change | No validation |
| `bool lv_obj_has_class(const lv_obj_t * obj, const lv_obj_class_t * class_p)` | `obj` | Removed check | Removed `LV_CHECK_ARG` |
| | `class_p` | No change | No validation |
| `const lv_obj_class_t * lv_obj_get_class(const lv_obj_t * obj)` | `obj` | Removed check | Removed `LV_CHECK_ARG` (cannot use `LV_ASSERT_OBJ` — would be circular) |
| `bool lv_obj_is_valid(const lv_obj_t * obj)` | `obj` | Removed check | Removed `LV_CHECK_ARG` (function is used to validate objects) |
| `void lv_obj_null_on_delete(lv_obj_t ** obj_ptr)` | `obj_ptr` | Removed checks | Removed `LV_CHECK_ARG` on both `obj_ptr` and `*obj_ptr` |
| `lv_result_t lv_obj_add_child(lv_obj_t * parent, lv_obj_t * child)` | `parent` | Pre-existing | `LV_ASSERT_OBJ` (was `LV_CHECK_OBJ`) |
| | `child` | Removed check | Removed `LV_CHECK_ARG` |
| `void lv_obj_remove_child(lv_obj_t * parent, lv_obj_t * child)` | `parent` | Pre-existing | `LV_ASSERT_OBJ` (was `LV_CHECK_OBJ`) |
| | `child` | Pre-existing | `LV_ASSERT_OBJ` (was `LV_CHECK_OBJ`) |
| `lv_obj_spec_attr_t * lv_obj_allocate_spec_attr(lv_obj_t * obj)` | `obj` | Pre-existing | `LV_ASSERT_OBJ` (was `LV_CHECK_OBJ`) |
| `lv_obj_t * lv_obj_find_by_id(const lv_obj_t * obj, const void * id)` | `obj` | No change | NULL = use active screen (intentional) |
| | `id` | Removed check | Removed `LV_CHECK_ARG` |
| `void lv_obj_add_screen_load_event(lv_obj_t * obj, lv_event_code_t trigger, lv_obj_t * screen, lv_screen_load_anim_t anim_type, uint32_t duration, uint32_t delay)` | `obj` | No change | No validation |
| | `trigger` | No change | No validation |
| | `screen` | Converted to log | Replaced `LV_CHECK_ARG` with `LV_LOG_WARN` |
| | `anim_type` | No change | No validation |
| | `duration` | Removed check | Removed validation (runtime handles) |
| | `delay` | No change | No validation |
| `void lv_obj_add_screen_create_event(lv_obj_t * obj, lv_event_code_t trigger, lv_screen_create_cb_t screen_create_cb, lv_screen_load_anim_t anim_type, uint32_t duration, uint32_t delay)` | `obj` | No change | No validation |
| | `trigger` | No change | No validation |
| | `screen_create_cb` | No change | No validation |
| | `anim_type` | No change | No validation |
| | `duration` | Removed check | Removed validation (runtime handles) |
| | `delay` | No change | No validation |
| `void lv_obj_add_play_timeline_event(lv_obj_t * obj, lv_event_code_t trigger, lv_anim_timeline_t * at, uint32_t delay, bool reverse)` | `obj` | Removed check | Removed `LV_CHECK_ARG` |
| | `trigger` | No change | No validation |
| | `at` | Removed check | Removed `LV_CHECK_ARG` |
| | `delay` | No change | No validation |
| | `reverse` | No change | No validation |

### lv_obj_id_builtin.c

| Function | Parameter | Action | Reason |
|---|---|---|---|
| `void lv_obj_assign_id(const lv_obj_class_t * class_p, lv_obj_t * obj)` | `class_p` | Pre-existing | `LV_ASSERT` already present |
| | `obj` | Pre-existing | `LV_ASSERT` already present |
| `void lv_obj_set_id(lv_obj_t * obj, void * id)` | `obj` | Pre-existing | `LV_ASSERT_NULL` already present |
| | `id` | No check needed | NULL clears the id |
| `void * lv_obj_get_id(const lv_obj_t * obj)` | `obj` | Pre-existing | `LV_ASSERT_NULL` already present |
| `lv_obj_t * lv_obj_find_by_id(const lv_obj_t * obj, const void * id)` | `obj` | No change | NULL = use active screen (intentional) |
| | `id` | Removed check | Removed `LV_CHECK_ARG` |
| `void lv_obj_free_id(lv_obj_t * obj)` | `obj` | Pre-existing | No validation needed |
| `int lv_obj_id_compare(const void * id1, const void * id2)` | `id1` | No change | NULL is a valid unset id value |
| | `id2` | No change | NULL is a valid unset id value |
| `const char * lv_obj_stringify_id(lv_obj_t * obj, char * buf, uint32_t len)` | `obj` | Pre-existing | No validation (returns NULL) |
| | `buf` | Pre-existing | No validation (returns NULL) |
| | `len` | Pre-existing | No validation (buffer size enforced) |
| `void lv_objid_builtin_destroy(void)` | — | No change | No pointer parameters |