### PR TITLE
refactor(draw/nanovg): remove color from image cache

### DIFF
--- a/src/draw/nanovg/lv_draw_nanovg_arc.c
+++ b/src/draw/nanovg/lv_draw_nanovg_arc.c
@@ -145,7 +145,7 @@ void lv_draw_nanovg_arc(lv_draw_task_t * t, const lv_draw_arc_dsc_t * dsc, const
 
     if(dsc->img_src) {
         lv_image_header_t header;
-        int image_handle = lv_nanovg_image_cache_get_handle(u, dsc->img_src, lv_color32_make(0, 0, 0, 0), 0, &header);
+        int image_handle = lv_nanovg_image_cache_get_handle(u, dsc->img_src, 0, &header);
         if(image_handle < 0) {
             LV_PROFILER_DRAW_END;
             return;

--- a/src/draw/nanovg/lv_draw_nanovg_image.c
+++ b/src/draw/nanovg/lv_draw_nanovg_image.c
@@ -88,7 +88,8 @@ void lv_draw_nanovg_image(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc, c
             }
         }
 
-        image_handle = lv_nanovg_image_cache_get_handle(u, dsc->src, lv_color_to_32(dsc->recolor, dsc->opa), image_flags, NULL);
+        image_handle = lv_nanovg_image_cache_get_handle(u, dsc->src,
+                                                        image_flags, NULL);
     }
 
     if(image_handle < 0) {

--- a/src/draw/nanovg/lv_draw_nanovg_vector.c
+++ b/src/draw/nanovg/lv_draw_nanovg_vector.c
@@ -98,8 +98,7 @@ static void draw_fill(lv_draw_nanovg_unit_t * u, const lv_vector_fill_dsc_t * fi
         case LV_VECTOR_DRAW_STYLE_PATTERN: {
                 const lv_draw_image_dsc_t * img_dsc = &fill_dsc->img_dsc;
                 lv_image_header_t header;
-                int image_handle = lv_nanovg_image_cache_get_handle(u, img_dsc->src, lv_color_to_32(img_dsc->recolor,
-                                                                                                    img_dsc->recolor_opa), 0, &header);
+                int image_handle = lv_nanovg_image_cache_get_handle(u, img_dsc->src, 0, &header);
                 if(image_handle < 0) {
                     LV_PROFILER_DRAW_END;
                     return;

--- a/src/draw/nanovg/lv_nanovg_image_cache.c
+++ b/src/draw/nanovg/lv_nanovg_image_cache.c
@@ -32,7 +32,6 @@ typedef struct {
 
     /* key */
     lv_draw_buf_t src_buf;
-    lv_color32_t color;
     int image_flags;
 
     /* for drop search */
@@ -100,7 +99,6 @@ void lv_nanovg_image_cache_deinit(struct _lv_draw_nanovg_unit_t * u)
 
 int lv_nanovg_image_cache_get_handle(struct _lv_draw_nanovg_unit_t * u,
                                      const void * src,
-                                     lv_color32_t color,
                                      int image_flags,
                                      lv_image_header_t * header)
 {
@@ -138,7 +136,6 @@ int lv_nanovg_image_cache_get_handle(struct _lv_draw_nanovg_unit_t * u,
     image_item_t search_key = { 0 };
     search_key.u = u;
     search_key.src_buf = *decoded;
-    search_key.color = color;
     search_key.image_flags = image_flags;
     search_key.src = src;
     search_key.src_type = lv_image_src_get_type(src);
@@ -314,13 +311,6 @@ static lv_cache_compare_res_t image_compare_cb(const image_item_t * lhs, const i
 {
     if(lhs->image_flags != rhs->image_flags) {
         return lhs->image_flags > rhs->image_flags ? 1 : -1;
-    }
-
-    uint32_t lhs_color = *(uint32_t *)&lhs->color;
-    uint32_t rhs_color = *(uint32_t *)&rhs->color;
-
-    if(lhs_color != rhs_color) {
-        return lhs_color > rhs_color ? 1 : -1;
     }
 
     int cmp_res = lv_memcmp(&lhs->src_buf, &rhs->src_buf, sizeof(lv_draw_buf_t));

--- a/src/draw/nanovg/lv_nanovg_image_cache.h
+++ b/src/draw/nanovg/lv_nanovg_image_cache.h
@@ -50,14 +50,12 @@ void lv_nanovg_image_cache_deinit(struct _lv_draw_nanovg_unit_t * u);
  * @brief Get the image handle from the cache, create a new one if not found
  * @param u pointer to the nanovg unit
  * @param src the source image data
- * @param color the color to apply
  * @param image_flags the image flags
  * @param header the image header to fill (can be NULL)
  * @return the image handle, or -1 on failure
  */
 int lv_nanovg_image_cache_get_handle(struct _lv_draw_nanovg_unit_t * u,
                                      const void * src,
-                                     lv_color32_t color,
                                      int image_flags,
                                      lv_image_header_t * header);
 


### PR DESCRIPTION
The image and opacity are handled at rendering time so there's no need to cache this information