### PR TITLE
fix(include): include api mapping headers after other includes

### DIFF
--- a/include/lvgl/lvgl.h
+++ b/include/lvgl/lvgl.h
@@ -8,18 +8,6 @@
 #include "3d/lv_gltf_model_loader.h"
 #include "3d/lv_gltf_model_node.h"
 
-/* Define LV_DISABLE_API_MAPPING using a compiler option
- * to make sure your application is not using deprecated names */
-#ifndef LV_DISABLE_API_MAPPING
-    #include "api_map/lv_api_map_v8.h"
-    #include "api_map/lv_api_map_v9_0.h"
-    #include "api_map/lv_api_map_v9_1.h"
-    #include "api_map/lv_api_map_v9_2.h"
-    #include "api_map/lv_api_map_v9_3.h"
-    #include "api_map/lv_api_map_v9_4.h"
-    #include "api_map/lv_api_map_v9_5.h"
-#endif /*LV_DISABLE_API_MAPPING*/
-
 #include "config/lv_conf_internal.h"
 #include "config/lv_conf_kconfig.h"
 #include "core/lv_anim.h"
@@ -221,6 +209,18 @@
 #include "widgets/lv_textarea.h"
 #include "widgets/lv_tileview.h"
 #include "widgets/lv_win.h"
+
+/* Define LV_DISABLE_API_MAPPING using a compiler option
+ * to make sure your application is not using deprecated names */
+#ifndef LV_DISABLE_API_MAPPING
+    #include "api_map/lv_api_map_v8.h"
+    #include "api_map/lv_api_map_v9_0.h"
+    #include "api_map/lv_api_map_v9_1.h"
+    #include "api_map/lv_api_map_v9_2.h"
+    #include "api_map/lv_api_map_v9_3.h"
+    #include "api_map/lv_api_map_v9_4.h"
+    #include "api_map/lv_api_map_v9_5.h"
+#endif /*LV_DISABLE_API_MAPPING*/
 
 /** Gives 1 if the x.y.z version is supported in the current version
  * Usage:


### PR DESCRIPTION
api mapping headers are included prior to inclusion of core obj header, leading to undefined function when including api mapping headers.

This fixes a build issue when LVGL is build within Zephyr, which seems to be due to the fact that api mapping headers are included after core obj headers. Part of the build error:

modules/lib/gui/lvgl/src/../include/lvgl/api_map/lv_api_map_v8.h: In function 'lv_obj_move_foreground':
modules/lib/gui/lvgl/src/../include/lvgl/api_map/lv_api_map_v8.h:92:25: error: implicit declaration of function 'lv_obj_get_parent' [-Wimplicit-function-declaration]
   92 |     lv_obj_t * parent = lv_obj_get_parent(obj);
      |                         ^~~~~~~~~~~~~~~~~
modules/lib/gui/lvgl/src/../include/lvgl/api_map/lv_api_map_v8.h:92:25: error: initialization of 'lv_obj_t *' {aka 'struct _lv_obj_t *'} from 'int' makes pointer from integer without a cast [-Wint-conversion]
modules/lib/gui/lvgl/src/../include/lvgl/api_map/lv_api_map_v8.h:98:5: error: implicit declaration of function 'lv_obj_move_to_index' [-Wimplicit-function-declaration]
   98 |     lv_obj_move_to_index(obj, lv_obj_get_child_count(parent) - 1);
      |     ^~~~~~~~~~~~~~~~~~~~
modules/lib/gui/lvgl/src/../include/lvgl/api_map/lv_api_map_v8.h:98:31: error: implicit declaration of function 'lv_obj_get_child_count' [-Wimplicit-function-declaration]
   98 |     lv_obj_move_to_index(obj, lv_obj_get_child_count(parent) - 1);
