### PR TITLE
fix(draw/sw): wait for in-flight draw tasks before freeing to prevent cross-thread UAF

### DIFF
--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -53,6 +53,9 @@ static void execute_drawing(lv_draw_task_t * t);
 static int32_t dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer);
 static int32_t evaluate(lv_draw_unit_t * draw_unit, lv_draw_task_t * task);
 static int32_t lv_draw_sw_delete(lv_draw_unit_t * draw_unit);
+#if LV_USE_OS
+    static int32_t lv_draw_sw_wait_for_finish(lv_draw_unit_t * draw_unit);
+#endif
 #if LV_USE_PARALLEL_DRAW_DEBUG
     static void parallel_debug_draw(lv_draw_task_t * t, uint32_t idx);
 #endif
@@ -81,6 +84,9 @@ void lv_draw_sw_init(void)
     draw_sw_unit->base_unit.dispatch_cb = dispatch;
     draw_sw_unit->base_unit.evaluate_cb = evaluate;
     draw_sw_unit->base_unit.delete_cb = LV_USE_OS ? lv_draw_sw_delete : NULL;
+#if LV_USE_OS
+    draw_sw_unit->base_unit.wait_for_finish_cb = lv_draw_sw_wait_for_finish;
+#endif
 #if LV_USE_DRAW_ARM2D_SYNC
     draw_sw_unit->base_unit.name = "SW_ARM2D";
 #else
@@ -120,6 +126,41 @@ void lv_draw_sw_deinit(void)
     lv_draw_sw_mask_deinit();
 #endif
 }
