### PR TITLE
feat(roller, dropdown): add translation tag support

### DIFF
--- a/docs/src/widgets/dropdown.mdx
+++ b/docs/src/widgets/dropdown.mdx
@@ -56,6 +56,20 @@ shows that string regardless of selection. Pass `NULL` to revert.
 
 <LvglExample name="lv_example_dropdown_text" path="widgets/dropdown/lv_example_dropdown_text" />
 
+## Set translation tag
+
+When using LVGL's [translation module](/main-modules/translation), you can bind a translation tag to a drop-down list directly.
+After binding, future changes to the language will automatically update the bound text or options to
+display the corresponding translation for that tag in the new language.
+
+- <ApiLink name="lv_dropdown_set_text_translation_tag" display="lv_dropdown_set_text_translation_tag(dd, tag)" /> binds the
+  button's fixed text (see [Show selected](#show-selected)).
+- <ApiLink name="lv_dropdown_set_options_translation_tag" display="lv_dropdown_set_options_translation_tag(dd, tag)" /> binds the
+  options. The translation should contain the options in a `\n` separated list, e.g. `"One\nTwo\nThree"`.
+
+Calling any of the regular `lv_dropdown_set_text…`/`lv_dropdown_set_options…` functions (or
+`lv_dropdown_add_option`/`lv_dropdown_clear_options`) afterwards removes the binding.
+
 ## Programmatically open/close
 
 <ApiLink name="lv_dropdown_open" display="lv_dropdown_open(dd)" /> and <ApiLink name="lv_dropdown_close" display="lv_dropdown_close(dd)" />.

--- a/docs/src/widgets/roller.mdx
+++ b/docs/src/widgets/roller.mdx
@@ -20,6 +20,16 @@ circular roller.
 Select programmatically with <ApiLink name="lv_roller_set_selected" display="lv_roller_set_selected(roller, id, LV_ANIM_ON)" />
 (index) or `_set_selected_str(roller, str, LV_ANIM_ON)` (option text).
 
+## Set translation tag
+
+When using LVGL's [translation module](/main-modules/translation), you can bind a translation tag to the roller's
+options with <ApiLink name="lv_roller_set_options_translation_tag" display="lv_roller_set_options_translation_tag(roller, tag, mode)" />.
+After binding, future changes to the language will automatically update the options to display the corresponding
+translation for that tag in the new language. The translation should contain the options in a `\n` separated list,
+e.g. `"One\nTwo\nThree"`.
+
+Calling <ApiLink name="lv_roller_set_options" /> afterwards removes the binding.
+
 ## Get selected option
 
 - <ApiLink name="lv_roller_get_selected" display="lv_roller_get_selected(roller)" /> returns the index.

--- a/include/lvgl/widgets/lv_dropdown.h
+++ b/include/lvgl/widgets/lv_dropdown.h
@@ -83,6 +83,18 @@ void lv_dropdown_set_text(lv_obj_t * obj, const char * text);
  */
 void lv_dropdown_set_text_static(lv_obj_t * obj, const char * text);
 
+#if LV_USE_TRANSLATION
+
+/**
+ * Assign a translation tag for the drop-down list's button text. Memory will be allocated to store the tag.
+ * The button text will automatically update when the language is changed via `lv_translation_set_language`.
+ * @param obj       pointer to a drop-down list object
+ * @param tag       '\0' terminated character string.
+ */
+void lv_dropdown_set_text_translation_tag(lv_obj_t * obj, const char * tag);
+
+#endif /*LV_USE_TRANSLATION*/
+
 /**
  * Set the options in a drop-down list from a string.
  * The options will be copied and saved in the object so the `options` can be destroyed after calling this function
@@ -98,6 +110,19 @@ void lv_dropdown_set_options(lv_obj_t * obj, const char * options);
  * @param options   a static string with '\n' separated options. E.g. "One\nTwo\nThree"
  */
 void lv_dropdown_set_options_static(lv_obj_t * obj, const char * options);
+
+#if LV_USE_TRANSLATION
+
+/**
+ * Assign a translation tag for the options of the drop-down list. Memory will be allocated to store the tag.
+ * The options will automatically update when the language is changed via `lv_translation_set_language`.
+ * The translation should contain the options in a '\n' separated list. E.g. "One\nTwo\nThree"
+ * @param obj       pointer to a drop-down list object
+ * @param tag       '\0' terminated character string.
+ */
+void lv_dropdown_set_options_translation_tag(lv_obj_t * obj, const char * tag);
+
+#endif /*LV_USE_TRANSLATION*/
 
 /**
  * Add an options to a drop-down list from a string.  Only works for non-static options.

--- a/include/lvgl/widgets/lv_roller.h
+++ b/include/lvgl/widgets/lv_roller.h
@@ -72,6 +72,20 @@ lv_obj_t * lv_roller_create(lv_obj_t * parent);
  */
 void lv_roller_set_options(lv_obj_t * obj, const char * options, lv_roller_mode_t mode);
 
