### PR TITLE
fix(dropdown): list coordinate position when screen base_dir is RTL.

### DIFF
--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -54,6 +54,7 @@ static void list_press_handler(lv_obj_t * page);
 static uint32_t get_id_on_point(lv_obj_t * dropdown_obj, int32_t y);
 static void position_to_selected(lv_obj_t * dropdown_obj, lv_anim_enable_t anim_en);
 static lv_obj_t * get_label(const lv_obj_t * obj);
+static void dropdown_list_align(lv_dropdown_t *dropdown, lv_area_t coord);
 
 #if LV_USE_OBSERVER
     static void dropdown_value_changed_event_cb(lv_event_t * e);
@@ -605,7 +606,7 @@ void lv_dropdown_open(lv_obj_t * dropdown_obj)
 
     position_to_selected(dropdown_obj, LV_ANIM_OFF);
 
-    if(dir == LV_DIR_BOTTOM)     lv_obj_align_to(dropdown->list, dropdown_obj, LV_ALIGN_OUT_BOTTOM_LEFT, 0, 0);
+    if(dir == LV_DIR_BOTTOM)     dropdown_list_align(dropdown, dropdown_obj->coords);
     else if(dir == LV_DIR_TOP)   lv_obj_align_to(dropdown->list, dropdown_obj, LV_ALIGN_OUT_TOP_LEFT, 0, 0);
     else if(dir == LV_DIR_LEFT)  lv_obj_align_to(dropdown->list, dropdown_obj, LV_ALIGN_OUT_LEFT_TOP, 0, 0);
     else if(dir == LV_DIR_RIGHT) lv_obj_align_to(dropdown->list, dropdown_obj, LV_ALIGN_OUT_RIGHT_TOP, 0, 0);
@@ -1375,6 +1376,26 @@ static lv_obj_t * get_label(const lv_obj_t * obj)
     if(dropdown->list == NULL) return NULL;
 
     return lv_obj_get_child(dropdown->list, 0);
+}
+
+static void dropdown_list_align(lv_dropdown_t *dropdown, lv_area_t coord)
+{
+    int32_t offset, pos_x;
+
+    lv_obj_t * list_parent = lv_obj_get_parent(dropdown->list);
+    bool rtl = lv_obj_get_style_base_dir(list_parent, LV_PART_MAIN) == LV_BASE_DIR_RTL;
+
+    int32_t scroll_x = lv_obj_get_scroll_x(list_parent);
+    int32_t space_left = lv_obj_get_style_space_left(list_parent, LV_PART_MAIN);
+
+    offset = (rtl)  ? (coord.x2 - lv_obj_get_width(dropdown->list) + 1) : coord.x1;
+
+    pos_x = (rtl)   ? ((list_parent->coords.x1 + space_left - scroll_x) +
+                        (lv_obj_get_content_width(list_parent) - lv_obj_get_width(dropdown->list) - offset))
+                    :   (offset - list_parent->coords.x1 - space_left + scroll_x);
+
+    lv_obj_set_x(dropdown->list, pos_x);
+    lv_obj_set_y(dropdown->list, coord.y2 + 1);
 }
 
 #if LV_USE_OBSERVER


### PR DESCRIPTION
## Summary
The PR aims to fix the dropdown list when the screen/parent has LV_BASE_DIR_RTL. In lv_dropdown_open() relied on lv_obj_align_to() with LV_ALIGN_OUT_BOTTOM_LEFT to place the open list under the button. However, lv_obj_align_to() always stores the resulting alignment as LV_ALIGN_TOP_LEFT, and lv_obj_refr_pos() later mirrors TOP_LEFT to TOP_RIGHT whenever the parent's base_dir is RTL

## Issue
- https://github.com/lvgl/lvgl/issues/10254
