### PR TITLE
fix(lodepng): fix relying on integer promotion and prevent buffer over-read

### DIFF
--- a/src/image/lv_lodepng.c
+++ b/src/image/lv_lodepng.c
@@ -125,8 +125,8 @@ static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_d
         header->cf = LV_COLOR_FORMAT_ARGB8888;
 
         /*The width and height are stored in Big endian format*/
-        uint32_t width = ((uint32_t)size[0] << 24) + ((uint32_t)size[1] << 16) + (size[2] << 8) + size[3];
-        uint32_t height = ((uint32_t)size[4] << 24) + ((uint32_t)size[5] << 16) + (size[6] << 8) + size[7];
+        uint32_t width = ((uint32_t)size[0] << 24) + ((uint32_t)size[1] << 16) + ((uint32_t)size[2] << 8) + (uint32_t)size[3];
+        uint32_t height = ((uint32_t)size[4] << 24) + ((uint32_t)size[5] << 16) + ((uint32_t)size[6] << 8) + (uint32_t)size[7];
 
         /*Avoid attempting to load images LVGL cannot use*/
         if(width > UINT16_MAX || height > UINT16_MAX) return LV_RESULT_INVALID;

--- a/src/image/lv_lodepng.c
+++ b/src/image/lv_lodepng.c
@@ -114,10 +114,11 @@ static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_d
         else {
             const lv_image_dsc_t * img_dsc = dsc->src;
             const uint32_t data_size = img_dsc->data_size;
-            size = img_dsc->data + 16;
 
-            if(data_size < sizeof(magic)) return LV_RESULT_INVALID;
+            if(data_size < sizeof(buf)) return LV_RESULT_INVALID;
             if(lv_memcmp(img_dsc->data, magic, sizeof(magic)) != 0) return LV_RESULT_INVALID;
+
+            size = img_dsc->data + 16;
         }
 
         /*Save the data in the header*/

--- a/src/image/lv_lodepng.c
+++ b/src/image/lv_lodepng.c
@@ -124,8 +124,8 @@ static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_d
         header->cf = LV_COLOR_FORMAT_ARGB8888;
 
         /*The width and height are stored in Big endian format*/
-        uint32_t width = (size[0] << 24) + (size[1] << 16) + (size[2] << 8) + size[3];
-        uint32_t height = (size[4] << 24) + (size[5] << 16) + (size[6] << 8) + size[7];
+        uint32_t width = ((uint32_t)size[0] << 24) + ((uint32_t)size[1] << 16) + (size[2] << 8) + size[3];
+        uint32_t height = ((uint32_t)size[4] << 24) + ((uint32_t)size[5] << 16) + (size[6] << 8) + size[7];
 
         /*Avoid attempting to load images LVGL cannot use*/
         if(width > UINT16_MAX || height > UINT16_MAX) return LV_RESULT_INVALID;

--- a/src/libs/lodepng/lv_lodepng.c
+++ b/src/libs/lodepng/lv_lodepng.c
@@ -125,8 +125,8 @@ static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_d
         header->cf = LV_COLOR_FORMAT_ARGB8888;
 
         /*The width and height are stored in Big endian format*/
-        uint32_t width = ((uint32_t)size[0] << 24) + ((uint32_t)size[1] << 16) + (size[2] << 8) + size[3];
-        uint32_t height = ((uint32_t)size[4] << 24) + ((uint32_t)size[5] << 16) + (size[6] << 8) + size[7];
+        uint32_t width = ((uint32_t)size[0] << 24) + ((uint32_t)size[1] << 16) + ((uint32_t)size[2] << 8) + (uint32_t)size[3];
+        uint32_t height = ((uint32_t)size[4] << 24) + ((uint32_t)size[5] << 16) + ((uint32_t)size[6] << 8) + (uint32_t)size[7];
 
         /*Avoid attempting to load images LVGL cannot use*/
         if(width > UINT16_MAX || height > UINT16_MAX) return LV_RESULT_INVALID;

--- a/src/libs/lodepng/lv_lodepng.c
+++ b/src/libs/lodepng/lv_lodepng.c
@@ -114,10 +114,11 @@ static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_d
         else {
             const lv_image_dsc_t * img_dsc = dsc->src;
             const uint32_t data_size = img_dsc->data_size;
-            size = img_dsc->data + 16;
 
-            if(data_size < sizeof(magic)) return LV_RESULT_INVALID;
+            if(data_size < sizeof(buf)) return LV_RESULT_INVALID;
             if(lv_memcmp(img_dsc->data, magic, sizeof(magic)) != 0) return LV_RESULT_INVALID;
+
+            size = img_dsc->data + 16;
         }
 
         /*Save the data in the header*/

--- a/src/libs/lodepng/lv_lodepng.c
+++ b/src/libs/lodepng/lv_lodepng.c
@@ -124,8 +124,8 @@ static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_d
         header->cf = LV_COLOR_FORMAT_ARGB8888;
 
         /*The width and height are stored in Big endian format*/
-        uint32_t width = (size[0] << 24) + (size[1] << 16) + (size[2] << 8) + size[3];
-        uint32_t height = (size[4] << 24) + (size[5] << 16) + (size[6] << 8) + size[7];
+        uint32_t width = ((uint32_t)size[0] << 24) + ((uint32_t)size[1] << 16) + (size[2] << 8) + size[3];
+        uint32_t height = ((uint32_t)size[4] << 24) + ((uint32_t)size[5] << 16) + (size[6] << 8) + size[7];
 
         /*Avoid attempting to load images LVGL cannot use*/
         if(width > UINT16_MAX || height > UINT16_MAX) return LV_RESULT_INVALID;


### PR DESCRIPTION
Fix potential issue decoding oversized PNGs on small-worded CPUs
Prevent buffer-overread of truncated PNG data.
Make size check more consistent.