### PR TITLE
fix(demo/music): fix flickering issue when going to the next album

### DIFF
--- a/demos/music/lv_demo_music.c
+++ b/demos/music/lv_demo_music.c
@@ -36,7 +36,7 @@
  **********************/
 static lv_obj_t * ctrl;
 static lv_obj_t * list;
-static uint32_t music_height;
+static int32_t music_height;
 
 static const char * title_list[] = {
     "Waiting for true love",

--- a/demos/music/lv_demo_music_main.c
+++ b/demos/music/lv_demo_music_main.c
@@ -97,8 +97,8 @@ static lv_obj_t * play_obj;
 static const uint16_t (* spectrum)[4];
 static uint32_t spectrum_len;
 static const uint16_t rnd_array[30] = {994, 285, 553, 11, 792, 707, 966, 641, 852, 827, 44, 352, 146, 581, 490, 80, 729, 58, 695, 940, 724, 561, 124, 653, 27, 292, 557, 506, 382, 199};
-static uint32_t music_width = 0;
-static uint32_t music_height = 0;
+static int32_t music_width = 0;
+static int32_t music_height = 0;
 static uint32_t bar_color3_stop = 0;
 
 /**********************


### PR DESCRIPTION
## Summary

The PR aims to fix n the music demo, the problem where, when pressing the "NEXT" button, the cover of the previous album flashes instead of sliding smoothly.

- https://github.com/lvgl/lvgl/issues/10229