+#if LV_USE_TRANSLATION
+
+/**
+ * Assign a translation tag for the options of the roller. Memory will be allocated to store the tag.
+ * The options will automatically update when the language is changed via `lv_translation_set_language`.
+ * The translation should contain the options in a '\n' separated list. E.g. "One\nTwo\nThree"
+ * @param obj       pointer to a roller object
+ * @param tag       '\0' terminated character string.
+ * @param mode      `LV_ROLLER_MODE_NORMAL` or `LV_ROLLER_MODE_INFINITE`
+ */
+void lv_roller_set_options_translation_tag(lv_obj_t * obj, const char * tag, lv_roller_mode_t mode);
+
+#endif /*LV_USE_TRANSLATION*/
+
 /**
  * Set the selected option
  * @param obj       pointer to a roller object

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -54,6 +54,8 @@ static void list_press_handler(lv_obj_t * page);
 static uint32_t get_id_on_point(lv_obj_t * dropdown_obj, int32_t y);
 static void position_to_selected(lv_obj_t * dropdown_obj, lv_anim_enable_t anim_en);
 static lv_obj_t * get_label(const lv_obj_t * obj);
+static void set_text_internal(lv_obj_t * obj, const char * text);
+static void set_options_internal(lv_obj_t * obj, const char * options);
 static void remove_options_translation_tag(lv_obj_t * obj);
 static void remove_text_translation_tag(lv_obj_t * obj);
 
@@ -163,23 +165,7 @@ void lv_dropdown_set_text(lv_obj_t * obj, const char * text)
     LV_CHECK_OBJ(obj, MY_CLASS, return);
 
     remove_text_translation_tag(obj);
-
-    lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
-    if(!dropdown->static_text && dropdown->text && text && lv_streq(dropdown->text, text)) {
-        return;
-    }
-
-    char * copied_text = NULL;
-    if(text) {
-        copied_text = lv_strdup(text);
-        LV_ASSERT_MALLOC(copied_text);
-    }
-
-    if(!dropdown->static_text) lv_free(dropdown->text);
-    dropdown->static_text = 0;
-    dropdown->text = copied_text;
-
-    lv_obj_invalidate(obj);
+    set_text_internal(obj, text);
 }
 
 void lv_dropdown_set_text_static(lv_obj_t * obj, const char * text)
@@ -202,12 +188,11 @@ void lv_dropdown_set_text_static(lv_obj_t * obj, const char * text)
     refresh_size(obj);
 }
 
-
 #if LV_USE_TRANSLATION
 void lv_dropdown_set_text_translation_tag(lv_obj_t * obj, const char * tag)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return);
-    lv_dropdown_t * dropdown = (lv_label_t *)obj;
+    lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
     if(!tag || tag[0] == '\0') {
         return;
     }
@@ -217,11 +202,12 @@ void lv_dropdown_set_text_translation_tag(lv_obj_t * obj, const char * tag)
         LV_LOG_WARN("Failed to allocate memory for new tag");
         return;
     }
+
     if(dropdown->text_translation_tag) {
         lv_free(dropdown->text_translation_tag);
     }
     dropdown->text_translation_tag = new_tag;
-    lv_dropdown_set_text(obj, lv_tr(tag));
+    set_text_internal(obj, lv_tr(tag));
 }
 #endif /*LV_USE_TRANSLATION*/
 
@@ -230,47 +216,8 @@ void lv_dropdown_set_options(lv_obj_t * obj, const char * options)
     LV_CHECK_OBJ(obj, MY_CLASS, return);
     LV_ASSERT_NULL(options);
 
-    lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
-
-    /*Count the '\n'-s to determine the number of options*/
-    dropdown->option_cnt = 0;
-    uint32_t i;
-    for(i = 0; options[i] != '\0'; i++) {
-        if(options[i] == '\n') dropdown->option_cnt++;
-    }
-    dropdown->option_cnt++;   /*Last option has no `\n`*/
-    dropdown->sel_opt_id      = 0;
-    dropdown->sel_opt_id_orig = 0;
-
-    /*Allocate space for the new text*/
-#if LV_USE_ARABIC_PERSIAN_CHARS == 0
-    size_t len = lv_strlen(options) + 1;
-#else
-    size_t len = lv_text_ap_strlen(options) + 1;
-#endif
-
-    if(dropdown->options != NULL && dropdown->static_options == 0) {
-        lv_free(dropdown->options);
-        dropdown->options = NULL;
-    }
-
-    dropdown->options = lv_malloc(len);
-
-    LV_ASSERT_MALLOC(dropdown->options);
-    if(dropdown->options == NULL) return;
-
-#if LV_USE_ARABIC_PERSIAN_CHARS == 0
-    lv_strcpy(dropdown->options, options);
-#else
-    lv_text_ap_proc(options, dropdown->options);
-#endif
-
-    /*Now the text is dynamically allocated*/
-    dropdown->static_options = 0;
-
-    refresh_size(obj);
-    if(dropdown->list)
-        lv_obj_invalidate(dropdown->list);
+    remove_options_translation_tag(obj);
+    set_options_internal(obj, options);
 }
 
 void lv_dropdown_set_options_static(lv_obj_t * obj, const char * options)
