### PR TITLE
Claude/lvgl test validation pq56h3

### DIFF
--- a/src/draw/espressif/ppa/lv_draw_ppa.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa.c
@@ -135,6 +135,13 @@ static int32_t ppa_evaluate(lv_draw_unit_t * u, lv_draw_task_t * t)
                     int32_t angle = dsc->rotation % 3600;
                     if(angle < 0) angle += 3600;
                     if(angle != 900 && angle != 1800 && angle != 2700) return 0;
+
+                    /* Rotation combined with scaling is not supported: the dispatcher
+                     * routes any rotated task to the rotate path, which transforms the
+                     * full source block and does not reproduce the SRM clip/gap handling
+                     * needed for a scaled tile. Reject the combination so another draw
+                     * unit handles it instead of producing a wrong result. */
+                    if(dsc->scale_x != LV_SCALE_NONE || dsc->scale_y != LV_SCALE_NONE) return 0;
                 }
 
                 if(t->preference_score > DRAW_UNIT_PPA_PREF_SCORE) {

--- a/src/draw/espressif/ppa/lv_draw_ppa.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa.c
@@ -108,6 +108,10 @@ static int32_t ppa_evaluate(lv_draw_unit_t * u, lv_draw_task_t * t)
 #if LV_USE_PPA_IMG
         case LV_DRAW_TASK_TYPE_IMAGE: {
                 lv_draw_image_dsc_t * dsc = t->draw_dsc;
+                /* Common constraints shared by the plain blend, scale (SRM) and
+                 * rotation paths. Scale and rotation are no longer required to be
+                 * identity here: the PPA SRM engine handles arbitrary scaling and
+                 * 90-degree rotation steps (see the dispatch below). */
                 if(!(dsc->header.cf < LV_COLOR_FORMAT_PROPRIETARY_START
                      && dsc->clip_radius == 0
                      && dsc->bitmap_mask_src == NULL
@@ -118,15 +122,19 @@ static int32_t ppa_evaluate(lv_draw_unit_t * u, lv_draw_task_t * t)
                      && dsc->opa >= (lv_opa_t)LV_OPA_MAX
                      && dsc->skew_y == 0
                      && dsc->skew_x == 0
-                     && dsc->scale_x == 256
-                     && dsc->scale_y == 256
-                     && dsc->rotation == 0
                      && lv_image_src_get_type(dsc->src) == LV_IMAGE_SRC_VARIABLE
                      && (dsc->header.cf == LV_COLOR_FORMAT_RGB888
                          || dsc->header.cf == LV_COLOR_FORMAT_RGB565)
                      && (dsc->base.layer->color_format == LV_COLOR_FORMAT_RGB888
                          || dsc->base.layer->color_format == LV_COLOR_FORMAT_RGB565))) {
                     return 0;
+                }
+
+                /* PPA SRM can only rotate in exact 90-degree steps. */
+                if(dsc->rotation != 0) {
+                    int32_t angle = dsc->rotation % 3600;
+                    if(angle < 0) angle += 3600;
+                    if(angle != 900 && angle != 1800 && angle != 2700) return 0;
                 }
 
                 if(t->preference_score > DRAW_UNIT_PPA_PREF_SCORE) {
@@ -189,10 +197,23 @@ static void ppa_execute_drawing(lv_draw_ppa_unit_t * u)
             lv_draw_ppa_fill(t, (lv_draw_fill_dsc_t *)t->draw_dsc, &area);
             lv_draw_buf_invalidate_cache(buf, &area);
             break;
-        case LV_DRAW_TASK_TYPE_IMAGE:
-            lv_draw_ppa_img(t, (lv_draw_image_dsc_t *)t->draw_dsc, &area);
-            lv_draw_buf_invalidate_cache(buf, &area);
-            break;
+        case LV_DRAW_TASK_TYPE_IMAGE: {
+                lv_draw_image_dsc_t * img_dsc = (lv_draw_image_dsc_t *)t->draw_dsc;
+#if LV_USE_PPA_IMG
+                if(img_dsc->rotation != 0) {
+                    lv_draw_ppa_img_rotate(t, img_dsc, &t->area);
+                }
+                else if(img_dsc->scale_x != LV_SCALE_NONE || img_dsc->scale_y != LV_SCALE_NONE) {
+                    lv_draw_ppa_img_srm(t, img_dsc, &t->area);
+                }
+                else
+#endif
+                {
+                    lv_draw_ppa_img(t, img_dsc, &area);
+                }
+                lv_draw_buf_invalidate_cache(buf, &area);
+                break;
+            }
         default:
             break;
     }

--- a/src/draw/espressif/ppa/lv_draw_ppa.h
+++ b/src/draw/espressif/ppa/lv_draw_ppa.h
@@ -44,6 +44,13 @@ void lv_draw_ppa_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc,
 void lv_draw_ppa_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
                      const lv_area_t * coords);
 
+#if LV_USE_PPA_IMG
+void lv_draw_ppa_img_srm(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
+                         const lv_area_t * coords);
+void lv_draw_ppa_img_rotate(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
+                            const lv_area_t * coords);
+#endif /* LV_USE_PPA_IMG */
+
 /**********************
  *      MACROS
  **********************/

--- a/src/draw/espressif/ppa/lv_draw_ppa_img.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa_img.c
@@ -11,6 +11,10 @@
 #include "../../lv_draw_image_private.h"
 #include "../../lv_image_decoder_private.h"
 
+#if LV_USE_PPA_IMG
+    #include <math.h>
+#endif
+
 static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                                  const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
                                  const lv_area_t * img_coords, const lv_area_t * clipped_img_area);
@@ -110,5 +114,315 @@ static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t *
         LV_LOG_WARN("PPA draw_img blend failed: %d", ret);
     }
 }
