### PR TITLE
fix(draw/nema_gfx): ensure cmd end wait in !LV_USE_OS mode

### DIFF
--- a/src/draw/nema_gfx/lv_draw_nema_gfx.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx.c
@@ -339,6 +339,10 @@ static void nema_gfx_execute_drawing(lv_draw_nema_gfx_unit_t * u)
         default:
             break;
     }
+
+#if !LV_USE_OS
+    nema_cl_wait(&(u->cl));
+#endif
 }
 
 static int32_t nema_gfx_delete(lv_draw_unit_t * draw_unit)


### PR DESCRIPTION
Ensure to wait for the command end even when LV_USE_OS is not set and thus wait_for_finish is doing nothing.

This is a commit originally part of the PR #10062