### PR TITLE
DON'T SQUASH: arch(win, list, menu, file_browser): deprecate, and convert them to examples for future reference

### DIFF
--- a/demos/keypad_encoder/lv_demo_keypad_encoder.c
+++ b/demos/keypad_encoder/lv_demo_keypad_encoder.c
@@ -124,7 +124,9 @@ static void selectors_create(lv_obj_t * parent)
     obj = lv_roller_create(parent);
     lv_obj_add_flag(obj, LV_OBJ_FLAG_SCROLL_ON_FOCUS);
 
+    LV_DEPRECATIONS_IGNORE_BEGIN
     lv_obj_t * list = lv_list_create(parent);
+    LV_DEPRECATIONS_IGNORE_END
     lv_obj_update_layout(list);
     if(lv_obj_get_height(list) > lv_obj_get_content_height(parent)) {
         lv_obj_set_height(list, lv_obj_get_content_height(parent));

--- a/demos/keypad_encoder/lv_demo_keypad_encoder.c
+++ b/demos/keypad_encoder/lv_demo_keypad_encoder.c
@@ -10,6 +10,9 @@
 
 #if LV_USE_DEMO_KEYPAD_AND_ENCODER
 
+/*The demo shows the deprecated `lv_list` widget too.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 /*********************
  *      DEFINES
  *********************/
@@ -213,5 +216,7 @@ static void ta_event_cb(lv_event_t * e)
         lv_obj_set_height(tv, LV_VER_RES);
     }
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif

--- a/demos/stress/lv_demo_stress.c
+++ b/demos/stress/lv_demo_stress.c
@@ -279,8 +279,9 @@ static void obj_test_task_cb(lv_timer_t * tmr)
             break;
 
         case 18:
+            LV_DEPRECATIONS_IGNORE_BEGIN
             obj = lv_list_create(main_page);
-            {
+            LV_DEPRECATIONS_IGNORE_END {
                 lv_obj_t * b;
                 b = lv_list_add_button(obj, LV_SYMBOL_OK, "1. Some very long text to scroll");
                 auto_delete(b, 10);

--- a/demos/stress/lv_demo_stress.c
+++ b/demos/stress/lv_demo_stress.c
@@ -178,7 +178,9 @@ static void obj_test_task_cb(lv_timer_t * tmr)
             break;
 
         case 8:
+            LV_DEPRECATIONS_IGNORE_BEGIN
             obj = lv_win_create(lv_screen_active());
+            LV_DEPRECATIONS_IGNORE_END
             lv_obj_set_size(obj, LV_HOR_RES / 2, LV_VER_RES / 2);
             lv_obj_align(obj, LV_ALIGN_BOTTOM_RIGHT, 0, 0);
             lv_win_add_title(obj, "Window title");

--- a/demos/stress/lv_demo_stress.c
+++ b/demos/stress/lv_demo_stress.c
@@ -9,6 +9,10 @@
 #include "lv_demo_stress.h"
 
 #if LV_USE_DEMO_STRESS
+
+/*The stressed widget set contains the deprecated `lv_list` and `lv_win` widgets.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 /*********************
  *      DEFINES
  *********************/
@@ -456,5 +460,7 @@ static void arc_set_end_angle_anim(void * obj, int32_t v)
 {
     lv_arc_set_end_angle(obj, v);
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif /* LV_USE_DEMO_STRESS */

--- a/docs/src/auxiliary-modules/file_explorer.mdx
+++ b/docs/src/auxiliary-modules/file_explorer.mdx
@@ -3,6 +3,14 @@ title: File Explorer
 description: "lv_file_explorer provides a UI enabling the end user to browse the contents of a file system. Its main area is called the \"Browsing Area\" and provides the list of files contained in the currently-v..."
 ---
 
+<Callout type="warning" title="Deprecated">
+The `lv_file_explorer` widget is deprecated and kept only for backward
+compatibility. A file explorer is a path header plus a table of directory entries
+read with the [`lv_fs`](/main-modules/fs) API, so build it directly instead. See
+the [`lv_example_table_file_browser`](/widgets/table#building-a-file-explorer)
+example for a starting point.
+</Callout>
+
 `lv_file_explorer` provides a UI enabling the end user to browse the contents of a
 file system.  Its main area is called the "Browsing Area" and provides the list of
 files contained in the currently-viewed directory.
@@ -185,6 +193,12 @@ You can also save the obtained **path** and **file** name into an array
 through functions such as <ApiLink name="strcpy" /> and <ApiLink name="strcat" /> for later use.
 
 ## Examples
+
+<Callout type="warning" title="Deprecated">
+The examples below use the deprecated `lv_file_explorer` widget. For new code,
+prefer building a file browser from a table and the `lv_fs` API, as shown in
+[`lv_example_table_file_browser`](/widgets/table#building-a-file-explorer).
+</Callout>
 
 ### Simple File Explorer
 

--- a/docs/src/changelog/migration-v10.mdx
+++ b/docs/src/changelog/migration-v10.mdx
@@ -440,6 +440,14 @@ if you need finer control.
   [`lv_example_menu_navigation`](widgets/menu#building-a-menu-without-lv_menu)
   example for a starting point.
 
+### lv_list
+
+- The `lv_list` widget is deprecated. A list is just a flex container with a
+  column flow, so build one directly from `lv_obj` with a `LV_FLEX_FLOW_COLUMN`
+  layout instead. See the
+  [`lv_example_flex_list`](common-widget-features/layouts/flex#building-a-list)
+  example for a starting point.
+
 ---
 
 ## Drawing

--- a/docs/src/changelog/migration-v10.mdx
+++ b/docs/src/changelog/migration-v10.mdx
@@ -432,6 +432,14 @@ if you need finer control.
   lv_scale_set_section_style_items(scale,     section, &my_style);
   ```
 
+### lv_menu
+
+- The `lv_menu` widget is deprecated. A menu is page navigation over base widgets
+  — pages built from `lv_obj` and a back button that swaps the visible page — so
+  build it directly instead. See the
+  [`lv_example_menu_navigation`](widgets/menu#building-a-menu-without-lv_menu)
+  example for a starting point.
+
 ---
 
 ## Drawing

--- a/docs/src/changelog/migration-v10.mdx
+++ b/docs/src/changelog/migration-v10.mdx
@@ -473,3 +473,12 @@ if you need finer control.
   so build it directly instead. See the
   [`lv_example_table_file_browser`](widgets/table#building-a-file-explorer) example
   for a starting point.
+
+---
+
+## Libraries
+
+### rlottie
+
+- The rlottie player is deprecated. Use the [`lv_lottie`](widgets/lottie) widget
+  instead.

--- a/docs/src/changelog/migration-v10.mdx
+++ b/docs/src/changelog/migration-v10.mdx
@@ -448,6 +448,13 @@ if you need finer control.
   [`lv_example_flex_list`](common-widget-features/layouts/flex#building-a-list)
   example for a starting point.
 
+### lv_win
+
+- The `lv_win` widget is deprecated. A window is just a flex column with a header
+  bar and a content area, so build one directly from `lv_obj` instead. See the
+  [`lv_example_flex_win`](common-widget-features/layouts/flex#building-a-window)
+  example for a starting point.
+
 ---
 
 ## Drawing

--- a/docs/src/changelog/migration-v10.mdx
+++ b/docs/src/changelog/migration-v10.mdx
@@ -453,3 +453,15 @@ if you need finer control.
   lv_snapshot_take_to_draw_buf(obj, cf, draw_buf);
   lv_draw_buf_destroy(draw_buf);
 ```
+
+---
+
+## Others
+
+### lv_file_explorer
+
+- The `lv_file_explorer` widget is deprecated. A file explorer is a path header
+  plus a table of directory entries read with the [`lv_fs`](main-modules/fs) API,
+  so build it directly instead. See the
+  [`lv_example_table_file_browser`](widgets/table#building-a-file-explorer) example
+  for a starting point.

--- a/docs/src/common-widget-features/layouts/flex.mdx
+++ b/docs/src/common-widget-features/layouts/flex.mdx
@@ -170,6 +170,15 @@ placed from right to left.
 
 You can easily build a list using a column flex with 100% wide buttons and text.
 
+## Building a window
+
+<LvglExample name="lv_example_flex_win" path="layouts/flex/lv_example_flex_win" />
+
+A window is a column flex too: a fixed-height header row on top and a content area
+below that grows to fill the rest with
+<ApiLink name="lv_obj_set_flex_grow" display="lv_obj_set_flex_grow(content, 1)" />.
+The title label grows so the header buttons are pushed to the right edge.
+
 ## Forcing a New Track
 
 <LvglExample name="lv_example_flex_new_track" path="layouts/flex/lv_example_flex_new_track" />

--- a/docs/src/common-widget-features/layouts/flex.mdx
+++ b/docs/src/common-widget-features/layouts/flex.mdx
@@ -164,6 +164,12 @@ If the base direction of the container is set the
 The items on `ROW` layouts, and tracks of `COLUMN` layouts will be
 placed from right to left.
 
+## Building a list
+
+<LvglExample name="lv_example_flex_list" path="layouts/flex/lv_example_flex_list" />
+
+You can easily build a list using a column flex with 100% wide buttons and text.
+
 ## Forcing a New Track
 
 <LvglExample name="lv_example_flex_new_track" path="layouts/flex/lv_example_flex_new_track" />

--- a/docs/src/migration-v10.mdx
+++ b/docs/src/migration-v10.mdx
@@ -169,6 +169,13 @@ if you need finer control.
   [`lv_example_flex_list`](common-widget-features/layouts/flex#building-a-list)
   example for a starting point.
 
+### lv_win
+
+- The `lv_win` widget is deprecated. A window is just a flex column with a header
+  bar and a content area, so build one directly from `lv_obj` instead. See the
+  [`lv_example_flex_win`](common-widget-features/layouts/flex#building-a-window)
+  example for a starting point.
+
 ---
 
 ## Drawing

--- a/docs/src/migration-v10.mdx
+++ b/docs/src/migration-v10.mdx
@@ -153,6 +153,14 @@ if you need finer control.
   lv_scale_set_section_style_items(scale,     section, &my_style);
   ```
 
+### lv_menu
+
+- The `lv_menu` widget is deprecated. A menu is page navigation over base widgets
+  — pages built from `lv_obj` and a back button that swaps the visible page — so
+  build it directly instead. See the
+  [`lv_example_menu_navigation`](widgets/menu#building-a-menu-without-lv_menu)
+  example for a starting point.
+
 ---
 
 ## Drawing

--- a/docs/src/migration-v10.mdx
+++ b/docs/src/migration-v10.mdx
@@ -194,3 +194,12 @@ if you need finer control.
   so build it directly instead. See the
   [`lv_example_table_file_browser`](widgets/table#building-a-file-explorer) example
   for a starting point.
+
+---
+
+## Libraries
+
+### rlottie
+
+- The rlottie player is deprecated. Use the [`lv_lottie`](widgets/lottie) widget
+  instead.

--- a/docs/src/migration-v10.mdx
+++ b/docs/src/migration-v10.mdx
@@ -174,3 +174,15 @@ if you need finer control.
   lv_snapshot_take_to_draw_buf(obj, cf, draw_buf);
   lv_draw_buf_destroy(draw_buf);
 ```
+
+---
+
+## Others
+
+### lv_file_explorer
+
+- The `lv_file_explorer` widget is deprecated. A file explorer is a path header
+  plus a table of directory entries read with the [`lv_fs`](main-modules/fs) API,
+  so build it directly instead. See the
+  [`lv_example_table_file_browser`](widgets/table#building-a-file-explorer) example
+  for a starting point.

--- a/docs/src/migration-v10.mdx
+++ b/docs/src/migration-v10.mdx
@@ -161,6 +161,14 @@ if you need finer control.
   [`lv_example_menu_navigation`](widgets/menu#building-a-menu-without-lv_menu)
   example for a starting point.
 
+### lv_list
+
+- The `lv_list` widget is deprecated. A list is just a flex container with a
+  column flow, so build one directly from `lv_obj` with a `LV_FLEX_FLOW_COLUMN`
+  layout instead. See the
+  [`lv_example_flex_list`](common-widget-features/layouts/flex#building-a-list)
+  example for a starting point.
+
 ---
 
 ## Drawing

--- a/docs/src/widgets/list.mdx
+++ b/docs/src/widgets/list.mdx
@@ -5,6 +5,14 @@ description: "A vertical container into which buttons and text rows can be added
 
 ## Overview
 
+<Callout type="warning" title="Deprecated">
+The `lv_list` widget is deprecated and kept only for backward compatibility. A
+list is just a flex container with a column flow, so build one directly from
+`lv_obj` with a `LV_FLEX_FLOW_COLUMN` layout instead. See the
+[`lv_example_flex_list`](/common-widget-features/layouts/flex#building-a-list)
+example for a starting point.
+</Callout>
+
 The List is a vertical container. You add full-width buttons and text rows
 to it; the layout takes care of stacking them.
 

--- a/docs/src/widgets/menu.mdx
+++ b/docs/src/widgets/menu.mdx
@@ -5,6 +5,14 @@ description: "Multi-level menu widget. Handles navigation between pages automati
 
 ## Overview
 
+<Callout type="warning" title="Deprecated">
+The `lv_menu` widget is deprecated and kept only for backward compatibility. A
+menu is page navigation over base widgets — pages built from `lv_obj` and a back
+button that swaps the visible page — so build it directly instead. See the
+[`lv_example_menu_navigation`](#building-a-menu-without-lv_menu) example for a
+starting point.
+</Callout>
+
 The Menu widget builds multi-level menus. It handles navigation between
 pages automatically and lets you react to page changes and item clicks.
 
@@ -105,7 +113,21 @@ Menu:
 
 Learn more about [Events](/common-widget-features/events) emitted by all Widgets.
 
+## Building a menu without lv_menu
+
+<LvglExample name="lv_example_menu_navigation" path="widgets/menu/lv_example_menu_navigation" />
+
+Since `lv_menu` is deprecated, this example shows the recommended approach: pages
+are `lv_obj` containers stacked in a content area, only one shown at a time by
+toggling `LV_OBJ_FLAG_HIDDEN`. A header back button returns to the root page. The
+small `menu_*` helpers mirror the parts of the old API you actually need.
+
 ## Examples
+
+<Callout type="warning" title="Deprecated">
+The examples below use the deprecated `lv_menu` widget. Prefer the approach in
+[Building a menu without lv_menu](#building-a-menu-without-lv_menu) for new code.
+</Callout>
 
 ### Simple Menu
 

--- a/docs/src/widgets/table.mdx
+++ b/docs/src/widgets/table.mdx
@@ -111,6 +111,20 @@ currently selected cell. Row and column will be set to
 
 Learn more about [Keys](/main-modules/indev/keypad).
 
+## Building a file explorer
+
+<LvglExample name="lv_example_table_file_browser" path="widgets/table/lv_example_table_file_browser" />
+
+A table can also be used to create a simple file explorer. In the example the table has 2 columns:
+a shorter one for an icon, and a longer one for the file/folder name.
+
+The contents of a directory are listed with the [`lv_fs`](/main-modules/fs) APIs
+(`lv_fs_dir_open`/`lv_fs_dir_read`/`lv_fs_dir_close`). Note that a file-system driver
+(e.g. <ApiLink name="LV_USE_FS_STDIO" />) needs to be enabled in `lv_conf.h`.
+
+The example also contains a few extra features, like a quick access sidebar.
+
+
 ## Examples
 
 ### Scrollable 200-item list with per-row toggle

--- a/docs/src/widgets/win.mdx
+++ b/docs/src/widgets/win.mdx
@@ -5,6 +5,14 @@ description: "A header (like a title bar) with a title and buttons, plus a conte
 
 ## Overview
 
+<Callout type="warning" title="Deprecated">
+The `lv_win` widget is deprecated and kept only for backward compatibility. A
+window is just a flex column with a header bar and a content area, so build one
+directly from `lv_obj` instead. See the
+[`lv_example_flex_win`](/common-widget-features/layouts/flex#building-a-window)
+example for a starting point.
+</Callout>
+
 The Window widget is built from a header (like a title bar) with a title
 and optional buttons, plus a content area below.
 

--- a/examples/layouts/flex/lv_example_flex.h
+++ b/examples/layouts/flex/lv_example_flex.h
@@ -15,6 +15,7 @@ void lv_example_flex_flow(void);
 void lv_example_flex_grow(void);
 void lv_example_flex_ignore_layout(void);
 void lv_example_flex_internal_padding(void);
+void lv_example_flex_list(void);
 void lv_example_flex_new_track(void);
 void lv_example_flex_rtl(void);
 

--- a/examples/layouts/flex/lv_example_flex.h
+++ b/examples/layouts/flex/lv_example_flex.h
@@ -18,6 +18,7 @@ void lv_example_flex_internal_padding(void);
 void lv_example_flex_list(void);
 void lv_example_flex_new_track(void);
 void lv_example_flex_rtl(void);
+void lv_example_flex_win(void);
 
 #ifdef __cplusplus
 } /*extern "C"*/

--- a/examples/layouts/flex/lv_example_flex_list.c
+++ b/examples/layouts/flex/lv_example_flex_list.c
@@ -1,0 +1,185 @@
+/**
+ * @file lv_example_flex_list.c
+ */
+
+#include "../../lv_examples.h"
+#if LV_USE_FLEX && LV_BUILD_EXAMPLES
+
+/*A list is a flex column of full-width text rows and buttons. The static helpers
+ *below build and populate one on top of a plain flex container.
+ *
+ *The widgets are styled by hand to give the list its look: a flat background,
+ *full-width buttons with a grey bottom divider, and grey section headers.*/
+
+static lv_obj_t * flex_list;
+
+static lv_style_t style_list;
+static lv_style_t style_header;
+static lv_style_t style_button;
+static lv_style_t style_button_pressed;
+
+/**
+ * Set up the styles that give the list its look.
+ */
+static void styles_init(void)
+{
+    /*List background: flatten the base object's card into a tight, edge-clipped column.*/
+    lv_style_init(&style_list);
+    lv_style_set_pad_ver(&style_list, 0);
+    lv_style_set_pad_gap(&style_list, 0);
+    lv_style_set_clip_corner(&style_list, true);
+
+    /*Section header: a full-width grey bar with dark text. The transform makes the
+     *grey reach the list edges despite the list's horizontal padding.*/
+    lv_style_init(&style_header);
+    lv_style_set_bg_opa(&style_header, LV_OPA_COVER);
+    lv_style_set_bg_color(&style_header, lv_palette_lighten(LV_PALETTE_GREY, 2));
+    lv_style_set_text_color(&style_header, lv_palette_darken(LV_PALETTE_GREY, 4));
+    lv_style_set_transform_width(&style_header, 16);
+
+    /*List button: a flat white row with a grey bottom divider, overriding the
+     *default blue button look.*/
+    lv_style_init(&style_button);
+    lv_style_set_radius(&style_button, 0);
+    lv_style_set_shadow_width(&style_button, 0);
+    lv_style_set_bg_opa(&style_button, LV_OPA_COVER);
+    lv_style_set_bg_color(&style_button, lv_color_white());
+    lv_style_set_text_color(&style_button, lv_palette_darken(LV_PALETTE_GREY, 4));
+    lv_style_set_border_width(&style_button, 1);
+    lv_style_set_border_color(&style_button, lv_palette_lighten(LV_PALETTE_GREY, 2));
+    lv_style_set_border_side(&style_button, LV_BORDER_SIDE_BOTTOM);
+    lv_style_set_pad_all(&style_button, 8);
+    lv_style_set_pad_column(&style_button, 8);
+
+    /*Pressed feedback: a subtle dark recolor.*/
+    lv_style_init(&style_button_pressed);
+    lv_style_set_recolor(&style_button_pressed, lv_color_black());
+    lv_style_set_recolor_opa(&style_button_pressed, LV_OPA_20);
+}
+
+/**
+ * Create a list: a flex container that stacks its children in a column.
+ */
+static lv_obj_t * flex_list_create(lv_obj_t * parent)
+{
+    lv_obj_t * list = lv_obj_create(parent);
+    lv_obj_set_flex_flow(list, LV_FLEX_FLOW_COLUMN);
+    lv_obj_add_style(list, &style_list, 0);
+    return list;
+}
+
+/**
+ * Add a full-width text row (a section header) to the list.
+ */
+static lv_obj_t * flex_list_add_text(lv_obj_t * list, const char * txt)
+{
+    lv_obj_t * label = lv_label_create(list);
+    lv_obj_set_width(label, lv_pct(100));
+    lv_obj_add_style(label, &style_header, 0);
+    lv_label_set_text(label, txt);
+    return label;
+}
+
+/**
+ * Add a full-width button holding an optional icon and a scrolling text label.
+ */
+static lv_obj_t * flex_list_add_button(lv_obj_t * list, const void * icon, const char * txt)
+{
+    lv_obj_t * btn = lv_button_create(list);
+    lv_obj_set_size(btn, lv_pct(100), LV_SIZE_CONTENT);
+    lv_obj_set_flex_flow(btn, LV_FLEX_FLOW_ROW);
+    lv_obj_add_style(btn, &style_button, 0);
+    lv_obj_add_style(btn, &style_button_pressed, LV_STATE_PRESSED);
+
+#if LV_USE_IMAGE == 1
+    if(icon) {
+        lv_obj_t * img = lv_image_create(btn);
+        lv_image_set_src(img, icon);
+    }
+#endif
+
+    if(txt) {
+        lv_obj_t * label = lv_label_create(btn);
+        lv_label_set_text(label, txt);
+        lv_label_set_long_mode(label, LV_LABEL_LONG_MODE_SCROLL_CIRCULAR);
+        lv_obj_set_flex_grow(label, 1);
+    }
+
+    return btn;
+}
+
+/**
+ * Find the text of a list button by looking for its child label.
+ */
+static const char * flex_list_get_button_text(lv_obj_t * btn)
+{
+    uint32_t i;
+    for(i = 0; i < lv_obj_get_child_count(btn); i++) {
+        lv_obj_t * child = lv_obj_get_child(btn, i);
+        if(lv_obj_check_type(child, &lv_label_class)) {
+            return lv_label_get_text(child);
+        }
+    }
+    return "";
+}
+
+static void event_handler(lv_event_t * e)
+{
+    lv_event_code_t code = lv_event_get_code(e);
+    lv_obj_t * obj = lv_event_get_target_obj(e);
+    if(code == LV_EVENT_CLICKED) {
+        LV_LOG_USER("Clicked: %s", flex_list_get_button_text(obj));
+    }
+}
+
+/**
+ * @title List built from a flex container
+ * @brief Build a list from a plain flex column.
+ *
+ * A column-flow flex container stacks full-width text headers and buttons. The
+ * static `flex_list_*` helpers wrap the few flex calls needed:
+ * `LV_FLEX_FLOW_COLUMN` for the list, full-width rows for the items, and
+ * `lv_obj_set_flex_grow` so each button's label fills the row next to its icon. The
+ * list look is produced with styles applied by hand.
+ */
+void lv_example_flex_list(void)
+{
+    styles_init();
+
+    /*Create a list from a flex column*/
+    flex_list = flex_list_create(lv_screen_active());
+    lv_obj_set_size(flex_list, 180, 220);
+    lv_obj_center(flex_list);
+
+    /*Add buttons to the list*/
+    lv_obj_t * btn;
+    flex_list_add_text(flex_list, "File");
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_FILE, "New");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_DIRECTORY, "Open");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_SAVE, "Save");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_CLOSE, "Delete");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_EDIT, "Edit");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+
+    flex_list_add_text(flex_list, "Connectivity");
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_BLUETOOTH, "Bluetooth");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_GPS, "Navigation");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_USB, "USB");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_BATTERY_FULL, "Battery");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+
+    flex_list_add_text(flex_list, "Exit");
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_OK, "Apply");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_CLOSE, "Close");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+}
+
+#endif

--- a/examples/layouts/flex/lv_example_flex_list.c
+++ b/examples/layouts/flex/lv_example_flex_list.c
@@ -1,0 +1,192 @@
+/**
+ * @file lv_example_flex_list.c
+ */
+
+#include "../../lv_examples.h"
+#if LV_USE_FLEX && LV_BUILD_EXAMPLES
+
+/*A list is a flex column of full-width text rows and buttons. The static helpers
+ *below build and populate one on top of a plain flex container.
+ *
+ *The widgets are styled by hand to give the list its look: a flat background,
+ *full-width buttons with a grey bottom divider, and grey section headers.*/
+
+static lv_obj_t * flex_list;
+
+static lv_style_t style_list;
+static lv_style_t style_header;
+static lv_style_t style_button;
+static lv_style_t style_button_pressed;
+
+/**
+ * Set up the styles that give the list its look.
+ *
+ * The styles are static and stay attached to the widgets that use them, so they are
+ * initialized only once even if the example is created multiple times.
+ */
+static void styles_init(void)
+{
+    static bool inited = false;
+    if(inited) return;
+    inited = true;
+
+    /*List background: flatten the base object's card into a tight, edge-clipped column.*/
+    lv_style_init(&style_list);
+    lv_style_set_pad_ver(&style_list, 0);
+    lv_style_set_pad_gap(&style_list, 0);
+    lv_style_set_clip_corner(&style_list, true);
+
+    /*Section header: a full-width grey bar with dark text. The transform makes the
+     *grey reach the list edges despite the list's horizontal padding.*/
+    lv_style_init(&style_header);
+    lv_style_set_bg_opa(&style_header, LV_OPA_COVER);
+    lv_style_set_bg_color(&style_header, lv_palette_lighten(LV_PALETTE_GREY, 2));
+    lv_style_set_text_color(&style_header, lv_palette_darken(LV_PALETTE_GREY, 4));
+    lv_style_set_transform_width(&style_header, 16);
+
+    /*List button: a flat white row with a grey bottom divider, overriding the
+     *default blue button look.*/
+    lv_style_init(&style_button);
+    lv_style_set_radius(&style_button, 0);
+    lv_style_set_shadow_width(&style_button, 0);
+    lv_style_set_bg_opa(&style_button, LV_OPA_COVER);
+    lv_style_set_bg_color(&style_button, lv_color_white());
+    lv_style_set_text_color(&style_button, lv_palette_darken(LV_PALETTE_GREY, 4));
+    lv_style_set_border_width(&style_button, 1);
+    lv_style_set_border_color(&style_button, lv_palette_lighten(LV_PALETTE_GREY, 2));
+    lv_style_set_border_side(&style_button, LV_BORDER_SIDE_BOTTOM);
+    lv_style_set_pad_all(&style_button, 8);
+    lv_style_set_pad_column(&style_button, 8);
+
+    /*Pressed feedback: a subtle dark recolor.*/
+    lv_style_init(&style_button_pressed);
+    lv_style_set_recolor(&style_button_pressed, lv_color_black());
+    lv_style_set_recolor_opa(&style_button_pressed, LV_OPA_20);
+}
+
+/**
+ * Create a list: a flex container that stacks its children in a column.
+ */
+static lv_obj_t * flex_list_create(lv_obj_t * parent)
+{
+    lv_obj_t * list = lv_obj_create(parent);
+    lv_obj_set_flex_flow(list, LV_FLEX_FLOW_COLUMN);
+    lv_obj_add_style(list, &style_list, 0);
+    return list;
+}
+
+/**
+ * Add a full-width text row (a section header) to the list.
+ */
+static lv_obj_t * flex_list_add_text(lv_obj_t * list, const char * txt)
+{
+    lv_obj_t * label = lv_label_create(list);
+    lv_obj_set_width(label, lv_pct(100));
+    lv_obj_add_style(label, &style_header, 0);
+    lv_label_set_text(label, txt);
+    return label;
+}
+
+/**
+ * Add a full-width button holding an optional icon and a scrolling text label.
+ */
+static lv_obj_t * flex_list_add_button(lv_obj_t * list, const void * icon, const char * txt)
+{
+    lv_obj_t * btn = lv_button_create(list);
+    lv_obj_set_size(btn, lv_pct(100), LV_SIZE_CONTENT);
+    lv_obj_set_flex_flow(btn, LV_FLEX_FLOW_ROW);
+    lv_obj_add_style(btn, &style_button, 0);
+    lv_obj_add_style(btn, &style_button_pressed, LV_STATE_PRESSED);
+
+#if LV_USE_IMAGE == 1
+    if(icon) {
+        lv_obj_t * img = lv_image_create(btn);
+        lv_image_set_src(img, icon);
+    }
+#endif
+
+    if(txt) {
+        lv_obj_t * label = lv_label_create(btn);
+        lv_label_set_text(label, txt);
+        lv_label_set_long_mode(label, LV_LABEL_LONG_MODE_SCROLL_CIRCULAR);
+        lv_obj_set_flex_grow(label, 1);
+    }
+
+    return btn;
+}
+
+/**
+ * Find the text of a list button by looking for its child label.
+ */
+static const char * flex_list_get_button_text(lv_obj_t * btn)
+{
+    uint32_t i;
+    for(i = 0; i < lv_obj_get_child_count(btn); i++) {
+        lv_obj_t * child = lv_obj_get_child(btn, i);
+        if(lv_obj_check_type(child, &lv_label_class)) {
+            return lv_label_get_text(child);
+        }
+    }
+    return "";
+}
+
+static void event_handler(lv_event_t * e)
+{
+    lv_event_code_t code = lv_event_get_code(e);
+    lv_obj_t * obj = lv_event_get_target_obj(e);
+    if(code == LV_EVENT_CLICKED) {
+        LV_LOG_USER("Clicked: %s", flex_list_get_button_text(obj));
+    }
+}
+
+/**
+ * @title List built from a flex container
+ * @brief Build a list from a plain flex column.
+ *
+ * A column-flow flex container stacks full-width text headers and buttons. The
+ * static `flex_list_*` helpers wrap the few flex calls needed:
+ * `LV_FLEX_FLOW_COLUMN` for the list, full-width rows for the items, and
+ * `lv_obj_set_flex_grow` so each button's label fills the row next to its icon. The
+ * list look is produced with styles applied by hand.
+ */
+void lv_example_flex_list(void)
+{
+    styles_init();
+
+    /*Create a list from a flex column*/
+    flex_list = flex_list_create(lv_screen_active());
+    lv_obj_set_size(flex_list, 180, 220);
+    lv_obj_center(flex_list);
+
+    /*Add buttons to the list*/
+    lv_obj_t * btn;
+    flex_list_add_text(flex_list, "File");
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_FILE, "New");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_DIRECTORY, "Open");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_SAVE, "Save");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_CLOSE, "Delete");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_EDIT, "Edit");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+
+    flex_list_add_text(flex_list, "Connectivity");
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_BLUETOOTH, "Bluetooth");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_GPS, "Navigation");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_USB, "USB");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_BATTERY_FULL, "Battery");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+
+    flex_list_add_text(flex_list, "Exit");
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_OK, "Apply");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+    btn = flex_list_add_button(flex_list, LV_SYMBOL_CLOSE, "Close");
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+}
+
+#endif

