### PR TITLE
fix(obj_pos): correct off-by-one in lv_obj_get_transformed_area

### DIFF
--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -1010,9 +1010,9 @@ void lv_obj_get_transformed_area(const lv_obj_t * obj, lv_area_t * area, lv_obj_
     lv_obj_transform_point_array(obj, p, 4, flags);
 
     area->x1 = LV_MIN4(p[0].x, p[1].x, p[2].x, p[3].x);
-    area->x2 = LV_MAX4(p[0].x, p[1].x, p[2].x, p[3].x);
+    area->x2 = LV_MAX4(p[0].x, p[1].x, p[2].x, p[3].x) - 1;
     area->y1 = LV_MIN4(p[0].y, p[1].y, p[2].y, p[3].y);
-    area->y2 = LV_MAX4(p[0].y, p[1].y, p[2].y, p[3].y);
+    area->y2 = LV_MAX4(p[0].y, p[1].y, p[2].y, p[3].y) - 1;
 }
 
 typedef struct {


### PR DESCRIPTION
## Description

Fixes an off-by-one error in `lv_obj_get_transformed_area()` that causes the returned area to be 1px wider and 1px taller than the actual transformed region.

### Root Cause

The function converts input coordinates to exclusive boundaries by adding +1 to x2/y2 before transforming the 4 corner points:

```c
lv_point_t p[4] = {
    {area->x1, area->y1},
    {area->x1, area->y2 + 1},      // +1 for exclusive
    {area->x2 + 1, area->y1},
    {area->x2 + 1, area->y2 + 1},
};
```

However, after computing the bounding box of the transformed points, it did not convert back to inclusive coordinates:

```c
// Before (wrong): output is in exclusive coordinates
area->x2 = LV_MAX4(p[0].x, p[1].x, p[2].x, p[3].x);
area->y2 = LV_MAX4(p[0].y, p[1].y, p[2].y, p[3].y);

// After (correct): convert back to inclusive coordinates
area->x2 = LV_MAX4(p[0].x, p[1].x, p[2].x, p[3].x) - 1;
area->y2 = LV_MAX4(p[0].y, p[1].y, p[2].y, p[3].y) - 1;
```

### Impact

Since `lv_area_t` uses inclusive coordinates (where x2/y2 represent the last included pixel), the returned area was consistently 1px too large in each dimension. This causes unnecessary display refreshes, which is especially noticeable on e-ink displays where partial refresh is used to minimize visual artifacts.

Fixes lvgl/lvgl#10211

Signed-off-by: hanzhijian [hanzhijian@zepp.com](<mailto:hanzhijian@zepp.com>)

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)