### PR TITLE
fix(config): disable obj class and validity checks by default

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -859,7 +859,7 @@ menu "LVGL configuration"
 
 			config LV_USE_CHECK_OBJ_CLASSTYPE
 				bool "Enable class check in LV_CHECK_OBJ"
-				default y if !LV_CONF_MINIMAL
+				default n
 				depends on LV_USE_CHECK_ARG
 				help
 					When enabled, LV_CHECK_OBJ verifies that the object has the
@@ -868,7 +868,7 @@ menu "LVGL configuration"
 
 			config LV_USE_CHECK_OBJ_VALIDITY
 				bool "Enable widget-tree validity check in LV_CHECK_OBJ"
-				default y if !LV_CONF_MINIMAL
+				default n
 				depends on LV_USE_CHECK_ARG
 				help
 					When enabled, LV_CHECK_OBJ also verifies that the object is

--- a/include/lvgl/config/lv_conf_internal.h
+++ b/include/lvgl/config/lv_conf_internal.h
@@ -1558,14 +1558,10 @@
  * When disabled the class check is skipped even if the class argument is supplied.
  * Requires LV_USE_CHECK_ARG to be enabled. */
 #ifndef LV_USE_CHECK_OBJ_CLASSTYPE
-    #ifdef LV_KCONFIG_PRESENT
-        #ifdef CONFIG_LV_USE_CHECK_OBJ_CLASSTYPE
-            #define LV_USE_CHECK_OBJ_CLASSTYPE CONFIG_LV_USE_CHECK_OBJ_CLASSTYPE
-        #else
-            #define LV_USE_CHECK_OBJ_CLASSTYPE 0
-        #endif
+    #ifdef CONFIG_LV_USE_CHECK_OBJ_CLASSTYPE
+        #define LV_USE_CHECK_OBJ_CLASSTYPE CONFIG_LV_USE_CHECK_OBJ_CLASSTYPE
     #else
-        #define LV_USE_CHECK_OBJ_CLASSTYPE 1
+        #define LV_USE_CHECK_OBJ_CLASSTYPE 0
     #endif
 #endif
 
@@ -1574,14 +1570,10 @@
  * if the associated argument is supplied.
  * Requires LV_USE_CHECK_ARG to be enabled. */
 #ifndef LV_USE_CHECK_OBJ_VALIDITY
-    #ifdef LV_KCONFIG_PRESENT
-        #ifdef CONFIG_LV_USE_CHECK_OBJ_VALIDITY
-            #define LV_USE_CHECK_OBJ_VALIDITY CONFIG_LV_USE_CHECK_OBJ_VALIDITY
-        #else
-            #define LV_USE_CHECK_OBJ_VALIDITY 0
-        #endif
+    #ifdef CONFIG_LV_USE_CHECK_OBJ_VALIDITY
+        #define LV_USE_CHECK_OBJ_VALIDITY CONFIG_LV_USE_CHECK_OBJ_VALIDITY
     #else
-        #define LV_USE_CHECK_OBJ_VALIDITY 1
+        #define LV_USE_CHECK_OBJ_VALIDITY 0
     #endif
 #endif
 

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -548,13 +548,13 @@
 /** If enabled, LV_CHECK_OBJ will also verify that the object has the expected class.
  * When disabled the class check is skipped even if the class argument is supplied.
  * Requires LV_USE_CHECK_ARG to be enabled. */
-#define LV_USE_CHECK_OBJ_CLASSTYPE 1
+#define LV_USE_CHECK_OBJ_CLASSTYPE 0
 
 /** If enabled, LV_CHECK_OBJ will also verify that the object is still part of the
  * widget tree (lv_obj_is_valid). When disabled the validity check is skipped even
  * if the associated argument is supplied.
  * Requires LV_USE_CHECK_ARG to be enabled. */
-#define LV_USE_CHECK_OBJ_VALIDITY 1
+#define LV_USE_CHECK_OBJ_VALIDITY 0
 
 /*-------------
  * Debug


### PR DESCRIPTION
Fixes #10213 <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