@@ -393,11 +340,11 @@ void lv_dropdown_set_options_translation_tag(lv_obj_t * obj, const char * tag)
         LV_LOG_WARN("Failed to allocate memory for new tag");
         return;
     }
-    if(dropdown->text_options_tag) {
-        lv_free(dropdown->text_options_tag);
+    if(dropdown->options_translation_tag) {
+        lv_free(dropdown->options_translation_tag);
     }
-    dropdown->text_options_tag = new_tag;
-    lv_dropdown_set_options(obj, lv_tr(tag));
+    dropdown->options_translation_tag = new_tag;
+    set_options_internal(obj, lv_tr(tag));
 }
 #endif /*LV_USE_TRANSLATION*/
 
@@ -409,7 +356,6 @@ void lv_dropdown_clear_options(lv_obj_t * obj)
 
     lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
     if(dropdown->options == NULL) return;
-
 
     if(dropdown->static_options == 0)
         lv_free(dropdown->options);
@@ -799,6 +745,13 @@ static void lv_dropdown_destructor(const lv_obj_class_t * class_p, lv_obj_t * ob
 
     if(!dropdown->static_text) lv_free(dropdown->text);
     dropdown->text = NULL;
+
+#if LV_USE_TRANSLATION
+    lv_free(dropdown->text_translation_tag);
+    dropdown->text_translation_tag = NULL;
+    lv_free(dropdown->options_translation_tag);
+    dropdown->options_translation_tag = NULL;
+#endif /*LV_USE_TRANSLATION*/
 }
 
 static void lv_dropdownlist_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
@@ -995,6 +948,16 @@ static void lv_dropdown_event(const lv_obj_class_t * class_p, lv_event_t * e)
     else if(code == LV_EVENT_DRAW_MAIN) {
         draw_main(e);
     }
+#if LV_USE_TRANSLATION
+    else if(code == LV_EVENT_TRANSLATION_LANGUAGE_CHANGED) {
+        if(dropdown->text_translation_tag) {
+            set_text_internal(obj, lv_tr(dropdown->text_translation_tag));
+        }
+        if(dropdown->options_translation_tag) {
+            set_options_internal(obj, lv_tr(dropdown->options_translation_tag));
+        }
+    }
+#endif /*LV_USE_TRANSLATION*/
 }
 
 static void lv_dropdown_list_event(const lv_obj_class_t * class_p, lv_event_t * e)
@@ -1437,27 +1400,94 @@ static lv_obj_t * get_label(const lv_obj_t * obj)
     return lv_obj_get_child(dropdown->list, 0);
 }
 