--- a/examples/layouts/flex/lv_example_flex_win.c
+++ b/examples/layouts/flex/lv_example_flex_win.c
@@ -1,0 +1,162 @@
+/**
+ * @file lv_example_flex_win.c
+ */
+
+#include "../../lv_examples.h"
+#if LV_USE_FLEX && LV_BUILD_EXAMPLES
+
+/*A window is a flex column with a header bar on top and a content area below. The
+ *static helpers below build one on top of base widgets.
+ *
+ *The widgets are styled by hand to give the window its look: a flat background, a
+ *grey header bar and a screen-coloured content area.*/
+
+static lv_style_t style_win;
+static lv_style_t style_header;
+static lv_style_t style_content;
+
+static void styles_init(void)
+{
+    /*Window background: a flat, edge-to-edge column with the base object's card
+     *flattened away (no padding, border or radius).*/
+    lv_style_init(&style_win);
+    lv_style_set_pad_all(&style_win, 0);
+    lv_style_set_pad_gap(&style_win, 0);
+    lv_style_set_border_width(&style_win, 0);
+    lv_style_set_radius(&style_win, 0);
+
+    /*Title bar: a grey header with tight padding.*/
+    lv_style_init(&style_header);
+    lv_style_set_bg_opa(&style_header, LV_OPA_COVER);
+    lv_style_set_bg_color(&style_header, lv_palette_lighten(LV_PALETTE_GREY, 2));
+    lv_style_set_text_color(&style_header, lv_palette_darken(LV_PALETTE_GREY, 4));
+    lv_style_set_pad_all(&style_header, 2);
+    lv_style_set_pad_gap(&style_header, 2);
+    lv_style_set_border_width(&style_header, 0);
+    lv_style_set_radius(&style_header, 0);
+
+    /*Content area: a screen-coloured body with normal padding.*/
+    lv_style_init(&style_content);
+    lv_style_set_bg_opa(&style_content, LV_OPA_COVER);
+    lv_style_set_bg_color(&style_content, lv_palette_lighten(LV_PALETTE_GREY, 4));
+    lv_style_set_pad_all(&style_content, 16);
+    lv_style_set_border_width(&style_content, 0);
+    lv_style_set_radius(&style_content, 0);
+}
+
+/**
+ * Create a window: a flex column holding a header bar and a content area.
+ */
+static lv_obj_t * win_create(lv_obj_t * parent)
+{
+    lv_obj_t * win = lv_obj_create(parent);
+    lv_obj_set_size(win, lv_obj_get_width(parent), lv_obj_get_height(parent));
+    lv_obj_set_flex_flow(win, LV_FLEX_FLOW_COLUMN);
+    lv_obj_add_style(win, &style_win, 0);
+
+    lv_obj_t * header = lv_obj_create(win);
+    lv_obj_set_size(header, lv_pct(100), lv_display_get_dpi(lv_obj_get_display(win)) / 2);
+    lv_obj_set_flex_flow(header, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(header, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_add_style(header, &style_header, 0);
+
+    lv_obj_t * content = lv_obj_create(win);
+    lv_obj_set_width(content, lv_pct(100));
+    lv_obj_set_flex_grow(content, 1);
+    lv_obj_add_style(content, &style_content, 0);
+
+    return win;
+}
+
+static lv_obj_t * win_get_header(lv_obj_t * win)
+{
+    return lv_obj_get_child(win, 0);
+}
+
+static lv_obj_t * win_get_content(lv_obj_t * win)
+{
+    return lv_obj_get_child(win, 1);
+}
+
+/**
+ * Add a title label that takes the free space in the header.
+ */
+static lv_obj_t * win_add_title(lv_obj_t * win, const char * txt)
+{
+    lv_obj_t * title = lv_label_create(win_get_header(win));
+    lv_label_set_long_mode(title, LV_LABEL_LONG_MODE_DOTS);
+    lv_label_set_text(title, txt);
+    lv_obj_set_flex_grow(title, 1);
+    return title;
+}
+
+/**
+ * Add a fixed-width header button with an optional centered icon.
+ */
+static lv_obj_t * win_add_button(lv_obj_t * win, const void * icon, int32_t btn_w)
+{
+    lv_obj_t * btn = lv_button_create(win_get_header(win));
+    lv_obj_set_size(btn, btn_w, lv_pct(100));
+
+#if LV_USE_IMAGE == 1
+    if(icon) {
+        lv_obj_t * img = lv_image_create(btn);
+        lv_image_set_src(img, icon);
+        lv_obj_align(img, LV_ALIGN_CENTER, 0, 0);
+    }
+#endif
+
+    return btn;
+}
+
+static void event_handler(lv_event_t * e)
+{
+    lv_obj_t * obj = lv_event_get_target_obj(e);
+    LV_LOG_USER("Button %d clicked", (int)lv_obj_get_index(obj));
+}
+
+/**
+ * @title Window built from a flex container
+ * @brief Build a window from a flex column.
+ *
+ * The static `win_*` helpers build the window from base widgets: a
+ * `LV_FLEX_FLOW_COLUMN` container with a fixed-height `LV_FLEX_FLOW_ROW` header bar
+ * and a `lv_obj_set_flex_grow` content area below. The title uses
+ * `lv_obj_set_flex_grow` to push the buttons to the right, and the content holds a
+ * long label so the body scrolls.
+ */
+void lv_example_flex_win(void)
+{
+    styles_init();
+
+    lv_obj_t * win = win_create(lv_screen_active());
+    lv_obj_t * btn;
+    btn = win_add_button(win, LV_SYMBOL_LEFT, 40);
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+
+    win_add_title(win, "A title");
+
+    btn = win_add_button(win, LV_SYMBOL_RIGHT, 40);
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+
+    btn = win_add_button(win, LV_SYMBOL_CLOSE, 60);
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+
+    lv_obj_t * content = win_get_content(win);  /*Content can be added here*/
+    lv_obj_t * label = lv_label_create(content);
+    lv_label_set_text(label, "This is\n"
+                      "a pretty\n"
+                      "long text\n"
+                      "to see how\n"
+                      "the window\n"
+                      "becomes\n"
+                      "scrollable.\n"
+                      "\n"
+                      "\n"
+                      "Some more\n"
+                      "text to be\n"
+                      "sure it\n"
+                      "overflows. :)");
+}
+
+#endif

--- a/examples/layouts/flex/lv_example_flex_win.c
+++ b/examples/layouts/flex/lv_example_flex_win.c
@@ -1,0 +1,172 @@
+/**
+ * @file lv_example_flex_win.c
+ */
+
+#include "../../lv_examples.h"
+#if LV_USE_FLEX && LV_BUILD_EXAMPLES
+
+/*A window is a flex column with a header bar on top and a content area below. The
+ *static helpers below build one on top of base widgets.
+ *
+ *The widgets are styled by hand to give the window its look: a flat background, a
+ *grey header bar and a screen-coloured content area.*/
+
+static lv_style_t style_win;
+static lv_style_t style_header;
+static lv_style_t style_content;
+
+/**
+ * Set up the styles that give the window its look.
+ *
+ * The styles are static and stay attached to the widgets that use them, so they are
+ * initialized only once even if the example is created multiple times.
+ */
+static void styles_init(void)
+{
+    static bool inited = false;
+    if(inited) return;
+    inited = true;
+
+    /*Window background: a flat, edge-to-edge column with the base object's card
+     *flattened away (no padding, border or radius).*/
+    lv_style_init(&style_win);
+    lv_style_set_pad_all(&style_win, 0);
+    lv_style_set_pad_gap(&style_win, 0);
+    lv_style_set_border_width(&style_win, 0);
+    lv_style_set_radius(&style_win, 0);
+
+    /*Title bar: a grey header with tight padding.*/
+    lv_style_init(&style_header);
+    lv_style_set_bg_opa(&style_header, LV_OPA_COVER);
+    lv_style_set_bg_color(&style_header, lv_palette_lighten(LV_PALETTE_GREY, 2));
+    lv_style_set_text_color(&style_header, lv_palette_darken(LV_PALETTE_GREY, 4));
+    lv_style_set_pad_all(&style_header, 2);
+    lv_style_set_pad_gap(&style_header, 2);
+    lv_style_set_border_width(&style_header, 0);
+    lv_style_set_radius(&style_header, 0);
+
+    /*Content area: a screen-coloured body with normal padding.*/
+    lv_style_init(&style_content);
+    lv_style_set_bg_opa(&style_content, LV_OPA_COVER);
+    lv_style_set_bg_color(&style_content, lv_palette_lighten(LV_PALETTE_GREY, 4));
+    lv_style_set_pad_all(&style_content, 16);
+    lv_style_set_border_width(&style_content, 0);
+    lv_style_set_radius(&style_content, 0);
+}
+
+/**
+ * Create a window: a flex column holding a header bar and a content area.
+ */
+static lv_obj_t * win_create(lv_obj_t * parent)
+{
+    lv_obj_t * win = lv_obj_create(parent);
+    lv_obj_set_size(win, lv_obj_get_width(parent), lv_obj_get_height(parent));
+    lv_obj_set_flex_flow(win, LV_FLEX_FLOW_COLUMN);
+    lv_obj_add_style(win, &style_win, 0);
+
+    lv_obj_t * header = lv_obj_create(win);
+    lv_obj_set_size(header, lv_pct(100), lv_display_get_dpi(lv_obj_get_display(win)) / 2);
+    lv_obj_set_flex_flow(header, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(header, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_add_style(header, &style_header, 0);
+
+    lv_obj_t * content = lv_obj_create(win);
+    lv_obj_set_width(content, lv_pct(100));
+    lv_obj_set_flex_grow(content, 1);
+    lv_obj_add_style(content, &style_content, 0);
+
+    return win;
+}
+
+static lv_obj_t * win_get_header(lv_obj_t * win)
+{
+    return lv_obj_get_child(win, 0);
+}
+
+static lv_obj_t * win_get_content(lv_obj_t * win)
+{
+    return lv_obj_get_child(win, 1);
+}
+
+/**
+ * Add a title label that takes the free space in the header.
+ */
+static lv_obj_t * win_add_title(lv_obj_t * win, const char * txt)
+{
+    lv_obj_t * title = lv_label_create(win_get_header(win));
+    lv_label_set_long_mode(title, LV_LABEL_LONG_MODE_DOTS);
+    lv_label_set_text(title, txt);
+    lv_obj_set_flex_grow(title, 1);
+    return title;
+}
+
+/**
+ * Add a fixed-width header button with an optional centered icon.
+ */
+static lv_obj_t * win_add_button(lv_obj_t * win, const void * icon, int32_t btn_w)
+{
+    lv_obj_t * btn = lv_button_create(win_get_header(win));
+    lv_obj_set_size(btn, btn_w, lv_pct(100));
+
+#if LV_USE_IMAGE == 1
+    if(icon) {
+        lv_obj_t * img = lv_image_create(btn);
+        lv_image_set_src(img, icon);
+        lv_obj_align(img, LV_ALIGN_CENTER, 0, 0);
+    }
+#endif
+
+    return btn;
+}
+
+static void event_handler(lv_event_t * e)
+{
+    lv_obj_t * obj = lv_event_get_target_obj(e);
+    LV_LOG_USER("Button %d clicked", (int)lv_obj_get_index(obj));
+}
+
+/**
+ * @title Window built from a flex container
+ * @brief Build a window from a flex column.
+ *
+ * The static `win_*` helpers build the window from base widgets: a
+ * `LV_FLEX_FLOW_COLUMN` container with a fixed-height `LV_FLEX_FLOW_ROW` header bar
+ * and a `lv_obj_set_flex_grow` content area below. The title uses
+ * `lv_obj_set_flex_grow` to push the buttons to the right, and the content holds a
+ * long label so the body scrolls.
+ */
+void lv_example_flex_win(void)
+{
+    styles_init();
+
+    lv_obj_t * win = win_create(lv_screen_active());
+    lv_obj_t * btn;
+    btn = win_add_button(win, LV_SYMBOL_LEFT, 40);
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+
+    win_add_title(win, "A title");
+
+    btn = win_add_button(win, LV_SYMBOL_RIGHT, 40);
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+
+    btn = win_add_button(win, LV_SYMBOL_CLOSE, 60);
+    lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
+
+    lv_obj_t * content = win_get_content(win);  /*Content can be added here*/
+    lv_obj_t * label = lv_label_create(content);
+    lv_label_set_text(label, "This is\n"
+                      "a pretty\n"
+                      "long text\n"
+                      "to see how\n"
+                      "the window\n"
+                      "becomes\n"
+                      "scrollable.\n"
+                      "\n"
+                      "\n"
+                      "Some more\n"
+                      "text to be\n"
+                      "sure it\n"
+                      "overflows. :)");
+}
+
+#endif

--- a/examples/libs/rlottie/lv_example_rlottie_1.c
+++ b/examples/libs/rlottie/lv_example_rlottie_1.c
@@ -6,6 +6,8 @@
  * @title Rlottie animation from array
  * @brief Play a Lottie animation decoded from a JSON byte array in flash.
  *
+ * @deprecated rlottie is deprecated. Use the `lv_lottie` widget instead.
+ *
  * `lv_rlottie_create_from_raw` builds a 100x100 Lottie widget from the
  * externally declared `lv_example_rlottie_approve` JSON data, and the
  * widget is centered on the active screen.
@@ -13,7 +15,9 @@
 void lv_example_rlottie_1(void)
 {
     extern const uint8_t lv_example_rlottie_approve[];
+    LV_DEPRECATIONS_IGNORE_BEGIN
     lv_obj_t * lottie = lv_rlottie_create_from_raw(lv_screen_active(), 100, 100, (const char *)lv_example_rlottie_approve);
+    LV_DEPRECATIONS_IGNORE_END
     lv_obj_center(lottie);
 }
 

--- a/examples/libs/rlottie/lv_example_rlottie_2.c
+++ b/examples/libs/rlottie/lv_example_rlottie_2.c
@@ -6,6 +6,8 @@
  * @title Rlottie animation from file
  * @brief Play a Lottie JSON file loaded directly through the rlottie stdio path.
  *
+ * @deprecated rlottie is deprecated. Use the `lv_lottie` widget instead.
+ *
  * `lv_rlottie_create_from_file` opens
  * `lvgl/examples/libs/rlottie/lv_example_rlottie_approve.json` as a 100x100
  * widget centered on the active screen. The path has no LVGL drive letter
@@ -15,8 +17,10 @@
 void lv_example_rlottie_2(void)
 {
     /*The rlottie library uses STDIO file API, so there is no driver letter for LVGL*/
+    LV_DEPRECATIONS_IGNORE_BEGIN
     lv_obj_t * lottie = lv_rlottie_create_from_file(lv_screen_active(), 100, 100,
                                                     "lvgl/examples/libs/rlottie/lv_example_rlottie_approve.json");
+    LV_DEPRECATIONS_IGNORE_END
     lv_obj_center(lottie);
 }
 

--- a/examples/others/file_explorer/lv_example_file_explorer_1.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_1.c
@@ -22,6 +22,8 @@ static void file_explorer_event_handler(lv_event_t * e)
  * @title File explorer with quick access
  * @brief Open a file explorer on the active screen and log the selected path.
  *
+ * @deprecated The `lv_file_explorer` widget is deprecated. See `lv_example_table_file_browser`.
+ *
  * `lv_file_explorer_create` builds a full-screen browser, `lv_file_explorer_set_sort`
  * sorts entries by `LV_EXPLORER_SORT_KIND`, and `lv_file_explorer_open_dir` opens the
  * platform root (`"C:C:/"` on Win32 or `"A:/"` on the `lv_fs` Linux driver). When
@@ -31,7 +33,9 @@ static void file_explorer_event_handler(lv_event_t * e)
  */
 void lv_example_file_explorer_1(void)
 {
+    LV_DEPRECATIONS_IGNORE_BEGIN
     lv_obj_t * file_explorer = lv_file_explorer_create(lv_screen_active());
+    LV_DEPRECATIONS_IGNORE_END
     lv_file_explorer_set_sort(file_explorer, LV_EXPLORER_SORT_KIND);
 
 #if LV_USE_FS_WIN32

--- a/examples/others/file_explorer/lv_example_file_explorer_1.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_1.c
@@ -6,6 +6,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+/*This example shows the deprecated `lv_file_explorer` widget on purpose.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 static void file_explorer_event_handler(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
@@ -21,6 +24,8 @@ static void file_explorer_event_handler(lv_event_t * e)
 /**
  * @title File explorer with quick access
  * @brief Open a file explorer on the active screen and log the selected path.
+ *
+ * @deprecated The `lv_file_explorer` widget is deprecated. See `lv_example_table_file_browser`.
  *
  * `lv_file_explorer_create` builds a full-screen browser, `lv_file_explorer_set_sort`
  * sorts entries by `LV_EXPLORER_SORT_KIND`, and `lv_file_explorer_open_dir` opens the
@@ -92,5 +97,7 @@ void lv_example_file_explorer_1(void)
 
     lv_obj_add_event_cb(file_explorer, file_explorer_event_handler, LV_EVENT_ALL, NULL);
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif

--- a/examples/others/file_explorer/lv_example_file_explorer_2.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_2.c
@@ -57,6 +57,8 @@ static void dd_event_handler(lv_event_t * e)
  * @title Quick access toggle and sort control
  * @brief File explorer with a header button to hide quick access and a dropdown to change sort mode.
  *
+ * @deprecated The `lv_file_explorer` widget is deprecated. See `lv_example_table_file_browser`.
+ *
  * Adds a checkable button and a dropdown into the file explorer's header
  * (`lv_file_explorer_get_header`). Toggling the button adds or removes
  * `LV_OBJ_FLAG_HIDDEN` on the quick access panel returned by
@@ -67,7 +69,9 @@ static void dd_event_handler(lv_event_t * e)
  */
 void lv_example_file_explorer_2(void)
 {
+    LV_DEPRECATIONS_IGNORE_BEGIN
     lv_obj_t * file_explorer = lv_file_explorer_create(lv_screen_active());
+    LV_DEPRECATIONS_IGNORE_END
 
 #if LV_USE_FS_WIN32
     /* Note to Windows users:  the initial "C:" on these paths corresponds to

--- a/examples/others/file_explorer/lv_example_file_explorer_2.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_2.c
@@ -6,6 +6,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+/*This example shows the deprecated `lv_file_explorer` widget on purpose.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 static void file_explorer_event_handler(lv_event_t * e)
 {
     lv_event_code_t code = lv_event_get_code(e);
@@ -56,6 +59,8 @@ static void dd_event_handler(lv_event_t * e)
 /**
  * @title Quick access toggle and sort control
  * @brief File explorer with a header button to hide quick access and a dropdown to change sort mode.
+ *
+ * @deprecated The `lv_file_explorer` widget is deprecated. See `lv_example_table_file_browser`.
  *
  * Adds a checkable button and a dropdown into the file explorer's header
  * (`lv_file_explorer_get_header`). Toggling the button adds or removes
@@ -156,5 +161,7 @@ void lv_example_file_explorer_2(void)
     lv_obj_add_event_cb(dd, dd_event_handler, LV_EVENT_VALUE_CHANGED, file_explorer);
 #endif
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif

--- a/examples/others/file_explorer/lv_example_file_explorer_3.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_3.c
@@ -65,6 +65,8 @@ static void file_explorer_event_handler(lv_event_t * e)
  * @title Custom file explorer sort
  * @brief Apply a 3-way quicksort over the file table after each directory load.
  *
+ * @deprecated The `lv_file_explorer` widget is deprecated. See `lv_example_table_file_browser`.
+ *
  * The file explorer is created with `LV_EXPLORER_SORT_NONE` so that default sorting
  * stays out of the way. On `LV_EVENT_READY`, `lv_file_explorer_get_file_table`
  * returns the underlying table and a static 3-way quicksort reorders rows by the
@@ -73,7 +75,9 @@ static void file_explorer_event_handler(lv_event_t * e)
  */
 void lv_example_file_explorer_3(void)
 {
+    LV_DEPRECATIONS_IGNORE_BEGIN
     lv_obj_t * file_explorer = lv_file_explorer_create(lv_screen_active());
+    LV_DEPRECATIONS_IGNORE_END
     /*Before custom sort, please set the default sorting to NONE. The default is NONE.*/
     lv_file_explorer_set_sort(file_explorer, LV_EXPLORER_SORT_NONE);
 

--- a/examples/others/file_explorer/lv_example_file_explorer_3.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_3.c
@@ -6,6 +6,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+/*This example shows the deprecated `lv_file_explorer` widget on purpose.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 static void exch_table_item(lv_obj_t * tb, int16_t i, int16_t j)
 {
     const char * tmp;
@@ -64,6 +67,8 @@ static void file_explorer_event_handler(lv_event_t * e)
 /**
  * @title Custom file explorer sort
  * @brief Apply a 3-way quicksort over the file table after each directory load.
+ *
+ * @deprecated The `lv_file_explorer` widget is deprecated. See `lv_example_table_file_browser`.
  *
  * The file explorer is created with `LV_EXPLORER_SORT_NONE` so that default sorting
  * stays out of the way. On `LV_EVENT_READY`, `lv_file_explorer_get_file_table`
@@ -134,5 +139,7 @@ void lv_example_file_explorer_3(void)
 
     lv_obj_add_event_cb(file_explorer, file_explorer_event_handler, LV_EVENT_ALL, NULL);
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif

--- a/examples/others/gridnav/lv_example_gridnav_2.c
+++ b/examples/others/gridnav/lv_example_gridnav_2.c
@@ -16,7 +16,9 @@ void lv_example_gridnav_2(void)
     /*It's assumed that the default group is set and
      *there is a keyboard indev*/
 
+    LV_DEPRECATIONS_IGNORE_BEGIN
     lv_obj_t * list1 = lv_list_create(lv_screen_active());
+    LV_DEPRECATIONS_IGNORE_END
     lv_gridnav_add(list1, LV_GRIDNAV_CTRL_NONE);
     lv_obj_set_size(list1, lv_pct(45), lv_pct(80));
     lv_obj_align(list1, LV_ALIGN_LEFT_MID, 5, 0);
@@ -32,7 +34,9 @@ void lv_example_gridnav_2(void)
         lv_group_remove_obj(item);   /*Not needed, we use the gridnav instead*/
     }
 
+    LV_DEPRECATIONS_IGNORE_BEGIN
     lv_obj_t * list2 = lv_list_create(lv_screen_active());
+    LV_DEPRECATIONS_IGNORE_END
     lv_gridnav_add(list2, LV_GRIDNAV_CTRL_ROLLOVER);
     lv_obj_set_size(list2, lv_pct(45), lv_pct(80));
     lv_obj_align(list2, LV_ALIGN_RIGHT_MID, -5, 0);

--- a/examples/others/gridnav/lv_example_gridnav_2.c
+++ b/examples/others/gridnav/lv_example_gridnav_2.c
@@ -1,6 +1,9 @@
 #include "../../lv_examples.h"
 #if LV_USE_GRIDNAV && LV_USE_LIST && LV_BUILD_EXAMPLES
 
+/*The navigated content is built from the deprecated `lv_list` widget.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 /**
  * @title Keypad navigation across two lists
  * @brief Side-by-side list widgets with distinct `lv_gridnav_ctrl_t` modes.
@@ -46,5 +49,7 @@ void lv_example_gridnav_2(void)
         lv_group_remove_obj(item);
     }
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif

--- a/examples/others/gridnav/lv_example_gridnav_4.c
+++ b/examples/others/gridnav/lv_example_gridnav_4.c
@@ -25,7 +25,9 @@ void lv_example_gridnav_4(void)
     /*It's assumed that the default group is set and
      *there is a keyboard indev*/
 
+    LV_DEPRECATIONS_IGNORE_BEGIN
     lv_obj_t * list = lv_list_create(lv_screen_active());
+    LV_DEPRECATIONS_IGNORE_END
     lv_gridnav_add(list, LV_GRIDNAV_CTRL_ROLLOVER);
     lv_obj_align(list, LV_ALIGN_LEFT_MID, 10, 0);
     lv_group_add_obj(lv_group_get_default(), list);

--- a/examples/others/gridnav/lv_example_gridnav_4.c
+++ b/examples/others/gridnav/lv_example_gridnav_4.c
@@ -1,6 +1,9 @@
 #include "../../lv_examples.h"
 #if LV_USE_GRIDNAV && LV_USE_FLEX && LV_BUILD_EXAMPLES
 
+/*The navigated content is built from the deprecated `lv_list` widget.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 static void event_handler(lv_event_t * e)
 {
     lv_obj_t * obj = lv_event_get_target_obj(e);
@@ -51,5 +54,7 @@ void lv_example_gridnav_4(void)
     lv_obj_t * label = lv_label_create(btn);
     lv_label_set_text(label, "Button");
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif

--- a/examples/others/observer/lv_example_observer_5.c
+++ b/examples/others/observer/lv_example_observer_5.c
@@ -50,7 +50,9 @@ void lv_example_observer_5(void)
 static void fw_update_btn_clicked_event_cb(lv_event_t * e)
 {
     LV_UNUSED(e);
+    LV_DEPRECATIONS_IGNORE_BEGIN
     lv_obj_t * win = lv_win_create(lv_screen_active());
+    LV_DEPRECATIONS_IGNORE_END
     lv_obj_set_size(win, lv_pct(90), lv_pct(90));
     lv_obj_set_height(lv_win_get_header(win), 40);
     lv_obj_set_style_radius(win, 8, 0);

--- a/examples/others/observer/lv_example_observer_5.c
+++ b/examples/others/observer/lv_example_observer_5.c
@@ -1,6 +1,9 @@
 #include "../../lv_examples.h"
 #if LV_USE_OBSERVER && LV_USE_ARC && LV_USE_LABEL && LV_USE_BUTTON && LV_USE_SPINNER && LV_BUILD_EXAMPLES
 
+/*The UI is built from the deprecated `lv_win` widget.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 typedef enum {
     FW_UPDATE_STATE_IDLE,
     FW_UPDATE_STATE_CONNECTING,
@@ -170,5 +173,7 @@ static void fw_upload_manager_observer_cb(lv_observer_t * observer, lv_subject_t
         lv_timer_create(download_timer_cb, 50, NULL);
     }
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif

--- a/examples/widgets/list/lv_example_list_reorder.c
+++ b/examples/widgets/list/lv_example_list_reorder.c
@@ -123,7 +123,9 @@ static void event_handler_swap(lv_event_t * e)
 void lv_example_list_reorder(void)
 {
     /*Create a list*/
+    LV_DEPRECATIONS_IGNORE_BEGIN
     list1 = lv_list_create(lv_screen_active());
+    LV_DEPRECATIONS_IGNORE_END
     lv_obj_set_size(list1, lv_pct(60), lv_pct(100));
     lv_obj_set_style_pad_row(list1, 5, 0);
 
@@ -144,7 +146,9 @@ void lv_example_list_reorder(void)
     lv_obj_add_state(currentButton, LV_STATE_CHECKED);
 
     /*Create a second list with up and down buttons*/
+    LV_DEPRECATIONS_IGNORE_BEGIN
     list2 = lv_list_create(lv_screen_active());
+    LV_DEPRECATIONS_IGNORE_END
     lv_obj_set_size(list2, lv_pct(40), lv_pct(100));
     lv_obj_align(list2, LV_ALIGN_TOP_RIGHT, 0, 0);
     lv_obj_set_flex_flow(list2, LV_FLEX_FLOW_COLUMN);

--- a/examples/widgets/list/lv_example_list_reorder.c
+++ b/examples/widgets/list/lv_example_list_reorder.c
@@ -1,6 +1,9 @@
 #include "../../lv_examples.h"
 #if LV_USE_LIST && LV_BUILD_EXAMPLES
 
+/*This example shows the deprecated `lv_list` widget on purpose.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 static lv_obj_t * list1;
 static lv_obj_t * list2;
 
@@ -173,5 +176,7 @@ void lv_example_list_reorder(void)
     lv_obj_add_event_cb(btn, event_handler_swap, LV_EVENT_ALL, NULL);
     lv_group_remove_obj(btn);
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif

--- a/examples/widgets/list/lv_example_list_sections.c
+++ b/examples/widgets/list/lv_example_list_sections.c
@@ -25,7 +25,9 @@ static void event_handler(lv_event_t * e)
 void lv_example_list_sections(void)
 {
     /*Create a list*/
+    LV_DEPRECATIONS_IGNORE_BEGIN
     list1 = lv_list_create(lv_screen_active());
+    LV_DEPRECATIONS_IGNORE_END
     lv_obj_set_size(list1, 180, 220);
     lv_obj_center(list1);
 

--- a/examples/widgets/list/lv_example_list_sections.c
+++ b/examples/widgets/list/lv_example_list_sections.c
@@ -1,5 +1,9 @@
 #include "../../lv_examples.h"
 #if LV_USE_LIST && LV_BUILD_EXAMPLES
+
+/*This example shows the deprecated `lv_list` widget on purpose.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 static lv_obj_t * list1;
 
 static void event_handler(lv_event_t * e)
@@ -59,5 +63,7 @@ void lv_example_list_sections(void)
     btn = lv_list_add_button(list1, LV_SYMBOL_CLOSE, "Close");
     lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif

--- a/examples/widgets/menu/lv_example_menu.h
+++ b/examples/widgets/menu/lv_example_menu.h
@@ -10,6 +10,7 @@
 extern "C" {
 #endif
 
+void lv_example_menu_navigation(void);
 void lv_example_menu_sub_page(void);
 void lv_example_menu_root_back_button(void);
 void lv_example_menu_custom_back_button(void);

--- a/examples/widgets/menu/lv_example_menu_custom_back_button.c
+++ b/examples/widgets/menu/lv_example_menu_custom_back_button.c
@@ -5,6 +5,8 @@
  * @title Customized back button header
  * @brief A menu with a labeled "Back" button in the header and three titled sub pages.
  *
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
+ *
  * `lv_menu_get_main_header_back_button` returns the default back
  * button, and a child `lv_label` adds the text `Back` next to its
  * icon. The main page lists three items, each wired with
@@ -14,7 +16,9 @@
 void lv_example_menu_custom_back_button(void)
 {
     /*Create a menu object*/
+    LV_DEPRECATIONS_IGNORE_BEGIN
     lv_obj_t * menu = lv_menu_create(lv_screen_active());
+    LV_DEPRECATIONS_IGNORE_END
     lv_obj_set_size(menu, lv_display_get_horizontal_resolution(NULL), lv_display_get_vertical_resolution(NULL));
     lv_obj_center(menu);
 

--- a/examples/widgets/menu/lv_example_menu_custom_back_button.c
+++ b/examples/widgets/menu/lv_example_menu_custom_back_button.c
@@ -1,9 +1,14 @@
 #include "../../lv_examples.h"
 #if LV_USE_MENU && LV_BUILD_EXAMPLES
 
+/*This example shows the deprecated `lv_menu` widget on purpose.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 /**
  * @title Customized back button header
  * @brief A menu with a labeled "Back" button in the header and three titled sub pages.
+ *
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
  *
  * `lv_menu_get_main_header_back_button` returns the default back
  * button, and a child `lv_label` adds the text `Back` next to its
@@ -65,5 +70,7 @@ void lv_example_menu_custom_back_button(void)
 
     lv_menu_set_page(menu, main_page);
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif

--- a/examples/widgets/menu/lv_example_menu_floating_button.c
+++ b/examples/widgets/menu/lv_example_menu_floating_button.c
@@ -32,6 +32,8 @@ static void float_button_event_cb(lv_event_t * e)
  * @title Menu with floating add button
  * @brief A circular floating button appends new items and matching sub pages.
  *
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
+ *
  * The menu starts with a single main-page item wired to a greeting
  * sub page. A circular `lv_button` flagged with
  * `LV_OBJ_FLAG_FLOATING` is anchored to the bottom-right corner with
@@ -44,7 +46,9 @@ static void float_button_event_cb(lv_event_t * e)
 void lv_example_menu_floating_button(void)
 {
     /*Create a menu object*/
+    LV_DEPRECATIONS_IGNORE_BEGIN
     menu = lv_menu_create(lv_screen_active());
+    LV_DEPRECATIONS_IGNORE_END
     lv_obj_set_size(menu, lv_display_get_horizontal_resolution(NULL), lv_display_get_vertical_resolution(NULL));
     lv_obj_center(menu);
 

--- a/examples/widgets/menu/lv_example_menu_floating_button.c
+++ b/examples/widgets/menu/lv_example_menu_floating_button.c
@@ -1,6 +1,9 @@
 #include "../../lv_examples.h"
 #if LV_USE_MENU && LV_BUILD_EXAMPLES
 
+/*This example shows the deprecated `lv_menu` widget on purpose.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 static uint32_t btn_cnt = 1;
 static lv_obj_t * main_page;
 static lv_obj_t * menu;
@@ -31,6 +34,8 @@ static void float_button_event_cb(lv_event_t * e)
 /**
  * @title Menu with floating add button
  * @brief A circular floating button appends new items and matching sub pages.
+ *
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
  *
  * The menu starts with a single main-page item wired to a greeting
  * sub page. A circular `lv_button` flagged with
@@ -78,5 +83,7 @@ void lv_example_menu_floating_button(void)
     lv_obj_set_style_bg_image_src(float_btn, LV_SYMBOL_PLUS, 0);
     lv_obj_set_style_text_font(float_btn, lv_theme_get_font_large(float_btn), 0);
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif

--- a/examples/widgets/menu/lv_example_menu_navigation.c
+++ b/examples/widgets/menu/lv_example_menu_navigation.c
@@ -1,0 +1,208 @@
+/**
+ * @file lv_example_menu_navigation.c
+ */
+
+#include "../../lv_examples.h"
+#if LV_USE_FLEX && LV_BUILD_EXAMPLES
+
+/*A menu is page navigation over base widgets: a header with a back button and a set
+ *of pages, only one of which is visible at a time. The static helpers below build
+ *the essentials: create pages, add clickable items, and wire an item to open
+ *another page with a back button to return.*/
+
+static lv_obj_t * menu_content;   /*Container the pages live in*/
+static lv_obj_t * menu_back_btn;  /*Header back button*/
+static lv_obj_t * menu_root_page; /*The first page shown*/
+static lv_obj_t * menu_cur_page;  /*The page currently visible*/
+
+/*The widgets are styled by hand to give the menu its flat look.*/
+static lv_style_t style_menu;
+static lv_style_t style_flat;        /*flatten a base object's card: no pad/border/radius*/
+static lv_style_t style_header;
+static lv_style_t style_header_btn;
+static lv_style_t style_item;
+static lv_style_t style_pressed;
+
+static void styles_init(void)
+{
+    /*Menu background: a flat white card.*/
+    lv_style_init(&style_menu);
+    lv_style_set_bg_opa(&style_menu, LV_OPA_COVER);
+    lv_style_set_bg_color(&style_menu, lv_color_white());
+    lv_style_set_pad_all(&style_menu, 0);
+    lv_style_set_pad_gap(&style_menu, 0);
+    lv_style_set_radius(&style_menu, 0);
+    lv_style_set_border_width(&style_menu, 0);
+
+    /*Inner containers (page area and pages) are transparent with no padding so the
+     *menu card shows through and rows reach the edges.*/
+    lv_style_init(&style_flat);
+    lv_style_set_bg_opa(&style_flat, LV_OPA_TRANSP);
+    lv_style_set_pad_all(&style_flat, 0);
+    lv_style_set_pad_gap(&style_flat, 0);
+    lv_style_set_radius(&style_flat, 0);
+    lv_style_set_border_width(&style_flat, 0);
+
+    /*Header: a transparent row with a little padding.*/
+    lv_style_init(&style_header);
+    lv_style_set_bg_opa(&style_header, LV_OPA_TRANSP);
+    lv_style_set_pad_hor(&style_header, 10);
+    lv_style_set_pad_ver(&style_header, 4);
+    lv_style_set_pad_gap(&style_header, 10);
+    lv_style_set_radius(&style_header, 0);
+    lv_style_set_border_width(&style_header, 0);
+
+    /*Back button: flat, just the dark icon, no fill or shadow.*/
+    lv_style_init(&style_header_btn);
+    lv_style_set_bg_opa(&style_header_btn, LV_OPA_TRANSP);
+    lv_style_set_shadow_opa(&style_header_btn, LV_OPA_TRANSP);
+    lv_style_set_pad_all(&style_header_btn, 4);
+    lv_style_set_text_color(&style_header_btn, lv_palette_darken(LV_PALETTE_GREY, 4));
+
+    /*Item: a flat clickable row, not a filled button.*/
+    lv_style_init(&style_item);
+    lv_style_set_bg_opa(&style_item, LV_OPA_TRANSP);
+    lv_style_set_shadow_opa(&style_item, LV_OPA_TRANSP);
+    lv_style_set_pad_all(&style_item, 10);
+    lv_style_set_pad_gap(&style_item, 10);
+    lv_style_set_radius(&style_item, 0);
+    lv_style_set_border_width(&style_item, 0);
+    lv_style_set_text_color(&style_item, lv_palette_darken(LV_PALETTE_GREY, 4));
+
+    /*Pressed feedback: a faint grey overlay.*/
+    lv_style_init(&style_pressed);
+    lv_style_set_bg_opa(&style_pressed, LV_OPA_20);
+    lv_style_set_bg_color(&style_pressed, lv_palette_main(LV_PALETTE_GREY));
+}
+
+static void show_page(lv_obj_t * page)
+{
+    if(menu_cur_page) lv_obj_add_flag(menu_cur_page, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_remove_flag(page, LV_OBJ_FLAG_HIDDEN);
+    menu_cur_page = page;
+
+    /*The back button is only useful when we left the root page*/
+    if(page == menu_root_page) lv_obj_add_flag(menu_back_btn, LV_OBJ_FLAG_HIDDEN);
+    else lv_obj_remove_flag(menu_back_btn, LV_OBJ_FLAG_HIDDEN);
+}
+
+static void load_page_event(lv_event_t * e)
+{
+    lv_obj_t * target = lv_event_get_user_data(e);
+    show_page(target);
+}
+
+static void back_event(lv_event_t * e)
+{
+    LV_UNUSED(e);
+    show_page(menu_root_page);
+}
+
+/**
+ * Create a menu: a column with a header (back button + title) and a page area.
+ */
+static lv_obj_t * menu_create(lv_obj_t * parent)
+{
+    lv_obj_t * menu = lv_obj_create(parent);
+    lv_obj_set_flex_flow(menu, LV_FLEX_FLOW_COLUMN);
+    lv_obj_add_style(menu, &style_menu, 0);
+
+    lv_obj_t * header = lv_obj_create(menu);
+    lv_obj_set_width(header, lv_pct(100));
+    lv_obj_set_height(header, LV_SIZE_CONTENT);
+    lv_obj_set_flex_flow(header, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(header, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_add_style(header, &style_header, 0);
+
+    menu_back_btn = lv_button_create(header);
+    lv_obj_add_style(menu_back_btn, &style_header_btn, 0);
+    lv_obj_add_style(menu_back_btn, &style_pressed, LV_STATE_PRESSED);
+#if LV_USE_IMAGE == 1
+    lv_obj_t * back_img = lv_image_create(menu_back_btn);
+    lv_image_set_src(back_img, LV_SYMBOL_LEFT);
+    lv_obj_center(back_img);
+#endif
+    lv_obj_add_event_cb(menu_back_btn, back_event, LV_EVENT_CLICKED, NULL);
+
+    lv_obj_t * title = lv_label_create(header);
+    lv_label_set_text(title, "Menu");
+
+    menu_content = lv_obj_create(menu);
+    lv_obj_set_width(menu_content, lv_pct(100));
+    lv_obj_set_flex_grow(menu_content, 1);
+    lv_obj_add_style(menu_content, &style_flat, 0);
+
+    return menu;
+}
+
+/**
+ * Create a page: a full-size column inside the page area, hidden until shown.
+ */
+static lv_obj_t * menu_page_create(void)
+{
+    lv_obj_t * page = lv_obj_create(menu_content);
+    lv_obj_set_size(page, lv_pct(100), lv_pct(100));
+    lv_obj_set_flex_flow(page, LV_FLEX_FLOW_COLUMN);
+    lv_obj_add_style(page, &style_flat, 0);
+    lv_obj_add_flag(page, LV_OBJ_FLAG_HIDDEN);
+    return page;
+}
+
+/**
+ * Add a full-width clickable item (a button with a label) to a page.
+ */
+static lv_obj_t * menu_add_item(lv_obj_t * page, const char * txt)
+{
+    lv_obj_t * item = lv_button_create(page);
+    lv_obj_set_width(item, lv_pct(100));
+    lv_obj_add_style(item, &style_item, 0);
+    lv_obj_add_style(item, &style_pressed, LV_STATE_PRESSED);
+    lv_obj_t * label = lv_label_create(item);
+    lv_label_set_text(label, txt);
+    return item;
+}
+
+/**
+ * Make an item open another page when clicked.
+ */
+static void menu_set_load_page_event(lv_obj_t * item, lv_obj_t * page)
+{
+    lv_obj_add_event_cb(item, load_page_event, LV_EVENT_CLICKED, page);
+}
+
+/**
+ * @title Menu built from base widgets
+ * @brief Build a menu with pages and a back button.
+ *
+ * The static `menu_*` helpers build the menu: `menu_page_create`
+ * makes a hidden full-size page, `menu_add_item` adds clickable rows, and
+ * `menu_set_load_page_event` wires an item to reveal another page. Navigation is
+ * just toggling `LV_OBJ_FLAG_HIDDEN` on the pages and showing the header back
+ * button whenever we are off the root page.
+ */
+void lv_example_menu_navigation(void)
+{
+    styles_init();
+
+    lv_obj_t * menu = menu_create(lv_screen_active());
+    lv_obj_set_size(menu, lv_display_get_horizontal_resolution(NULL), lv_display_get_vertical_resolution(NULL));
+    lv_obj_center(menu);
+
+    /*Create a sub page*/
+    lv_obj_t * sub_page = menu_page_create();
+    lv_obj_t * label = lv_label_create(sub_page);
+    lv_label_set_text(label, "Hello, I am hiding here");
+
+    /*Create the main page*/
+    lv_obj_t * main_page = menu_page_create();
+    menu_add_item(main_page, "Item 1");
+    menu_add_item(main_page, "Item 2");
+    lv_obj_t * item3 = menu_add_item(main_page, "Item 3 (Click me!)");
+    menu_set_load_page_event(item3, sub_page);
+
+    /*Show the main page first*/
+    menu_root_page = main_page;
+    show_page(main_page);
+}
+
+#endif

--- a/examples/widgets/menu/lv_example_menu_navigation.c
+++ b/examples/widgets/menu/lv_example_menu_navigation.c
@@ -1,0 +1,218 @@
+/**
+ * @file lv_example_menu_navigation.c
+ */
+
+#include "../../lv_examples.h"
+#if LV_USE_FLEX && LV_BUILD_EXAMPLES
+
+/*A menu is page navigation over base widgets: a header with a back button and a set
+ *of pages, only one of which is visible at a time. The static helpers below build
+ *the essentials: create pages, add clickable items, and wire an item to open
+ *another page with a back button to return.*/
+
+static lv_obj_t * menu_content;   /*Container the pages live in*/
+static lv_obj_t * menu_back_btn;  /*Header back button*/
+static lv_obj_t * menu_root_page; /*The first page shown*/
+static lv_obj_t * menu_cur_page;  /*The page currently visible*/
+
+/*The widgets are styled by hand to give the menu its flat look.*/
+static lv_style_t style_menu;
+static lv_style_t style_flat;        /*flatten a base object's card: no pad/border/radius*/
+static lv_style_t style_header;
+static lv_style_t style_header_btn;
+static lv_style_t style_item;
+static lv_style_t style_pressed;
+
+/**
+ * Set up the styles that give the menu its look.
+ *
+ * The styles are static and stay attached to the widgets that use them, so they are
+ * initialized only once even if the example is created multiple times.
+ */
+static void styles_init(void)
+{
+    static bool inited = false;
+    if(inited) return;
+    inited = true;
+
+    /*Menu background: a flat white card.*/
+    lv_style_init(&style_menu);
+    lv_style_set_bg_opa(&style_menu, LV_OPA_COVER);
+    lv_style_set_bg_color(&style_menu, lv_color_white());
+    lv_style_set_pad_all(&style_menu, 0);
+    lv_style_set_pad_gap(&style_menu, 0);
+    lv_style_set_radius(&style_menu, 0);
+    lv_style_set_border_width(&style_menu, 0);
+
+    /*Inner containers (page area and pages) are transparent with no padding so the
+     *menu card shows through and rows reach the edges.*/
+    lv_style_init(&style_flat);
+    lv_style_set_bg_opa(&style_flat, LV_OPA_TRANSP);
+    lv_style_set_pad_all(&style_flat, 0);
+    lv_style_set_pad_gap(&style_flat, 0);
+    lv_style_set_radius(&style_flat, 0);
+    lv_style_set_border_width(&style_flat, 0);
+
+    /*Header: a transparent row with a little padding.*/
+    lv_style_init(&style_header);
+    lv_style_set_bg_opa(&style_header, LV_OPA_TRANSP);
+    lv_style_set_pad_hor(&style_header, 10);
+    lv_style_set_pad_ver(&style_header, 4);
+    lv_style_set_pad_gap(&style_header, 10);
+    lv_style_set_radius(&style_header, 0);
+    lv_style_set_border_width(&style_header, 0);
+
+    /*Back button: flat, just the dark icon, no fill or shadow.*/
+    lv_style_init(&style_header_btn);
+    lv_style_set_bg_opa(&style_header_btn, LV_OPA_TRANSP);
+    lv_style_set_shadow_opa(&style_header_btn, LV_OPA_TRANSP);
+    lv_style_set_pad_all(&style_header_btn, 4);
+    lv_style_set_text_color(&style_header_btn, lv_palette_darken(LV_PALETTE_GREY, 4));
+
+    /*Item: a flat clickable row, not a filled button.*/
+    lv_style_init(&style_item);
+    lv_style_set_bg_opa(&style_item, LV_OPA_TRANSP);
+    lv_style_set_shadow_opa(&style_item, LV_OPA_TRANSP);
+    lv_style_set_pad_all(&style_item, 10);
+    lv_style_set_pad_gap(&style_item, 10);
+    lv_style_set_radius(&style_item, 0);
+    lv_style_set_border_width(&style_item, 0);
+    lv_style_set_text_color(&style_item, lv_palette_darken(LV_PALETTE_GREY, 4));
+
+    /*Pressed feedback: a faint grey overlay.*/
+    lv_style_init(&style_pressed);
+    lv_style_set_bg_opa(&style_pressed, LV_OPA_20);
+    lv_style_set_bg_color(&style_pressed, lv_palette_main(LV_PALETTE_GREY));
+}
+
+static void show_page(lv_obj_t * page)
+{
+    if(menu_cur_page) lv_obj_set_hidden(menu_cur_page, true);
+    lv_obj_set_hidden(page, false);
+    menu_cur_page = page;
+
+    /*The back button is only useful when we left the root page*/
+    if(page == menu_root_page) lv_obj_set_hidden(menu_back_btn, true);
+    else lv_obj_set_hidden(menu_back_btn, false);
+}
+
+static void load_page_event(lv_event_t * e)
+{
+    lv_obj_t * target = (lv_obj_t *)lv_event_get_user_data(e);
+    show_page(target);
+}
+
+static void back_event(lv_event_t * e)
+{
+    LV_UNUSED(e);
+    show_page(menu_root_page);
+}
+
+/**
+ * Create a menu: a column with a header (back button + title) and a page area.
+ */
+static lv_obj_t * menu_create(lv_obj_t * parent)
+{
+    lv_obj_t * menu = lv_obj_create(parent);
+    lv_obj_set_flex_flow(menu, LV_FLEX_FLOW_COLUMN);
+    lv_obj_add_style(menu, &style_menu, 0);
+
+    lv_obj_t * header = lv_obj_create(menu);
+    lv_obj_set_width(header, lv_pct(100));
+    lv_obj_set_height(header, LV_SIZE_CONTENT);
+    lv_obj_set_flex_flow(header, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(header, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_add_style(header, &style_header, 0);
+
+    menu_back_btn = lv_button_create(header);
+    lv_obj_add_style(menu_back_btn, &style_header_btn, 0);
+    lv_obj_add_style(menu_back_btn, &style_pressed, LV_STATE_PRESSED);
+#if LV_USE_IMAGE == 1
+    lv_obj_t * back_img = lv_image_create(menu_back_btn);
+    lv_image_set_src(back_img, LV_SYMBOL_LEFT);
+    lv_obj_center(back_img);
+#endif
+    lv_obj_add_event_cb(menu_back_btn, back_event, LV_EVENT_CLICKED, NULL);
+
+    lv_obj_t * title = lv_label_create(header);
+    lv_label_set_text(title, "Menu");
+
+    menu_content = lv_obj_create(menu);
+    lv_obj_set_width(menu_content, lv_pct(100));
+    lv_obj_set_flex_grow(menu_content, 1);
+    lv_obj_add_style(menu_content, &style_flat, 0);
+
+    return menu;
+}
+
+/**
+ * Create a page: a full-size column inside the page area, hidden until shown.
+ */
+static lv_obj_t * menu_page_create(void)
+{
+    lv_obj_t * page = lv_obj_create(menu_content);
+    lv_obj_set_size(page, lv_pct(100), lv_pct(100));
+    lv_obj_set_flex_flow(page, LV_FLEX_FLOW_COLUMN);
+    lv_obj_add_style(page, &style_flat, 0);
+    lv_obj_set_hidden(page, true);
+    return page;
+}
+
+/**
+ * Add a full-width clickable item (a button with a label) to a page.
+ */
+static lv_obj_t * menu_add_item(lv_obj_t * page, const char * txt)
+{
+    lv_obj_t * item = lv_button_create(page);
+    lv_obj_set_width(item, lv_pct(100));
+    lv_obj_add_style(item, &style_item, 0);
+    lv_obj_add_style(item, &style_pressed, LV_STATE_PRESSED);
+    lv_obj_t * label = lv_label_create(item);
+    lv_label_set_text(label, txt);
+    return item;
+}
+
+/**
+ * Make an item open another page when clicked.
+ */
+static void menu_set_load_page_event(lv_obj_t * item, lv_obj_t * page)
+{
+    lv_obj_add_event_cb(item, load_page_event, LV_EVENT_CLICKED, page);
+}
+
+/**
+ * @title Menu built from base widgets
+ * @brief Build a menu with pages and a back button.
+ *
+ * The static `menu_*` helpers build the menu: `menu_page_create`
+ * makes a hidden full-size page, `menu_add_item` adds clickable rows, and
+ * `menu_set_load_page_event` wires an item to reveal another page. Navigation is
+ * just toggling `LV_OBJ_FLAG_HIDDEN` on the pages and showing the header back
+ * button whenever we are off the root page.
+ */
+void lv_example_menu_navigation(void)
+{
+    styles_init();
+
+    lv_obj_t * menu = menu_create(lv_screen_active());
+    lv_obj_set_size(menu, lv_display_get_horizontal_resolution(NULL), lv_display_get_vertical_resolution(NULL));
+    lv_obj_center(menu);
+
+    /*Create a sub page*/
+    lv_obj_t * sub_page = menu_page_create();
+    lv_obj_t * label = lv_label_create(sub_page);
+    lv_label_set_text(label, "Hello, I am hiding here");
+
+    /*Create the main page*/
+    lv_obj_t * main_page = menu_page_create();
+    menu_add_item(main_page, "Item 1");
+    menu_add_item(main_page, "Item 2");
+    lv_obj_t * item3 = menu_add_item(main_page, "Item 3 (Click me!)");
+    menu_set_load_page_event(item3, sub_page);
+
+    /*Show the main page first*/
+    menu_root_page = main_page;
+    show_page(main_page);
+}
+
+#endif

--- a/examples/widgets/menu/lv_example_menu_root_back_button.c
+++ b/examples/widgets/menu/lv_example_menu_root_back_button.c
@@ -18,6 +18,8 @@ static void back_event_handler(lv_event_t * e)
  * @title Menu with root back button
  * @brief A menu whose always-visible root back button pops a message box when tapped.
  *
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
+ *
  * `lv_menu_set_mode_root_back_button` turns on
  * `LV_MENU_ROOT_BACK_BUTTON_ENABLED` so the back button remains on
  * the header at the top of the navigation stack. The main page holds
@@ -29,7 +31,9 @@ static void back_event_handler(lv_event_t * e)
  */
 void lv_example_menu_root_back_button(void)
 {
+    LV_DEPRECATIONS_IGNORE_BEGIN
     lv_obj_t * menu = lv_menu_create(lv_screen_active());
+    LV_DEPRECATIONS_IGNORE_END
     lv_menu_set_mode_root_back_button(menu, LV_MENU_ROOT_BACK_BUTTON_ENABLED);
     lv_obj_add_event_cb(menu, back_event_handler, LV_EVENT_CLICKED, menu);
     lv_obj_set_size(menu, lv_display_get_horizontal_resolution(NULL), lv_display_get_vertical_resolution(NULL));

--- a/examples/widgets/menu/lv_example_menu_root_back_button.c
+++ b/examples/widgets/menu/lv_example_menu_root_back_button.c
@@ -1,6 +1,9 @@
 #include "../../lv_examples.h"
 #if LV_USE_MENU && LV_USE_MSGBOX && LV_BUILD_EXAMPLES
 
+/*This example shows the deprecated `lv_menu` widget on purpose.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 static void back_event_handler(lv_event_t * e)
 {
     lv_obj_t * obj = lv_event_get_target_obj(e);
@@ -17,6 +20,8 @@ static void back_event_handler(lv_event_t * e)
 /**
  * @title Menu with root back button
  * @brief A menu whose always-visible root back button pops a message box when tapped.
+ *
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
  *
  * `lv_menu_set_mode_root_back_button` turns on
  * `LV_MENU_ROOT_BACK_BUTTON_ENABLED` so the back button remains on
@@ -63,5 +68,7 @@ void lv_example_menu_root_back_button(void)
 
     lv_menu_set_page(menu, main_page);
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif

--- a/examples/widgets/menu/lv_example_menu_sidebar.c
+++ b/examples/widgets/menu/lv_example_menu_sidebar.c
@@ -20,6 +20,8 @@ static lv_obj_t * create_switch(lv_obj_t * parent,
  * @title Settings menu with sidebar mode
  * @brief A full Settings screen with sidebar navigation and a switch that toggles between sidebar and stacked modes.
  *
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
+ *
  * A root page named `Settings` lists Mechanics, Sound, Display, and
  * About entries inside `lv_menu_section` groups, with a Menu mode row
  * that holds a `lv_switch` to flip between sidebar and stacked
@@ -33,7 +35,9 @@ static lv_obj_t * create_switch(lv_obj_t * parent,
  */
 void lv_example_menu_sidebar(void)
 {
+    LV_DEPRECATIONS_IGNORE_BEGIN
     lv_obj_t * menu = lv_menu_create(lv_screen_active());
+    LV_DEPRECATIONS_IGNORE_END
 
     lv_color_t bg_color = lv_obj_get_style_bg_color(menu, LV_PART_MAIN);
     if(lv_color_brightness(bg_color) > 127) {

--- a/examples/widgets/menu/lv_example_menu_sidebar.c
+++ b/examples/widgets/menu/lv_example_menu_sidebar.c
@@ -1,6 +1,9 @@
 #include "../../lv_examples.h"
 #if LV_USE_MENU && LV_USE_MSGBOX && LV_BUILD_EXAMPLES
 
+/*This example shows the deprecated `lv_menu` widget on purpose.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 typedef enum {
     LV_MENU_ITEM_BUILDER_VARIANT_1,
     LV_MENU_ITEM_BUILDER_VARIANT_2
@@ -19,6 +22,8 @@ static lv_obj_t * create_switch(lv_obj_t * parent,
 /**
  * @title Settings menu with sidebar mode
  * @brief A full Settings screen with sidebar navigation and a switch that toggles between sidebar and stacked modes.
+ *
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
  *
  * A root page named `Settings` lists Mechanics, Sound, Display, and
  * About entries inside `lv_menu_section` groups, with a Menu mode row
@@ -214,5 +219,7 @@ static lv_obj_t * create_switch(lv_obj_t * parent, const char * icon, const char
 
     return obj;
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif

--- a/examples/widgets/menu/lv_example_menu_sub_page.c
+++ b/examples/widgets/menu/lv_example_menu_sub_page.c
@@ -5,6 +5,8 @@
  * @title Basic menu with sub page
  * @brief A three-item main page whose third entry opens a hidden sub page.
  *
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
+ *
  * A display-sized `lv_menu` holds a main page with three
  * `lv_menu_cont` items labeled `Item 1`, `Item 2`, and
  * `Item 3 (Click me!)`. A separate sub page created with
@@ -15,7 +17,9 @@
 void lv_example_menu_sub_page(void)
 {
     /*Create a menu object*/
+    LV_DEPRECATIONS_IGNORE_BEGIN
     lv_obj_t * menu = lv_menu_create(lv_screen_active());
+    LV_DEPRECATIONS_IGNORE_END
     lv_obj_set_size(menu, lv_display_get_horizontal_resolution(NULL), lv_display_get_vertical_resolution(NULL));
     lv_obj_center(menu);
 

--- a/examples/widgets/menu/lv_example_menu_sub_page.c
+++ b/examples/widgets/menu/lv_example_menu_sub_page.c
@@ -1,9 +1,14 @@
 #include "../../lv_examples.h"
 #if LV_USE_MENU && LV_BUILD_EXAMPLES
 
+/*This example shows the deprecated `lv_menu` widget on purpose.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 /**
  * @title Basic menu with sub page
  * @brief A three-item main page whose third entry opens a hidden sub page.
+ *
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
  *
  * A display-sized `lv_menu` holds a main page with three
  * `lv_menu_cont` items labeled `Item 1`, `Item 2`, and
@@ -47,5 +52,7 @@ void lv_example_menu_sub_page(void)
 
     lv_menu_set_page(menu, main_page);
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif

--- a/examples/widgets/table/lv_example_table.h
+++ b/examples/widgets/table/lv_example_table.h
@@ -11,6 +11,7 @@ extern "C" {
 #endif
 
 void lv_example_table_cells(void);
+void lv_example_table_file_browser(void);
 void lv_example_table_merge_cells(void);
 void lv_example_table_rows_columns(void);
 void lv_example_table_scroll(void);

--- a/examples/widgets/table/lv_example_table_file_browser.c
+++ b/examples/widgets/table/lv_example_table_file_browser.c
@@ -1,0 +1,305 @@
+/**
+ * @file lv_example_table_file_browser.c
+ */
+
+#include "../../lv_examples.h"
+
+#if LV_USE_TABLE && (LV_USE_FS_STDIO || LV_USE_FS_POSIX || LV_USE_FS_WIN32 || LV_USE_FS_FATFS) && LV_BUILD_EXAMPLES
+
+#include <stdlib.h>
+#include <string.h>
+
+/*A file explorer is a quick-access sidebar plus a path header and a table of
+ *directory entries read with the `lv_fs` API. The static helpers below build one on
+ *top of base widgets, styled by hand to give it a flat look.*/
+
+#if LV_USE_FS_WIN32
+    #define BROWSER_ROOT "C:C:/"
+#else
+    #define BROWSER_ROOT "A:/"
+#endif
+
+#define COLOR_BG    lv_color_hex(0xf2f1f6)   /*sidebar + window background*/
+#define COLOR_PANEL lv_color_white()         /*browser area*/
+
+static lv_obj_t * quick_access;
+static lv_obj_t * browser_path_label;
+static lv_obj_t * browser_table;
+static char browser_path[LV_FS_MAX_PATH_LENGTH];
+
+static lv_style_t style_bg;       /*window + sidebar background, fully flat*/
+static lv_style_t style_flat;     /*strip a base object's card (pad/border/radius)*/
+static lv_style_t style_panel;    /*white browser area*/
+static lv_style_t style_sidebar;
+static lv_style_t style_qa_header;
+static lv_style_t style_qa_btn;
+static lv_style_t style_header;
+static lv_style_t style_table;
+static lv_style_t style_pressed;
+
+static void styles_init(void)
+{
+    lv_style_init(&style_bg);
+    lv_style_set_bg_opa(&style_bg, LV_OPA_COVER);
+    lv_style_set_bg_color(&style_bg, COLOR_BG);
+    lv_style_set_pad_all(&style_bg, 0);
+    lv_style_set_pad_gap(&style_bg, 0);
+    lv_style_set_radius(&style_bg, 0);
+    lv_style_set_border_width(&style_bg, 0);
+
+    lv_style_init(&style_flat);
+    lv_style_set_bg_opa(&style_flat, LV_OPA_TRANSP);
+    lv_style_set_pad_all(&style_flat, 0);
+    lv_style_set_pad_gap(&style_flat, 0);
+    lv_style_set_radius(&style_flat, 0);
+    lv_style_set_border_width(&style_flat, 0);
+
+    lv_style_init(&style_panel);
+    lv_style_set_bg_opa(&style_panel, LV_OPA_COVER);
+    lv_style_set_bg_color(&style_panel, COLOR_PANEL);
+    lv_style_set_pad_all(&style_panel, 0);
+    lv_style_set_pad_gap(&style_panel, 0);
+    lv_style_set_radius(&style_panel, 0);
+    lv_style_set_border_width(&style_panel, 0);
+
+    /*Sidebar: grey background with a thin divider on its right edge*/
+    lv_style_init(&style_sidebar);
+    lv_style_set_bg_opa(&style_sidebar, LV_OPA_COVER);
+    lv_style_set_bg_color(&style_sidebar, COLOR_BG);
+    lv_style_set_pad_all(&style_sidebar, 6);
+    lv_style_set_pad_row(&style_sidebar, 4);
+    lv_style_set_radius(&style_sidebar, 0);
+    lv_style_set_border_width(&style_sidebar, 1);
+    lv_style_set_border_color(&style_sidebar, lv_palette_lighten(LV_PALETTE_GREY, 1));
+    lv_style_set_border_side(&style_sidebar, LV_BORDER_SIDE_RIGHT);
+
+    /*Section header (DEVICE / PLACES): a small full-width coloured chip*/
+    lv_style_init(&style_qa_header);
+    lv_style_set_bg_opa(&style_qa_header, LV_OPA_COVER);
+    lv_style_set_text_color(&style_qa_header, lv_color_white());
+    lv_style_set_pad_hor(&style_qa_header, 6);
+    lv_style_set_pad_ver(&style_qa_header, 2);
+    lv_style_set_radius(&style_qa_header, 3);
+
+    /*Quick-access entry: a flat transparent row so the grey sidebar shows through*/
+    lv_style_init(&style_qa_btn);
+    lv_style_set_bg_opa(&style_qa_btn, LV_OPA_TRANSP);
+    lv_style_set_shadow_opa(&style_qa_btn, LV_OPA_TRANSP);
+    lv_style_set_text_color(&style_qa_btn, lv_palette_darken(LV_PALETTE_GREY, 4));
+    lv_style_set_pad_all(&style_qa_btn, 4);
+    lv_style_set_pad_gap(&style_qa_btn, 6);
+    lv_style_set_radius(&style_qa_btn, 0);
+
+    /*Path header above the table*/
+    lv_style_init(&style_header);
+    lv_style_set_bg_opa(&style_header, LV_OPA_COVER);
+    lv_style_set_bg_color(&style_header, COLOR_PANEL);
+    lv_style_set_text_color(&style_header, lv_palette_darken(LV_PALETTE_GREY, 4));
+    lv_style_set_pad_all(&style_header, 6);
+    lv_style_set_radius(&style_header, 0);
+    lv_style_set_border_width(&style_header, 1);
+    lv_style_set_border_color(&style_header, lv_palette_lighten(LV_PALETTE_GREY, 1));
+    lv_style_set_border_side(&style_header, LV_BORDER_SIDE_BOTTOM);
+
+    lv_style_init(&style_table);
+    lv_style_set_bg_opa(&style_table, LV_OPA_COVER);
+    lv_style_set_bg_color(&style_table, COLOR_PANEL);
+    lv_style_set_pad_all(&style_table, 0);
+    lv_style_set_radius(&style_table, 0);
+    lv_style_set_border_width(&style_table, 0);
+
+    lv_style_init(&style_pressed);
+    lv_style_set_bg_opa(&style_pressed, LV_OPA_20);
+    lv_style_set_bg_color(&style_pressed, lv_palette_main(LV_PALETTE_GREY));
+}
+
+/**
+ * List the entries of `path` into the table. Does nothing if `path` is not a
+ * readable directory, so a failed navigation simply leaves the view unchanged.
+ */
+static void browser_open(const char * path)
+{
+    lv_fs_dir_t dir;
+    if(lv_fs_dir_open(&dir, path) != LV_FS_RES_OK) return;
+
+    lv_snprintf(browser_path, sizeof(browser_path), "%s", path);
+    lv_label_set_text(browser_path_label, browser_path);
+
+    lv_table_set_row_count(browser_table, 0);
+
+    /*First row goes up to the parent directory*/
+    uint32_t row = 0;
+    lv_table_set_cell_value(browser_table, row, 0, LV_SYMBOL_LEFT);
+    lv_table_set_cell_value(browser_table, row, 1, "..");
+    row++;
+
+    /*lv_fs_dir_read prefixes directory names with '/'; an empty name ends the list*/
+    char fn[LV_FS_MAX_PATH_LENGTH];
+    while(lv_fs_dir_read(&dir, fn, sizeof(fn)) == LV_FS_RES_OK && fn[0] != '\0') {
+        bool is_dir = fn[0] == '/';
+        const char * name = is_dir ? fn + 1 : fn;
+        lv_table_set_cell_value(browser_table, row, 0, is_dir ? LV_SYMBOL_DIRECTORY : LV_SYMBOL_FILE);
+        lv_table_set_cell_value(browser_table, row, 1, name);
+        row++;
+    }
+
+    lv_fs_dir_close(&dir);
+}
+
+/**
+ * Navigate to the parent directory by dropping the last path component.
+ */
+static void browser_up(void)
+{
+    char buf[LV_FS_MAX_PATH_LENGTH];
+    lv_snprintf(buf, sizeof(buf), "%s", browser_path);
+
+    size_t len = strlen(buf);
+    if(len > 0 && buf[len - 1] == '/') buf[len - 1] = '\0';   /*drop a trailing slash*/
+
+    char * slash = strrchr(buf, '/');
+    if(slash == NULL) return;        /*already at the drive root*/
+    slash[1] = '\0';                 /*keep the slash, cut the last component*/
+    browser_open(buf);
+}
+
+static void table_event(lv_event_t * e)
+{
+    LV_UNUSED(e);
+    uint32_t row, col;
+    lv_table_get_selected_cell(browser_table, &row, &col);
+    if(row == LV_TABLE_CELL_NONE) return;
+
+    const char * icon = lv_table_get_cell_value(browser_table, row, 0);
+    const char * name = lv_table_get_cell_value(browser_table, row, 1);
+
+    if(strcmp(name, "..") == 0) {
+        browser_up();
+        return;
+    }
+
+    /*Only folders can be opened; clicking a file just logs it*/
+    if(strcmp(icon, LV_SYMBOL_DIRECTORY) != 0) {
+        LV_LOG_USER("Selected file: %s%s", browser_path, name);
+        return;
+    }
+
+    char child[LV_FS_MAX_PATH_LENGTH];
+    const char * sep = (browser_path[strlen(browser_path) - 1] == '/') ? "" : "/";
+    lv_snprintf(child, sizeof(child), "%s%s%s", browser_path, sep, name);
+    browser_open(child);
+}
+
+static void quick_access_event(lv_event_t * e)
+{
+    const char * path = lv_event_get_user_data(e);
+    browser_open(path);
+}
+
+/**
+ * Add a coloured section header (e.g. "PLACES") to the quick-access sidebar.
+ */
+static void quick_add_header(const char * txt, lv_color_t color)
+{
+    lv_obj_t * label = lv_label_create(quick_access);
+    lv_obj_set_width(label, lv_pct(100));
+    lv_obj_add_style(label, &style_qa_header, 0);
+    lv_obj_set_style_bg_color(label, color, 0);
+    lv_label_set_text(label, txt);
+}
+
+/**
+ * Add a clickable shortcut row that opens `path` when tapped.
+ */
+static void quick_add_shortcut(const char * icon, const char * name, const char * path)
+{
+    lv_obj_t * btn = lv_button_create(quick_access);
+    lv_obj_set_width(btn, lv_pct(100));
+    lv_obj_add_style(btn, &style_qa_btn, 0);
+    lv_obj_add_style(btn, &style_pressed, LV_STATE_PRESSED);
+
+    lv_obj_t * label = lv_label_create(btn);
+    lv_label_set_text_fmt(label, "%s %s", icon, name);
+
+    /*lv_strdup keeps the path alive for the lifetime of the example*/
+    lv_obj_add_event_cb(btn, quick_access_event, LV_EVENT_CLICKED, lv_strdup(path));
+}
+
+/**
+ * @title File browser built from a table
+ * @brief Build a file browser with a sidebar, path header and table.
+ *
+ * A grey quick-access sidebar holds DEVICE/PLACES shortcuts; the white browser area
+ * shows the current path over an `lv_table` filled from a directory read with the
+ * `lv_fs` API (`lv_fs_dir_open`/`lv_fs_dir_read`/`lv_fs_dir_close`). Clicking a
+ * folder row opens the child directory, the ".." row walks back up, and the sidebar
+ * shortcuts jump straight to a path. Requires a file-system driver in `lv_conf.h`.
+ */
+void lv_example_table_file_browser(void)
+{
+    styles_init();
+
+    lv_obj_t * root = lv_obj_create(lv_screen_active());
+    lv_obj_set_size(root, lv_pct(100), lv_pct(100));
+    lv_obj_set_flex_flow(root, LV_FLEX_FLOW_ROW);
+    lv_obj_add_style(root, &style_bg, 0);
+
+    /*Quick-access sidebar (fixed width so the browser gets a predictable size)*/
+    quick_access = lv_obj_create(root);
+    lv_obj_set_size(quick_access, 100, lv_pct(100));
+    lv_obj_set_flex_flow(quick_access, LV_FLEX_FLOW_COLUMN);
+    lv_obj_add_style(quick_access, &style_sidebar, 0);
+
+    char home[LV_FS_MAX_PATH_LENGTH];
+#if LV_USE_FS_WIN32
+    lv_snprintf(home, sizeof(home), "C:C:/Users/Public");
+#else
+    const char * env = getenv("HOME");
+    lv_snprintf(home, sizeof(home), "A:%s", env ? env : "");
+#endif
+
+    char buf[LV_FS_MAX_PATH_LENGTH];
+    quick_add_header("PLACES", lv_palette_main(LV_PALETTE_LIME));
+    quick_add_shortcut(LV_SYMBOL_HOME, "Home", home);
+    lv_snprintf(buf, sizeof(buf), "%s/Documents", home);
+    quick_add_shortcut(LV_SYMBOL_FILE, "Docs", buf);
+    lv_snprintf(buf, sizeof(buf), "%s/Pictures", home);
+    quick_add_shortcut(LV_SYMBOL_IMAGE, "Pics", buf);
+    lv_snprintf(buf, sizeof(buf), "%s/Music", home);
+    quick_add_shortcut(LV_SYMBOL_AUDIO, "Music", buf);
+
+    quick_add_header("DEVICE", lv_palette_main(LV_PALETTE_ORANGE));
+    quick_add_shortcut(LV_SYMBOL_DRIVE, "Files", BROWSER_ROOT);
+
+    /*Browser area: path header above the file table*/
+    lv_obj_t * browser = lv_obj_create(root);
+    lv_obj_set_height(browser, lv_pct(100));
+    lv_obj_set_flex_grow(browser, 1);
+    lv_obj_set_flex_flow(browser, LV_FLEX_FLOW_COLUMN);
+    lv_obj_add_style(browser, &style_panel, 0);
+
+    browser_path_label = lv_label_create(browser);
+    lv_obj_set_width(browser_path_label, lv_pct(100));
+    lv_label_set_long_mode(browser_path_label, LV_LABEL_LONG_MODE_DOTS);
+    lv_obj_add_style(browser_path_label, &style_header, 0);
+
+    browser_table = lv_table_create(browser);
+    lv_obj_set_width(browser_table, lv_pct(100));
+    lv_obj_set_flex_grow(browser_table, 1);
+    lv_obj_add_style(browser_table, &style_table, 0);
+    /*Tighten the cell padding; the theme default is large enough to clip the icon*/
+    lv_obj_set_style_pad_hor(browser_table, 6, LV_PART_ITEMS);
+    lv_obj_set_style_pad_ver(browser_table, 8, LV_PART_ITEMS);
+
+    /*Icon column fits a symbol; name column fills the rest of the browser area*/
+    int32_t icon_col = 30;
+    int32_t name_col = lv_display_get_horizontal_resolution(NULL) - 100 - icon_col - 16;
+    lv_table_set_column_count(browser_table, 2);
+    lv_table_set_column_width(browser_table, 0, icon_col);
+    lv_table_set_column_width(browser_table, 1, name_col);
+    lv_obj_add_event_cb(browser_table, table_event, LV_EVENT_VALUE_CHANGED, NULL);
+
+    browser_open(BROWSER_ROOT);
+}
+
+#endif

--- a/examples/widgets/table/lv_example_table_file_browser.c
+++ b/examples/widgets/table/lv_example_table_file_browser.c
@@ -1,0 +1,343 @@
+/**
+ * @file lv_example_table_file_browser.c
+ */
+
+#include "../../lv_examples.h"
+
+#if LV_USE_TABLE && (LV_USE_FS_STDIO || LV_USE_FS_POSIX || LV_USE_FS_WIN32 || LV_USE_FS_FATFS) && LV_BUILD_EXAMPLES
+
+#include <stdlib.h>
+#include <string.h>
+
+/*A file explorer is a quick-access sidebar plus a path header and a table of
+ *directory entries read with the `lv_fs` API. The static helpers below build one on
+ *top of base widgets, styled by hand to give it a flat look.*/
+
+#if LV_USE_FS_WIN32
+    #define BROWSER_ROOT "C:C:/"
+#else
+    #define BROWSER_ROOT "A:/"
+#endif
+
+#define COLOR_BG    lv_color_hex(0xf2f1f6)   /*sidebar + window background*/
+#define COLOR_PANEL lv_color_white()         /*browser area*/
+
+/*The sidebar shortcuts store their path here so the click callback gets a pointer that
+ *stays valid without a heap allocation to free when the buttons are deleted.*/
+#define QUICK_ACCESS_MAX 8
+
+static lv_obj_t * quick_access;
+static lv_obj_t * browser_path_label;
+static lv_obj_t * browser_table;
+static char browser_path[LV_FS_MAX_PATH_LENGTH];
+static char quick_access_paths[QUICK_ACCESS_MAX][LV_FS_MAX_PATH_LENGTH];
+static uint32_t quick_access_cnt;
+
+static lv_style_t style_bg;       /*window + sidebar background, fully flat*/
+static lv_style_t style_panel;    /*white browser area*/
+static lv_style_t style_sidebar;
+static lv_style_t style_qa_header;
+static lv_style_t style_qa_btn;
+static lv_style_t style_header;
+static lv_style_t style_table;
+static lv_style_t style_pressed;
+
+/**
+ * Set up the styles that give the file browser its look.
+ *
+ * The styles are static and stay attached to the widgets that use them, so they are
+ * initialized only once even if the example is created multiple times.
+ */
+static void styles_init(void)
+{
+    static bool inited = false;
+    if(inited) return;
+    inited = true;
+
+    lv_style_init(&style_bg);
+    lv_style_set_bg_opa(&style_bg, LV_OPA_COVER);
+    lv_style_set_bg_color(&style_bg, COLOR_BG);
+    lv_style_set_pad_all(&style_bg, 0);
+    lv_style_set_pad_gap(&style_bg, 0);
+    lv_style_set_radius(&style_bg, 0);
+    lv_style_set_border_width(&style_bg, 0);
+
+    lv_style_init(&style_panel);
+    lv_style_set_bg_opa(&style_panel, LV_OPA_COVER);
+    lv_style_set_bg_color(&style_panel, COLOR_PANEL);
+    lv_style_set_pad_all(&style_panel, 0);
+    lv_style_set_pad_gap(&style_panel, 0);
+    lv_style_set_radius(&style_panel, 0);
+    lv_style_set_border_width(&style_panel, 0);
+
+    /*Sidebar: grey background with a thin divider on its right edge*/
+    lv_style_init(&style_sidebar);
+    lv_style_set_bg_opa(&style_sidebar, LV_OPA_COVER);
+    lv_style_set_bg_color(&style_sidebar, COLOR_BG);
+    lv_style_set_pad_all(&style_sidebar, 6);
+    lv_style_set_pad_row(&style_sidebar, 4);
+    lv_style_set_radius(&style_sidebar, 0);
+    lv_style_set_border_width(&style_sidebar, 1);
+    lv_style_set_border_color(&style_sidebar, lv_palette_lighten(LV_PALETTE_GREY, 1));
+    lv_style_set_border_side(&style_sidebar, LV_BORDER_SIDE_RIGHT);
+
+    /*Section header (DEVICE / PLACES): a small full-width coloured chip*/
+    lv_style_init(&style_qa_header);
+    lv_style_set_bg_opa(&style_qa_header, LV_OPA_COVER);
+    lv_style_set_text_color(&style_qa_header, lv_color_white());
+    lv_style_set_pad_hor(&style_qa_header, 6);
+    lv_style_set_pad_ver(&style_qa_header, 2);
+    lv_style_set_radius(&style_qa_header, 3);
+
+    /*Quick-access entry: a flat transparent row so the grey sidebar shows through*/
+    lv_style_init(&style_qa_btn);
+    lv_style_set_bg_opa(&style_qa_btn, LV_OPA_TRANSP);
+    lv_style_set_shadow_opa(&style_qa_btn, LV_OPA_TRANSP);
+    lv_style_set_text_color(&style_qa_btn, lv_palette_darken(LV_PALETTE_GREY, 4));
+    lv_style_set_pad_all(&style_qa_btn, 4);
+    lv_style_set_pad_gap(&style_qa_btn, 6);
+    lv_style_set_radius(&style_qa_btn, 0);
+
+    /*Path header above the table*/
+    lv_style_init(&style_header);
+    lv_style_set_bg_opa(&style_header, LV_OPA_COVER);
+    lv_style_set_bg_color(&style_header, COLOR_PANEL);
+    lv_style_set_text_color(&style_header, lv_palette_darken(LV_PALETTE_GREY, 4));
+    lv_style_set_pad_all(&style_header, 6);
+    lv_style_set_radius(&style_header, 0);
+    lv_style_set_border_width(&style_header, 1);
+    lv_style_set_border_color(&style_header, lv_palette_lighten(LV_PALETTE_GREY, 1));
+    lv_style_set_border_side(&style_header, LV_BORDER_SIDE_BOTTOM);
+
+    lv_style_init(&style_table);
+    lv_style_set_bg_opa(&style_table, LV_OPA_COVER);
+    lv_style_set_bg_color(&style_table, COLOR_PANEL);
+    lv_style_set_pad_all(&style_table, 0);
+    lv_style_set_radius(&style_table, 0);
+    lv_style_set_border_width(&style_table, 0);
+
+    lv_style_init(&style_pressed);
+    lv_style_set_bg_opa(&style_pressed, LV_OPA_20);
+    lv_style_set_bg_color(&style_pressed, lv_palette_main(LV_PALETTE_GREY));
+}
+
+/**
+ * Join `base` and `name` into `buf` with `lv_fs_path_join`, which adds or removes the
+ * separator as needed.
+ * @return  false if the result wouldn't fit into `buf`
+ */
+static bool path_join(char * buf, size_t buf_size, const char * base, const char * name)
+{
+    int res = lv_fs_path_join(buf, buf_size, base, name);
+    return res >= 0 && (size_t)res < buf_size;
+}
+
+/**
+ * List the entries of `path` into the table. Does nothing if `path` is not a
+ * readable directory, so a failed navigation simply leaves the view unchanged.
+ * If reading stops with an error the listing is left incomplete and a warning is
+ * logged.
+ */
+static void browser_open(const char * path)
+{
+    lv_fs_dir_t dir;
+    if(lv_fs_dir_open(&dir, path) != LV_FS_RES_OK) return;
+
+    lv_snprintf(browser_path, sizeof(browser_path), "%s", path);
+    lv_label_set_text(browser_path_label, browser_path);
+
+    lv_table_set_row_count(browser_table, 0);
+
+    /*First row goes up to the parent directory*/
+    uint32_t row = 0;
+    lv_table_set_cell_value(browser_table, row, 0, LV_SYMBOL_LEFT);
+    lv_table_set_cell_value(browser_table, row, 1, "..");
+    row++;
+
+    /*lv_fs_dir_read prefixes directory names with '/'; an empty name ends the list*/
+    char fn[LV_FS_MAX_PATH_LENGTH];
+    lv_fs_res_t res;
+    while((res = lv_fs_dir_read(&dir, fn, sizeof(fn))) == LV_FS_RES_OK && fn[0] != '\0') {
+        bool is_dir = fn[0] == '/';
+        const char * name = is_dir ? fn + 1 : fn;
+        lv_table_set_cell_value(browser_table, row, 0, is_dir ? LV_SYMBOL_DIRECTORY : LV_SYMBOL_FILE);
+        lv_table_set_cell_value(browser_table, row, 1, name);
+        row++;
+    }
+
+    if(res != LV_FS_RES_OK) LV_LOG_WARN("Reading %s failed, the listing is incomplete", path);
+
+    lv_fs_dir_close(&dir);
+}
+
+/**
+ * Navigate to the parent directory by dropping the last path component.
+ */
+static void browser_up(void)
+{
+    char buf[LV_FS_MAX_PATH_LENGTH];
+    lv_snprintf(buf, sizeof(buf), "%s", browser_path);
+
+    size_t len = strlen(buf);
+    if(len > 0 && buf[len - 1] == '/') buf[len - 1] = '\0';   /*drop a trailing slash*/
+
+    char * slash = strrchr(buf, '/');
+    if(slash == NULL) return;        /*already at the drive root*/
+    slash[1] = '\0';                 /*keep the slash, cut the last component*/
+    browser_open(buf);
+}
+
+static void table_event(lv_event_t * e)
+{
+    LV_UNUSED(e);
+    uint32_t row, col;
+    lv_table_get_selected_cell(browser_table, &row, &col);
+    if(row == LV_TABLE_CELL_NONE) return;
+
+    const char * icon = lv_table_get_cell_value(browser_table, row, 0);
+    const char * name = lv_table_get_cell_value(browser_table, row, 1);
+
+    if(strcmp(name, "..") == 0) {
+        browser_up();
+        return;
+    }
+
+    char child[LV_FS_MAX_PATH_LENGTH];
+    if(!path_join(child, sizeof(child), browser_path, name)) {
+        LV_LOG_WARN("Path of %s is too long", name);
+        return;
+    }
+
+    /*Only folders can be opened; clicking a file just logs it*/
+    if(strcmp(icon, LV_SYMBOL_DIRECTORY) != 0) {
+        LV_LOG_USER("Selected file: %s", child);
+        return;
+    }
+
+    browser_open(child);
+}
+
+static void quick_access_event(lv_event_t * e)
+{
+    const char * path = (const char *)lv_event_get_user_data(e);
+    browser_open(path);
+}
+
+/**
+ * Add a coloured section header (e.g. "PLACES") to the quick-access sidebar.
+ */
+static void quick_add_header(const char * txt, lv_color_t color)
+{
+    lv_obj_t * label = lv_label_create(quick_access);
+    lv_obj_set_width(label, lv_pct(100));
+    lv_obj_add_style(label, &style_qa_header, 0);
+    lv_obj_set_style_bg_color(label, color, 0);
+    lv_label_set_text(label, txt);
+}
+
+/**
+ * Add a clickable shortcut row that opens `path` when tapped.
+ */
+static void quick_add_shortcut(const char * icon, const char * name, const char * path)
+{
+    if(quick_access_cnt >= QUICK_ACCESS_MAX) {
+        LV_LOG_WARN("No room for the %s shortcut", name);
+        return;
+    }
+
+    /*The path is copied into static storage so no allocation needs to be freed later*/
+    char * stored_path = quick_access_paths[quick_access_cnt];
+    if(lv_strlcpy(stored_path, path, LV_FS_MAX_PATH_LENGTH) >= LV_FS_MAX_PATH_LENGTH) {
+        LV_LOG_WARN("Path of the %s shortcut is too long", name);
+        return;
+    }
+    quick_access_cnt++;
+
+    lv_obj_t * btn = lv_button_create(quick_access);
+    lv_obj_set_width(btn, lv_pct(100));
+    lv_obj_add_style(btn, &style_qa_btn, 0);
+    lv_obj_add_style(btn, &style_pressed, LV_STATE_PRESSED);
+
+    lv_obj_t * label = lv_label_create(btn);
+    lv_label_set_text_fmt(label, "%s %s", icon, name);
+
+    lv_obj_add_event_cb(btn, quick_access_event, LV_EVENT_CLICKED, stored_path);
+}
+
+/**
+ * @title File browser built from a table
+ * @brief Build a file browser with a sidebar, path header and table.
+ *
+ * A grey quick-access sidebar holds DEVICE/PLACES shortcuts; the white browser area
+ * shows the current path over an `lv_table` filled from a directory read with the
+ * `lv_fs` API (`lv_fs_dir_open`/`lv_fs_dir_read`/`lv_fs_dir_close`). Clicking a
+ * folder row opens the child directory, the ".." row walks back up, and the sidebar
+ * shortcuts jump straight to a path. Requires a file-system driver in `lv_conf.h`.
+ */
+void lv_example_table_file_browser(void)
+{
+    styles_init();
+    quick_access_cnt = 0;   /*The sidebar buttons are created from scratch below*/
+
+    lv_obj_t * root = lv_obj_create(lv_screen_active());
+    lv_obj_set_size(root, lv_pct(100), lv_pct(100));
+    lv_obj_set_flex_flow(root, LV_FLEX_FLOW_ROW);
+    lv_obj_add_style(root, &style_bg, 0);
+
+    /*Quick-access sidebar (fixed width so the browser gets a predictable size)*/
+    quick_access = lv_obj_create(root);
+    lv_obj_set_size(quick_access, 100, lv_pct(100));
+    lv_obj_set_flex_flow(quick_access, LV_FLEX_FLOW_COLUMN);
+    lv_obj_add_style(quick_access, &style_sidebar, 0);
+
+    char home[LV_FS_MAX_PATH_LENGTH];
+#if LV_USE_FS_WIN32
+    lv_snprintf(home, sizeof(home), "C:C:/Users/Public");
+#else
+    /*Without HOME fall back to the drive root so the shortcuts still open something*/
+    const char * env = getenv("HOME");
+    lv_snprintf(home, sizeof(home), "A:%s", (env && env[0] != '\0') ? env : "/");
+#endif
+
+    char buf[LV_FS_MAX_PATH_LENGTH];
+    quick_add_header("PLACES", lv_palette_main(LV_PALETTE_LIME));
+    quick_add_shortcut(LV_SYMBOL_HOME, "Home", home);
+    if(path_join(buf, sizeof(buf), home, "Documents")) quick_add_shortcut(LV_SYMBOL_FILE, "Docs", buf);
+    if(path_join(buf, sizeof(buf), home, "Pictures")) quick_add_shortcut(LV_SYMBOL_IMAGE, "Pics", buf);
+    if(path_join(buf, sizeof(buf), home, "Music")) quick_add_shortcut(LV_SYMBOL_AUDIO, "Music", buf);
+
+    quick_add_header("DEVICE", lv_palette_main(LV_PALETTE_ORANGE));
+    quick_add_shortcut(LV_SYMBOL_DRIVE, "Files", BROWSER_ROOT);
+
+    /*Browser area: path header above the file table*/
+    lv_obj_t * browser = lv_obj_create(root);
+    lv_obj_set_height(browser, lv_pct(100));
+    lv_obj_set_flex_grow(browser, 1);
+    lv_obj_set_flex_flow(browser, LV_FLEX_FLOW_COLUMN);
+    lv_obj_add_style(browser, &style_panel, 0);
+
+    browser_path_label = lv_label_create(browser);
+    lv_obj_set_width(browser_path_label, lv_pct(100));
+    lv_label_set_long_mode(browser_path_label, LV_LABEL_LONG_MODE_DOTS);
+    lv_obj_add_style(browser_path_label, &style_header, 0);
+
+    browser_table = lv_table_create(browser);
+    lv_obj_set_width(browser_table, lv_pct(100));
+    lv_obj_set_flex_grow(browser_table, 1);
+    lv_obj_add_style(browser_table, &style_table, 0);
+    /*Tighten the cell padding; the theme default is large enough to clip the icon*/
+    lv_obj_set_style_pad_hor(browser_table, 6, LV_PART_ITEMS);
+    lv_obj_set_style_pad_ver(browser_table, 8, LV_PART_ITEMS);
+
+    /*Icon column fits a symbol; name column fills the rest of the browser area*/
+    int32_t icon_col = 30;
+    int32_t name_col = lv_display_get_horizontal_resolution(NULL) - 100 - icon_col - 16;
+    lv_table_set_column_count(browser_table, 2);
+    lv_table_set_column_width(browser_table, 0, icon_col);
+    lv_table_set_column_width(browser_table, 1, name_col);
+    lv_obj_add_event_cb(browser_table, table_event, LV_EVENT_VALUE_CHANGED, NULL);
+
+    browser_open(BROWSER_ROOT);
+}
+
+#endif

--- a/examples/widgets/tileview/lv_example_tileview_l_shape.c
+++ b/examples/widgets/tileview/lv_example_tileview_l_shape.c
@@ -36,7 +36,9 @@ void lv_example_tileview_l_shape(void)
 
     /*Tile3: a list*/
     lv_obj_t * tile3 = lv_tileview_add_tile(tv, 1, 1, LV_DIR_LEFT);
+    LV_DEPRECATIONS_IGNORE_BEGIN
     lv_obj_t * list = lv_list_create(tile3);
+    LV_DEPRECATIONS_IGNORE_END
     lv_obj_set_size(list, LV_PCT(100), LV_PCT(100));
 
     lv_list_add_button(list, NULL, "One");

--- a/examples/widgets/tileview/lv_example_tileview_l_shape.c
+++ b/examples/widgets/tileview/lv_example_tileview_l_shape.c
@@ -1,6 +1,9 @@
 #include "../../lv_examples.h"
 #if LV_USE_TILEVIEW && LV_BUILD_EXAMPLES
 
+/*The tile content is built from the deprecated `lv_list` widget.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 /**
  * @title L-shaped tile view with scroll chaining
  * @brief Three tiles in an L layout where a ten-item list chains its scroll to the tile view.
@@ -51,5 +54,7 @@ void lv_example_tileview_l_shape(void)
     lv_list_add_button(list, NULL, "Ten");
 
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif

--- a/examples/widgets/win/lv_example_win_toolbar.c
+++ b/examples/widgets/win/lv_example_win_toolbar.c
@@ -12,6 +12,9 @@ static void event_handler(lv_event_t * e)
  * @title Window with title and toolbar buttons
  * @brief A window whose header carries three symbol buttons over a scrollable label body.
  *
+ * @deprecated The `lv_win` widget is deprecated. See `lv_example_flex_win` for the
+ * recommended way to build a window from a flex container.
+ *
  * `lv_win_create` fills the active screen and `lv_win_add_button`
  * places a 40 px `LV_SYMBOL_LEFT`, a 40 px `LV_SYMBOL_RIGHT`, and a
  * 60 px `LV_SYMBOL_CLOSE` button on the header around a
@@ -22,7 +25,9 @@ static void event_handler(lv_event_t * e)
  */
 void lv_example_win_toolbar(void)
 {
+    LV_DEPRECATIONS_IGNORE_BEGIN
     lv_obj_t * win = lv_win_create(lv_screen_active());
+    LV_DEPRECATIONS_IGNORE_END
     lv_obj_t * btn;
     btn = lv_win_add_button(win, LV_SYMBOL_LEFT, 40);
     lv_obj_add_event_cb(btn, event_handler, LV_EVENT_CLICKED, NULL);

--- a/examples/widgets/win/lv_example_win_toolbar.c
+++ b/examples/widgets/win/lv_example_win_toolbar.c
@@ -1,6 +1,9 @@
 #include "../../lv_examples.h"
 #if LV_USE_WIN && LV_BUILD_EXAMPLES
 
+/*This example shows the deprecated `lv_win` widget on purpose.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 static void event_handler(lv_event_t * e)
 {
     lv_obj_t * obj = lv_event_get_target_obj(e);
@@ -11,6 +14,9 @@ static void event_handler(lv_event_t * e)
 /**
  * @title Window with title and toolbar buttons
  * @brief A window whose header carries three symbol buttons over a scrollable label body.
+ *
+ * @deprecated The `lv_win` widget is deprecated. See `lv_example_flex_win` for the
+ * recommended way to build a window from a flex container.
  *
  * `lv_win_create` fills the active screen and `lv_win_add_button`
  * places a 40 px `LV_SYMBOL_LEFT`, a 40 px `LV_SYMBOL_RIGHT`, and a
@@ -51,5 +57,7 @@ void lv_example_win_toolbar(void)
                       "sure it\n"
                       "overflows. :)");
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif

--- a/include/lvgl/others/file_explorer/lv_file_explorer.h
+++ b/include/lvgl/others/file_explorer/lv_file_explorer.h
@@ -22,6 +22,16 @@ extern "C" {
  *      DEFINES
  *********************/
 
+/**
+ * @deprecated The `lv_file_explorer` widget is deprecated and kept only for
+ * backward compatibility. A file explorer is a path header plus a table of
+ * directory entries read with the `lv_fs` API, so build it directly instead. See
+ * the `lv_example_table_file_browser` example. All `lv_file_explorer_*`
+ * functions below are deprecated.
+ */
+#define LV_FILE_EXPLORER_DEPRECATED_MSG \
+    "lv_file_explorer is deprecated; build a file browser from a table + lv_fs instead. See the lv_example_table_file_browser example."
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -51,6 +61,15 @@ extern const lv_obj_class_t lv_file_explorer_class;
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
+
+/**
+ * Create a file explorer object
+ * @param parent    pointer to an object, it will be the parent of the new explorer
+ * @return          pointer to the created file explorer
+ * @deprecated The `lv_file_explorer` widget is deprecated. Build a file browser from
+ *             a table and the `lv_fs` API instead. See `lv_example_table_file_browser`.
+ */
+LV_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG)
 lv_obj_t * lv_file_explorer_create(lv_obj_t * parent);
 
 /*=====================

--- a/include/lvgl/others/file_explorer/lv_file_explorer.h
+++ b/include/lvgl/others/file_explorer/lv_file_explorer.h
@@ -22,6 +22,16 @@ extern "C" {
  *      DEFINES
  *********************/
 
+/**
+ * @deprecated The `lv_file_explorer` widget is deprecated and kept only for
+ * backward compatibility. A file explorer is a path header plus a table of
+ * directory entries read with the `lv_fs` API, so build it directly instead. See
+ * the `lv_example_table_file_browser` example. All `lv_file_explorer_*`
+ * functions below are deprecated.
+ */
+#define LV_FILE_EXPLORER_DEPRECATED_MSG \
+    "lv_file_explorer is deprecated; build a file browser from a table + lv_fs instead. See the lv_example_table_file_browser example."
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -51,6 +61,15 @@ extern const lv_obj_class_t lv_file_explorer_class;
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
+
+/**
+ * Create a file explorer object
+ * @param parent    pointer to an object, it will be the parent of the new explorer
+ * @return          pointer to the created file explorer
+ * @deprecated The `lv_file_explorer` widget is deprecated. Build a file browser from
+ *             a table and the `lv_fs` API instead. See `lv_example_table_file_browser`.
+ */
+LV_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG)
 lv_obj_t * lv_file_explorer_create(lv_obj_t * parent);
 
 /*=====================
@@ -63,8 +82,9 @@ lv_obj_t * lv_file_explorer_create(lv_obj_t * parent);
  * @param obj   pointer to a label object
  * @param dir   the dir from 'lv_file_explorer_dir_t' enum.
  * @param path   path
-
+ * @deprecated The `lv_file_explorer` widget is deprecated. See `lv_example_table_file_browser`.
  */
+LV_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG)
 void lv_file_explorer_set_quick_access_path(lv_obj_t * obj, lv_file_explorer_dir_t dir, const char * path);
 #endif
 
@@ -72,14 +92,18 @@ void lv_file_explorer_set_quick_access_path(lv_obj_t * obj, lv_file_explorer_dir
  * Set file_explorer sort
  * @param obj   pointer to a file explorer object
  * @param sort  the sort from 'lv_file_explorer_sort_t' enum.
+ * @deprecated The `lv_file_explorer` widget is deprecated. See `lv_example_table_file_browser`.
  */
+LV_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG)
 void lv_file_explorer_set_sort(lv_obj_t * obj, lv_file_explorer_sort_t sort);
 
 /**
  * Set the visibility of the "< Back" button
  * @param obj   pointer to a file explorer object
  * @param show  bool true/false, enable or disable button
+ * @deprecated The `lv_file_explorer` widget is deprecated. See `lv_example_table_file_browser`.
  */
+LV_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG)
 void lv_file_explorer_show_back_button(lv_obj_t * obj, bool show);
 
 /*=====================
@@ -90,35 +114,45 @@ void lv_file_explorer_show_back_button(lv_obj_t * obj, bool show);
  * Get file explorer Selected file
  * @param obj   pointer to a file explorer object
  * @return      pointer to the file explorer selected file name
+ * @deprecated The `lv_file_explorer` widget is deprecated. See `lv_example_table_file_browser`.
  */
+LV_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG)
 const char * lv_file_explorer_get_selected_file_name(const lv_obj_t * obj);
 
 /**
  * Get file explorer cur path
  * @param obj   pointer to a file explorer object
  * @return      pointer to the file explorer cur path
+ * @deprecated The `lv_file_explorer` widget is deprecated. See `lv_example_table_file_browser`.
  */
+LV_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG)
 const char * lv_file_explorer_get_current_path(const lv_obj_t * obj);
 
 /**
  * Get file explorer file list obj(lv_table)
  * @param obj   pointer to a file explorer object
  * @return      pointer to the file explorer file table obj(lv_table)
+ * @deprecated The `lv_file_explorer` widget is deprecated. See `lv_example_table_file_browser`.
  */
+LV_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG)
 lv_obj_t * lv_file_explorer_get_file_table(lv_obj_t * obj);
 
 /**
  * Get file explorer head area obj
  * @param obj   pointer to a file explorer object
  * @return      pointer to the file explorer head area obj(lv_obj)
+ * @deprecated The `lv_file_explorer` widget is deprecated. See `lv_example_table_file_browser`.
  */
+LV_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG)
 lv_obj_t * lv_file_explorer_get_header(lv_obj_t * obj);
 
 /**
  * Get file explorer path obj(label)
  * @param obj   pointer to a file explorer object
  * @return      pointer to the file explorer path obj(lv_label)
+ * @deprecated The `lv_file_explorer` widget is deprecated. See `lv_example_table_file_browser`.
  */
+LV_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG)
 lv_obj_t * lv_file_explorer_get_path_label(lv_obj_t * obj);
 
 #if LV_FILE_EXPLORER_QUICK_ACCESS
@@ -126,21 +160,27 @@ lv_obj_t * lv_file_explorer_get_path_label(lv_obj_t * obj);
  * Get file explorer head area obj
  * @param obj   pointer to a file explorer object
  * @return      pointer to the file explorer quick access area obj(lv_obj)
+ * @deprecated The `lv_file_explorer` widget is deprecated. See `lv_example_table_file_browser`.
  */
+LV_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG)
 lv_obj_t * lv_file_explorer_get_quick_access_area(lv_obj_t * obj);
 
 /**
  * Get file explorer places list obj(lv_list)
  * @param obj   pointer to a file explorer object
  * @return      pointer to the file explorer places list obj(lv_list)
+ * @deprecated The `lv_file_explorer` widget is deprecated. See `lv_example_table_file_browser`.
  */
+LV_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG)
 lv_obj_t * lv_file_explorer_get_places_list(lv_obj_t * obj);
 
 /**
  * Get file explorer device list obj(lv_list)
  * @param obj   pointer to a file explorer object
  * @return      pointer to the file explorer device list obj(lv_list)
+ * @deprecated The `lv_file_explorer` widget is deprecated. See `lv_example_table_file_browser`.
  */
+LV_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG)
 lv_obj_t * lv_file_explorer_get_device_list(lv_obj_t * obj);
 #endif
 
@@ -148,7 +188,9 @@ lv_obj_t * lv_file_explorer_get_device_list(lv_obj_t * obj);
  * Set file_explorer sort
  * @param obj   pointer to a file explorer object
  * @return the current mode from 'lv_file_explorer_sort_t'
+ * @deprecated The `lv_file_explorer` widget is deprecated. See `lv_example_table_file_browser`.
  */
+LV_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG)
 lv_file_explorer_sort_t lv_file_explorer_get_sort(const lv_obj_t * obj);
 
 /*=====================
@@ -159,7 +201,9 @@ lv_file_explorer_sort_t lv_file_explorer_get_sort(const lv_obj_t * obj);
  * Open a specified path
  * @param obj   pointer to a file explorer object
  * @param dir   pointer to the path
+ * @deprecated The `lv_file_explorer` widget is deprecated. See `lv_example_table_file_browser`.
  */
+LV_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG)
 void lv_file_explorer_open_dir(lv_obj_t * obj, const char * dir);
 
 /**********************

--- a/include/lvgl/widgets/lv_list.h
+++ b/include/lvgl/widgets/lv_list.h
@@ -21,6 +21,15 @@ extern "C" {
 #error "lv_list: lv_flex is required. Enable it in lv_conf.h (LV_USE_FLEX 1)"
 #endif
 
+/**
+ * @deprecated The `lv_list` widget is deprecated and kept only for backward
+ * compatibility. A list is just a flex container with a column flow, so build
+ * one directly from `lv_obj` + a `LV_FLEX_FLOW_COLUMN` layout instead. See the
+ * `lv_example_flex_list` example for a starting point.
+ */
+#define LV_LIST_DEPRECATED_MSG \
+    "lv_list is deprecated; build a list from a flex column instead. See the lv_example_flex_list example."
+
 /*********************
  *      DEFINES
  *********************/
@@ -40,7 +49,9 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_list_button_class;
  * Create a list object
  * @param parent    pointer to an object, it will be the parent of the new list
  * @return          pointer to the created list
+ * @deprecated Use a flex container with `LV_FLEX_FLOW_COLUMN` instead. See `lv_example_flex_list`.
  */
+LV_DEPRECATED(LV_LIST_DEPRECATED_MSG)
 lv_obj_t * lv_list_create(lv_obj_t * parent);
 
 /**
@@ -48,6 +59,7 @@ lv_obj_t * lv_list_create(lv_obj_t * parent);
  * @param list      pointer to a list, it will be the parent of the new label
  * @param txt       text of the new label
  * @return          pointer to the created label
+ * @deprecated Add a full-width `lv_label` to a flex container instead. See `lv_example_flex_list`.
  */
 lv_obj_t * lv_list_add_text(lv_obj_t * list, const char * txt);
 
@@ -57,6 +69,7 @@ lv_obj_t * lv_list_add_text(lv_obj_t * list, const char * txt);
  * @param icon      icon for the button, when NULL it will have no icon
  * @param txt       text of the new button, when NULL no text will be added
  * @return          pointer to the created button
+ * @deprecated Add a full-width `lv_button` to a flex container instead. See `lv_example_flex_list`.
  */
 lv_obj_t * lv_list_add_button(lv_obj_t * list, const void * icon, const char * txt);
 
@@ -65,6 +78,7 @@ lv_obj_t * lv_list_add_button(lv_obj_t * list, const void * icon, const char * t
  * @param list      pointer to a list
  * @param btn       pointer to the button
  * @return          text of btn, if btn doesn't have text "" will be returned
+ * @deprecated The `lv_list` widget is deprecated. See `lv_example_flex_list`.
  */
 const char * lv_list_get_button_text(lv_obj_t * list, lv_obj_t * btn);
 
@@ -73,7 +87,9 @@ const char * lv_list_get_button_text(lv_obj_t * list, lv_obj_t * btn);
  * @param list      pointer to a list
  * @param btn       pointer to the button
  * @param txt       pointer to the text
+ * @deprecated The `lv_list` widget is deprecated. See `lv_example_flex_list`.
  */
+LV_DEPRECATED(LV_LIST_DEPRECATED_MSG)
 void lv_list_set_button_text(lv_obj_t * list, lv_obj_t * btn, const char * txt);
 
 #if LV_USE_TRANSLATION
@@ -83,6 +99,7 @@ void lv_list_set_button_text(lv_obj_t * list, lv_obj_t * btn, const char * txt);
  * @param list      pointer to a list, it will be the parent of the new label
  * @param tag       translation tag of the new label
  * @return          pointer to the created label
+ * @deprecated The `lv_list` widget is deprecated. See `lv_example_flex_list`.
  */
 lv_obj_t * lv_list_add_translation_tag(lv_obj_t * list, const char * tag);
 
@@ -92,6 +109,7 @@ lv_obj_t * lv_list_add_translation_tag(lv_obj_t * list, const char * tag);
  * @param icon      icon for the button, when NULL it will have no icon
  * @param tag       translation tag of the new button, when NULL no translation tag will be added
  * @return          pointer to the created button
+ * @deprecated The `lv_list` widget is deprecated. See `lv_example_flex_list`.
  */
 lv_obj_t * lv_list_add_button_translation_tag(lv_obj_t * list, const void * icon, const char * tag);
 
@@ -100,6 +118,7 @@ lv_obj_t * lv_list_add_button_translation_tag(lv_obj_t * list, const void * icon
  * @param list      pointer to a list
  * @param btn       pointer to the button
  * @param tag       pointer to the translation tag
+ * @deprecated The `lv_list` widget is deprecated. See `lv_example_flex_list`.
  */
 void lv_list_set_button_translation_tag(lv_obj_t * list, lv_obj_t * btn, const char * tag);
 

--- a/include/lvgl/widgets/lv_list.h
+++ b/include/lvgl/widgets/lv_list.h
@@ -21,6 +21,15 @@ extern "C" {
 #error "lv_list: lv_flex is required. Enable it in lv_conf.h (LV_USE_FLEX 1)"
 #endif
 
+/**
+ * @deprecated The `lv_list` widget is deprecated and kept only for backward
+ * compatibility. A list is just a flex container with a column flow, so build
+ * one directly from `lv_obj` + a `LV_FLEX_FLOW_COLUMN` layout instead. See the
+ * `lv_example_flex_list` example for a starting point.
+ */
+#define LV_LIST_DEPRECATED_MSG \
+    "lv_list is deprecated; build a list from a flex column instead. See the lv_example_flex_list example."
+
 /*********************
  *      DEFINES
  *********************/
@@ -40,7 +49,9 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_list_button_class;
  * Create a list object
  * @param parent    pointer to an object, it will be the parent of the new list
  * @return          pointer to the created list
+ * @deprecated Use a flex container with `LV_FLEX_FLOW_COLUMN` instead. See `lv_example_flex_list`.
  */
+LV_DEPRECATED(LV_LIST_DEPRECATED_MSG)
 lv_obj_t * lv_list_create(lv_obj_t * parent);
 
 /**
@@ -48,7 +59,9 @@ lv_obj_t * lv_list_create(lv_obj_t * parent);
  * @param list      pointer to a list, it will be the parent of the new label
  * @param txt       text of the new label
  * @return          pointer to the created label
+ * @deprecated Add a full-width `lv_label` to a flex container instead. See `lv_example_flex_list`.
  */
+LV_DEPRECATED(LV_LIST_DEPRECATED_MSG)
 lv_obj_t * lv_list_add_text(lv_obj_t * list, const char * txt);
 
 /**
@@ -57,7 +70,9 @@ lv_obj_t * lv_list_add_text(lv_obj_t * list, const char * txt);
  * @param icon      icon for the button, when NULL it will have no icon
  * @param txt       text of the new button, when NULL no text will be added
  * @return          pointer to the created button
+ * @deprecated Add a full-width `lv_button` to a flex container instead. See `lv_example_flex_list`.
  */
+LV_DEPRECATED(LV_LIST_DEPRECATED_MSG)
 lv_obj_t * lv_list_add_button(lv_obj_t * list, const void * icon, const char * txt);
 
 /**
@@ -65,7 +80,9 @@ lv_obj_t * lv_list_add_button(lv_obj_t * list, const void * icon, const char * t
  * @param list      pointer to a list
  * @param btn       pointer to the button
  * @return          text of btn, if btn doesn't have text "" will be returned
+ * @deprecated The `lv_list` widget is deprecated. See `lv_example_flex_list`.
  */
+LV_DEPRECATED(LV_LIST_DEPRECATED_MSG)
 const char * lv_list_get_button_text(lv_obj_t * list, lv_obj_t * btn);
 
 /**
@@ -73,7 +90,9 @@ const char * lv_list_get_button_text(lv_obj_t * list, lv_obj_t * btn);
  * @param list      pointer to a list
  * @param btn       pointer to the button
  * @param txt       pointer to the text
+ * @deprecated The `lv_list` widget is deprecated. See `lv_example_flex_list`.
  */
+LV_DEPRECATED(LV_LIST_DEPRECATED_MSG)
 void lv_list_set_button_text(lv_obj_t * list, lv_obj_t * btn, const char * txt);
 
 #if LV_USE_TRANSLATION
@@ -83,7 +102,9 @@ void lv_list_set_button_text(lv_obj_t * list, lv_obj_t * btn, const char * txt);
  * @param list      pointer to a list, it will be the parent of the new label
  * @param tag       translation tag of the new label
  * @return          pointer to the created label
+ * @deprecated The `lv_list` widget is deprecated. See `lv_example_flex_list`.
  */
+LV_DEPRECATED(LV_LIST_DEPRECATED_MSG)
 lv_obj_t * lv_list_add_translation_tag(lv_obj_t * list, const char * tag);
 
 /**
@@ -92,7 +113,9 @@ lv_obj_t * lv_list_add_translation_tag(lv_obj_t * list, const char * tag);
  * @param icon      icon for the button, when NULL it will have no icon
  * @param tag       translation tag of the new button, when NULL no translation tag will be added
  * @return          pointer to the created button
+ * @deprecated The `lv_list` widget is deprecated. See `lv_example_flex_list`.
  */
+LV_DEPRECATED(LV_LIST_DEPRECATED_MSG)
 lv_obj_t * lv_list_add_button_translation_tag(lv_obj_t * list, const void * icon, const char * tag);
 
 /**
@@ -100,7 +123,9 @@ lv_obj_t * lv_list_add_button_translation_tag(lv_obj_t * list, const void * icon
  * @param list      pointer to a list
  * @param btn       pointer to the button
  * @param tag       pointer to the translation tag
+ * @deprecated The `lv_list` widget is deprecated. See `lv_example_flex_list`.
  */
+LV_DEPRECATED(LV_LIST_DEPRECATED_MSG)
 void lv_list_set_button_translation_tag(lv_obj_t * list, lv_obj_t * btn, const char * tag);
 
 #endif

--- a/include/lvgl/widgets/lv_menu.h
+++ b/include/lvgl/widgets/lv_menu.h
@@ -26,6 +26,16 @@ extern "C" {
  *      DEFINES
  *********************/
 
+/**
+ * @deprecated The `lv_menu` widget is deprecated and kept only for backward
+ * compatibility. A menu is page navigation over base widgets: pages built from
+ * `lv_obj` and a back button that swaps the visible page. Build it directly
+ * instead. See the `lv_example_menu_navigation` example. All `lv_menu_*` functions
+ * below are deprecated.
+ */
+#define LV_MENU_DEPRECATED_MSG \
+    "lv_menu is deprecated; build menu navigation from base widgets instead. See the lv_example_menu_navigation example."
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -66,7 +76,10 @@ enum __lv_property_menu_id_t {
  * Create a menu object
  * @param parent    pointer to an object, it will be the parent of the new menu
  * @return          pointer to the created menu
+ * @deprecated The `lv_menu` widget is deprecated. Build menu navigation from base
+ *             widgets instead. See `lv_example_menu_navigation`.
  */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 lv_obj_t * lv_menu_create(lv_obj_t * parent);
 
 /**

--- a/include/lvgl/widgets/lv_menu.h
+++ b/include/lvgl/widgets/lv_menu.h
@@ -26,6 +26,16 @@ extern "C" {
  *      DEFINES
  *********************/
 
+/**
+ * @deprecated The `lv_menu` widget is deprecated and kept only for backward
+ * compatibility. A menu is page navigation over base widgets: pages built from
+ * `lv_obj` and a back button that swaps the visible page. Build it directly
+ * instead. See the `lv_example_menu_navigation` example. All `lv_menu_*` functions
+ * below are deprecated.
+ */
+#define LV_MENU_DEPRECATED_MSG \
+    "lv_menu is deprecated; build menu navigation from base widgets instead. See the lv_example_menu_navigation example."
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -66,7 +76,10 @@ enum __lv_property_menu_id_t {
  * Create a menu object
  * @param parent    pointer to an object, it will be the parent of the new menu
  * @return          pointer to the created menu
+ * @deprecated The `lv_menu` widget is deprecated. Build menu navigation from base
+ *             widgets instead. See `lv_example_menu_navigation`.
  */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 lv_obj_t * lv_menu_create(lv_obj_t * parent);
 
 /**
@@ -78,28 +91,36 @@ lv_obj_t * lv_menu_create(lv_obj_t * parent);
  * @param menu      pointer to menu object.
  * @param title     pointer to text for title in header (NULL to not display title)
  * @return          pointer to the created menu page
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
  */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 lv_obj_t * lv_menu_page_create(lv_obj_t * menu, char const * const title);
 
 /**
  * Create a menu cont object
  * @param parent    pointer to a menu page or menu section object, it will be the parent of the new menu cont object
  * @return          pointer to the created menu cont
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
  */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 lv_obj_t * lv_menu_cont_create(lv_obj_t * parent);
 
 /**
  * Create a menu section object
  * @param parent    pointer to a menu page object, it will be the parent of the new menu section object
  * @return          pointer to the created menu section
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
  */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 lv_obj_t * lv_menu_section_create(lv_obj_t * parent);
 
 /**
  * Create a menu separator object
  * @param parent    pointer to a menu page object, it will be the parent of the new menu separator object
  * @return          pointer to the created menu separator
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
  */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 lv_obj_t * lv_menu_separator_create(lv_obj_t * parent);
 /*=====================
  * Setter functions
@@ -108,14 +129,18 @@ lv_obj_t * lv_menu_separator_create(lv_obj_t * parent);
  * Set menu page to display in main
  * @param obj       pointer to the menu
  * @param page      pointer to the menu page to set (NULL to clear main and clear menu history)
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
  */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 void lv_menu_set_page(lv_obj_t * obj, lv_obj_t * page);
 
 /**
  * Set menu page title
  * @param page      pointer to the menu page
  * @param title     pointer to text for title in header (NULL to not display title)
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
  */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 void lv_menu_set_page_title(lv_obj_t * page, char const * const title);
 
 /**
@@ -123,28 +148,36 @@ void lv_menu_set_page_title(lv_obj_t * page, char const * const title);
  * has to be 'alive' while the page exists.
  * @param page      pointer to the menu page
  * @param title     pointer to text for title in header (NULL to not display title)
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
  */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 void lv_menu_set_page_title_static(lv_obj_t * page, char const * const title);
 
 /**
  * Set menu page to display in sidebar
  * @param obj       pointer to the menu
  * @param page      pointer to the menu page to set (NULL to clear sidebar)
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
  */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 void lv_menu_set_sidebar_page(lv_obj_t * obj, lv_obj_t * page);
 
 /**
  * Set the how the header should behave and its position
  * @param obj       pointer to a menu
  * @param mode      LV_MENU_HEADER_TOP_FIXED/TOP_UNFIXED/BOTTOM_FIXED
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
  */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 void lv_menu_set_mode_header(lv_obj_t * obj, lv_menu_mode_header_t mode);
 
 /**
  * Set whether back button should appear at root
  * @param obj       pointer to a menu
  * @param mode      LV_MENU_ROOT_BACK_BUTTON_DISABLED/ENABLED
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
  */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 void lv_menu_set_mode_root_back_button(lv_obj_t * obj, lv_menu_mode_root_back_button_t mode);
 
 /**
@@ -152,7 +185,9 @@ void lv_menu_set_mode_root_back_button(lv_obj_t * obj, lv_menu_mode_root_back_bu
  * @param menu      pointer to the menu
  * @param obj       pointer to the obj
  * @param page      pointer to the page to load when obj is clicked
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
  */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 void lv_menu_set_load_page_event(lv_obj_t * menu, lv_obj_t * obj, lv_obj_t * page);
 
 /*=====================
@@ -162,42 +197,54 @@ void lv_menu_set_load_page_event(lv_obj_t * menu, lv_obj_t * obj, lv_obj_t * pag
 * Get a pointer to menu page that is currently displayed in main
 * @param obj        pointer to the menu
 * @return           pointer to current page
+* @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
 */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 lv_obj_t * lv_menu_get_cur_main_page(lv_obj_t * obj);
 
 /**
 * Get a pointer to menu page that is currently displayed in sidebar
 * @param obj        pointer to the menu
 * @return           pointer to current page
+* @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
 */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 lv_obj_t * lv_menu_get_cur_sidebar_page(lv_obj_t * obj);
 
 /**
 * Get a pointer to main header obj
 * @param obj        pointer to the menu
 * @return           pointer to main header obj
+* @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
 */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 lv_obj_t * lv_menu_get_main_header(lv_obj_t * obj);
 
 /**
 * Get a pointer to main header back btn obj
 * @param obj        pointer to the menu
 * @return           pointer to main header back btn obj
+* @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
 */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 lv_obj_t * lv_menu_get_main_header_back_button(lv_obj_t * obj);
 
 /**
 * Get a pointer to sidebar header obj
 * @param obj        pointer to the menu
 * @return           pointer to sidebar header obj
+* @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
 */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 lv_obj_t * lv_menu_get_sidebar_header(lv_obj_t * obj);
 
 /**
 * Get a pointer to sidebar header obj
 * @param obj        pointer to the menu
 * @return           pointer to sidebar header back btn obj
+* @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
 */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 lv_obj_t * lv_menu_get_sidebar_header_back_button(lv_obj_t * obj);
 
 /**
@@ -205,27 +252,35 @@ lv_obj_t * lv_menu_get_sidebar_header_back_button(lv_obj_t * obj);
  * @param menu      pointer to the menu
  * @param obj       pointer to the back button
  * @return          true if it is a root back btn
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
  */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 bool lv_menu_back_button_is_root(lv_obj_t * menu, lv_obj_t * obj);
 
 /**
  * Get the header mode of the menu
  * @param obj       pointer to a menu
  * @return          LV_MENU_HEADER_TOP_FIXED/TOP_UNFIXED/BOTTOM_FIXED
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
  */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 lv_menu_mode_header_t lv_menu_get_mode_header(lv_obj_t * obj);
 
 /**
  * Get the root back button mode of the menu
  * @param obj       pointer to a menu
  * @return          LV_MENU_ROOT_BACK_BUTTON_DISABLED/ENABLED
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
  */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 lv_menu_mode_root_back_button_t lv_menu_get_mode_root_back_button(lv_obj_t * obj);
 
 /**
  * Clear menu history
  * @param obj       pointer to the menu
+ * @deprecated The `lv_menu` widget is deprecated. See `lv_example_menu_navigation`.
  */
+LV_DEPRECATED(LV_MENU_DEPRECATED_MSG)
 void lv_menu_clear_history(lv_obj_t * obj);
 
 /**********************

--- a/include/lvgl/widgets/lv_rlottie.h
+++ b/include/lvgl/widgets/lv_rlottie.h
@@ -14,11 +14,19 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "../config/lv_conf_internal.h"
+#include "../lv_types.h"
 #if LV_USE_RLOTTIE
 
 /*********************
  *      DEFINES
  *********************/
+
+/**
+ * @deprecated The rlottie player is deprecated and kept only for backward
+ * compatibility. Use the `lv_lottie` widget instead. See the Lottie widget docs.
+ */
+#define LV_RLOTTIE_DEPRECATED_MSG \
+    "rlottie is deprecated; use the lv_lottie widget instead."
 
 /**********************
  *      TYPEDEFS
@@ -37,12 +45,25 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_rlottie_class;
  * GLOBAL PROTOTYPES
  **********************/
 
+/**
+ * Create an rlottie animation from a JSON file.
+ * @deprecated rlottie is deprecated. Use the `lv_lottie` widget instead.
+ */
+LV_DEPRECATED(LV_RLOTTIE_DEPRECATED_MSG)
 lv_obj_t * lv_rlottie_create_from_file(lv_obj_t * parent, int32_t width, int32_t height, const char * path);
 
+/**
+ * Create an rlottie animation from a raw JSON description.
+ * @deprecated rlottie is deprecated. Use the `lv_lottie` widget instead.
+ */
+LV_DEPRECATED(LV_RLOTTIE_DEPRECATED_MSG)
 lv_obj_t * lv_rlottie_create_from_raw(lv_obj_t * parent, int32_t width, int32_t height,
                                       const char * rlottie_desc);
 
+/** @deprecated rlottie is deprecated. Use the `lv_lottie` widget instead. */
 void lv_rlottie_set_play_mode(lv_obj_t * rlottie, const lv_rlottie_ctrl_t ctrl);
+
+/** @deprecated rlottie is deprecated. Use the `lv_lottie` widget instead. */
 void lv_rlottie_set_current_frame(lv_obj_t * rlottie, const size_t goto_frame);
 
 /**********************

--- a/include/lvgl/widgets/lv_rlottie.h
+++ b/include/lvgl/widgets/lv_rlottie.h
@@ -14,11 +14,19 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "../config/lv_conf_internal.h"
+#include "../lv_types.h"
 #if LV_USE_RLOTTIE
 
 /*********************
  *      DEFINES
  *********************/
+
+/**
+ * @deprecated The rlottie player is deprecated and kept only for backward
+ * compatibility. Use the `lv_lottie` widget instead. See the Lottie widget docs.
+ */
+#define LV_RLOTTIE_DEPRECATED_MSG \
+    "rlottie is deprecated; use the lv_lottie widget instead."
 
 /**********************
  *      TYPEDEFS
@@ -37,12 +45,27 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_rlottie_class;
  * GLOBAL PROTOTYPES
  **********************/
 
+/**
+ * Create an rlottie animation from a JSON file.
+ * @deprecated rlottie is deprecated. Use the `lv_lottie` widget instead.
+ */
+LV_DEPRECATED(LV_RLOTTIE_DEPRECATED_MSG)
 lv_obj_t * lv_rlottie_create_from_file(lv_obj_t * parent, int32_t width, int32_t height, const char * path);
 
+/**
+ * Create an rlottie animation from a raw JSON description.
+ * @deprecated rlottie is deprecated. Use the `lv_lottie` widget instead.
+ */
+LV_DEPRECATED(LV_RLOTTIE_DEPRECATED_MSG)
 lv_obj_t * lv_rlottie_create_from_raw(lv_obj_t * parent, int32_t width, int32_t height,
                                       const char * rlottie_desc);
 
+/** @deprecated rlottie is deprecated. Use the `lv_lottie` widget instead. */
+LV_DEPRECATED(LV_RLOTTIE_DEPRECATED_MSG)
 void lv_rlottie_set_play_mode(lv_obj_t * rlottie, const lv_rlottie_ctrl_t ctrl);
+
+/** @deprecated rlottie is deprecated. Use the `lv_lottie` widget instead. */
+LV_DEPRECATED(LV_RLOTTIE_DEPRECATED_MSG)
 void lv_rlottie_set_current_frame(lv_obj_t * rlottie, const size_t goto_frame);
 
 /**********************

--- a/include/lvgl/widgets/lv_win.h
+++ b/include/lvgl/widgets/lv_win.h
@@ -20,6 +20,15 @@ extern "C" {
  *      DEFINES
  *********************/
 
+/**
+ * @deprecated The `lv_win` widget is deprecated and kept only for backward
+ * compatibility. A window is just a flex column with a header bar and a content
+ * area, so build one directly from `lv_obj` instead. See the `lv_example_flex_win`
+ * example for a starting point.
+ */
+#define LV_WIN_DEPRECATED_MSG \
+    "lv_win is deprecated; build a window from a flex column instead. See the lv_example_flex_win example."
+
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_win_class;
 
 /**********************
@@ -30,7 +39,9 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_win_class;
  * Create a window widget
  * @param parent    pointer to a parent widget
  * @return          the created window
+ * @deprecated Use a flex column with a header and content area instead. See `lv_example_flex_win`.
  */
+LV_DEPRECATED(LV_WIN_DEPRECATED_MSG)
 lv_obj_t * lv_win_create(lv_obj_t * parent);
 
 /**
@@ -38,6 +49,7 @@ lv_obj_t * lv_win_create(lv_obj_t * parent);
  * @param obj       pointer to a window widget
  * @param txt       the text of the title
  * @return          the widget where the content of the title can be created
+ * @deprecated The `lv_win` widget is deprecated. See `lv_example_flex_win`.
  */
 lv_obj_t * lv_win_add_title(lv_obj_t * win, const char * txt);
 
@@ -47,6 +59,7 @@ lv_obj_t * lv_win_add_title(lv_obj_t * win, const char * txt);
  * @param icon      an icon to be displayed on the button
  * @param btn_w     width of the button
  * @return          the widget where the content of the button can be created
+ * @deprecated The `lv_win` widget is deprecated. See `lv_example_flex_win`.
  */
 lv_obj_t * lv_win_add_button(lv_obj_t * win, const void * icon, int32_t btn_w);
 
@@ -54,6 +67,7 @@ lv_obj_t * lv_win_add_button(lv_obj_t * win, const void * icon, int32_t btn_w);
  * Get the header of the window
  * @param win       pointer to a window widget
  * @return          the header of the window
+ * @deprecated The `lv_win` widget is deprecated. See `lv_example_flex_win`.
  */
 lv_obj_t * lv_win_get_header(lv_obj_t * win);
 
@@ -61,6 +75,7 @@ lv_obj_t * lv_win_get_header(lv_obj_t * win);
  * Get the content of the window
  * @param win       pointer to a window widget
  * @return          the content of the window
+ * @deprecated The `lv_win` widget is deprecated. See `lv_example_flex_win`.
  */
 lv_obj_t * lv_win_get_content(lv_obj_t * win);
 /**********************

--- a/include/lvgl/widgets/lv_win.h
+++ b/include/lvgl/widgets/lv_win.h
@@ -20,6 +20,15 @@ extern "C" {
  *      DEFINES
  *********************/
 
+/**
+ * @deprecated The `lv_win` widget is deprecated and kept only for backward
+ * compatibility. A window is just a flex column with a header bar and a content
+ * area, so build one directly from `lv_obj` instead. See the `lv_example_flex_win`
+ * example for a starting point.
+ */
+#define LV_WIN_DEPRECATED_MSG \
+    "lv_win is deprecated; build a window from a flex column instead. See the lv_example_flex_win example."
+
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_win_class;
 
 /**********************
@@ -30,7 +39,9 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_win_class;
  * Create a window widget
  * @param parent    pointer to a parent widget
  * @return          the created window
+ * @deprecated Use a flex column with a header and content area instead. See `lv_example_flex_win`.
  */
+LV_DEPRECATED(LV_WIN_DEPRECATED_MSG)
 lv_obj_t * lv_win_create(lv_obj_t * parent);
 
 /**
@@ -38,7 +49,9 @@ lv_obj_t * lv_win_create(lv_obj_t * parent);
  * @param obj       pointer to a window widget
  * @param txt       the text of the title
  * @return          the widget where the content of the title can be created
+ * @deprecated The `lv_win` widget is deprecated. See `lv_example_flex_win`.
  */
+LV_DEPRECATED(LV_WIN_DEPRECATED_MSG)
 lv_obj_t * lv_win_add_title(lv_obj_t * win, const char * txt);
 
 /**
@@ -47,21 +60,27 @@ lv_obj_t * lv_win_add_title(lv_obj_t * win, const char * txt);
  * @param icon      an icon to be displayed on the button
  * @param btn_w     width of the button
  * @return          the widget where the content of the button can be created
+ * @deprecated The `lv_win` widget is deprecated. See `lv_example_flex_win`.
  */
+LV_DEPRECATED(LV_WIN_DEPRECATED_MSG)
 lv_obj_t * lv_win_add_button(lv_obj_t * win, const void * icon, int32_t btn_w);
 
 /**
  * Get the header of the window
  * @param win       pointer to a window widget
  * @return          the header of the window
+ * @deprecated The `lv_win` widget is deprecated. See `lv_example_flex_win`.
  */
+LV_DEPRECATED(LV_WIN_DEPRECATED_MSG)
 lv_obj_t * lv_win_get_header(lv_obj_t * win);
 
 /**
  * Get the content of the window
  * @param win       pointer to a window widget
  * @return          the content of the window
+ * @deprecated The `lv_win` widget is deprecated. See `lv_example_flex_win`.
  */
+LV_DEPRECATED(LV_WIN_DEPRECATED_MSG)
 lv_obj_t * lv_win_get_content(lv_obj_t * win);
 /**********************
  *      MACROS

--- a/src/libs/rlottie/lv_rlottie.c
+++ b/src/libs/rlottie/lv_rlottie.c
@@ -64,6 +64,7 @@ static lv_rlottie_create_info_t create_info;
 
 lv_obj_t * lv_rlottie_create_from_file(lv_obj_t * parent, int32_t width, int32_t height, const char * path)
 {
+    LV_LOG_DEPRECATED(LV_RLOTTIE_DEPRECATED_MSG);
     create_info.width = width;
     create_info.height = height;
     create_info.path = path;
@@ -78,6 +79,7 @@ lv_obj_t * lv_rlottie_create_from_file(lv_obj_t * parent, int32_t width, int32_t
 
 lv_obj_t * lv_rlottie_create_from_raw(lv_obj_t * parent, int32_t width, int32_t height, const char * rlottie_desc)
 {
+    LV_LOG_DEPRECATED(LV_RLOTTIE_DEPRECATED_MSG);
     create_info.width = width;
     create_info.height = height;
     create_info.rlottie_desc = rlottie_desc;

--- a/src/libs/rlottie/lv_rlottie.c
+++ b/src/libs/rlottie/lv_rlottie.c
@@ -64,6 +64,7 @@ static lv_rlottie_create_info_t create_info;
 
 lv_obj_t * lv_rlottie_create_from_file(lv_obj_t * parent, int32_t width, int32_t height, const char * path)
 {
+    LV_LOG_DEPRECATED(LV_RLOTTIE_DEPRECATED_MSG);
     create_info.width = width;
     create_info.height = height;
     create_info.path = path;
@@ -78,6 +79,7 @@ lv_obj_t * lv_rlottie_create_from_file(lv_obj_t * parent, int32_t width, int32_t
 
 lv_obj_t * lv_rlottie_create_from_raw(lv_obj_t * parent, int32_t width, int32_t height, const char * rlottie_desc)
 {
+    LV_LOG_DEPRECATED(LV_RLOTTIE_DEPRECATED_MSG);
     create_info.width = width;
     create_info.height = height;
     create_info.rlottie_desc = rlottie_desc;
@@ -92,6 +94,7 @@ lv_obj_t * lv_rlottie_create_from_raw(lv_obj_t * parent, int32_t width, int32_t 
 
 void lv_rlottie_set_play_mode(lv_obj_t * obj, const lv_rlottie_ctrl_t ctrl)
 {
+    LV_LOG_DEPRECATED(LV_RLOTTIE_DEPRECATED_MSG);
     lv_rlottie_t * rlottie = (lv_rlottie_t *) obj;
     rlottie->play_ctrl = ctrl;
 
@@ -103,6 +106,7 @@ void lv_rlottie_set_play_mode(lv_obj_t * obj, const lv_rlottie_ctrl_t ctrl)
 
 void lv_rlottie_set_current_frame(lv_obj_t * obj, const size_t goto_frame)
 {
+    LV_LOG_DEPRECATED(LV_RLOTTIE_DEPRECATED_MSG);
     lv_rlottie_t * rlottie = (lv_rlottie_t *) obj;
     rlottie->current_frame = goto_frame < rlottie->total_frames ? goto_frame : rlottie->total_frames - 1;
 }

--- a/src/others/file_explorer/lv_file_explorer.c
+++ b/src/others/file_explorer/lv_file_explorer.c
@@ -313,7 +313,9 @@ static void lv_file_explorer_constructor(const lv_obj_class_t * class_p, lv_obj_
     /*Two lists of quick access bar*/
     lv_obj_t * btn;
     /*list 1*/
+    LV_DEPRECATIONS_IGNORE_BEGIN
     explorer->list_device = lv_list_create(explorer->quick_access_area);
+    LV_DEPRECATIONS_IGNORE_END
     lv_obj_set_size(explorer->list_device, LV_PCT(100), LV_SIZE_CONTENT);
     lv_obj_set_style_bg_color(lv_list_add_text(explorer->list_device, "DEVICE"), lv_palette_main(LV_PALETTE_ORANGE), 0);
 
@@ -321,7 +323,9 @@ static void lv_file_explorer_constructor(const lv_obj_class_t * class_p, lv_obj_
     lv_obj_add_event_cb(btn, quick_access_event_handler, LV_EVENT_CLICKED, obj);
 
     /*list 2*/
+    LV_DEPRECATIONS_IGNORE_BEGIN
     explorer->list_places = lv_list_create(explorer->quick_access_area);
+    LV_DEPRECATIONS_IGNORE_END
     lv_obj_set_size(explorer->list_places, LV_PCT(100), LV_SIZE_CONTENT);
     lv_obj_set_style_bg_color(lv_list_add_text(explorer->list_places, "PLACES"), lv_palette_main(LV_PALETTE_LIME), 0);
 

--- a/src/others/file_explorer/lv_file_explorer.c
+++ b/src/others/file_explorer/lv_file_explorer.c
@@ -79,6 +79,7 @@ const lv_obj_class_t lv_file_explorer_class = {
 
 lv_obj_t * lv_file_explorer_create(lv_obj_t * parent)
 {
+    LV_LOG_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG);
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(MY_CLASS, parent);
     lv_obj_class_init_obj(obj);

--- a/src/others/file_explorer/lv_file_explorer.c
+++ b/src/others/file_explorer/lv_file_explorer.c
@@ -15,6 +15,9 @@
 #include "../../lvgl_public.h"
 #include "../../core/lv_global.h"
 
+/*This widget is deprecated and it is built from the deprecated `lv_list` widget.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 /*********************
  *      DEFINES
  *********************/
@@ -79,6 +82,7 @@ const lv_obj_class_t lv_file_explorer_class = {
 
 lv_obj_t * lv_file_explorer_create(lv_obj_t * parent)
 {
+    LV_LOG_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG);
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(MY_CLASS, parent);
     lv_obj_class_init_obj(obj);
@@ -91,6 +95,7 @@ lv_obj_t * lv_file_explorer_create(lv_obj_t * parent)
 #if LV_FILE_EXPLORER_QUICK_ACCESS
 void lv_file_explorer_set_quick_access_path(lv_obj_t * obj, lv_file_explorer_dir_t dir, const char * path)
 {
+    LV_LOG_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return);
 
     lv_file_explorer_t * explorer = (lv_file_explorer_t *)obj;
@@ -138,6 +143,7 @@ void lv_file_explorer_set_quick_access_path(lv_obj_t * obj, lv_file_explorer_dir
 
 void lv_file_explorer_set_sort(lv_obj_t * obj, lv_file_explorer_sort_t sort)
 {
+    LV_LOG_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return);
 
     lv_file_explorer_t * explorer = (lv_file_explorer_t *)obj;
@@ -149,6 +155,7 @@ void lv_file_explorer_set_sort(lv_obj_t * obj, lv_file_explorer_sort_t sort)
 
 void lv_file_explorer_show_back_button(lv_obj_t * obj, bool show)
 {
+    LV_LOG_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return);
 
     lv_file_explorer_t * explorer = (lv_file_explorer_t *)obj;
@@ -161,6 +168,7 @@ void lv_file_explorer_show_back_button(lv_obj_t * obj, bool show)
  *====================*/
 const char * lv_file_explorer_get_selected_file_name(const lv_obj_t * obj)
 {
+    LV_LOG_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
 
     lv_file_explorer_t * explorer = (lv_file_explorer_t *)obj;
@@ -170,6 +178,7 @@ const char * lv_file_explorer_get_selected_file_name(const lv_obj_t * obj)
 
 const char * lv_file_explorer_get_current_path(const lv_obj_t * obj)
 {
+    LV_LOG_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
 
     lv_file_explorer_t * explorer = (lv_file_explorer_t *)obj;
@@ -179,6 +188,7 @@ const char * lv_file_explorer_get_current_path(const lv_obj_t * obj)
 
 lv_obj_t * lv_file_explorer_get_file_table(lv_obj_t * obj)
 {
+    LV_LOG_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
 
     lv_file_explorer_t * explorer = (lv_file_explorer_t *)obj;
@@ -188,6 +198,7 @@ lv_obj_t * lv_file_explorer_get_file_table(lv_obj_t * obj)
 
 lv_obj_t * lv_file_explorer_get_header(lv_obj_t * obj)
 {
+    LV_LOG_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
 
     lv_file_explorer_t * explorer = (lv_file_explorer_t *)obj;
@@ -197,6 +208,7 @@ lv_obj_t * lv_file_explorer_get_header(lv_obj_t * obj)
 
 lv_obj_t * lv_file_explorer_get_path_label(lv_obj_t * obj)
 {
+    LV_LOG_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
 
     lv_file_explorer_t * explorer = (lv_file_explorer_t *)obj;
@@ -207,6 +219,7 @@ lv_obj_t * lv_file_explorer_get_path_label(lv_obj_t * obj)
 #if LV_FILE_EXPLORER_QUICK_ACCESS
 lv_obj_t * lv_file_explorer_get_quick_access_area(lv_obj_t * obj)
 {
+    LV_LOG_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
 
     lv_file_explorer_t * explorer = (lv_file_explorer_t *)obj;
@@ -216,6 +229,7 @@ lv_obj_t * lv_file_explorer_get_quick_access_area(lv_obj_t * obj)
 
 lv_obj_t * lv_file_explorer_get_places_list(lv_obj_t * obj)
 {
+    LV_LOG_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
 
     lv_file_explorer_t * explorer = (lv_file_explorer_t *)obj;
@@ -225,6 +239,7 @@ lv_obj_t * lv_file_explorer_get_places_list(lv_obj_t * obj)
 
 lv_obj_t * lv_file_explorer_get_device_list(lv_obj_t * obj)
 {
+    LV_LOG_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
 
     lv_file_explorer_t * explorer = (lv_file_explorer_t *)obj;
@@ -236,6 +251,7 @@ lv_obj_t * lv_file_explorer_get_device_list(lv_obj_t * obj)
 
 lv_file_explorer_sort_t lv_file_explorer_get_sort(const lv_obj_t * obj)
 {
+    LV_LOG_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return 0);
 
     lv_file_explorer_t * explorer = (lv_file_explorer_t *)obj;
@@ -248,6 +264,7 @@ lv_file_explorer_sort_t lv_file_explorer_get_sort(const lv_obj_t * obj)
  *====================*/
 void lv_file_explorer_open_dir(lv_obj_t * obj, const char * dir)
 {
+    LV_LOG_DEPRECATED(LV_FILE_EXPLORER_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return);
 
     show_dir(obj, dir);
@@ -804,5 +821,7 @@ static bool is_end_with(const char * str1, const char * str2)
 
     return true;
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif  /*LV_USE_FILE_EXPLORER*/

--- a/src/widgets/list/lv_list.c
+++ b/src/widgets/list/lv_list.c
@@ -63,6 +63,7 @@ const lv_obj_class_t lv_list_text_class = {
 
 lv_obj_t * lv_list_create(lv_obj_t * parent)
 {
+    LV_LOG_DEPRECATED(LV_LIST_DEPRECATED_MSG);
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(MY_CLASS, parent);
     lv_obj_class_init_obj(obj);

--- a/src/widgets/list/lv_list.c
+++ b/src/widgets/list/lv_list.c
@@ -14,6 +14,9 @@
 
 #include "../../core/lv_obj_class_private.h"
 
+/*The `lv_list` API is deprecated as a whole and its functions call each other.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 /*********************
  *      DEFINES
  *********************/
@@ -63,6 +66,7 @@ const lv_obj_class_t lv_list_text_class = {
 
 lv_obj_t * lv_list_create(lv_obj_t * parent)
 {
+    LV_LOG_DEPRECATED(LV_LIST_DEPRECATED_MSG);
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(MY_CLASS, parent);
     lv_obj_class_init_obj(obj);
@@ -72,6 +76,7 @@ lv_obj_t * lv_list_create(lv_obj_t * parent)
 
 lv_obj_t * lv_list_add_text(lv_obj_t * list, const char * txt)
 {
+    LV_LOG_DEPRECATED(LV_LIST_DEPRECATED_MSG);
     LV_LOG_INFO("begin");
 
     lv_obj_t * obj = lv_obj_class_create_obj(MY_CLASS_TEXT, list);
@@ -82,6 +87,7 @@ lv_obj_t * lv_list_add_text(lv_obj_t * list, const char * txt)
 
 lv_obj_t * lv_list_add_button(lv_obj_t * list, const void * icon, const char * txt)
 {
+    LV_LOG_DEPRECATED(LV_LIST_DEPRECATED_MSG);
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(MY_CLASS_BUTTON, list);
     lv_obj_class_init_obj(obj);
@@ -106,6 +112,7 @@ lv_obj_t * lv_list_add_button(lv_obj_t * list, const void * icon, const char * t
 
 const char * lv_list_get_button_text(lv_obj_t * list, lv_obj_t * btn)
 {
+    LV_LOG_DEPRECATED(LV_LIST_DEPRECATED_MSG);
     LV_UNUSED(list);
     uint32_t i;
     for(i = 0; i < lv_obj_get_child_count(btn); i++) {
@@ -121,6 +128,7 @@ const char * lv_list_get_button_text(lv_obj_t * list, lv_obj_t * btn)
 
 void lv_list_set_button_text(lv_obj_t * list, lv_obj_t * btn, const char * txt)
 {
+    LV_LOG_DEPRECATED(LV_LIST_DEPRECATED_MSG);
     LV_UNUSED(list);
     uint32_t i;
     for(i = 0; i < lv_obj_get_child_count(btn); i++) {
@@ -136,6 +144,7 @@ void lv_list_set_button_text(lv_obj_t * list, lv_obj_t * btn, const char * txt)
 
 lv_obj_t * lv_list_add_translation_tag(lv_obj_t * list, const char * tag)
 {
+    LV_LOG_DEPRECATED(LV_LIST_DEPRECATED_MSG);
     LV_LOG_INFO("begin");
 
     lv_obj_t * obj = lv_list_add_text(list, NULL);
@@ -145,6 +154,7 @@ lv_obj_t * lv_list_add_translation_tag(lv_obj_t * list, const char * tag)
 
 lv_obj_t * lv_list_add_button_translation_tag(lv_obj_t * list, const void * icon, const char * tag)
 {
+    LV_LOG_DEPRECATED(LV_LIST_DEPRECATED_MSG);
     LV_LOG_INFO("begin");
 
     lv_obj_t * obj = lv_list_add_button(list, icon, "");
@@ -155,6 +165,7 @@ lv_obj_t * lv_list_add_button_translation_tag(lv_obj_t * list, const void * icon
 
 void lv_list_set_button_translation_tag(lv_obj_t * list, lv_obj_t * btn, const char * tag)
 {
+    LV_LOG_DEPRECATED(LV_LIST_DEPRECATED_MSG);
     LV_UNUSED(list);
     uint32_t i;
     for(i = 0; i < lv_obj_get_child_count(btn); i++) {
@@ -171,5 +182,7 @@ void lv_list_set_button_translation_tag(lv_obj_t * list, lv_obj_t * btn, const c
 /**********************
  *   STATIC FUNCTIONS
  **********************/
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif /*LV_USE_LIST*/

--- a/src/widgets/menu/lv_menu.c
+++ b/src/widgets/menu/lv_menu.c
@@ -132,6 +132,7 @@ void lv_menu_clear_history(lv_obj_t * obj);
 
 lv_obj_t * lv_menu_create(lv_obj_t * parent)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(MY_CLASS, parent);
     lv_obj_class_init_obj(obj);

--- a/src/widgets/menu/lv_menu.c
+++ b/src/widgets/menu/lv_menu.c
@@ -18,6 +18,9 @@
 #include "../../core/lv_obj_class_private.h"
 #include "../../core/lv_obj_private.h"
 
+/*The `lv_menu` API is deprecated as a whole and its functions call each other.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -132,6 +135,7 @@ void lv_menu_clear_history(lv_obj_t * obj);
 
 lv_obj_t * lv_menu_create(lv_obj_t * parent)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(MY_CLASS, parent);
     lv_obj_class_init_obj(obj);
@@ -140,6 +144,7 @@ lv_obj_t * lv_menu_create(lv_obj_t * parent)
 
 lv_obj_t * lv_menu_page_create(lv_obj_t * menu, char const * const title)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_CHECK_OBJ(menu, MY_CLASS, return NULL);
 
     LV_LOG_INFO("begin");
@@ -157,6 +162,7 @@ lv_obj_t * lv_menu_page_create(lv_obj_t * menu, char const * const title)
 
 lv_obj_t * lv_menu_cont_create(lv_obj_t * parent)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_ASSERT_NULL(parent);
     if(!parent || (LV_USE_ASSERT_OBJ &&
                    !(lv_obj_has_class(parent, &lv_menu_page_class)
@@ -173,6 +179,7 @@ lv_obj_t * lv_menu_cont_create(lv_obj_t * parent)
 
 lv_obj_t * lv_menu_section_create(lv_obj_t * parent)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_CHECK_OBJ(parent, &lv_menu_page_class, return NULL);
 
     LV_LOG_INFO("begin");
@@ -183,6 +190,7 @@ lv_obj_t * lv_menu_section_create(lv_obj_t * parent)
 
 lv_obj_t * lv_menu_separator_create(lv_obj_t * parent)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_CHECK_OBJ(parent, &lv_menu_page_class, return NULL);
 
     LV_LOG_INFO("begin");
@@ -221,6 +229,7 @@ void lv_menu_refr(lv_obj_t * obj)
 
 void lv_menu_set_page(lv_obj_t * obj, lv_obj_t * page)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return);
 
     lv_menu_t * menu = (lv_menu_t *)obj;
@@ -301,6 +310,7 @@ void lv_menu_set_page(lv_obj_t * obj, lv_obj_t * page)
 
 void lv_menu_set_sidebar_page(lv_obj_t * obj, lv_obj_t * page)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return);
 
     lv_menu_t * menu = (lv_menu_t *)obj;
@@ -364,6 +374,7 @@ void lv_menu_set_sidebar_page(lv_obj_t * obj, lv_obj_t * page)
 
 void lv_menu_set_mode_header(lv_obj_t * obj, lv_menu_mode_header_t mode)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return);
 
     lv_menu_t * menu = (lv_menu_t *)obj;
@@ -377,6 +388,7 @@ void lv_menu_set_mode_header(lv_obj_t * obj, lv_menu_mode_header_t mode)
 
 void lv_menu_set_mode_root_back_button(lv_obj_t * obj, lv_menu_mode_root_back_button_t mode)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return);
 
     lv_menu_t * menu = (lv_menu_t *)obj;
@@ -389,6 +401,7 @@ void lv_menu_set_mode_root_back_button(lv_obj_t * obj, lv_menu_mode_root_back_bu
 
 void lv_menu_set_load_page_event(lv_obj_t * menu, lv_obj_t * obj, lv_obj_t * page)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_CHECK_OBJ(menu, MY_CLASS, return);
 
     lv_obj_set_clickable(obj, true);
@@ -429,6 +442,7 @@ void lv_menu_set_load_page_event(lv_obj_t * menu, lv_obj_t * obj, lv_obj_t * pag
 
 void lv_menu_set_page_title(lv_obj_t * page_obj, char const * const title)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_CHECK_OBJ(page_obj, &lv_menu_page_class, return);
 
     LV_LOG_INFO("begin");
@@ -456,6 +470,7 @@ void lv_menu_set_page_title(lv_obj_t * page_obj, char const * const title)
 
 void lv_menu_set_page_title_static(lv_obj_t * page_obj, char const * const title)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_CHECK_OBJ(page_obj, &lv_menu_page_class, return);
 
     LV_LOG_INFO("begin");
@@ -483,6 +498,7 @@ void lv_menu_set_page_title_static(lv_obj_t * page_obj, char const * const title
  *====================*/
 lv_obj_t * lv_menu_get_cur_main_page(lv_obj_t * obj)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
 
     lv_menu_t * menu = (lv_menu_t *)obj;
@@ -491,6 +507,7 @@ lv_obj_t * lv_menu_get_cur_main_page(lv_obj_t * obj)
 
 lv_obj_t * lv_menu_get_cur_sidebar_page(lv_obj_t * obj)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
 
     lv_menu_t * menu = (lv_menu_t *)obj;
@@ -499,6 +516,7 @@ lv_obj_t * lv_menu_get_cur_sidebar_page(lv_obj_t * obj)
 
 lv_obj_t * lv_menu_get_main_header(lv_obj_t * obj)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
 
     lv_menu_t * menu = (lv_menu_t *)obj;
@@ -507,6 +525,7 @@ lv_obj_t * lv_menu_get_main_header(lv_obj_t * obj)
 
 lv_obj_t * lv_menu_get_main_header_back_button(lv_obj_t * obj)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
 
     lv_menu_t * menu = (lv_menu_t *)obj;
@@ -515,6 +534,7 @@ lv_obj_t * lv_menu_get_main_header_back_button(lv_obj_t * obj)
 
 lv_obj_t * lv_menu_get_sidebar_header(lv_obj_t * obj)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
 
     lv_menu_t * menu = (lv_menu_t *)obj;
@@ -523,6 +543,7 @@ lv_obj_t * lv_menu_get_sidebar_header(lv_obj_t * obj)
 
 lv_obj_t * lv_menu_get_sidebar_header_back_button(lv_obj_t * obj)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
 
     lv_menu_t * menu = (lv_menu_t *)obj;
@@ -531,6 +552,7 @@ lv_obj_t * lv_menu_get_sidebar_header_back_button(lv_obj_t * obj)
 
 bool lv_menu_back_button_is_root(lv_obj_t * menu, lv_obj_t * obj)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_CHECK_OBJ(menu, MY_CLASS, return false);
 
     if(obj == ((lv_menu_t *)menu)->sidebar_header_back_btn) {
@@ -546,6 +568,7 @@ bool lv_menu_back_button_is_root(lv_obj_t * menu, lv_obj_t * obj)
 
 lv_menu_mode_header_t lv_menu_get_mode_header(lv_obj_t * obj)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return 0);
     lv_menu_t * menu = (lv_menu_t *)obj;
     return menu->mode_header;
@@ -553,6 +576,7 @@ lv_menu_mode_header_t lv_menu_get_mode_header(lv_obj_t * obj)
 
 lv_menu_mode_root_back_button_t lv_menu_get_mode_root_back_button(lv_obj_t * obj)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return 0);
     lv_menu_t * menu = (lv_menu_t *)obj;
     return menu->mode_root_back_btn;
@@ -560,6 +584,7 @@ lv_menu_mode_root_back_button_t lv_menu_get_mode_root_back_button(lv_obj_t * obj
 
 void lv_menu_clear_history(lv_obj_t * obj)
 {
+    LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_CHECK_OBJ(obj, MY_CLASS, return);
 
     lv_menu_t * menu = (lv_menu_t *)obj;
@@ -878,4 +903,6 @@ static void lv_menu_value_changed_event_cb(lv_event_t * e)
         }
     }
 }
+LV_DEPRECATIONS_IGNORE_END
+
 #endif /*LV_USE_MENU*/

--- a/src/widgets/win/lv_win.c
+++ b/src/widgets/win/lv_win.c
@@ -45,6 +45,7 @@ const lv_obj_class_t lv_win_class = {
 
 lv_obj_t * lv_win_create(lv_obj_t * parent)
 {
+    LV_LOG_DEPRECATED(LV_WIN_DEPRECATED_MSG);
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(&lv_win_class, parent);
     lv_obj_class_init_obj(obj);

--- a/src/widgets/win/lv_win.c
+++ b/src/widgets/win/lv_win.c
@@ -11,6 +11,9 @@
 #include "../../lvgl.h"
 #if LV_USE_WIN
 
+/*The `lv_win` API is deprecated as a whole and its functions call each other.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 /*********************
  *      DEFINES
  *********************/
@@ -45,6 +48,7 @@ const lv_obj_class_t lv_win_class = {
 
 lv_obj_t * lv_win_create(lv_obj_t * parent)
 {
+    LV_LOG_DEPRECATED(LV_WIN_DEPRECATED_MSG);
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(&lv_win_class, parent);
     lv_obj_class_init_obj(obj);
@@ -53,6 +57,7 @@ lv_obj_t * lv_win_create(lv_obj_t * parent)
 
 lv_obj_t * lv_win_add_title(lv_obj_t * win, const char * txt)
 {
+    LV_LOG_DEPRECATED(LV_WIN_DEPRECATED_MSG);
     lv_obj_t * header = lv_win_get_header(win);
     lv_obj_t * title = lv_label_create(header);
     lv_label_set_long_mode(title, LV_LABEL_LONG_MODE_DOTS);
@@ -63,6 +68,7 @@ lv_obj_t * lv_win_add_title(lv_obj_t * win, const char * txt)
 
 lv_obj_t * lv_win_add_button(lv_obj_t * win, const void * icon, int32_t btn_w)
 {
+    LV_LOG_DEPRECATED(LV_WIN_DEPRECATED_MSG);
     lv_obj_t * header = lv_win_get_header(win);
     lv_obj_t * btn = lv_button_create(header);
     lv_obj_set_size(btn, btn_w, LV_PCT(100));
@@ -78,11 +84,13 @@ lv_obj_t * lv_win_add_button(lv_obj_t * win, const void * icon, int32_t btn_w)
 
 lv_obj_t * lv_win_get_header(lv_obj_t * win)
 {
+    LV_LOG_DEPRECATED(LV_WIN_DEPRECATED_MSG);
     return lv_obj_get_child(win, 0);
 }
 
 lv_obj_t * lv_win_get_content(lv_obj_t * win)
 {
+    LV_LOG_DEPRECATED(LV_WIN_DEPRECATED_MSG);
     return lv_obj_get_child(win, 1);
 }
 
@@ -106,5 +114,7 @@ static void lv_win_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
     lv_obj_set_flex_grow(cont, 1);
     lv_obj_set_width(cont, LV_PCT(100));
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif

--- a/tests/src/test_cases/test_file_explorer.c
+++ b/tests/src/test_cases/test_file_explorer.c
@@ -18,7 +18,9 @@ static void read_dir(void);
 void setUp(void)
 {
     active_screen = lv_screen_active();
+    LV_DEPRECATIONS_IGNORE_BEGIN
     file_explorer_obj = lv_file_explorer_create(active_screen);
+    LV_DEPRECATIONS_IGNORE_END
     file_explorer = (lv_file_explorer_t *)file_explorer_obj;
     file_table = (lv_table_t *)file_explorer->file_table;
 

--- a/tests/src/test_cases/test_file_explorer.c
+++ b/tests/src/test_cases/test_file_explorer.c
@@ -8,6 +8,9 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
+/*These tests exercise the deprecated `lv_file_explorer` widget on purpose.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 static lv_obj_t * active_screen = NULL;
 static lv_obj_t * file_explorer_obj;
 static lv_file_explorer_t * file_explorer;
@@ -132,5 +135,7 @@ void test_file_explorer_show_back_button(void)
     lv_file_explorer_show_back_button(file_explorer_obj, false);
     TEST_ASSERT_EQUAL_SCREENSHOT("widgets/file_explorer_01.png");
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif

--- a/tests/src/test_cases/test_theme.c
+++ b/tests/src/test_cases/test_theme.c
@@ -69,7 +69,9 @@ static void test_widgets(const char * img_name)
     lv_obj_set_size(tabview, 100, 100);
     lv_tabview_add_tab(tabview, "Tab 1");
 
+    LV_DEPRECATIONS_IGNORE_BEGIN
     lv_obj_t * win = lv_win_create(scr_act);
+    LV_DEPRECATIONS_IGNORE_END
     lv_obj_set_size(win, 100, 100);
     lv_win_add_title(win, "Window");
     lv_win_add_button(win, LV_SYMBOL_CLOSE, 20);

--- a/tests/src/test_cases/test_theme.c
+++ b/tests/src/test_cases/test_theme.c
@@ -136,7 +136,9 @@ static void test_widgets(const char * img_name)
 
     lv_led_create(scr_act);
 
+    LV_DEPRECATIONS_IGNORE_BEGIN
     lv_obj_t * menu = lv_menu_create(scr_act);
+    LV_DEPRECATIONS_IGNORE_END
     lv_obj_set_size(menu, 100, 100);
 
     lv_spinner_create(scr_act);

--- a/tests/src/test_cases/test_theme.c
+++ b/tests/src/test_cases/test_theme.c
@@ -121,7 +121,9 @@ static void test_widgets(const char * img_name)
     lv_obj_t * keyboard = lv_keyboard_create(scr_act);
     lv_obj_set_size(keyboard, 300, 150);
 
+    LV_DEPRECATIONS_IGNORE_BEGIN
     lv_obj_t * list = lv_list_create(scr_act);
+    LV_DEPRECATIONS_IGNORE_END
     lv_obj_set_size(list, 100, 100);
     lv_list_add_text(list, "List item");
     lv_list_add_button(list, LV_SYMBOL_OK, "List button");

--- a/tests/src/test_cases/test_theme.c
+++ b/tests/src/test_cases/test_theme.c
@@ -3,6 +3,9 @@
 #include "../../src/themes/lv_theme_private.h"
 #include "unity/unity.h"
 
+/*The themes are tested on the deprecated `lv_menu`, `lv_list` and `lv_win` widgets too.*/
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 void setUp(void)
 {
     /* Function run before every test */
@@ -239,5 +242,7 @@ void test_theme_simple(void)
     TEST_ASSERT_FALSE(lv_theme_simple_is_inited());
     TEST_ASSERT_NULL(lv_theme_simple_get());
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif

--- a/tests/src/test_cases/widgets/test_list.c
+++ b/tests/src/test_cases/widgets/test_list.c
@@ -4,6 +4,9 @@
 
 #include "unity/unity.h"
 
+/* These tests exercise the deprecated lv_list widget on purpose. */
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 static lv_obj_t * list;
 
 void setUp(void)
@@ -119,5 +122,7 @@ void test_list_translation_tag(void)
     TEST_ASSERT_EQUAL_STRING(lv_list_get_button_text(list, list_button), "rabbit");
 
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif

--- a/tests/src/test_cases/widgets/test_menu.c
+++ b/tests/src/test_cases/widgets/test_menu.c
@@ -3,6 +3,9 @@
 #include "../../lvgl_private.h"
 #include "unity/unity.h"
 
+/* These tests exercise the deprecated lv_menu widget on purpose. */
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 void setUp(void)
 {
 }
@@ -709,5 +712,7 @@ void test_menu_selected_tab_clear_without_sidebar(void)
 
     lv_refr_now(NULL);
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif

--- a/tests/src/test_cases/widgets/test_win.c
+++ b/tests/src/test_cases/widgets/test_win.c
@@ -3,6 +3,9 @@
 #include "../../lvgl_private.h"
 #include "unity/unity.h"
 
+/* These tests exercise the deprecated lv_win widget on purpose. */
+LV_DEPRECATIONS_IGNORE_BEGIN
+
 static lv_obj_t * active_screen = NULL;
 static lv_obj_t * win = NULL;
 static lv_obj_t * header = NULL;
@@ -157,5 +160,7 @@ void test_win_add_multiple_elements(void)
     // Check the output remains visually consistent
     TEST_ASSERT_EQUAL_SCREENSHOT("widgets/win_02.png");
 }
+
+LV_DEPRECATIONS_IGNORE_END
 
 #endif


### PR DESCRIPTION
`lv_win`, `lv_list`, `lv_menu`, `lv_file_browser` are converted to examples and deprecated becasue:
- real life use cases are too complex and specific, therefore these generic widgets can't be used effectively
- conceptually widgets should be smaller building blocks, and these built from many widgets
- some of these are easy to recreate with higher freedom.

Now the examples and the original code coexist but after v9.6 in v10 the original code will be removed. 

  
### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
