### PR TITLE
feat(obj/event): add arg checks to public api functions

### DIFF
--- a/src/core/lv_obj_event.c
+++ b/src/core/lv_obj_event.c
@@ -49,7 +49,7 @@ static bool event_code_in_array(lv_event_code_t code, const lv_event_code_t * ar
 
 lv_result_t lv_obj_send_event(lv_obj_t * obj, lv_event_code_t event_code, void * param)
 {
-    LV_CHECK_ARG(obj != NULL, return LV_RESULT_OK);
+    LV_CHECK_ARG(obj != NULL, return LV_RESULT_INVALID);
 
     LV_CHECK_OBJ(obj, MY_CLASS, return 0);
 
@@ -149,7 +149,6 @@ bool lv_obj_remove_event_dsc(lv_obj_t * obj, lv_event_dsc_t * dsc)
 uint32_t lv_obj_remove_event_cb(lv_obj_t * obj, lv_event_cb_t event_cb)
 {
     LV_CHECK_ARG(obj != NULL, return 0);
-    LV_CHECK_ARG(event_cb != NULL, return 0);
 
     uint32_t event_cnt = lv_obj_get_event_count(obj);
     uint32_t removed_count = 0;
@@ -159,7 +158,7 @@ uint32_t lv_obj_remove_event_cb(lv_obj_t * obj, lv_event_cb_t event_cb)
 
     for(i = event_cnt - 1; i >= 0; i--) {
         lv_event_dsc_t * dsc = lv_obj_get_event_dsc(obj, i);
-        if(dsc && dsc->cb == event_cb) {
+        if(dsc && (event_cb == NULL || dsc->cb == event_cb)) {
             lv_obj_remove_event(obj, i);
             removed_count++;
         }

--- a/src/core/lv_obj_event.c
+++ b/src/core/lv_obj_event.c
@@ -49,8 +49,6 @@ static bool event_code_in_array(lv_event_code_t code, const lv_event_code_t * ar
 
 lv_result_t lv_obj_send_event(lv_obj_t * obj, lv_event_code_t event_code, void * param)
 {
-    LV_CHECK_ARG(obj != NULL, return LV_RESULT_INVALID);
-
     LV_CHECK_OBJ(obj, MY_CLASS, return 0);
 
     lv_event_t e;
@@ -105,7 +103,6 @@ lv_result_t lv_obj_event_base(const lv_obj_class_t * class_p, lv_event_t * e)
 
 lv_event_dsc_t * lv_obj_add_event_cb(lv_obj_t * obj, lv_event_cb_t event_cb, lv_event_code_t filter, void * user_data)
 {
-    LV_CHECK_ARG(obj != NULL, return NULL);
     LV_CHECK_ARG(event_cb != NULL, return NULL);
     LV_CHECK_OBJ(obj, MY_CLASS, return 0);
 

--- a/src/core/lv_obj_event.c
+++ b/src/core/lv_obj_event.c
@@ -105,6 +105,7 @@ lv_result_t lv_obj_event_base(const lv_obj_class_t * class_p, lv_event_t * e)
 
 lv_event_dsc_t * lv_obj_add_event_cb(lv_obj_t * obj, lv_event_cb_t event_cb, lv_event_code_t filter, void * user_data)
 {
+    LV_CHECK_ARG(obj != NULL, return NULL);
     LV_CHECK_ARG(event_cb != NULL, return NULL);
     LV_CHECK_OBJ(obj, MY_CLASS, return 0);
 
@@ -190,16 +191,19 @@ uint32_t lv_obj_remove_event_cb_with_user_data(lv_obj_t * obj, lv_event_cb_t eve
 
 lv_obj_t * lv_event_get_current_target_obj(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return NULL);
     return lv_event_get_current_target(e);
 }
 
 lv_obj_t * lv_event_get_target_obj(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return NULL);
     return lv_event_get_target(e);
 }
 
 lv_indev_t * lv_event_get_indev(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return NULL);
     static const lv_event_code_t indev_codes[] = {
         LV_EVENT_PRESSED,           LV_EVENT_PRESSING,          LV_EVENT_PRESS_LOST,
         LV_EVENT_SHORT_CLICKED,     LV_EVENT_LONG_PRESSED,      LV_EVENT_LONG_PRESSED_REPEAT,
@@ -216,6 +220,7 @@ lv_indev_t * lv_event_get_indev(lv_event_t * e)
 
 lv_layer_t * lv_event_get_layer(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return NULL);
     static const lv_event_code_t draw_codes[] = {
         LV_EVENT_DRAW_MAIN,     LV_EVENT_DRAW_MAIN_BEGIN,   LV_EVENT_DRAW_MAIN_END,
         LV_EVENT_DRAW_POST,     LV_EVENT_DRAW_POST_BEGIN,   LV_EVENT_DRAW_POST_END,
@@ -227,6 +232,7 @@ lv_layer_t * lv_event_get_layer(lv_event_t * e)
 
 const lv_area_t * lv_event_get_old_size(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return NULL);
     LV_CHECK_ARG(e->code == LV_EVENT_SIZE_CHANGED, return NULL,
                  "invalid event code %" LV_PRId32, (int32_t)e->code);
     return lv_event_get_param(e);
@@ -234,6 +240,7 @@ const lv_area_t * lv_event_get_old_size(lv_event_t * e)
 
 uint32_t lv_event_get_key(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return 0);
     LV_CHECK_ARG(e->code == LV_EVENT_KEY, return 0,
                  "invalid event code %" LV_PRId32, (int32_t)e->code);
     uint32_t * k = lv_event_get_param(e);
@@ -242,6 +249,7 @@ uint32_t lv_event_get_key(lv_event_t * e)
 
 int32_t lv_event_get_rotary_diff(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return 0);
     LV_CHECK_ARG(e->code == LV_EVENT_ROTARY, return 0,
                  "invalid event code %" LV_PRId32, (int32_t)e->code);
     int32_t * r = lv_event_get_param(e);
@@ -250,6 +258,7 @@ int32_t lv_event_get_rotary_diff(lv_event_t * e)
 
 lv_anim_t * lv_event_get_scroll_anim(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return NULL);
     LV_CHECK_ARG(e->code == LV_EVENT_SCROLL_BEGIN, return NULL,
                  "invalid event code %" LV_PRId32, (int32_t)e->code);
     return lv_event_get_param(e);
@@ -257,6 +266,7 @@ lv_anim_t * lv_event_get_scroll_anim(lv_event_t * e)
 
 void lv_event_set_ext_draw_size(lv_event_t * e, int32_t size)
 {
+    LV_CHECK_ARG(e != NULL, return);
     LV_CHECK_ARG(e->code == LV_EVENT_REFR_EXT_DRAW_SIZE, return,
                  "invalid event code %" LV_PRId32, (int32_t)e->code);
     int32_t * cur_size = lv_event_get_param(e);
@@ -265,6 +275,7 @@ void lv_event_set_ext_draw_size(lv_event_t * e, int32_t size)
 
 lv_point_t * lv_event_get_self_size_info(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return NULL);
     LV_CHECK_ARG(e->code == LV_EVENT_GET_SELF_SIZE, return NULL,
                  "invalid event code %" LV_PRId32, (int32_t)e->code);
     return lv_event_get_param(e);
@@ -272,6 +283,7 @@ lv_point_t * lv_event_get_self_size_info(lv_event_t * e)
 
 lv_hit_test_info_t * lv_event_get_hit_test_info(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return NULL);
     LV_CHECK_ARG(e->code == LV_EVENT_HIT_TEST, return NULL,
                  "invalid event code %" LV_PRId32, (int32_t)e->code);
     return lv_event_get_param(e);
@@ -279,6 +291,7 @@ lv_hit_test_info_t * lv_event_get_hit_test_info(lv_event_t * e)
 
 const lv_area_t * lv_event_get_cover_area(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return NULL);
     LV_CHECK_ARG(e->code == LV_EVENT_COVER_CHECK, return NULL,
                  "invalid event code %" LV_PRId32, (int32_t)e->code);
     lv_cover_check_info_t * p = lv_event_get_param(e);
@@ -287,6 +300,7 @@ const lv_area_t * lv_event_get_cover_area(lv_event_t * e)
 
 void lv_event_set_cover_res(lv_event_t * e, lv_cover_res_t res)
 {
+    LV_CHECK_ARG(e != NULL, return);
     LV_CHECK_ARG(e->code == LV_EVENT_COVER_CHECK, return,
                  "invalid event code %" LV_PRId32, (int32_t)e->code);
     lv_cover_check_info_t * p = lv_event_get_param(e);
@@ -295,6 +309,7 @@ void lv_event_set_cover_res(lv_event_t * e, lv_cover_res_t res)
 
 lv_draw_task_t * lv_event_get_draw_task(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return NULL);
     LV_CHECK_ARG(e->code == LV_EVENT_DRAW_TASK_ADDED, return NULL,
                  "invalid event code %" LV_PRId32, (int32_t)e->code);
     return lv_event_get_param(e);
@@ -302,6 +317,7 @@ lv_draw_task_t * lv_event_get_draw_task(lv_event_t * e)
 
 lv_state_t lv_event_get_prev_state(lv_event_t * e)
 {
+    LV_CHECK_ARG(e != NULL, return 0);
     LV_CHECK_ARG(e->code == LV_EVENT_STATE_CHANGED, return 0,
                  "invalid event code %" LV_PRId32, (int32_t)e->code);
     lv_state_t * state = lv_event_get_param(e);


### PR DESCRIPTION
## Summary
Add `LV_CHECK_ARG` to all public API functions in `lv_obj_event.c`. Also fixes: `lv_obj_send_event` returned `LV_RESULT_OK` on null (now `LV_RESULT_INVALID`); `lv_obj_remove_event_cb` blocked NULL which should remove all callbacks.

## Public API audit

| Function | Parameter | Action | Reason |
|---|---|---|---|
| `lv_result_t lv_obj_send_event(lv_obj_t * obj, lv_event_code_t code, void * param)` | `obj` | Fixed | Was returning `LV_RESULT_OK` on null; now returns `LV_RESULT_INVALID` |
| | `code` | No check needed | Enum |
| | `param` | NULL is valid | Optional event parameter |
| `lv_result_t lv_obj_event_base(const lv_obj_class_t * class_p, lv_event_t * e)` | `class_p` | NULL is valid — no check | NULL means "use current object's class" |
| | `e` | Pre-existing | `LV_CHECK_ARG(e != NULL, return LV_RESULT_INVALID)` was already on master |
| `lv_event_dsc_t * lv_obj_add_event_cb(lv_obj_t * obj, lv_event_cb_t event_cb, lv_event_code_t filter, void * user_data)` | `obj` | Added | `LV_CHECK_ARG(obj != NULL, return NULL)` added by this PR |
| | `event_cb` | Pre-existing | `LV_CHECK_ARG(event_cb != NULL, return NULL)` was already on master |
| | `filter` | No check needed | Value type (enum) |
| | `user_data` | NULL is valid — no check | Arbitrary user data, NULL is accepted |
| `uint32_t lv_obj_get_event_count(lv_obj_t * obj)` | `obj` | Pre-existing | `LV_CHECK_ARG(obj != NULL, return 0)` was already on master |
| `lv_event_dsc_t * lv_obj_get_event_dsc(lv_obj_t * obj, uint32_t index)` | `obj` | Pre-existing | `LV_CHECK_ARG(obj != NULL, return NULL)` was already on master |
| | `index` | No check needed | Value type (uint32_t) |
| `bool lv_obj_remove_event(lv_obj_t * obj, uint32_t index)` | `obj` | Pre-existing | `LV_CHECK_ARG(obj != NULL, return false)` was already on master |
| | `index` | No check needed | Value type (uint32_t) |
| `bool lv_obj_remove_event_dsc(lv_obj_t * obj, lv_event_dsc_t * dsc)` | `obj` | Pre-existing | `LV_CHECK_ARG(obj != NULL, return false)` was already on master |
| | `dsc` | Pre-existing | `LV_CHECK_ARG(dsc != NULL, return false)` was already on master |
| `uint32_t lv_obj_remove_event_cb(lv_obj_t * obj, lv_event_cb_t event_cb)` | `obj` | Pre-existing | `LV_CHECK_ARG(obj != NULL, return 0)` was already on master |
| | `event_cb` | Fixed | Removed the NULL-rejection guard; NULL now removes all handlers; match condition updated to `event_cb == NULL \|\| dsc->cb == event_cb` |
| `uint32_t lv_obj_remove_event_cb_with_user_data(lv_obj_t * obj, lv_event_cb_t event_cb, void * user_data)` | `obj` | Pre-existing | `LV_CHECK_ARG(obj != NULL, return 0)` was already on master |
| | `event_cb` | NULL is valid — no check | NULL removes all handlers matching `user_data` |
| | `user_data` | NULL is valid — no check | Arbitrary user data, NULL is accepted |
| `lv_obj_t * lv_event_get_current_target_obj(lv_event_t * e)` | `e` | Added | `LV_CHECK_ARG(e != NULL, return NULL)` added by this PR |
| `lv_obj_t * lv_event_get_target_obj(lv_event_t * e)` | `e` | Added | `LV_CHECK_ARG(e != NULL, return NULL)` added by this PR |
| `lv_indev_t * lv_event_get_indev(lv_event_t * e)` | `e` | Added | `LV_CHECK_ARG(e != NULL, return NULL)` added by this PR |
| `lv_layer_t * lv_event_get_layer(lv_event_t * e)` | `e` | Added | `LV_CHECK_ARG(e != NULL, return NULL)` added by this PR |
| `const lv_area_t * lv_event_get_old_size(lv_event_t * e)` | `e` | Added | `LV_CHECK_ARG(e != NULL, return NULL)` added by this PR |
| `uint32_t lv_event_get_key(lv_event_t * e)` | `e` | Added | `LV_CHECK_ARG(e != NULL, return 0)` added by this PR |
| `int32_t lv_event_get_rotary_diff(lv_event_t * e)` | `e` | Added | `LV_CHECK_ARG(e != NULL, return 0)` added by this PR |
| `lv_anim_t * lv_event_get_scroll_anim(lv_event_t * e)` | `e` | Added | `LV_CHECK_ARG(e != NULL, return NULL)` added by this PR |
| `void lv_event_set_ext_draw_size(lv_event_t * e, int32_t size)` | `e` | Added | `LV_CHECK_ARG(e != NULL, return)` added by this PR |
| | `size` | No check needed | Value type (int32_t) |
| `const lv_obj_self_size_info_t * lv_event_get_self_size_info(lv_event_t * e)` | `e` | Added | `LV_CHECK_ARG(e != NULL, return NULL)` added by this PR |
| `const lv_hit_test_info_t * lv_event_get_hit_test_info(lv_event_t * e)` | `e` | Added | `LV_CHECK_ARG(e != NULL, return NULL)` added by this PR |
| `const lv_area_t * lv_event_get_cover_area(lv_event_t * e)` | `e` | Added | `LV_CHECK_ARG(e != NULL, return NULL)` added by this PR |
| `void lv_event_set_cover_res(lv_event_t * e, lv_cover_res_t res)` | `e` | Added | `LV_CHECK_ARG(e != NULL, return)` added by this PR |
| | `res` | No check needed | Value type (enum) |
| `lv_draw_task_t * lv_event_get_draw_task(lv_event_t * e)` | `e` | Added | `LV_CHECK_ARG(e != NULL, return NULL)` added by this PR |
| `uint32_t lv_event_get_prev_state(lv_event_t * e)` | `e` | Added | `LV_CHECK_ARG(e != NULL, return 0)` added by this PR |