-static void remove_options_translation_tag(lv_obj_t * obj)
+static void set_text_internal(lv_obj_t * obj, const char * text)
 {
     lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
+    if(!dropdown->static_text && dropdown->text && text && lv_streq(dropdown->text, text)) {
+        return;
+    }
+
+    char * copied_text = NULL;
+    if(text) {
+        copied_text = lv_strdup(text);
+        LV_ASSERT_MALLOC(copied_text);
+    }
+
+    if(!dropdown->static_text) lv_free(dropdown->text);
+    dropdown->static_text = 0;
+    dropdown->text = copied_text;
+
+    lv_obj_invalidate(obj);
+}
+
+static void set_options_internal(lv_obj_t * obj, const char * options)
+{
+    lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
+
+    /*Count the '\n'-s to determine the number of options*/
+    dropdown->option_cnt = 0;
+    uint32_t i;
+    for(i = 0; options[i] != '\0'; i++) {
+        if(options[i] == '\n') dropdown->option_cnt++;
+    }
+    dropdown->option_cnt++;   /*Last option has no `\n`*/
+    dropdown->sel_opt_id      = 0;
+    dropdown->sel_opt_id_orig = 0;
+
+    /*Allocate space for the new text*/
+#if LV_USE_ARABIC_PERSIAN_CHARS == 0
+    size_t len = lv_strlen(options) + 1;
+#else
+    size_t len = lv_text_ap_strlen(options) + 1;
+#endif
+
+    if(dropdown->options != NULL && dropdown->static_options == 0) {
+        lv_free(dropdown->options);
+        dropdown->options = NULL;
+    }
+
+    dropdown->options = lv_malloc(len);
+
+    LV_ASSERT_MALLOC(dropdown->options);
+    if(dropdown->options == NULL) return;
+
+#if LV_USE_ARABIC_PERSIAN_CHARS == 0
+    lv_strcpy(dropdown->options, options);
+#else
+    lv_text_ap_proc(options, dropdown->options);
+#endif
+
+    /*Now the text is dynamically allocated*/
+    dropdown->static_options = 0;
+
+    refresh_size(obj);
+    if(dropdown->list)
+        lv_obj_invalidate(dropdown->list);
+}
+
+static void remove_options_translation_tag(lv_obj_t * obj)
+{
 #if LV_USE_TRANSLATION
-    /* Remove translation tag so we don't update the text automatically if the language changes*/
+    lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
     if(dropdown->options_translation_tag) {
         lv_free(dropdown->options_translation_tag);
         dropdown->options_translation_tag = NULL;
     }
+#else
+    LV_UNUSED(obj);
 #endif /*LV_USE_TRANSLATION*/
 }
 
 static void remove_text_translation_tag(lv_obj_t * obj)
 {
-    lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
 #if LV_USE_TRANSLATION
-    /* Remove translation tag so we don't update the text automatically if the language changes*/
+    lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
     if(dropdown->text_translation_tag) {
         lv_free(dropdown->text_translation_tag);
         dropdown->text_translation_tag = NULL;
     }
+#else
+    LV_UNUSED(obj);
 #endif /*LV_USE_TRANSLATION*/
 }
 

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -54,6 +54,8 @@ static void list_press_handler(lv_obj_t * page);
 static uint32_t get_id_on_point(lv_obj_t * dropdown_obj, int32_t y);
 static void position_to_selected(lv_obj_t * dropdown_obj, lv_anim_enable_t anim_en);
 static lv_obj_t * get_label(const lv_obj_t * obj);
+static void remove_options_translation_tag(lv_obj_t * obj);
+static void remove_text_translation_tag(lv_obj_t * obj);
 
 #if LV_USE_OBSERVER
     static void dropdown_value_changed_event_cb(lv_event_t * e);
@@ -159,8 +161,11 @@ lv_obj_t * lv_dropdown_create(lv_obj_t * parent)
 void lv_dropdown_set_text(lv_obj_t * obj, const char * text)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return);
+
+    remove_text_translation_tag(obj);
+
     lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
-    if(!dropdown->static_text && dropdown->text && text && lv_strcmp(dropdown->text, text) == 0) {
+    if(!dropdown->static_text && dropdown->text && text && lv_streq(dropdown->text, text)) {
         return;
     }
 
@@ -180,9 +185,12 @@ void lv_dropdown_set_text(lv_obj_t * obj, const char * text)
 void lv_dropdown_set_text_static(lv_obj_t * obj, const char * text)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return);
+
+    remove_text_translation_tag(obj);
+
     lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
 
-    if(dropdown->static_text && dropdown->text && text && lv_strcmp(dropdown->text, text) == 0) {
+    if(dropdown->static_text && dropdown->text && text && lv_streq(dropdown->text, text)) {
         return;
     }
 
@@ -193,6 +201,29 @@ void lv_dropdown_set_text_static(lv_obj_t * obj, const char * text)
 
     refresh_size(obj);
 }
+
+
+#if LV_USE_TRANSLATION
+void lv_dropdown_set_text_translation_tag(lv_obj_t * obj, const char * tag)
+{
+    LV_CHECK_OBJ(obj, MY_CLASS, return);
+    lv_dropdown_t * dropdown = (lv_label_t *)obj;
+    if(!tag || tag[0] == '\0') {
+        return;
+    }
+    char * new_tag = lv_strdup(tag);
+    LV_ASSERT_MALLOC(new_tag);
+    if(!new_tag) {
+        LV_LOG_WARN("Failed to allocate memory for new tag");
+        return;
+    }
+    if(dropdown->text_translation_tag) {
+        lv_free(dropdown->text_translation_tag);
+    }
+    dropdown->text_translation_tag = new_tag;
+    lv_dropdown_set_text(obj, lv_tr(tag));
+}
+#endif /*LV_USE_TRANSLATION*/
 
 void lv_dropdown_set_options(lv_obj_t * obj, const char * options)
 {
@@ -247,8 +278,9 @@ void lv_dropdown_set_options_static(lv_obj_t * obj, const char * options)
     LV_CHECK_OBJ(obj, MY_CLASS, return);
     LV_ASSERT_NULL(options);
 
-    lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
+    remove_options_translation_tag(obj);
 
+    lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
     /*Count the '\n'-s to determine the number of options*/
     dropdown->option_cnt = 0;
     uint32_t i;
@@ -276,6 +308,8 @@ void lv_dropdown_add_option(lv_obj_t * obj, const char * option, uint32_t pos)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return);
     LV_ASSERT_NULL(option);
