### PR TITLE
build(cmake): link targets publicly when private api is set

### DIFF
--- a/env_support/cmake/dependencies/wayland.cmake
+++ b/env_support/cmake/dependencies/wayland.cmake
@@ -193,3 +193,7 @@ target_sources(lvgl PRIVATE $<TARGET_OBJECTS:lv_wayland_protocols>)
 target_include_directories(
   lvgl
   PRIVATE $<TARGET_PROPERTY:lv_wayland_protocols,INTERFACE_INCLUDE_DIRECTORIES>)
+
+if(CONFIG_LV_USE_PRIVATE_API)
+  target_include_directories(lvgl PUBLIC $<BUILD_INTERFACE:${PROTOCOLS_DIR}>)
+endif()

--- a/env_support/cmake/lvgl_link_libraries.cmake
+++ b/env_support/cmake/lvgl_link_libraries.cmake
@@ -56,7 +56,7 @@ function(lvgl_link_packages)
   cmake_parse_arguments(ARG "${options}" "" "${multiValueArgs}" ${ARGN})
 
   set(SCOPE PRIVATE)
-  if(ARG_PUBLIC)
+  if(ARG_PUBLIC OR CONFIG_LV_USE_PRIVATE_API)
     set(SCOPE PUBLIC)
   endif()
 
@@ -97,7 +97,7 @@ function(lvgl_link_pkg_config)
   cmake_parse_arguments(ARG "${options}" "" "${multiValueArgs}" ${ARGN})
 
   set(SCOPE PRIVATE)
-  if(ARG_PUBLIC)
+  if(ARG_PUBLIC OR CONFIG_LV_USE_PRIVATE_API)
     set(SCOPE PUBLIC)
   endif()
 
@@ -131,8 +131,13 @@ function(lvgl_link_raw)
   set(multiValueArgs TARGETS PKG_LIB_PRIVATE)
   cmake_parse_arguments(ARG "" "" "${multiValueArgs}" ${ARGN})
 
+  set(SCOPE PRIVATE)
+  if(CONFIG_LV_USE_PRIVATE_API)
+    set(SCOPE PUBLIC)
+  endif()
+
   if(ARG_TARGETS)
-    target_link_libraries(lvgl PRIVATE ${ARG_TARGETS})
+    target_link_libraries(lvgl ${SCOPE} ${ARG_TARGETS})
   endif()
 
   if(ARG_PKG_LIB_PRIVATE)


### PR DESCRIPTION
When using PRIVATE_API, apps linking with LVGL require access to LVGL dependencies headers, so we link these dependencies as PUBLIC to simplify integration for users