### PR TITLE
fix(obj/event): avoid unused variable when LV_CHECK_ARGS is disabled

### DIFF
--- a/src/core/lv_obj_event.c
+++ b/src/core/lv_obj_event.c
@@ -28,7 +28,9 @@
 static lv_result_t event_send_core(lv_event_t * e);
 static bool event_is_bubbled(lv_event_t * e);
 static bool event_is_trickled(lv_event_t * e);
-static bool event_code_in_array(lv_event_code_t code, const lv_event_code_t * arr, uint32_t len);
+#if LV_USE_CHECK_ARG
+    static bool event_code_in_array(lv_event_code_t code, const lv_event_code_t * arr, uint32_t len);
+#endif
 
 /**********************
  *  STATIC VARIABLES
@@ -200,6 +202,7 @@ lv_obj_t * lv_event_get_target_obj(lv_event_t * e)
 lv_indev_t * lv_event_get_indev(lv_event_t * e)
 {
     LV_CHECK_ARG(e != NULL, return NULL);
+#if LV_USE_CHECK_ARG
     static const lv_event_code_t indev_codes[] = {
         LV_EVENT_PRESSED,           LV_EVENT_PRESSING,          LV_EVENT_PRESS_LOST,
         LV_EVENT_SHORT_CLICKED,     LV_EVENT_LONG_PRESSED,      LV_EVENT_LONG_PRESSED_REPEAT,
@@ -209,6 +212,7 @@ lv_indev_t * lv_event_get_indev(lv_event_t * e)
         LV_EVENT_FOCUSED,           LV_EVENT_DEFOCUSED,         LV_EVENT_LEAVE,
         LV_EVENT_HOVER_OVER,        LV_EVENT_HOVER_LEAVE,
     };
+#endif
     LV_CHECK_ARG(event_code_in_array(e->code, indev_codes, sizeof(indev_codes) / sizeof(indev_codes[0])),
                  return NULL, "invalid event code %" LV_PRId32, (int32_t)e->code);
     return lv_event_get_param(e);
@@ -217,10 +221,12 @@ lv_indev_t * lv_event_get_indev(lv_event_t * e)
 lv_layer_t * lv_event_get_layer(lv_event_t * e)
 {
     LV_CHECK_ARG(e != NULL, return NULL);
+#if LV_USE_CHECK_ARG
     static const lv_event_code_t draw_codes[] = {
         LV_EVENT_DRAW_MAIN,     LV_EVENT_DRAW_MAIN_BEGIN,   LV_EVENT_DRAW_MAIN_END,
         LV_EVENT_DRAW_POST,     LV_EVENT_DRAW_POST_BEGIN,   LV_EVENT_DRAW_POST_END,
     };
+#endif
     LV_CHECK_ARG(event_code_in_array(e->code, draw_codes, sizeof(draw_codes) / sizeof(draw_codes[0])),
                  return NULL, "invalid event code %" LV_PRId32, (int32_t)e->code);
     return lv_event_get_param(e);
@@ -450,6 +456,7 @@ static bool event_is_trickled(lv_event_t * e)
     }
 }
 
+#if LV_USE_CHECK_ARG
 static bool event_code_in_array(lv_event_code_t code, const lv_event_code_t * arr, uint32_t len)
 {
     uint32_t i;
@@ -458,3 +465,4 @@ static bool event_code_in_array(lv_event_code_t code, const lv_event_code_t * ar
     }
     return false;
 }
+#endif


### PR DESCRIPTION
Prevent having variables or function defined but not used in case of LV_CHECK_ARGS is disabled

Fixes #10248

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