+
+    remove_options_translation_tag(obj);
 
     lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
 
@@ -345,11 +379,37 @@ void lv_dropdown_add_option(lv_obj_t * obj, const char * option, uint32_t pos)
         lv_obj_invalidate(dropdown->list);
 }
 
-void lv_dropdown_clear_options(lv_obj_t * obj)
+#if LV_USE_TRANSLATION
+void lv_dropdown_set_options_translation_tag(lv_obj_t * obj, const char * tag)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return);
     lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
+    if(!tag || tag[0] == '\0') {
+        return;
+    }
+    char * new_tag = lv_strdup(tag);
+    LV_ASSERT_MALLOC(new_tag);
+    if(!new_tag) {
+        LV_LOG_WARN("Failed to allocate memory for new tag");
+        return;
+    }
+    if(dropdown->text_options_tag) {
+        lv_free(dropdown->text_options_tag);
+    }
+    dropdown->text_options_tag = new_tag;
+    lv_dropdown_set_options(obj, lv_tr(tag));
+}
+#endif /*LV_USE_TRANSLATION*/
+
+void lv_dropdown_clear_options(lv_obj_t * obj)
+{
+    LV_CHECK_OBJ(obj, MY_CLASS, return);
+
+    remove_options_translation_tag(obj);
+
+    lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
     if(dropdown->options == NULL) return;
+
 
     if(dropdown->static_options == 0)
         lv_free(dropdown->options);
@@ -1375,6 +1435,30 @@ static lv_obj_t * get_label(const lv_obj_t * obj)
     if(dropdown->list == NULL) return NULL;
 
     return lv_obj_get_child(dropdown->list, 0);
+}
+
+static void remove_options_translation_tag(lv_obj_t * obj)
+{
+    lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
+#if LV_USE_TRANSLATION
+    /* Remove translation tag so we don't update the text automatically if the language changes*/
+    if(dropdown->options_translation_tag) {
+        lv_free(dropdown->options_translation_tag);
+        dropdown->options_translation_tag = NULL;
+    }
+#endif /*LV_USE_TRANSLATION*/
+}
+
+static void remove_text_translation_tag(lv_obj_t * obj)
+{
+    lv_dropdown_t * dropdown = (lv_dropdown_t *)obj;
+#if LV_USE_TRANSLATION
+    /* Remove translation tag so we don't update the text automatically if the language changes*/
+    if(dropdown->text_translation_tag) {
+        lv_free(dropdown->text_translation_tag);
+        dropdown->text_translation_tag = NULL;
+    }
+#endif /*LV_USE_TRANSLATION*/
 }
 
 #if LV_USE_OBSERVER

--- a/src/widgets/dropdown/lv_dropdown_private.h
+++ b/src/widgets/dropdown/lv_dropdown_private.h
@@ -37,6 +37,10 @@ struct _lv_dropdown_t {
     char * text;                    /**< Text to display on the dropdown's button*/
     const void * symbol;            /**< Arrow or other icon when the drop-down list is closed*/
     char * options;                 /**< Options in a '\n' separated list*/
+#if LV_USE_TRANSLATION
+    const char *
+#endif
+
     uint32_t option_cnt;            /**< Number of options*/
     uint32_t sel_opt_id;            /**< Index of the currently selected option*/
     uint32_t sel_opt_id_orig;       /**< Store the original index on focus*/

--- a/src/widgets/dropdown/lv_dropdown_private.h
+++ b/src/widgets/dropdown/lv_dropdown_private.h
@@ -38,9 +38,9 @@ struct _lv_dropdown_t {
     const void * symbol;            /**< Arrow or other icon when the drop-down list is closed*/
     char * options;                 /**< Options in a '\n' separated list*/
 #if LV_USE_TRANSLATION
-    const char *
+    char * text_translation_tag;    /**< Translation tag for the button's text*/
+    char * options_translation_tag; /**< Translation tag for the options*/
 #endif
-
     uint32_t option_cnt;            /**< Number of options*/
     uint32_t sel_opt_id;            /**< Index of the currently selected option*/
     uint32_t sel_opt_id_orig;       /**< Store the original index on focus*/

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -36,7 +36,10 @@
  *  STATIC PROTOTYPES
  **********************/
 static void lv_roller_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj);
+static void lv_roller_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj);
 static void lv_roller_event(const lv_obj_class_t * class_p, lv_event_t * e);
