### PR TITLE
feat(group): check for null object in lv_group_remove_obj

### DIFF
--- a/src/core/lv_group.c
+++ b/src/core/lv_group.c
@@ -76,7 +76,7 @@ lv_group_t * lv_group_create(void)
 
 void lv_group_delete(lv_group_t * group)
 {
-    LV_CHECK_ARG(group != NULL, return);
+    if(group == NULL) return;
 
     /*Defocus the currently focused object*/
     if(group->obj_focus != NULL) {

--- a/src/core/lv_group.c
+++ b/src/core/lv_group.c
@@ -76,7 +76,7 @@ lv_group_t * lv_group_create(void)
 
 void lv_group_delete(lv_group_t * group)
 {
-    if(group == NULL) return;
+    LV_CHECK_ARG(group != NULL, return);
 
     /*Defocus the currently focused object*/
     if(group->obj_focus != NULL) {
@@ -180,6 +180,8 @@ void lv_group_swap_obj(lv_obj_t * obj1, lv_obj_t * obj2)
 
 void lv_group_remove_obj(lv_obj_t * obj)
 {
+    LV_CHECK_ARG(obj != NULL, return);
+
     lv_group_t * g = lv_obj_get_group(obj);
     if(g == NULL) return;
 


### PR DESCRIPTION
## Summary
Add `LV_CHECK_ARG` to all public API functions in `lv_group.c` to validate NULL arguments where appropriate.

## Public API audit

| Function | Parameter | Action | Reason |
|---|---|---|---|
| `lv_group_t * lv_group_create(void)` | — | No parameters | — |
| `void lv_group_delete(lv_group_t * group)` | `group` | Added | Replaced bare `if(group == NULL) return` with `LV_CHECK_ARG` |
| `void lv_group_set_default(lv_group_t * group)` | `group` | NULL is valid | NULL clears the default group |