### PR TITLE
build(cmake): don't override fetchcontent base dir if it's already defined by the user

### DIFF
--- a/env_support/cmake/dependencies.cmake
+++ b/env_support/cmake/dependencies.cmake
@@ -1,8 +1,10 @@
 include(FetchContent)
 
-set(FETCHCONTENT_BASE_DIR
-    "${CMAKE_SOURCE_DIR}/.deps"
-    CACHE PATH "Directory for fetched dependencies" FORCE)
+if(NOT DEFINED FETCHCONTENT_BASE_DIR)
+  set(FETCHCONTENT_BASE_DIR
+      "${CMAKE_SOURCE_DIR}/.deps"
+      CACHE PATH "Directory for fetched dependencies" FORCE)
+endif()
 
 find_package(PkgConfig)
 


### PR DESCRIPTION
Allows having multiple dependencies folders in case we're cross compiling an application