+static void set_options_internal(lv_obj_t * obj, const char * options, lv_roller_mode_t mode);
+static void remove_options_translation_tag(lv_obj_t * obj);
 static void lv_roller_label_event(const lv_obj_class_t * class_p, lv_event_t * e);
 static void draw_main(lv_event_t * e);
 static void draw_label(lv_event_t * e);
@@ -80,6 +83,7 @@ static const lv_property_ops_t lv_roller_properties[] = {
 
 const lv_obj_class_t lv_roller_class = {
     .constructor_cb = lv_roller_constructor,
+    .destructor_cb = lv_roller_destructor,
     .event_cb = lv_roller_event,
     .width_def = LV_SIZE_CONTENT,
     .height_def = LV_DPI_DEF,
@@ -123,6 +127,34 @@ void lv_roller_set_options(lv_obj_t * obj, const char * options, lv_roller_mode_
     LV_CHECK_OBJ(obj, MY_CLASS, return);
     LV_ASSERT_NULL(options);
 
+    remove_options_translation_tag(obj);
+    set_options_internal(obj, options, mode);
+}
+
+#if LV_USE_TRANSLATION
+void lv_roller_set_options_translation_tag(lv_obj_t * obj, const char * tag, lv_roller_mode_t mode)
+{
+    LV_CHECK_OBJ(obj, MY_CLASS, return);
+    lv_roller_t * roller = (lv_roller_t *)obj;
+    if(!tag || tag[0] == '\0') {
+        return;
+    }
+    char * new_tag = lv_strdup(tag);
+    LV_ASSERT_MALLOC(new_tag);
+    if(!new_tag) {
+        LV_LOG_WARN("Failed to allocate memory for new tag");
+        return;
+    }
+    if(roller->options_translation_tag) {
+        lv_free(roller->options_translation_tag);
+    }
+    roller->options_translation_tag = new_tag;
+    set_options_internal(obj, lv_tr(tag), mode);
+}
+#endif /*LV_USE_TRANSLATION*/
+
+static void set_options_internal(lv_obj_t * obj, const char * options, lv_roller_mode_t mode)
+{
     lv_roller_t * roller = (lv_roller_t *)obj;
     lv_obj_t * label = get_label(obj);
 
@@ -378,6 +410,32 @@ static void lv_roller_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj
     LV_LOG_TRACE("finished");
 }
 
+static void lv_roller_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
+{
+    LV_UNUSED(class_p);
+#if LV_USE_TRANSLATION
+    lv_roller_t * roller = (lv_roller_t *)obj;
+    lv_free(roller->options_translation_tag);
+    roller->options_translation_tag = NULL;
+#else
+    LV_UNUSED(obj);
+#endif /*LV_USE_TRANSLATION*/
+}
+
+static void remove_options_translation_tag(lv_obj_t * obj)
+{
+#if LV_USE_TRANSLATION
+    lv_roller_t * roller = (lv_roller_t *)obj;
+    /* Remove translation tag so we don't update the options automatically if the language changes*/
+    if(roller->options_translation_tag) {
+        lv_free(roller->options_translation_tag);
+        roller->options_translation_tag = NULL;
+    }
+#else
+    LV_UNUSED(obj);
+#endif /*LV_USE_TRANSLATION*/
+}
+
 static void lv_roller_event(const lv_obj_class_t * class_p, lv_event_t * e)
 {
     LV_UNUSED(class_p);
@@ -505,6 +563,13 @@ static void lv_roller_event(const lv_obj_class_t * class_p, lv_event_t * e)
     else if(code == LV_EVENT_DRAW_MAIN || code == LV_EVENT_DRAW_POST) {
         draw_main(e);
     }
+#if LV_USE_TRANSLATION
+    else if(code == LV_EVENT_TRANSLATION_LANGUAGE_CHANGED) {
+        if(roller->options_translation_tag) {
+            set_options_internal(obj, lv_tr(roller->options_translation_tag), roller->mode);
+        }
+    }
+#endif /*LV_USE_TRANSLATION*/
 }
 
 static void lv_roller_label_event(const lv_obj_class_t * class_p, lv_event_t * e)

--- a/src/widgets/roller/lv_roller_private.h
+++ b/src/widgets/roller/lv_roller_private.h
@@ -33,6 +33,9 @@ struct _lv_roller_t {
     uint32_t sel_opt_id;          /**< Index of the current option*/
     uint32_t sel_opt_id_ori;      /**< Store the original index on focus*/
     uint32_t inf_page_cnt;        /**< Number of extra pages added to make the roller look infinite */
+#if LV_USE_TRANSLATION
+    char * options_translation_tag; /**< Translation tag for the options*/
+#endif
     lv_roller_mode_t mode : 2;
     uint32_t moved : 1;
 };

--- a/tests/src/test_cases/widgets/test_dropdown.c
+++ b/tests/src/test_cases/widgets/test_dropdown.c
@@ -558,4 +558,120 @@ void test_dropdown_content_size()
     lv_dropdown_set_selected(dd, 2);
     TEST_ASSERT_EQUAL_SCREENSHOT("widgets/dropdown_content_size_3.png");
 }
+
+#if LV_USE_TRANSLATION
+void test_dropdown_text_translation_tag(void)
+{
+    /* Arrays are defined `const` to place them in program space instead of RAM. */
+    static const char * const tags[] = {"tiger", NULL};
+    static const char * const languages[]    = {"en", "de", "es", NULL};
+    static const char * const translations[] = { "The Tiger", "Der Tiger", "El Tigre" };
+    lv_translation_add_static(languages, tags, translations);
+
+    lv_obj_t * dd = lv_dropdown_create(lv_screen_active());
+    lv_dropdown_set_text_translation_tag(dd, "tiger");
+
+    lv_translation_set_language("en");
+    TEST_ASSERT_EQUAL_STRING("The Tiger", lv_dropdown_get_text(dd));
+
+    lv_translation_set_language("de");
+    TEST_ASSERT_EQUAL_STRING("Der Tiger", lv_dropdown_get_text(dd));
+
+    lv_translation_set_language("es");
+    TEST_ASSERT_EQUAL_STRING("El Tigre", lv_dropdown_get_text(dd));
+
+    /* Unknown language translates to the tag */
+    lv_translation_set_language("fr");
+    TEST_ASSERT_EQUAL_STRING("tiger", lv_dropdown_get_text(dd));
+}
+
+void test_dropdown_options_translation_tag(void)
+{
+    /* Arrays are defined `const` to place them in program space instead of RAM. */
+    static const char * const tags[] = {"animals", NULL};
+    static const char * const languages[]    = {"en", "de", NULL};
+    static const char * const translations[] = { "Dog\nLion", "Hund\nLowe" };
+    lv_translation_add_static(languages, tags, translations);
+
+    lv_obj_t * dd = lv_dropdown_create(lv_screen_active());
+    lv_dropdown_set_options_translation_tag(dd, "animals");
+
+    lv_translation_set_language("en");
+    TEST_ASSERT_EQUAL_STRING("Dog\nLion", lv_dropdown_get_options(dd));
+
+    lv_translation_set_language("de");
+    TEST_ASSERT_EQUAL_STRING("Hund\nLowe", lv_dropdown_get_options(dd));
+
+    /* Unknown language translates to the tag */
+    lv_translation_set_language("fr");
+    TEST_ASSERT_EQUAL_STRING("animals", lv_dropdown_get_options(dd));
+}
+
+void test_dropdown_setting_text_disables_translation(void)
+{
+    /* Arrays are defined `const` to place them in program space instead of RAM. */
+    static const char * const tags[] = {"tiger", NULL};
+    static const char * const languages[]    = {"en", "de", "es", NULL};
+    static const char * const translations[] = { "The Tiger", "Der Tiger", "El Tigre" };
+    lv_translation_add_static(languages, tags, translations);
+
+    lv_obj_t * dd = lv_dropdown_create(lv_screen_active());
+    lv_dropdown_set_text_translation_tag(dd, "tiger");
+
+    lv_translation_set_language("de");
+    TEST_ASSERT_EQUAL_STRING("Der Tiger", lv_dropdown_get_text(dd));
+
+    /* Using set text should unbind the translation tag*/
+    lv_dropdown_set_text(dd, "Hello world");
+    lv_translation_set_language("en");
+    TEST_ASSERT_EQUAL_STRING("Hello world", lv_dropdown_get_text(dd));
+
+    lv_dropdown_set_text_translation_tag(dd, "tiger");
+    TEST_ASSERT_EQUAL_STRING("The Tiger", lv_dropdown_get_text(dd));
+
+    /* Using set text static should unbind the translation tag*/
+    lv_dropdown_set_text_static(dd, "Hello world");
+    lv_translation_set_language("de");
+    TEST_ASSERT_EQUAL_STRING("Hello world", lv_dropdown_get_text(dd));
+}
+
+void test_dropdown_setting_options_disables_translation(void)
+{
+    /* Arrays are defined `const` to place them in program space instead of RAM. */
+    static const char * const tags[] = {"animals", NULL};
+    static const char * const languages[]    = {"en", "de", NULL};
+    static const char * const translations[] = { "Dog\nLion", "Hund\nLowe" };
+    lv_translation_add_static(languages, tags, translations);
+
+    lv_obj_t * dd = lv_dropdown_create(lv_screen_active());
+    lv_dropdown_set_options_translation_tag(dd, "animals");
+
+    lv_translation_set_language("de");
+    TEST_ASSERT_EQUAL_STRING("Hund\nLowe", lv_dropdown_get_options(dd));
+
+    /* Using set options should unbind the translation tag*/
+    lv_dropdown_set_options(dd, "One\nTwo");
+    lv_translation_set_language("en");
+    TEST_ASSERT_EQUAL_STRING("One\nTwo", lv_dropdown_get_options(dd));
+
+    lv_dropdown_set_options_translation_tag(dd, "animals");
+    TEST_ASSERT_EQUAL_STRING("Dog\nLion", lv_dropdown_get_options(dd));
+
+    /* Using set options static should unbind the translation tag*/
+    lv_dropdown_set_options_static(dd, "One\nTwo");
+    lv_translation_set_language("de");
+    TEST_ASSERT_EQUAL_STRING("One\nTwo", lv_dropdown_get_options(dd));
+
+    /* Adding/clearing options should unbind the translation tag*/
+    lv_dropdown_set_options_translation_tag(dd, "animals");
+    lv_dropdown_add_option(dd, "Bear", LV_DROPDOWN_POS_LAST);
+    lv_translation_set_language("en");
+    TEST_ASSERT_EQUAL_STRING("Hund\nLowe\nBear", lv_dropdown_get_options(dd));
+
+    lv_dropdown_set_options_translation_tag(dd, "animals");
+    lv_dropdown_clear_options(dd);
+    lv_translation_set_language("de");
+    TEST_ASSERT_EQUAL_STRING("", lv_dropdown_get_options(dd));
+}
+#endif /*LV_USE_TRANSLATION*/
 #endif

--- a/tests/src/test_cases/widgets/test_roller.c
+++ b/tests/src/test_cases/widgets/test_roller.c
@@ -415,4 +415,52 @@ void test_roller_properties(void)
 #endif
 }
 
