### PR TITLE
fix(nema_gfx): fix compilation warning due to void * in arithmetic

### DIFF
--- a/src/draw/nema_gfx/lv_draw_nema_gfx_img.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_img.c
@@ -134,7 +134,7 @@ static void _draw_nema_gfx_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * d
         if(dsc->bitmap_mask_src->header.cf == LV_COLOR_FORMAT_A8 || dsc->bitmap_mask_src->header.cf == LV_COLOR_FORMAT_L8) {
             blending_mode |= NEMA_BLOP_STENCIL_TXTY;
             const lv_image_dsc_t * mask = dsc->bitmap_mask_src;
-            const void * mask_buf = mask->data;
+            const uint8_t * mask_buf = mask->data;
 
             const lv_area_t * image_area;
             lv_area_t mask_area;

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_label.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_label.c
@@ -338,7 +338,7 @@ static void _draw_nema_gfx_letter(lv_draw_task_t * t, lv_draw_glyph_dsc_t * glyp
                 return;
 
             const lv_draw_buf_t * draw_buf = glyph_draw_dsc->glyph_data;
-            const void * mask_buf;
+            const uint8_t * mask_buf;
             uint32_t src_cf;
             lv_area_t mask_area = *glyph_draw_dsc->letter_coords;
 


### PR DESCRIPTION
mask_buf computation in img and label part of the nema_gfx draw unit lead to the following compilation warning:

lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_label.c: In function '_draw_nema_gfx_letter': lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_label.c:365:26: warning: pointer of type 'void *' used in arithmetic [-Wpointer-arith]
  365 |                 mask_buf += draw_buf->header.stride * (blend_area.y1 - mask_area.y1) + (blend_area.x1 - mask_area.x1);
      |                          ^~

lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_img.c: In function '_draw_nema_gfx_img': lvgl/src/draw/nema_gfx/lv_draw_nema_gfx_img.c:147:22: warning: pointer of type 'void *' used in arithmetic [-Wpointer-arith]
  147 |             mask_buf += dsc->bitmap_mask_src->header.w * (img_coords->y1 - mask_area.y1) + (img_coords->x1 - mask_area.x1);
      |                      ^~

Indeed, mask_buf is a void pointer. Use a uint8_t pointer instead to avoid this warning and make the type explicit.