### PR TITLE
feat(uefi): support building on loongarch64 and riscv64

### DIFF
--- a/include/lvgl/drivers/uefi/lv_uefi.h
+++ b/include/lvgl/drivers/uefi/lv_uefi.h
@@ -20,6 +20,12 @@
         #elif defined(__aarch64__)
             #define __LV_UEFI_ARCH_AARCH64__
             #define __LV_UEFI_64BIT__
+        #elif defined(__loongarch_lp64)
+            #define __LV_UEFI_ARCH_LOONGARCH64__
+            #define __LV_UEFI_64BIT__
+        #elif defined(__riscv) && (__riscv_xlen == 64)
+            #define __LV_UEFI_ARCH_RISCV64__
+            #define __LV_UEFI_64BIT__
         #else
             #error Architecture is not supported
         #endif

--- a/include/lvgl/lv_types.h
+++ b/include/lvgl/lv_types.h
@@ -36,7 +36,7 @@ extern "C" {
 #define LV_ARCH_64
 
 /*Otherwise use compiler-dependent means to determine arch size*/
-#elif defined(_WIN64) || defined(__x86_64__) || defined(__ppc64__) || defined (__aarch64__)
+#elif defined(_WIN64) || defined(__x86_64__) || defined(__ppc64__) || defined (__aarch64__) || defined(__loongarch_lp64) || (defined(__riscv) && __riscv_xlen == 64)
 #define LV_ARCH_64
 
 #endif

--- a/tests/makefiles_uefi/efi.h
+++ b/tests/makefiles_uefi/efi.h
@@ -38,7 +38,7 @@
     typedef UINT32 UINTN;
     typedef INT32 INTN;
     typedef INT64 INTMAX;
-#elif defined(__aarch64__)
+#elif defined(__aarch64__) || defined(__loongarch_lp64) || (defined(__riscv) && __riscv_xlen == 64)
     typedef unsigned long long UINT64;
     typedef long long INT64;
     typedef unsigned int UINT32;


### PR DESCRIPTION
  ## What

  LVGL's UEFI backend `#error`s on any arch outside `{x86_64, i386, aarch64}`.
  This adds **LoongArch64** and **RISC-V64**, both fully supported EDK2 UEFI
  targets. The change only touches architecture detection — the software renderer
  and the rest of the UEFI port are already portable C.

  ## Changes
  
  - `src/drivers/uefi/lv_uefi.h` — add `__loongarch_lp64` and `__riscv`(XLEN 64)
    branches to the arch gate (each sets `__LV_UEFI_64BIT__`).
  - `src/misc/lv_types.h` — add both arches to the `LV_ARCH_64` fallback list.
  - `tests/makefiles_uefi/efi.h` — cover both LP64 arches in the UEFI compile test.

  ## Validation

  - **LoongArch64**: built with EDK2 GCC into a PE32+ LoongArch UEFI app and **run
    on real LoongArch hardware** — LVGL renders to the GOP framebuffer correctly.
  - **RISC-V64**: same standard ABI guard; the UEFI arch gate compiles.

  No behavior change for existing architectures (purely additive `#elif`s).
