### PR TITLE
feat(style): add arg checks to public functions args

### DIFF
--- a/include/lvgl/core/lv_style.h
+++ b/include/lvgl/core/lv_style.h
@@ -720,14 +720,43 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_style_prop_t lv_style_const_prop_id_inv
  *      MACROS
  **********************/
 
+/**
+ * Evaluate to true if `style_p`'s sentinel marker is intact, i.e. the style was
+ * initialized by `lv_style_init()` and is not corrupted. Always true when
+ * LV_USE_ASSERT_STYLE is disabled, because the sentinel field is absent then.
+ *
+ * Intended for use inside LV_CHECK_ARG, combined with a NULL check so the
+ * dereference is short-circuited for NULL pointers:
+ * @code
+ *   LV_CHECK_ARG(style != NULL && LV_STYLE_SENTINEL_OK(style), return);
+ * @endcode
+ */
 #if LV_USE_ASSERT_STYLE
+#  define LV_STYLE_SENTINEL_OK(style_p) ((style_p)->sentinel == LV_STYLE_SENTINEL_VALUE)
+#else
+#  define LV_STYLE_SENTINEL_OK(style_p) (true)
+#endif
+
+#if LV_USE_ASSERT_STYLE
+/**
+ * @deprecated Use `LV_CHECK_ARG(style != NULL && LV_STYLE_SENTINEL_OK(style), return ...)`
+ *             instead. `LV_ASSERT_STYLE` aborts on failure; `LV_CHECK_ARG` logs a
+ *             warning and executes the supplied action, which is safer in production.
+ */
 #  define LV_ASSERT_STYLE(style_p)                                                                            \
     do {                                                                                                      \
+        LV_DEPRECATED_MACRO_WARN("LV_ASSERT_STYLE is deprecated. Use LV_CHECK_ARG instead.");                 \
         LV_ASSERT_MSG(style_p != NULL, "The style is NULL");                                                  \
         LV_ASSERT_MSG(style_p->sentinel == LV_STYLE_SENTINEL_VALUE, "Style is not initialized or corrupted"); \
     } while(0)
 #else
-#  define LV_ASSERT_STYLE(p) do{}while(0)
+/**
+ * @deprecated Use `LV_CHECK_ARG(style != NULL, return ...)` instead.
+ */
+#  define LV_ASSERT_STYLE(style_p)                                                                 \
+    do {                                                                                           \
+        LV_DEPRECATED_MACRO_WARN("LV_ASSERT_STYLE is deprecated. Use LV_CHECK_ARG instead.");      \
+    } while(0)
 #endif
 
 #ifdef __cplusplus

--- a/src/misc/lv_style.c
+++ b/src/misc/lv_style.c
@@ -357,7 +357,7 @@ void lv_style_set_prop(lv_style_t * style, lv_style_prop_t prop, lv_style_value_
         return;
     }
 
-    LV_ASSERT(prop != LV_STYLE_PROP_INV);
+    LV_CHECK_ARG(prop != LV_STYLE_PROP_INV, return);
     LV_PROFILER_STYLE_BEGIN;
     lv_style_prop_t * props;
     int32_t i;