+
+#if LV_USE_PPA_IMG
+
+/* Round a byte count up to the cache line, as required by PPA DMA and esp_cache_msync(). */
+static inline uint32_t lv_draw_ppa_align_size(uint32_t size)
+{
+    return (uint32_t)PPA_ALIGN_UP(size, CONFIG_CACHE_L2_CACHE_LINE_SIZE);
+}
+
+void lv_draw_ppa_img_srm(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
+                         const lv_area_t * coords)
+{
+    if(dsc->opa <= (lv_opa_t)LV_OPA_MIN) return;
+
+    lv_draw_ppa_unit_t * u   = (lv_draw_ppa_unit_t *)t->draw_unit;
+    lv_layer_t * layer        = t->target_layer;
+    lv_draw_buf_t * dest_buf  = layer->draw_buf;
+
+    /* coords = image rect at 1:1 scale (may extend off-screen).
+     * Intersect with the render tile to get the actual visible clip. */
+    lv_area_t visible_area;
+    if(!lv_area_intersect(&visible_area, coords, &layer->buf_area)) return;
+
+    lv_image_decoder_dsc_t decoder_dsc;
+    lv_image_decoder_args_t dec_args;
+    lv_memzero(&dec_args, sizeof(dec_args));
+    dec_args.flush_cache = true;
+
+    lv_result_t res = lv_image_decoder_open(&decoder_dsc, dsc->src, &dec_args);
+    if(res != LV_RESULT_OK) return;
+
+    const lv_draw_buf_t * decoded = decoder_dsc.decoded;
+    if(!decoded || !decoded->data) {
+        lv_image_decoder_close(&decoder_dsc);
+        return;
+    }
+
+    lv_color_format_t src_cf  = decoded->header.cf;
+    lv_color_format_t dest_cf = dest_buf->header.cf;
+    if(!ppa_src_cf_supported(src_cf) || !ppa_dest_cf_supported(dest_cf)) {
+        lv_image_decoder_close(&decoder_dsc);
+        return;
+    }
+
+    float sx = (dsc->scale_x != LV_SCALE_NONE) ? ((float)dsc->scale_x / 256.0f) : 1.0f;
+    float sy = (dsc->scale_y != LV_SCALE_NONE) ? ((float)dsc->scale_y / 256.0f) : 1.0f;
+
+    uint32_t src_w = decoded->header.w;
+    uint32_t src_h = decoded->header.h;
+
+    /* Virtual image origin: pivot stays fixed on screen as scale changes.
+     * coords->x1/y1 = image top-left at 1:1 scale. */
+    float virt_x = (float)coords->x1 + (float)dsc->pivot.x * (1.0f - sx);
+    float virt_y = (float)coords->y1 + (float)dsc->pivot.y * (1.0f - sy);
+
+    /* Visible clip dimensions and buffer-local destination (always non-negative) */
+    int32_t clip_w = lv_area_get_width(&visible_area);
+    int32_t clip_h = lv_area_get_height(&visible_area);
+
+    lv_area_t dest_area;
+    lv_area_copy(&dest_area, &visible_area);
+    lv_area_move(&dest_area, -layer->buf_area.x1, -layer->buf_area.y1);
+
+    /* Map visible tile top-left back into source image space */
+    int32_t src_bx = (int32_t)(((float)visible_area.x1 - virt_x) / sx);
+    int32_t src_by = (int32_t)(((float)visible_area.y1 - virt_y) / sy);
+
+    /* ceilf gives the ideal source block; floorf clamp keeps PPA happy.
+     * The PPA may render 1 pixel short — we fix that after the call. */
+    uint32_t src_bw = (uint32_t)ceilf((float)clip_w / sx);
+    uint32_t src_bh = (uint32_t)ceilf((float)clip_h / sy);
+
+    uint32_t avail_w = (uint32_t)(dest_buf->header.w - dest_area.x1);
+    uint32_t avail_h = (uint32_t)(dest_buf->header.h - dest_area.y1);
+    uint32_t max_src_bw = (uint32_t)floorf((float)avail_w / sx);
+    uint32_t max_src_bh = (uint32_t)floorf((float)avail_h / sy);
+    bool gap_right  = (src_bw > max_src_bw);
+    bool gap_bottom = (src_bh > max_src_bh);
+    if(src_bw > max_src_bw) src_bw = max_src_bw;
+    if(src_bh > max_src_bh) src_bh = max_src_bh;
+
+    if(src_bx < 0 || src_by < 0 ||
+       (uint32_t)src_bx >= src_w || (uint32_t)src_by >= src_h) {
+        lv_image_decoder_close(&decoder_dsc);
+        return;
+    }
+    if((uint32_t)src_bx + src_bw > src_w) src_bw = src_w - (uint32_t)src_bx;
+    if((uint32_t)src_by + src_bh > src_h) src_bh = src_h - (uint32_t)src_by;
+    if(src_bw == 0 || src_bh == 0) {
+        lv_image_decoder_close(&decoder_dsc);
+        return;
+    }
+
+    if(decoded->data_size > 0) {
+        esp_cache_msync((void *)decoded->data,
+                        lv_draw_ppa_align_size(decoded->data_size),
+                        ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_UNALIGNED);
+    }
+
+    uint32_t out_bpp = (dest_cf == LV_COLOR_FORMAT_RGB565) ? 2u :
+                       (dest_cf == LV_COLOR_FORMAT_RGB888)  ? 3u : 4u;
+    uint32_t raw_bytes    = (uint32_t)dest_buf->header.w * dest_buf->header.h * out_bpp;
+    uint32_t aligned_size = lv_draw_ppa_align_size(raw_bytes);
+
+    ppa_srm_oper_config_t cfg;
+    lv_memzero(&cfg, sizeof(cfg));
+
+    cfg.in.buffer         = (void *)decoded->data;
+    cfg.in.pic_w          = src_w;
+    cfg.in.pic_h          = src_h;
+    cfg.in.block_w        = src_bw;
+    cfg.in.block_h        = src_bh;
+    cfg.in.block_offset_x = (uint32_t)src_bx;
+    cfg.in.block_offset_y = (uint32_t)src_by;
+    cfg.in.srm_cm         = lv_color_format_to_ppa_srm(src_cf);
+
+    cfg.out.buffer         = dest_buf->data;
+    cfg.out.buffer_size    = aligned_size;
+    cfg.out.pic_w          = dest_buf->header.w;
+    cfg.out.pic_h          = dest_buf->header.h;
+    cfg.out.block_offset_x = (uint32_t)dest_area.x1;
+    cfg.out.block_offset_y = (uint32_t)dest_area.y1;
+    cfg.out.srm_cm         = lv_color_format_to_ppa_srm(dest_cf);
+
+    cfg.rotation_angle    = PPA_SRM_ROTATION_ANGLE_0;
+    cfg.scale_x           = sx;
+    cfg.scale_y           = sy;
+    cfg.mirror_x          = false;
+    cfg.mirror_y          = false;
+    cfg.rgb_swap          = false;
+    cfg.byte_swap         = false;
+    cfg.alpha_update_mode = PPA_ALPHA_NO_CHANGE;
+    cfg.mode              = PPA_TRANS_MODE_BLOCKING;
+    cfg.user_data         = u;
+
+    esp_err_t ret = ppa_do_scale_rotate_mirror(u->srm_client, &cfg);
+    if(ret != ESP_OK) {
+        LV_LOG_WARN("PPA SRM scale failed: %d (src %ux%u scale %.2f/%.2f)",
+                    (int)ret, src_w, src_h, (double)sx, (double)sy);
+    }
+
+    /* PPA floorf rounding leaves a 1-pixel gap at right/bottom edges.
+     * Fill it by duplicating the last rendered column/row.
+     * Must invalidate CPU cache first: PPA wrote via DMA, CPU cache is stale. */
+    if(ret == ESP_OK && (gap_right || gap_bottom)) {
+        esp_cache_msync(dest_buf->data, aligned_size,
+                        ESP_CACHE_MSYNC_FLAG_DIR_M2C | ESP_CACHE_MSYNC_FLAG_UNALIGNED);
+
+        uint8_t * base = dest_buf->data;
+        uint32_t stride = dest_buf->header.w * out_bpp;
+
+        if(gap_right && clip_w >= 2) {
+            uint32_t col = dest_area.x1 + (uint32_t)clip_w - 1;
+            uint32_t col_prev = col - 1;
+            for(int32_t y = 0; y < clip_h; y++) {
+                uint32_t row_off = (dest_area.y1 + (uint32_t)y) * stride;
+                lv_memcpy(base + row_off + col * out_bpp,
+                          base + row_off + col_prev * out_bpp, out_bpp);
+            }
+        }
+        if(gap_bottom && clip_h >= 2) {
+            uint32_t row = dest_area.y1 + (uint32_t)clip_h - 1;
+            uint32_t row_prev = row - 1;
+            lv_memcpy(base + row * stride + dest_area.x1 * out_bpp,
+                      base + row_prev * stride + dest_area.x1 * out_bpp,
+                      (uint32_t)clip_w * out_bpp);
+        }
+
+        esp_cache_msync(dest_buf->data, aligned_size,
+                        ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_UNALIGNED);
+    }
+
+    lv_image_decoder_close(&decoder_dsc);
+}
+
+/**
+ * PPA SRM hardware-accelerated image rotation (0/90/180/270 degrees)
+ * Uses the ESP32-P4 PPA Scale-Rotate-Mirror engine for zero-CPU-cost rotation.
+ */
+void lv_draw_ppa_img_rotate(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
+                            const lv_area_t * coords)
+{
+    LV_UNUSED(coords);
+
+    if(dsc->opa <= (lv_opa_t)LV_OPA_MIN)
+        return;
+
+    lv_draw_ppa_unit_t * u = (lv_draw_ppa_unit_t *)t->draw_unit;
+    lv_layer_t * layer = t->target_layer;
+    lv_draw_buf_t * dest_buf = layer->draw_buf;
+
+    /* Decode the source image */
+    lv_image_decoder_dsc_t decoder_dsc;
+    lv_image_decoder_args_t dec_args;
+    lv_memzero(&dec_args, sizeof(dec_args));
+    dec_args.stride_align = false;
+    dec_args.premultiply = false;
+    dec_args.no_cache = false;
+    dec_args.use_indexed = false;
+    dec_args.flush_cache = true;  /* Ensure cache coherency for PPA DMA */
+
+    lv_result_t res = lv_image_decoder_open(&decoder_dsc, dsc->src, &dec_args);
+    if(res != LV_RESULT_OK) {
+        LV_LOG_WARN("PPA SRM: failed to decode image");
+        return;
+    }
+
+    const lv_draw_buf_t * decoded = decoder_dsc.decoded;
+    if(!decoded || !decoded->data) {
+        lv_image_decoder_close(&decoder_dsc);
+        return;
+    }
+
+    lv_color_format_t src_cf = decoded->header.cf;
+    lv_color_format_t dest_cf = dest_buf->header.cf;
+
+    /* Verify PPA format support for both source and destination */
+    if(!ppa_src_cf_supported(src_cf) || !ppa_dest_cf_supported(dest_cf)) {
+        LV_LOG_WARN("PPA SRM: unsupported color format src=%d dest=%d", src_cf, dest_cf);
+        lv_image_decoder_close(&decoder_dsc);
+        return;
+    }
+
+    /* Map LVGL rotation (clockwise, 0.1 deg units) to PPA rotation (counter-clockwise) */
+    int32_t angle = dsc->rotation % 3600;
+    if(angle < 0) angle += 3600;
+
+    ppa_srm_rotation_angle_t ppa_rot;
+    switch(angle) {
+        case 0:
+            ppa_rot = PPA_SRM_ROTATION_ANGLE_0;
+            break;
+        case 900:
+            ppa_rot = PPA_SRM_ROTATION_ANGLE_270;
+            break;  /* 90° CW = 270° CCW */
+        case 1800:
+            ppa_rot = PPA_SRM_ROTATION_ANGLE_180;
+            break;
+        case 2700:
+            ppa_rot = PPA_SRM_ROTATION_ANGLE_90;
+            break;  /* 270° CW = 90° CCW */
+        default:
+            lv_image_decoder_close(&decoder_dsc);
+            return;
+    }
+
+    uint32_t src_w = decoded->header.w;
+    uint32_t src_h = decoded->header.h;
+
+    /* Compute destination area relative to layer buffer origin */
+    lv_area_t dest_area;
+    lv_area_copy(&dest_area, &t->area);
+    lv_area_move(&dest_area, -layer->buf_area.x1, -layer->buf_area.y1);
+
+    /* Flush decoded source buffer for PPA DMA access. Align size to cache
+     * line; _UNALIGNED flag is only a safety net for the address. */
+    if(decoded->data_size > 0) {
+        esp_cache_msync((void *)decoded->data,
+                        lv_draw_ppa_align_size(decoded->data_size),
+                        ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_UNALIGNED);
+    }
+
+    /* Configure PPA SRM operation */
+    ppa_srm_oper_config_t cfg;
+    lv_memzero(&cfg, sizeof(cfg));
+
+    /* Input: full source image block */
+    cfg.in.buffer         = (void *)decoded->data;
+    cfg.in.pic_w          = src_w;
+    cfg.in.pic_h          = src_h;
+    cfg.in.block_w        = src_w;
+    cfg.in.block_h        = src_h;
+    cfg.in.block_offset_x = 0;
+    cfg.in.block_offset_y = 0;
+    cfg.in.srm_cm         = lv_color_format_to_ppa_srm(src_cf);
+
+    uint32_t out_bpp_r    = (dest_cf == LV_COLOR_FORMAT_RGB565) ? 2u :
+                            (dest_cf == LV_COLOR_FORMAT_RGB888)  ? 3u : 4u;
+    uint32_t aligned_size_r = lv_draw_ppa_align_size(
+                                  (uint32_t)dest_buf->header.w * dest_buf->header.h * out_bpp_r);
+
+    /* Draw buffers are cache-aligned (lv_draw_buf_ppa_init_handlers). */
+    cfg.out.buffer         = dest_buf->data;
+    cfg.out.buffer_size    = aligned_size_r;
+    cfg.out.pic_w          = dest_buf->header.w;
+    cfg.out.pic_h          = dest_buf->header.h;
+    cfg.out.block_offset_x = (uint32_t)dest_area.x1;
+    cfg.out.block_offset_y = (uint32_t)dest_area.y1;
+    cfg.out.srm_cm         = lv_color_format_to_ppa_srm(dest_cf);
+
+    cfg.rotation_angle     = ppa_rot;
+    cfg.scale_x            = (dsc->scale_x != LV_SCALE_NONE) ? ((float)dsc->scale_x / 256.0f) : 1.0f;
+    cfg.scale_y            = (dsc->scale_y != LV_SCALE_NONE) ? ((float)dsc->scale_y / 256.0f) : 1.0f;
+    cfg.mirror_x           = false;
+    cfg.mirror_y           = false;
+    cfg.rgb_swap           = false;
+    cfg.byte_swap          = false;
+    cfg.alpha_update_mode  = PPA_ALPHA_NO_CHANGE;
+    cfg.mode               = PPA_TRANS_MODE_BLOCKING;
+    cfg.user_data          = u;
+
+    esp_err_t ret = ppa_do_scale_rotate_mirror(u->srm_client, &cfg);
+    if(ret != ESP_OK) {
+        LV_LOG_WARN("PPA SRM rotation failed: %d  (src %ux%u, angle %d)", (int)ret, src_w, src_h, angle);
+    }
+
+    lv_image_decoder_close(&decoder_dsc);
+}
+
+#endif /* LV_USE_PPA_IMG */
 
 #endif /* LV_USE_PPA */