+
+#if LV_USE_OS
+/**
+ * Block until every SW render thread has finished its in-flight task.
+ *
+ * With LV_USE_OS the SW renderer runs draw tasks on separate render threads
+ * while the LVGL thread keeps going. lv_draw_dispatch() calls
+ * lv_draw_wait_for_finish() (via each unit's wait_for_finish_cb) when there is
+ * nothing left to dispatch, providing the ordering guarantee that no draw task
+ * is still being processed on a render thread once dispatching completes.
+ *
+ * Without this callback the SW unit reports "finished" while a render thread may
+ * still be inside execute_drawing(), dereferencing data owned by a widget
+ * subtree (e.g. label/font glyph descriptors). If the LVGL thread then frees
+ * that subtree (a deferred lv_obj_delete_async firing on the next timer tick),
+ * the render thread reads freed memory — a cross-thread use-after-free that
+ * segfaults in release builds where asserts are compiled out.
+ */
+static int32_t lv_draw_sw_wait_for_finish(lv_draw_unit_t * draw_unit)
+{
+    lv_draw_sw_unit_t * draw_sw_unit = (lv_draw_sw_unit_t *) draw_unit;
+
+    uint32_t i;
+    for(i = 0; i < LV_DRAW_SW_DRAW_UNIT_CNT; i++) {
+        /* task_act is cleared by the render thread once execute_drawing() returns.
+         * The volatile read forces the compiler to re-fetch it each iteration;
+         * lv_sleep_ms() yields and acts as a memory barrier between threads. */
+        while(*(lv_draw_task_t * volatile *) &draw_sw_unit->thread_dscs[i].task_act) {
+            lv_sleep_ms(1);
+        }
+    }
+
+    return 1;
+}
+#endif
 
 static int32_t lv_draw_sw_delete(lv_draw_unit_t * draw_unit)
 {


### PR DESCRIPTION

## Summary

The software renderer never installs a `wait_for_finish_cb` on its draw unit. With
`LV_USE_OS` enabled this leaves a cross-thread use-after-free window: a render thread
can still be inside `execute_drawing()` — dereferencing data owned by a widget subtree
(label/font glyph descriptors, image dsc, etc.) — at the moment the LVGL thread frees
that subtree. This PR implements `lv_draw_sw_wait_for_finish()` so the SW unit honors
the same finish/sync contract the HW units (NemaGFX, DMA2D, Dave2D) already implement.

## Background: the LV_USE_OS render-thread model

When `LV_USE_OS` is set, the SW renderer spawns `LV_DRAW_SW_DRAW_UNIT_CNT` render
threads (`render_thread_cb` in `lv_draw_sw.c`). The LVGL thread enqueues draw tasks and
hands each off to a render thread by setting `thread_dsc->task_act`. The render thread
runs `execute_drawing(task_act)` and only then clears `task_act = NULL`. This is the
asynchronous case described in the `wait_for_finish_cb` doc comment in
`lv_draw_private.h`: the LVGL thread keeps running while tasks complete on other threads.

`lv_draw.c` already provides the ordering primitive:

```c
void lv_draw_wait_for_finish(void)
{
#if LV_USE_OS
    lv_draw_unit_t * u = _draw_info.unit_head;
    while(u) {
        if(u->wait_for_finish_cb) u->wait_for_finish_cb(u);
        u = u->next;
    }
#endif
}
```

and `lv_draw_dispatch()` calls it once there is nothing left to dispatch. NemaGFX,
DMA2D and Dave2D all set `wait_for_finish_cb`. The SW unit is the only one that does
**not** — `lv_draw_sw_init()` wires up `dispatch_cb`, `evaluate_cb` and `delete_cb`, but
leaves `wait_for_finish_cb` NULL. So for the most widely-used renderer, "dispatch is
done" does not actually imply "no render thread is touching task memory."

## The use-after-free

1. The LVGL thread dispatches a draw task for a label; render thread N begins
   `execute_drawing()` and starts walking the label's glyph data
   (`draw_letter_cb` → font/glyph descriptors owned by the widget subtree).
2. A deferred `lv_obj_delete_async()` queued earlier fires on the next
   `lv_timer_handler()` tick and frees that widget subtree — including the font/glyph
   data the render thread is mid-read on.
3. Because the SW unit has no `wait_for_finish_cb`, nothing forced step 1 to complete
   before step 2 freed the memory. Render thread N now dereferences freed memory.

In debug builds this often trips an assert; in **release builds (asserts compiled out)**
it is a straight segfault. We see this in the field on embedded Linux devices running
multi-threaded SW draw — a crash whose backtrace points into `draw_letter_cb` /
`lv_font_get_*` with a garbage or freed font/glyph pointer.

## The fix

Install a `wait_for_finish_cb` on the SW draw unit that blocks until every render
thread has cleared its `task_act`:

```c
static int32_t lv_draw_sw_wait_for_finish(lv_draw_unit_t * draw_unit)
{
    lv_draw_sw_unit_t * draw_sw_unit = (lv_draw_sw_unit_t *) draw_unit;
    for(uint32_t i = 0; i < LV_DRAW_SW_DRAW_UNIT_CNT; i++) {
        while(*(lv_draw_task_t * volatile *) &draw_sw_unit->thread_dscs[i].task_act) {
            lv_sleep_ms(1);
        }
    }
    return 1;
}
```

`task_act` is written by the render thread; the volatile read forces a re-fetch each
iteration and `lv_sleep_ms()` yields and provides a memory barrier between threads. The
callback is `#if LV_USE_OS`-gated (the field only exists in that build) and wired in
`lv_draw_sw_init()` next to the existing `delete_cb` assignment. This restores the
ordering guarantee the rest of the draw core already assumes: once
`lv_draw_wait_for_finish()` returns, no render thread is still inside a draw task, so it
is safe to free widget-owned data.

## Relation to the deref-guard discussion (PR #9831)

PR #9831 added NULL/plausibility guards inside `lv_draw_sw_label` / `draw_letter_cb`
(skip the draw if the descriptor/font/glyph pointer is NULL or obviously corrupt). Those
guards reduce the blast radius but only mask the symptom — by the time the renderer is
holding a freed pointer, the UAF has already happened, and a non-NULL-but-freed pointer
still races. @AndreCostaaa asked for the structural root-cause fix rather than defensive
deref guards. **This PR is that root-cause fix**: it closes the ordering window itself by
making the SW unit participate in `wait_for_finish`, the same contract the HW draw units
already satisfy. The two are complementary — this PR removes the window; the guards (if
kept) are belt-and-suspenders — but this is the fix that actually prevents the
cross-thread free-during-draw race.

## Testing

- Syntax/compile verified for the affected translation unit with
  `LV_USE_OS=1` (`LV_DRAW_SW_DRAW_UNIT_CNT=2`) and with `LV_USE_OS=0` — both clean.
- `lv_sleep_ms` is the public OSAL primitive declared in `osal/lv_os.h`, already in
  scope in this file (it uses `lv_thread_*`); no new includes required.
- Downstream we have shipped the equivalent change on embedded Linux devices and it
  eliminates the intermittent render-thread segfault under heavy navigation/redraw with
  multi-threaded SW draw.

## Notes

- No behavior change when `LV_USE_OS` is disabled (single-threaded SW draw already
  completes each task synchronously in `dispatch`).
- Only `src/draw/sw/lv_draw_sw.c` is touched; no public API or struct layout changes.
