### PR TITLE
fix(buttonmatrix): keep selection in place when the map changes

### DIFF
--- a/src/widgets/buttonmatrix/lv_buttonmatrix.c
+++ b/src/widgets/buttonmatrix/lv_buttonmatrix.c
@@ -116,6 +116,20 @@ void lv_buttonmatrix_set_map(lv_obj_t * obj, const char * const map[])
     if(map == NULL) return;
 
     lv_buttonmatrix_t * btnm = (lv_buttonmatrix_t *)obj;
+
+    /*Remember the on-screen position of the selected button. Changing the map changes which
+     *button each index refers to, so the selection is restored by position below to avoid the
+     *highlight jumping to an unrelated button.*/
+    bool had_sel = btnm->btn_id_sel != LV_BUTTONMATRIX_BUTTON_NONE && btnm->btn_id_sel < btnm->btn_cnt;
+    lv_point_t sel_center;
+    if(had_sel) {
+        lv_area_t obj_cords;
+        lv_obj_get_coords(obj, &obj_cords);
+        const lv_area_t * a = &btnm->button_areas[btnm->btn_id_sel];
+        sel_center.x = obj_cords.x1 + a->x1 + (lv_area_get_width(a) >> 1);
+        sel_center.y = obj_cords.y1 + a->y1 + (lv_area_get_height(a) >> 1);
+    }
+
     if(btnm->auto_free_map) free_map(btnm);
     btnm->auto_free_map = 0;
 
@@ -124,6 +138,17 @@ void lv_buttonmatrix_set_map(lv_obj_t * obj, const char * const map[])
     btnm->map_p = map;
 
     update_map(obj);
+
+    /*Restore the selection on the button now occupying the previous selection's position*/
+    if(had_sel) {
+        uint32_t new_sel = get_button_from_point(obj, &sel_center);
+        if(new_sel != LV_BUTTONMATRIX_BUTTON_NONE &&
+           (button_is_hidden(btnm->ctrl_bits[new_sel]) || button_is_inactive(btnm->ctrl_bits[new_sel]))) {
+            new_sel = LV_BUTTONMATRIX_BUTTON_NONE;
+        }
+        btnm->btn_id_sel = new_sel;
+        invalidate_button_area(obj, btnm->btn_id_sel);
+    }
 }
 
 void lv_buttonmatrix_set_ctrl_map(lv_obj_t * obj, const lv_buttonmatrix_ctrl_t ctrl_map[])

--- a/tests/src/test_cases/widgets/test_keyboard.c
+++ b/tests/src/test_cases/widgets/test_keyboard.c
@@ -16,6 +16,15 @@ void tearDown(void)
     lv_obj_clean(active_screen);
 }
 
+static uint32_t keyboard_find_button(lv_obj_t * kb, const char * text)
+{
+    const char * txt;
+    for(uint32_t i = 0; (txt = lv_keyboard_get_button_text(kb, i)) != NULL; i++) {
+        if(lv_strcmp(txt, text) == 0) return i;
+    }
+    return LV_BUTTONMATRIX_BUTTON_NONE;
+}
+
 void test_keyboard_mode(void)
 {
     lv_obj_t * keyboard  = lv_keyboard_create(active_screen);
@@ -37,6 +46,29 @@ void test_keyboard_mode(void)
     lv_keyboard_set_mode(keyboard, LV_KEYBOARD_MODE_NUMBER);
 
     TEST_ASSERT_EQUAL_SCREENSHOT("widgets/keyboard_4.png");
+}
+
+void test_keyboard_mode_switch_keeps_selection_in_place(void)
+{
+    /*Regression test for https://github.com/lvgl/lvgl/issues/10118:
+     *switching modes must keep the selection on the key in that position,
+     *not move it to an unrelated button (backspace).*/
+    lv_obj_t * keyboard = lv_keyboard_create(active_screen);
+    lv_obj_set_size(keyboard, LV_PCT(100), LV_PCT(50));
+    lv_keyboard_set_mode(keyboard, LV_KEYBOARD_MODE_SPECIAL);
+    lv_obj_update_layout(keyboard);
+
+    /*Select the "abc" mode-switch button and press it*/
+    uint32_t abc_btn = keyboard_find_button(keyboard, "abc");
+    TEST_ASSERT_NOT_EQUAL(LV_BUTTONMATRIX_BUTTON_NONE, abc_btn);
+    lv_buttonmatrix_set_selected_button(keyboard, abc_btn);
+    lv_obj_send_event(keyboard, LV_EVENT_VALUE_CHANGED, NULL);
+
+    /*The selection follows the position: it lands on the "ABC" toggle that
+     *took the "abc" button's spot, not the backspace key at the old index.*/
+    TEST_ASSERT_EQUAL_INT(LV_KEYBOARD_MODE_TEXT_LOWER, lv_keyboard_get_mode(keyboard));
+    uint32_t sel = lv_keyboard_get_selected_button(keyboard);
+    TEST_ASSERT_EQUAL_STRING("ABC", lv_keyboard_get_button_text(keyboard, sel));
 }
 
 void test_keyboard_properties(void)


### PR DESCRIPTION
Changing the map reassigns button indices, so the selected button kept its old index and jumped to an unrelated key (e.g. backspace when switching keyboard modes). Restore the selection by its on-screen position instead.

Fixes https://github.com/lvgl/lvgl/issues/10118


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