--- a/src/draw/espressif/ppa/lv_draw_ppa_img.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa_img.c
@@ -5,15 +5,12 @@
 
 #include "lv_draw_ppa_private.h"
 #include "lv_draw_ppa.h"
+#include "lv_draw_ppa_srm.h"
 
 #if LV_USE_PPA
 
 #include "../../lv_draw_image_private.h"
 #include "../../lv_image_decoder_private.h"
-
-#if LV_USE_PPA_IMG
-    #include <math.h>
-#endif
 
 static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                                  const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
@@ -133,9 +130,10 @@ void lv_draw_ppa_img_srm(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
     lv_draw_buf_t * dest_buf  = layer->draw_buf;
 
     /* coords = image rect at 1:1 scale (may extend off-screen).
-     * Intersect with the render tile to get the actual visible clip. */
+     * Skip the decode entirely if nothing intersects the render tile. */
     lv_area_t visible_area;
     if(!lv_area_intersect(&visible_area, coords, &layer->buf_area)) return;
+    LV_UNUSED(visible_area);
 
     lv_image_decoder_dsc_t decoder_dsc;
     lv_image_decoder_args_t dec_args;
@@ -158,51 +156,17 @@ void lv_draw_ppa_img_srm(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
         return;
     }
 
-    float sx = (dsc->scale_x != LV_SCALE_NONE) ? ((float)dsc->scale_x / 256.0f) : 1.0f;
-    float sy = (dsc->scale_y != LV_SCALE_NONE) ? ((float)dsc->scale_y / 256.0f) : 1.0f;
-
     uint32_t src_w = decoded->header.w;
     uint32_t src_h = decoded->header.h;
 
-    /* Virtual image origin: pivot stays fixed on screen as scale changes.
-     * coords->x1/y1 = image top-left at 1:1 scale. */
-    float virt_x = (float)coords->x1 + (float)dsc->pivot.x * (1.0f - sx);
-    float virt_y = (float)coords->y1 + (float)dsc->pivot.y * (1.0f - sy);
-
-    /* Visible clip dimensions and buffer-local destination (always non-negative) */
-    int32_t clip_w = lv_area_get_width(&visible_area);
-    int32_t clip_h = lv_area_get_height(&visible_area);
-
-    lv_area_t dest_area;
-    lv_area_copy(&dest_area, &visible_area);
-    lv_area_move(&dest_area, -layer->buf_area.x1, -layer->buf_area.y1);
-
-    /* Map visible tile top-left back into source image space */
-    int32_t src_bx = (int32_t)(((float)visible_area.x1 - virt_x) / sx);
-    int32_t src_by = (int32_t)(((float)visible_area.y1 - virt_y) / sy);
-
-    /* ceilf gives the ideal source block; floorf clamp keeps PPA happy.
-     * The PPA may render 1 pixel short — we fix that after the call. */
-    uint32_t src_bw = (uint32_t)ceilf((float)clip_w / sx);
-    uint32_t src_bh = (uint32_t)ceilf((float)clip_h / sy);
-
-    uint32_t avail_w = (uint32_t)(dest_buf->header.w - dest_area.x1);
-    uint32_t avail_h = (uint32_t)(dest_buf->header.h - dest_area.y1);
-    uint32_t max_src_bw = (uint32_t)floorf((float)avail_w / sx);
-    uint32_t max_src_bh = (uint32_t)floorf((float)avail_h / sy);
-    bool gap_right  = (src_bw > max_src_bw);
-    bool gap_bottom = (src_bh > max_src_bh);
-    if(src_bw > max_src_bw) src_bw = max_src_bw;
-    if(src_bh > max_src_bh) src_bh = max_src_bh;
-
-    if(src_bx < 0 || src_by < 0 ||
-       (uint32_t)src_bx >= src_w || (uint32_t)src_by >= src_h) {
-        lv_image_decoder_close(&decoder_dsc);
-        return;
-    }
-    if((uint32_t)src_bx + src_bw > src_w) src_bw = src_w - (uint32_t)src_bx;
-    if((uint32_t)src_by + src_bh > src_h) src_bh = src_h - (uint32_t)src_by;
-    if(src_bw == 0 || src_bh == 0) {
+    /* Map the visible render tile back onto a PPA source block.
+     * Pure geometry, shared with the host unit test (lv_draw_ppa_srm.h). */
+    lv_draw_ppa_srm_block_t blk = lv_draw_ppa_srm_calc_block(
+                                      coords, &layer->buf_area,
+                                      (int32_t)dest_buf->header.w, (int32_t)dest_buf->header.h,
+                                      (int32_t)src_w, (int32_t)src_h,
+                                      dsc->scale_x, dsc->scale_y, dsc->pivot.x, dsc->pivot.y);
+    if(!blk.draw) {
         lv_image_decoder_close(&decoder_dsc);
         return;
     }
@@ -224,23 +188,23 @@ void lv_draw_ppa_img_srm(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
     cfg.in.buffer         = (void *)decoded->data;
     cfg.in.pic_w          = src_w;
     cfg.in.pic_h          = src_h;
-    cfg.in.block_w        = src_bw;
-    cfg.in.block_h        = src_bh;
-    cfg.in.block_offset_x = (uint32_t)src_bx;
-    cfg.in.block_offset_y = (uint32_t)src_by;
+    cfg.in.block_w        = (uint32_t)blk.block_w;
+    cfg.in.block_h        = (uint32_t)blk.block_h;
+    cfg.in.block_offset_x = (uint32_t)blk.block_x;
+    cfg.in.block_offset_y = (uint32_t)blk.block_y;
     cfg.in.srm_cm         = lv_color_format_to_ppa_srm(src_cf);
 
     cfg.out.buffer         = dest_buf->data;
     cfg.out.buffer_size    = aligned_size;
     cfg.out.pic_w          = dest_buf->header.w;
     cfg.out.pic_h          = dest_buf->header.h;
-    cfg.out.block_offset_x = (uint32_t)dest_area.x1;
-    cfg.out.block_offset_y = (uint32_t)dest_area.y1;
+    cfg.out.block_offset_x = (uint32_t)blk.dest_area.x1;
+    cfg.out.block_offset_y = (uint32_t)blk.dest_area.y1;
     cfg.out.srm_cm         = lv_color_format_to_ppa_srm(dest_cf);
 
     cfg.rotation_angle    = PPA_SRM_ROTATION_ANGLE_0;
-    cfg.scale_x           = sx;
-    cfg.scale_y           = sy;
+    cfg.scale_x           = blk.scale_x;
+    cfg.scale_y           = blk.scale_y;
     cfg.mirror_x          = false;
     cfg.mirror_y          = false;
     cfg.rgb_swap          = false;
@@ -252,34 +216,34 @@ void lv_draw_ppa_img_srm(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
     esp_err_t ret = ppa_do_scale_rotate_mirror(u->srm_client, &cfg);
     if(ret != ESP_OK) {
         LV_LOG_WARN("PPA SRM scale failed: %d (src %ux%u scale %.2f/%.2f)",
-                    (int)ret, src_w, src_h, (double)sx, (double)sy);
+                    (int)ret, src_w, src_h, (double)blk.scale_x, (double)blk.scale_y);
     }
 
     /* PPA floorf rounding leaves a 1-pixel gap at right/bottom edges.
      * Fill it by duplicating the last rendered column/row.
      * Must invalidate CPU cache first: PPA wrote via DMA, CPU cache is stale. */
-    if(ret == ESP_OK && (gap_right || gap_bottom)) {
+    if(ret == ESP_OK && (blk.gap_right || blk.gap_bottom)) {
         esp_cache_msync(dest_buf->data, aligned_size,
                         ESP_CACHE_MSYNC_FLAG_DIR_M2C | ESP_CACHE_MSYNC_FLAG_UNALIGNED);
 
         uint8_t * base = dest_buf->data;
         uint32_t stride = dest_buf->header.w * out_bpp;
 
-        if(gap_right && clip_w >= 2) {
-            uint32_t col = dest_area.x1 + (uint32_t)clip_w - 1;
+        if(blk.gap_right && blk.clip_w >= 2) {
+            uint32_t col = blk.dest_area.x1 + (uint32_t)blk.clip_w - 1;
             uint32_t col_prev = col - 1;
-            for(int32_t y = 0; y < clip_h; y++) {
-                uint32_t row_off = (dest_area.y1 + (uint32_t)y) * stride;
+            for(int32_t y = 0; y < blk.clip_h; y++) {
+                uint32_t row_off = (blk.dest_area.y1 + (uint32_t)y) * stride;
                 lv_memcpy(base + row_off + col * out_bpp,
                           base + row_off + col_prev * out_bpp, out_bpp);
             }
         }
-        if(gap_bottom && clip_h >= 2) {
-            uint32_t row = dest_area.y1 + (uint32_t)clip_h - 1;
+        if(blk.gap_bottom && blk.clip_h >= 2) {
+            uint32_t row = blk.dest_area.y1 + (uint32_t)blk.clip_h - 1;
             uint32_t row_prev = row - 1;
-            lv_memcpy(base + row * stride + dest_area.x1 * out_bpp,
-                      base + row_prev * stride + dest_area.x1 * out_bpp,
-                      (uint32_t)clip_w * out_bpp);
+            lv_memcpy(base + row * stride + blk.dest_area.x1 * out_bpp,
+                      base + row_prev * stride + blk.dest_area.x1 * out_bpp,
+                      (uint32_t)blk.clip_w * out_bpp);
         }
 
         esp_cache_msync(dest_buf->data, aligned_size,

--- a/src/draw/espressif/ppa/lv_draw_ppa_img.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa_img.c
@@ -260,8 +260,6 @@ void lv_draw_ppa_img_srm(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
 void lv_draw_ppa_img_rotate(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
                             const lv_area_t * coords)
 {
-    LV_UNUSED(coords);
-
     if(dsc->opa <= (lv_opa_t)LV_OPA_MIN)
         return;
 
@@ -327,10 +325,18 @@ void lv_draw_ppa_img_rotate(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
     uint32_t src_w = decoded->header.w;
     uint32_t src_h = decoded->header.h;
 
-    /* Compute destination area relative to layer buffer origin */
-    lv_area_t dest_area;
-    lv_area_copy(&dest_area, &t->area);
-    lv_area_move(&dest_area, -layer->buf_area.x1, -layer->buf_area.y1);
+    /* Map the visible render tile back onto a PPA source block, clipping to the
+     * layer buffer. Pure geometry, shared with the host unit test
+     * (lv_draw_ppa_rot.h); also guarantees the destination stays inside the
+     * buffer so the PPA cannot write out of bounds. */
+    lv_draw_ppa_rot_block_t blk = lv_draw_ppa_rot_calc_block(
+                                      coords, &layer->buf_area,
+                                      (int32_t)dest_buf->header.w, (int32_t)dest_buf->header.h,
+                                      (int32_t)src_w, (int32_t)src_h, angle);
+    if(!blk.draw) {
+        lv_image_decoder_close(&decoder_dsc);
+        return;
+    }
 
     /* Flush decoded source buffer for PPA DMA access. Align size to cache
      * line; _UNALIGNED flag is only a safety net for the address. */
@@ -344,14 +350,14 @@ void lv_draw_ppa_img_rotate(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
     ppa_srm_oper_config_t cfg;
     lv_memzero(&cfg, sizeof(cfg));
 
-    /* Input: full source image block */
+    /* Input: the source sub-block that maps onto the visible (clipped) tile. */
     cfg.in.buffer         = (void *)decoded->data;
     cfg.in.pic_w          = src_w;
     cfg.in.pic_h          = src_h;
-    cfg.in.block_w        = src_w;
-    cfg.in.block_h        = src_h;
-    cfg.in.block_offset_x = 0;
-    cfg.in.block_offset_y = 0;
+    cfg.in.block_w        = (uint32_t)blk.block_w;
+    cfg.in.block_h        = (uint32_t)blk.block_h;
+    cfg.in.block_offset_x = (uint32_t)blk.block_x;
+    cfg.in.block_offset_y = (uint32_t)blk.block_y;
     cfg.in.srm_cm         = lv_color_format_to_ppa_srm(src_cf);
 
     uint32_t out_bpp_r    = (dest_cf == LV_COLOR_FORMAT_RGB565) ? 2u :
@@ -364,13 +370,15 @@ void lv_draw_ppa_img_rotate(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
     cfg.out.buffer_size    = aligned_size_r;
     cfg.out.pic_w          = dest_buf->header.w;
     cfg.out.pic_h          = dest_buf->header.h;
-    cfg.out.block_offset_x = (uint32_t)dest_area.x1;
-    cfg.out.block_offset_y = (uint32_t)dest_area.y1;
+    cfg.out.block_offset_x = (uint32_t)blk.dest_area.x1;
+    cfg.out.block_offset_y = (uint32_t)blk.dest_area.y1;
     cfg.out.srm_cm         = lv_color_format_to_ppa_srm(dest_cf);
 
     cfg.rotation_angle     = ppa_rot;
-    cfg.scale_x            = (dsc->scale_x != LV_SCALE_NONE) ? ((float)dsc->scale_x / 256.0f) : 1.0f;
-    cfg.scale_y            = (dsc->scale_y != LV_SCALE_NONE) ? ((float)dsc->scale_y / 256.0f) : 1.0f;
+    /* ppa_evaluate() rejects rotation combined with scaling, so this path is
+     * always 1:1 and the source-block geometry above assumes it. */
+    cfg.scale_x            = 1.0f;
+    cfg.scale_y            = 1.0f;
     cfg.mirror_x           = false;
     cfg.mirror_y           = false;
     cfg.rgb_swap           = false;

--- a/src/draw/espressif/ppa/lv_draw_ppa_private.h
+++ b/src/draw/espressif/ppa/lv_draw_ppa_private.h
@@ -84,6 +84,7 @@ static inline bool ppa_src_cf_supported(lv_color_format_t cf)
 
     switch(cf) {
         case LV_COLOR_FORMAT_RGB565:
+        case LV_COLOR_FORMAT_RGB888:
         case LV_COLOR_FORMAT_ARGB8888:
         case LV_COLOR_FORMAT_XRGB8888:
             is_cf_supported = true;

--- a/src/draw/espressif/ppa/lv_draw_ppa_rot.h
+++ b/src/draw/espressif/ppa/lv_draw_ppa_rot.h
@@ -1,0 +1,155 @@
+/**
+ * @file lv_draw_ppa_rot.h
+ *
+ */
+
+#ifndef LV_DRAW_PPA_ROT_H
+#define LV_DRAW_PPA_ROT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "../../../lvgl_public.h"
+#include "../../../misc/lv_area_private.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**
+ * Result of mapping a visible render tile back onto a PPA source block for a
+ * 90/180/270-degree rotation (no scaling).
+ *
+ * Like lv_draw_ppa_srm_calc_block(), this is pure geometry: it depends only on
+ * coordinates and the rotation step, never on the PPA hardware or the ESP-IDF,
+ * so it can be exercised by the host test suite even though the rotation itself
+ * only runs on an ESP32-P4.
+ */
+typedef struct {
+    bool draw;              /**< false: nothing is visible / off-screen, skip the operation */
+    lv_area_t dest_area;    /**< visible window relative to the layer buffer origin (PPA writes here) */
+    int32_t block_x;        /**< source block top-left X (un-rotated source image space) */
+    int32_t block_y;        /**< source block top-left Y */
+    int32_t block_w;        /**< source block width  */
+    int32_t block_h;        /**< source block height */
+} lv_draw_ppa_rot_block_t;
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**
+ * Map a visible render tile back into the PPA source block for a 90/180/270
+ * rotation step (scale fixed at 1:1).
+ *
+ * Clips the rotated image to the render tile, computes a non-negative
+ * buffer-local destination window (clamped to the destination buffer so the
+ * PPA can never write out of bounds), and inverts the rotation to find the
+ * source sub-block that maps onto that window.
+ *
+ * Rotation convention: @p angle is the LVGL clockwise angle in 1/10-degree
+ * units, already normalised to one of 900 / 1800 / 2700. @p coords is the
+ * on-screen bounding box of the rotated image (LVGL's task area): for 90/270
+ * its size is img_h x img_w, for 180 it is img_w x img_h. The block geometry
+ * for the 90/270 steps assumes screen-space clockwise rotation; a maintainer
+ * with P4 hardware can swap the 900/2700 cases if the rendered result is
+ * mirrored, without affecting the clamping/safety guarantees.
+ *
+ * @param coords     on-screen bounding box of the rotated image (screen coords)
+ * @param buf_area   the layer buffer (render tile) area, in screen coordinates
+ * @param buf_w      destination buffer width  in pixels
+ * @param buf_h      destination buffer height in pixels
+ * @param img_w      decoded source image width  in pixels
+ * @param img_h      decoded source image height in pixels
+ * @param angle      normalised rotation, one of 900 / 1800 / 2700
+ * @return           the computed block; check `.draw` before using the rest
+ */
+static inline lv_draw_ppa_rot_block_t lv_draw_ppa_rot_calc_block(
+    const lv_area_t * coords, const lv_area_t * buf_area,
+    int32_t buf_w, int32_t buf_h, int32_t img_w, int32_t img_h,
+    int32_t angle)
+{
+    lv_draw_ppa_rot_block_t r;
+    lv_memzero(&r, sizeof(r));
+
+    /* Clip the rotated image to the render tile. */
+    lv_area_t vis;
+    if(!lv_area_intersect(&vis, coords, buf_area)) return r;
+
+    /* Offset of the visible window inside the full rotated output. */
+    int32_t out_dx = vis.x1 - coords->x1;
+    int32_t out_dy = vis.y1 - coords->y1;
+    int32_t vw = lv_area_get_width(&vis);
+    int32_t vh = lv_area_get_height(&vis);
+
+    /* Buffer-local destination (non-negative: vis is inside buf_area). */
+    lv_area_copy(&r.dest_area, &vis);
+    lv_area_move(&r.dest_area, -buf_area->x1, -buf_area->y1);
+
+    /* Clamp the destination window to the buffer so the PPA never writes out
+     * of bounds, even if coords and buf_area disagree. */
+    if(r.dest_area.x1 < 0 || r.dest_area.y1 < 0) return r;
+    if(r.dest_area.x1 >= buf_w || r.dest_area.y1 >= buf_h) return r;
+    if(r.dest_area.x1 + vw > buf_w) vw = buf_w - r.dest_area.x1;
+    if(r.dest_area.y1 + vh > buf_h) vh = buf_h - r.dest_area.y1;
+    if(vw <= 0 || vh <= 0) return r;
+
+    /* Invert the rotation: find the source sub-block that maps onto the visible
+     * output window. For 90/270 the source axes are swapped, so the source
+     * block dimensions are (vh, vw); for 180 they stay (vw, vh). */
+    int32_t sx, sy, sw, sh;
+    switch(angle) {
+        case 1800: /* 180 */
+            sw = vw;
+            sh = vh;
+            sx = img_w - out_dx - vw;
+            sy = img_h - out_dy - vh;
+            break;
+        case 900:  /* 90 clockwise */
+            sw = vh;
+            sh = vw;
+            sx = out_dy;
+            sy = img_h - out_dx - vw;
+            break;
+        case 2700: /* 270 clockwise */
+            sw = vh;
+            sh = vw;
+            sx = img_w - out_dy - vh;
+            sy = out_dx;
+            break;
+        default:
+            return r;
+    }
+
+    /* Reject any block that falls outside the source image; clamp the far edge. */
+    if(sx < 0 || sy < 0 || sx >= img_w || sy >= img_h) return r;
+    if(sx + sw > img_w) sw = img_w - sx;
+    if(sy + sh > img_h) sh = img_h - sy;
+    if(sw <= 0 || sh <= 0) return r;
+
+    r.block_x = sx;
+    r.block_y = sy;
+    r.block_w = sw;
+    r.block_h = sh;
+    r.draw = true;
+    return r;
+}
+
+/**********************
+ *      MACROS
+ **********************/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /* LV_DRAW_PPA_ROT_H */

--- a/src/draw/espressif/ppa/lv_draw_ppa_srm.h
+++ b/src/draw/espressif/ppa/lv_draw_ppa_srm.h
@@ -17,8 +17,6 @@ extern "C" {
 #include "../../../lvgl_public.h"
 #include "../../../misc/lv_area_private.h"
 
-#include <math.h>
-
 /*********************
  *      DEFINES
  *********************/
@@ -106,15 +104,22 @@ static inline lv_draw_ppa_srm_block_t lv_draw_ppa_srm_calc_block(
     int32_t src_bx = (int32_t)(((float)r.visible_area.x1 - virt_x) / sx);
     int32_t src_by = (int32_t)(((float)r.visible_area.y1 - virt_y) / sy);
 
-    /* ceilf gives the ideal source block; floorf clamp keeps PPA happy.
-     * The PPA may render 1 pixel short — the caller fixes that afterwards. */
-    uint32_t src_bw = (uint32_t)ceilf((float)r.clip_w / sx);
-    uint32_t src_bh = (uint32_t)ceilf((float)r.clip_h / sy);
+    /* Ceil gives the ideal source block; the floor clamp keeps PPA happy.
+     * The PPA may render 1 pixel short — the caller fixes that afterwards.
+     * All operands are non-negative here, so ceil/floor are plain integer
+     * truncation (+ a fractional bump for ceil); this avoids a <math.h>
+     * dependency that breaks freestanding builds (e.g. UEFI). */
+    float bw_f = (float)r.clip_w / sx;
+    float bh_f = (float)r.clip_h / sy;
+    uint32_t src_bw = (uint32_t)bw_f;
+    uint32_t src_bh = (uint32_t)bh_f;
+    if((float)src_bw < bw_f) src_bw++;
+    if((float)src_bh < bh_f) src_bh++;
 
     uint32_t avail_w = (uint32_t)(buf_w - r.dest_area.x1);
     uint32_t avail_h = (uint32_t)(buf_h - r.dest_area.y1);
-    uint32_t max_src_bw = (uint32_t)floorf((float)avail_w / sx);
-    uint32_t max_src_bh = (uint32_t)floorf((float)avail_h / sy);
+    uint32_t max_src_bw = (uint32_t)((float)avail_w / sx);
+    uint32_t max_src_bh = (uint32_t)((float)avail_h / sy);
     r.gap_right  = (src_bw > max_src_bw);
     r.gap_bottom = (src_bh > max_src_bh);
     if(src_bw > max_src_bw) src_bw = max_src_bw;

--- a/src/draw/espressif/ppa/lv_draw_ppa_srm.h
+++ b/src/draw/espressif/ppa/lv_draw_ppa_srm.h
@@ -1,0 +1,147 @@
+/**
+ * @file lv_draw_ppa_srm.h
+ *
+ */
+
+#ifndef LV_DRAW_PPA_SRM_H
+#define LV_DRAW_PPA_SRM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "../../../lvgl_public.h"
+#include "../../../misc/lv_area_private.h"
+
+#include <math.h>
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**
+ * Result of mapping a visible render tile back onto a PPA SRM source block.
+ *
+ * This is pure geometry: it depends only on coordinates and scale, never on
+ * the PPA hardware or the ESP-IDF, so it can be exercised by the host test
+ * suite even though the SRM operation itself only runs on an ESP32-P4.
+ */
+typedef struct {
+    bool draw;                /**< false: nothing is visible, skip the operation */
+    lv_area_t visible_area;   /**< image area clipped to the render tile (screen coords) */
+    lv_area_t dest_area;      /**< visible area relative to the layer buffer origin */
+    int32_t clip_w;           /**< visible width  (= width of visible_area) */
+    int32_t clip_h;           /**< visible height (= height of visible_area) */
+    int32_t block_x;          /**< source block top-left X */
+    int32_t block_y;          /**< source block top-left Y */
+    int32_t block_w;          /**< source block width  */
+    int32_t block_h;          /**< source block height */
+    bool gap_right;           /**< PPA floor-rounding leaves a 1px gap on the right edge */
+    bool gap_bottom;          /**< ... and/or on the bottom edge */
+    float scale_x;            /**< horizontal scale factor (1.0 = no scaling) */
+    float scale_y;            /**< vertical scale factor */
+} lv_draw_ppa_srm_block_t;
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**
+ * Map a visible render tile back into PPA SRM source-block coordinates.
+ *
+ * Keeps the transform pivot fixed on screen as the scale changes, clamps the
+ * source block to the image and to the destination buffer, and flags the
+ * single-pixel right/bottom gap left by the PPA's floor-rounding so the caller
+ * can patch it.
+ *
+ * @param coords     image rectangle at 1:1 scale, in screen coordinates
+ * @param buf_area   the layer buffer (render tile) area, in screen coordinates
+ * @param buf_w      destination buffer width  in pixels
+ * @param buf_h      destination buffer height in pixels
+ * @param img_w      decoded source image width  in pixels
+ * @param img_h      decoded source image height in pixels
+ * @param scale_x    horizontal scale, 256 (LV_SCALE_NONE) = 1:1
+ * @param scale_y    vertical scale,   256 (LV_SCALE_NONE) = 1:1
+ * @param pivot_x    transform pivot X relative to the image top-left
+ * @param pivot_y    transform pivot Y relative to the image top-left
+ * @return           the computed block; check `.draw` before using the rest
+ */
+static inline lv_draw_ppa_srm_block_t lv_draw_ppa_srm_calc_block(
+    const lv_area_t * coords, const lv_area_t * buf_area,
+    int32_t buf_w, int32_t buf_h, int32_t img_w, int32_t img_h,
+    int32_t scale_x, int32_t scale_y, int32_t pivot_x, int32_t pivot_y)
+{
+    lv_draw_ppa_srm_block_t r;
+    lv_memzero(&r, sizeof(r));
+
+    /* coords = image rect at 1:1 scale (may extend off-screen).
+     * Intersect with the render tile to get the actual visible clip. */
+    if(!lv_area_intersect(&r.visible_area, coords, buf_area)) return r;
+
+    float sx = (scale_x != LV_SCALE_NONE) ? ((float)scale_x / 256.0f) : 1.0f;
+    float sy = (scale_y != LV_SCALE_NONE) ? ((float)scale_y / 256.0f) : 1.0f;
+    r.scale_x = sx;
+    r.scale_y = sy;
+
+    /* Virtual image origin: pivot stays fixed on screen as scale changes. */
+    float virt_x = (float)coords->x1 + (float)pivot_x * (1.0f - sx);
+    float virt_y = (float)coords->y1 + (float)pivot_y * (1.0f - sy);
+
+    /* Visible clip dimensions and buffer-local destination (always non-negative) */
+    r.clip_w = lv_area_get_width(&r.visible_area);
+    r.clip_h = lv_area_get_height(&r.visible_area);
+
+    lv_area_copy(&r.dest_area, &r.visible_area);
+    lv_area_move(&r.dest_area, -buf_area->x1, -buf_area->y1);
+
+    /* Map visible tile top-left back into source image space */
+    int32_t src_bx = (int32_t)(((float)r.visible_area.x1 - virt_x) / sx);
+    int32_t src_by = (int32_t)(((float)r.visible_area.y1 - virt_y) / sy);
+
+    /* ceilf gives the ideal source block; floorf clamp keeps PPA happy.
+     * The PPA may render 1 pixel short — the caller fixes that afterwards. */
+    uint32_t src_bw = (uint32_t)ceilf((float)r.clip_w / sx);
+    uint32_t src_bh = (uint32_t)ceilf((float)r.clip_h / sy);
+
+    uint32_t avail_w = (uint32_t)(buf_w - r.dest_area.x1);
+    uint32_t avail_h = (uint32_t)(buf_h - r.dest_area.y1);
+    uint32_t max_src_bw = (uint32_t)floorf((float)avail_w / sx);
+    uint32_t max_src_bh = (uint32_t)floorf((float)avail_h / sy);
+    r.gap_right  = (src_bw > max_src_bw);
+    r.gap_bottom = (src_bh > max_src_bh);
+    if(src_bw > max_src_bw) src_bw = max_src_bw;
+    if(src_bh > max_src_bh) src_bh = max_src_bh;
+
+    if(src_bx < 0 || src_by < 0 ||
+       (uint32_t)src_bx >= (uint32_t)img_w || (uint32_t)src_by >= (uint32_t)img_h) {
+        return r;
+    }
+    if((uint32_t)src_bx + src_bw > (uint32_t)img_w) src_bw = (uint32_t)img_w - (uint32_t)src_bx;
+    if((uint32_t)src_by + src_bh > (uint32_t)img_h) src_bh = (uint32_t)img_h - (uint32_t)src_by;
+    if(src_bw == 0 || src_bh == 0) return r;
+
+    r.block_x = src_bx;
+    r.block_y = src_by;
+    r.block_w = (int32_t)src_bw;
+    r.block_h = (int32_t)src_bh;
+    r.draw = true;
+    return r;
+}
+
+/**********************
+ *      MACROS
+ **********************/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /* LV_DRAW_PPA_SRM_H */

--- a/src/lvgl_private.h
+++ b/src/lvgl_private.h
@@ -34,6 +34,7 @@
 #include "draw/espressif/ppa/lv_draw_ppa.h"
 #include "draw/espressif/ppa/lv_draw_ppa_private.h"
 #include "draw/espressif/ppa/lv_draw_ppa_srm.h"
+#include "draw/espressif/ppa/lv_draw_ppa_rot.h"
 #include "draw/eve/lv_draw_eve.h"
 #include "draw/eve/lv_draw_eve_private.h"
 #include "draw/eve/lv_draw_eve_ram_g.h"

--- a/src/lvgl_private.h
+++ b/src/lvgl_private.h
@@ -33,6 +33,7 @@
 #include "draw/dma2d/lv_draw_dma2d_private.h"
 #include "draw/espressif/ppa/lv_draw_ppa.h"
 #include "draw/espressif/ppa/lv_draw_ppa_private.h"
+#include "draw/espressif/ppa/lv_draw_ppa_srm.h"
 #include "draw/eve/lv_draw_eve.h"
 #include "draw/eve/lv_draw_eve_private.h"
 #include "draw/eve/lv_draw_eve_ram_g.h"

--- a/tests/src/test_cases/test_draw_ppa_rot.c
+++ b/tests/src/test_cases/test_draw_ppa_rot.c
@@ -1,0 +1,145 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+#include "../../lvgl_private.h"
+
+#include "unity/unity.h"
+
+/* The PPA rotation only runs on an ESP32-P4, but the source-block geometry
+ * (lv_draw_ppa_rot_calc_block) is pure math and can be verified here on the
+ * host. These tests cover the parts that are easy to get wrong: clipping the
+ * rotated image to the render tile, the axis swap for the 90/270 steps, the
+ * 180 offset inversion, the off-screen guard, and clamping the destination to
+ * the buffer so the PPA can never write out of bounds. */
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+/* 180, image fully inside the tile: source block == whole image, no flip of size. */
+void test_ppa_rot_180_full(void)
+{
+    lv_area_t coords = {.x1 = 0, .y1 = 0, .x2 = 99, .y2 = 99};
+    lv_area_t buf = {.x1 = 0, .y1 = 0, .x2 = 199, .y2 = 199};
+
+    lv_draw_ppa_rot_block_t b = lv_draw_ppa_rot_calc_block(
+                                    &coords, &buf, 200, 200, 100, 100, 1800);
+
+    TEST_ASSERT_TRUE(b.draw);
+    TEST_ASSERT_EQUAL_INT32(0, b.dest_area.x1);
+    TEST_ASSERT_EQUAL_INT32(0, b.dest_area.y1);
+    TEST_ASSERT_EQUAL_INT32(0, b.block_x);
+    TEST_ASSERT_EQUAL_INT32(0, b.block_y);
+    TEST_ASSERT_EQUAL_INT32(100, b.block_w);
+    TEST_ASSERT_EQUAL_INT32(100, b.block_h);
+}
+
+/* 90 of a 100x60 image: on-screen bbox is 60x100 (axes swapped). Full tile maps
+ * to the full source block, with source dimensions un-swapped (100x60). */
+void test_ppa_rot_90_full(void)
+{
+    lv_area_t coords = {.x1 = 0, .y1 = 0, .x2 = 59, .y2 = 99};
+    lv_area_t buf = {.x1 = 0, .y1 = 0, .x2 = 199, .y2 = 199};
+
+    lv_draw_ppa_rot_block_t b = lv_draw_ppa_rot_calc_block(
+                                    &coords, &buf, 200, 200, 100, 60, 900);
+
+    TEST_ASSERT_TRUE(b.draw);
+    TEST_ASSERT_EQUAL_INT32(0, b.block_x);
+    TEST_ASSERT_EQUAL_INT32(0, b.block_y);
+    TEST_ASSERT_EQUAL_INT32(100, b.block_w);
+    TEST_ASSERT_EQUAL_INT32(60, b.block_h);
+}
+
+/* 270 of the same 100x60 image, full tile: also maps to the full source block. */
+void test_ppa_rot_270_full(void)
+{
+    lv_area_t coords = {.x1 = 0, .y1 = 0, .x2 = 59, .y2 = 99};
+    lv_area_t buf = {.x1 = 0, .y1 = 0, .x2 = 199, .y2 = 199};
+
+    lv_draw_ppa_rot_block_t b = lv_draw_ppa_rot_calc_block(
+                                    &coords, &buf, 200, 200, 100, 60, 2700);
+
+    TEST_ASSERT_TRUE(b.draw);
+    TEST_ASSERT_EQUAL_INT32(0, b.block_x);
+    TEST_ASSERT_EQUAL_INT32(0, b.block_y);
+    TEST_ASSERT_EQUAL_INT32(100, b.block_w);
+    TEST_ASSERT_EQUAL_INT32(60, b.block_h);
+}
+
+/* 90, partial tile (right half of the on-screen image). The visible output
+ * column range maps back to a clipped source row range; the source axes stay
+ * swapped. This is exactly what the old full-image path got wrong. */
+void test_ppa_rot_90_partial_tile(void)
+{
+    lv_area_t coords = {.x1 = 0, .y1 = 0, .x2 = 59, .y2 = 99};
+    lv_area_t buf = {.x1 = 30, .y1 = 0, .x2 = 59, .y2 = 99}; /* right half, 30x100 tile */
+
+    lv_draw_ppa_rot_block_t b = lv_draw_ppa_rot_calc_block(
+                                    &coords, &buf, 30, 100, 100, 60, 900);
+
+    TEST_ASSERT_TRUE(b.draw);
+    /* destination is buffer-local, so it starts at the tile origin */
+    TEST_ASSERT_EQUAL_INT32(0, b.dest_area.x1);
+    TEST_ASSERT_EQUAL_INT32(0, b.dest_area.y1);
+    /* output x[30,60) -> source y[0,30); full image height in x */
+    TEST_ASSERT_EQUAL_INT32(0, b.block_x);
+    TEST_ASSERT_EQUAL_INT32(0, b.block_y);
+    TEST_ASSERT_EQUAL_INT32(100, b.block_w);
+    TEST_ASSERT_EQUAL_INT32(30, b.block_h);
+}
+
+/* 180, bottom-right tile maps to the top-left of the source (both axes flip). */
+void test_ppa_rot_180_partial_tile(void)
+{
+    lv_area_t coords = {.x1 = 0, .y1 = 0, .x2 = 99, .y2 = 99};
+    lv_area_t buf = {.x1 = 50, .y1 = 50, .x2 = 99, .y2 = 99}; /* bottom-right, 50x50 tile */
+
+    lv_draw_ppa_rot_block_t b = lv_draw_ppa_rot_calc_block(
+                                    &coords, &buf, 50, 50, 100, 100, 1800);
+
+    TEST_ASSERT_TRUE(b.draw);
+    TEST_ASSERT_EQUAL_INT32(0, b.dest_area.x1);
+    TEST_ASSERT_EQUAL_INT32(0, b.dest_area.y1);
+    TEST_ASSERT_EQUAL_INT32(0, b.block_x);
+    TEST_ASSERT_EQUAL_INT32(0, b.block_y);
+    TEST_ASSERT_EQUAL_INT32(50, b.block_w);
+    TEST_ASSERT_EQUAL_INT32(50, b.block_h);
+}
+
+/* Nothing intersects the render tile: skip the operation entirely (the old path
+ * would have decoded and submitted a PPA op writing at a bogus offset). */
+void test_ppa_rot_offscreen(void)
+{
+    lv_area_t coords = {.x1 = 500, .y1 = 500, .x2 = 559, .y2 = 599};
+    lv_area_t buf = {.x1 = 0, .y1 = 0, .x2 = 199, .y2 = 199};
+
+    lv_draw_ppa_rot_block_t b = lv_draw_ppa_rot_calc_block(
+                                    &coords, &buf, 200, 200, 100, 60, 900);
+
+    TEST_ASSERT_FALSE(b.draw);
+}
+
+/* Destination clamp: a buffer narrower/shorter than the visible window must be
+ * clamped so the PPA cannot write past the buffer. */
+void test_ppa_rot_dest_clamped_to_buffer(void)
+{
+    lv_area_t coords = {.x1 = 0, .y1 = 0, .x2 = 99, .y2 = 99};
+    lv_area_t buf = {.x1 = 0, .y1 = 0, .x2 = 99, .y2 = 99};
+
+    /* buffer is only 80x80 even though the visible window is 100x100 */
+    lv_draw_ppa_rot_block_t b = lv_draw_ppa_rot_calc_block(
+                                    &coords, &buf, 80, 80, 100, 100, 1800);
+
+    TEST_ASSERT_TRUE(b.draw);
+    /* source block (and therefore the PPA output) is clamped to 80x80 */
+    TEST_ASSERT_EQUAL_INT32(80, b.block_w);
+    TEST_ASSERT_EQUAL_INT32(80, b.block_h);
+    TEST_ASSERT_TRUE(b.dest_area.x1 + b.block_w <= 80);
+    TEST_ASSERT_TRUE(b.dest_area.y1 + b.block_h <= 80);
+}
+
+#endif

--- a/tests/src/test_cases/test_draw_ppa_srm.c
+++ b/tests/src/test_cases/test_draw_ppa_srm.c
@@ -1,0 +1,133 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+#include "../../lvgl_private.h"
+
+#include "unity/unity.h"
+
+/* The PPA SRM operation itself only runs on an ESP32-P4, but the source-block
+ * geometry (lv_draw_ppa_srm_calc_block) is pure math and can be verified here
+ * on the host. These tests cover the parts that are easy to get wrong:
+ * scale mapping, clamping to the image, and the 1-pixel right/bottom gap that
+ * the PPA's floor-rounding leaves behind. */
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+/* 1:1, image fully inside the render tile: source block == whole image. */
+void test_ppa_srm_identity(void)
+{
+    lv_area_t coords = {.x1 = 0, .y1 = 0, .x2 = 99, .y2 = 99};
+    lv_area_t buf = {.x1 = 0, .y1 = 0, .x2 = 199, .y2 = 199};
+
+    lv_draw_ppa_srm_block_t b = lv_draw_ppa_srm_calc_block(
+                                    &coords, &buf, 200, 200, 100, 100,
+                                    LV_SCALE_NONE, LV_SCALE_NONE, 0, 0);
+
+    TEST_ASSERT_TRUE(b.draw);
+    TEST_ASSERT_EQUAL_INT32(0, b.block_x);
+    TEST_ASSERT_EQUAL_INT32(0, b.block_y);
+    TEST_ASSERT_EQUAL_INT32(100, b.block_w);
+    TEST_ASSERT_EQUAL_INT32(100, b.block_h);
+    TEST_ASSERT_EQUAL_INT32(100, b.clip_w);
+    TEST_ASSERT_EQUAL_INT32(100, b.clip_h);
+    TEST_ASSERT_EQUAL_INT32(0, b.dest_area.x1);
+    TEST_ASSERT_EQUAL_INT32(0, b.dest_area.y1);
+    TEST_ASSERT_FALSE(b.gap_right);
+    TEST_ASSERT_FALSE(b.gap_bottom);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, b.scale_x);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, b.scale_y);
+}
+
+/* 2x upscale: a 100x100 image drawn over a 200x200 on-screen area reads the
+ * full 100x100 source block. */
+void test_ppa_srm_upscale_2x(void)
+{
+    lv_area_t coords = {.x1 = 0, .y1 = 0, .x2 = 199, .y2 = 199};
+    lv_area_t buf = {.x1 = 0, .y1 = 0, .x2 = 399, .y2 = 399};
+
+    lv_draw_ppa_srm_block_t b = lv_draw_ppa_srm_calc_block(
+                                    &coords, &buf, 400, 400, 100, 100,
+                                    512, 512, 0, 0);
+
+    TEST_ASSERT_TRUE(b.draw);
+    TEST_ASSERT_EQUAL_INT32(0, b.block_x);
+    TEST_ASSERT_EQUAL_INT32(0, b.block_y);
+    TEST_ASSERT_EQUAL_INT32(100, b.block_w);
+    TEST_ASSERT_EQUAL_INT32(100, b.block_h);
+    TEST_ASSERT_EQUAL_INT32(200, b.clip_w);
+    TEST_ASSERT_EQUAL_INT32(200, b.clip_h);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 2.0f, b.scale_x);
+}
+
+/* 0.5x downscale: a 100x100 image drawn over a 50x50 on-screen area still
+ * reads the full 100x100 source block. */
+void test_ppa_srm_downscale_half(void)
+{
+    lv_area_t coords = {.x1 = 0, .y1 = 0, .x2 = 49, .y2 = 49};
+    lv_area_t buf = {.x1 = 0, .y1 = 0, .x2 = 199, .y2 = 199};
+
+    lv_draw_ppa_srm_block_t b = lv_draw_ppa_srm_calc_block(
+                                    &coords, &buf, 200, 200, 100, 100,
+                                    128, 128, 0, 0);
+
+    TEST_ASSERT_TRUE(b.draw);
+    TEST_ASSERT_EQUAL_INT32(100, b.block_w);
+    TEST_ASSERT_EQUAL_INT32(100, b.block_h);
+    TEST_ASSERT_EQUAL_INT32(50, b.clip_w);
+    TEST_ASSERT_EQUAL_INT32(50, b.clip_h);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.5f, b.scale_x);
+}
+
+/* Nothing intersects the render tile: skip the operation entirely. */
+void test_ppa_srm_offscreen(void)
+{
+    lv_area_t coords = {.x1 = 500, .y1 = 500, .x2 = 599, .y2 = 599};
+    lv_area_t buf = {.x1 = 0, .y1 = 0, .x2 = 199, .y2 = 199};
+
+    lv_draw_ppa_srm_block_t b = lv_draw_ppa_srm_calc_block(
+                                    &coords, &buf, 200, 200, 100, 100,
+                                    LV_SCALE_NONE, LV_SCALE_NONE, 0, 0);
+
+    TEST_ASSERT_FALSE(b.draw);
+}
+
+/* Fractional scale (1.5x horizontally) makes ceil(clip/scale) overshoot
+ * floor(avail/scale) at the buffer's right edge: the gap flag must fire and
+ * the block width must be clamped. */
+void test_ppa_srm_right_gap(void)
+{
+    lv_area_t coords = {.x1 = 0, .y1 = 0, .x2 = 99, .y2 = 99};
+    lv_area_t buf = {.x1 = 0, .y1 = 0, .x2 = 99, .y2 = 99};
+
+    lv_draw_ppa_srm_block_t b = lv_draw_ppa_srm_calc_block(
+                                    &coords, &buf, 100, 100, 100, 100,
+                                    384, LV_SCALE_NONE, 0, 0);
+
+    TEST_ASSERT_TRUE(b.draw);
+    TEST_ASSERT_TRUE(b.gap_right);
+    TEST_ASSERT_FALSE(b.gap_bottom);
+    TEST_ASSERT_EQUAL_INT32(66, b.block_w);   /* clamped from ceil(100/1.5)=67 */
+    TEST_ASSERT_EQUAL_INT32(100, b.block_h);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.5f, b.scale_x);
+}
+
+/* A pivot + downscale that maps the visible tile before the source origin:
+ * the negative-offset guard must reject the block. */
+void test_ppa_srm_negative_block_rejected(void)
+{
+    lv_area_t coords = {.x1 = 0, .y1 = 0, .x2 = 49, .y2 = 49};
+    lv_area_t buf = {.x1 = 0, .y1 = 0, .x2 = 199, .y2 = 199};
+
+    lv_draw_ppa_srm_block_t b = lv_draw_ppa_srm_calc_block(
+                                    &coords, &buf, 200, 200, 100, 100,
+                                    128, 128, 100, 100);
+
+    TEST_ASSERT_FALSE(b.draw);
+}
+
+#endif


### PR DESCRIPTION
Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