--- a/src/misc/lv_style.c
+++ b/src/misc/lv_style.c
@@ -181,6 +181,7 @@ const uint8_t lv_style_builtin_prop_flag_lookup_table[LV_STYLE_NUM_BUILT_IN_PROP
 
 void lv_style_init(lv_style_t * style)
 {
+    LV_CHECK_ARG(style != NULL, return);
 #if LV_USE_ASSERT_STYLE
     if(style->sentinel == LV_STYLE_SENTINEL_VALUE && style->prop_cnt > 1) {
         LV_LOG_WARN("Style might be already inited. (Potential memory leak)");
@@ -195,6 +196,7 @@ void lv_style_init(lv_style_t * style)
 
 void lv_style_reset(lv_style_t * style)
 {
+    LV_CHECK_ARG(style != NULL, return);
     LV_ASSERT_STYLE(style);
 
     if(style->prop_cnt != 255) lv_free(style->values_and_props);
@@ -207,6 +209,8 @@ void lv_style_reset(lv_style_t * style)
 
 void lv_style_copy(lv_style_t * dst, const lv_style_t * src)
 {
+    LV_CHECK_ARG(dst != NULL, return);
+    LV_CHECK_ARG(src != NULL, return);
     if(lv_style_is_const(dst)) {
         LV_LOG_WARN("The destination can not be a constant style");
         return;
@@ -219,6 +223,8 @@ void lv_style_copy(lv_style_t * dst, const lv_style_t * src)
 
 void lv_style_merge(lv_style_t * dst, const lv_style_t * src)
 {
+    LV_CHECK_ARG(dst != NULL, return);
+    LV_CHECK_ARG(src != NULL, return);
     if(lv_style_is_const(dst)) {
         LV_LOG_WARN("The destination can not be a constant style");
         return;
@@ -289,6 +295,7 @@ lv_style_prop_t lv_style_get_num_custom_props(void)
 
 bool lv_style_remove_prop(lv_style_t * style, lv_style_prop_t prop)
 {
+    LV_CHECK_ARG(style != NULL, return false);
     LV_ASSERT_STYLE(style);
 
     if(lv_style_is_const(style)) {
@@ -342,6 +349,7 @@ bool lv_style_remove_prop(lv_style_t * style, lv_style_prop_t prop)
 
 void lv_style_set_prop(lv_style_t * style, lv_style_prop_t prop, lv_style_value_t value)
 {
+    LV_CHECK_ARG(style != NULL, return);
     LV_ASSERT_STYLE(style);
 
     if(lv_style_is_const(style)) {
@@ -397,12 +405,16 @@ void lv_style_set_prop(lv_style_t * style, lv_style_prop_t prop, lv_style_value_
 
 lv_style_res_t lv_style_get_prop(const lv_style_t * style, lv_style_prop_t prop, lv_style_value_t * value)
 {
+    LV_CHECK_ARG(style != NULL, return LV_STYLE_RES_NOT_FOUND);
+    LV_CHECK_ARG(value != NULL, return LV_STYLE_RES_NOT_FOUND);
     return lv_style_get_prop_inlined(style, prop, value);
 }
 
 void lv_style_transition_dsc_init(lv_style_transition_dsc_t * tr, const lv_style_prop_t props[],
                                   lv_anim_path_cb_t path_cb, uint32_t time, uint32_t delay, void * user_data)
 {
+    LV_CHECK_ARG(tr != NULL, return);
+    LV_CHECK_ARG(props != NULL, return);
     lv_memzero(tr, sizeof(lv_style_transition_dsc_t));
     tr->props = props;
     tr->path_xcb = path_cb == NULL ? lv_anim_path_linear : path_cb;
@@ -496,6 +508,7 @@ lv_style_value_t lv_style_prop_get_default(lv_style_prop_t prop)
 
 bool lv_style_is_empty(const lv_style_t * style)
 {
+    LV_CHECK_ARG(style != NULL, return false);
     LV_ASSERT_STYLE(style);
 
     return style->prop_cnt == 0;

--- a/src/misc/lv_style.c
+++ b/src/misc/lv_style.c
@@ -196,8 +196,7 @@ void lv_style_init(lv_style_t * style)
 
 void lv_style_reset(lv_style_t * style)
 {
-    LV_CHECK_ARG(style != NULL, return);
-    LV_ASSERT_STYLE(style);
+    LV_CHECK_ARG(style != NULL && LV_STYLE_SENTINEL_OK(style), return);
 
     if(style->prop_cnt != 255) lv_free(style->values_and_props);
     lv_memzero(style, sizeof(lv_style_t));
@@ -295,8 +294,7 @@ lv_style_prop_t lv_style_get_num_custom_props(void)
 
 bool lv_style_remove_prop(lv_style_t * style, lv_style_prop_t prop)
 {
-    LV_CHECK_ARG(style != NULL, return false);
-    LV_ASSERT_STYLE(style);
+    LV_CHECK_ARG(style != NULL && LV_STYLE_SENTINEL_OK(style), return false);
 
     if(lv_style_is_const(style)) {
         LV_LOG_ERROR("Cannot remove prop from const style");
@@ -349,8 +347,7 @@ bool lv_style_remove_prop(lv_style_t * style, lv_style_prop_t prop)
 
 void lv_style_set_prop(lv_style_t * style, lv_style_prop_t prop, lv_style_value_t value)
 {
-    LV_CHECK_ARG(style != NULL, return);
-    LV_ASSERT_STYLE(style);
+    LV_CHECK_ARG(style != NULL && LV_STYLE_SENTINEL_OK(style), return);
 
     if(lv_style_is_const(style)) {
         LV_LOG_ERROR("Cannot set property of constant style");
@@ -508,8 +505,7 @@ lv_style_value_t lv_style_prop_get_default(lv_style_prop_t prop)
 
 bool lv_style_is_empty(const lv_style_t * style)
 {
-    LV_CHECK_ARG(style != NULL, return false);
-    LV_ASSERT_STYLE(style);
+    LV_CHECK_ARG(style != NULL && LV_STYLE_SENTINEL_OK(style), return false);
 
     return style->prop_cnt == 0;
 }


### PR DESCRIPTION
## Summary
Add `LV_CHECK_ARG` to all public API functions in `lv_style.c` to ensure safe null-checks across all builds, not just debug/assert builds.

## Public API audit

| Function | Parameter | Action | Reason |
|---|---|---|---|
| `void lv_style_init(lv_style_t * style)` | `style` | Added | No null guard existed on master |
| `void lv_style_reset(lv_style_t * style)` | `style` | Added | Added before existing `LV_ASSERT_STYLE` |
| `void lv_style_copy(lv_style_t * dst, const lv_style_t * src)` | `dst` | Added | No null guard existed on master |
| | `src` | Added | No null guard existed on master |