+#if LV_USE_TRANSLATION
+void test_roller_options_translation_tag(void)
+{
+    /* Arrays are defined `const` to place them in program space instead of RAM. */
+    static const char * const tags[] = {"animals", NULL};
+    static const char * const languages[]    = {"en", "de", NULL};
+    static const char * const translations[] = { "Dog\nLion", "Hund\nLowe" };
+    lv_translation_add_static(languages, tags, translations);
+
+    lv_obj_t * obj = lv_roller_create(active_screen);
+    lv_roller_set_options_translation_tag(obj, "animals", LV_ROLLER_MODE_NORMAL);
+
+    lv_translation_set_language("en");
+    TEST_ASSERT_EQUAL_STRING("Dog\nLion", lv_roller_get_options(obj));
+    TEST_ASSERT_EQUAL(2, lv_roller_get_option_count(obj));
+
+    lv_translation_set_language("de");
+    TEST_ASSERT_EQUAL_STRING("Hund\nLowe", lv_roller_get_options(obj));
+
+    /* Unknown language translates to the tag */
+    lv_translation_set_language("fr");
+    TEST_ASSERT_EQUAL_STRING("animals", lv_roller_get_options(obj));
+}
+
+void test_roller_setting_options_disables_translation(void)
+{
+    /* Arrays are defined `const` to place them in program space instead of RAM. */
+    static const char * const tags[] = {"animals", NULL};
+    static const char * const languages[]    = {"en", "de", NULL};
+    static const char * const translations[] = { "Dog\nLion", "Hund\nLowe" };
+    lv_translation_add_static(languages, tags, translations);
+
+    lv_obj_t * obj = lv_roller_create(active_screen);
+    lv_roller_set_options_translation_tag(obj, "animals", LV_ROLLER_MODE_NORMAL);
+
+    lv_translation_set_language("de");
+    TEST_ASSERT_EQUAL_STRING("Hund\nLowe", lv_roller_get_options(obj));
+
+    /* Using set options should unbind the translation tag*/
+    lv_roller_set_options(obj, "One\nTwo", LV_ROLLER_MODE_NORMAL);
+    lv_translation_set_language("en");
+    TEST_ASSERT_EQUAL_STRING("One\nTwo", lv_roller_get_options(obj));
+
+    lv_roller_set_options_translation_tag(obj, "animals", LV_ROLLER_MODE_NORMAL);
+    TEST_ASSERT_EQUAL_STRING("Dog\nLion", lv_roller_get_options(obj));
+}
+#endif /*LV_USE_TRANSLATION*/
+
 #endif


### PR DESCRIPTION
Add
- `lv_dropdown_set_text_translation_tag`
- `lv_dropdown_set_options_translation_tag`
- `lv_roller_set_options_translation_tag`


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
