### PR TITLE
docs(copilot): add argument checking contract

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,6 +13,12 @@ Code must be portable, memory-efficient, and bare-metal safe.
 - Missing `#if LV_USE_xxx` / `#endif` guards for optional features
 - Global variables not in `lv_global_t` — must use `LV_GLOBAL_DEFAULT()`
 - Test headers included in production source (`#include "lv_test_..."` in `src/`)
+- Missing `LV_CHECK_ARG(...)` on arguments of public API functions
+- Missing `LV_CHECK_OBJ(obj, cls, action)` for `lv_obj_t *` parameters in public API functions
+
+## Argument Checking Contract
+- Public API functions use `LV_CHECK_ARG`/`LV_CHECK_OBJ` as the sole argument-safety mechanism
+- When `LV_USE_CHECK_ARG=0` checks compile out by design. Do not flag missing unconditional `NULL` guards; passing invalid args with checks disabled is caller UB, not a library defect
 
 ## Embedded Performance (flag in hot paths)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,11 +14,11 @@ Code must be portable, memory-efficient, and bare-metal safe.
 - Global variables not in `lv_global_t` — must use `LV_GLOBAL_DEFAULT()`
 - Test headers included in production source (`#include "lv_test_..."` in `src/`)
 - Missing `LV_CHECK_ARG(...)` on arguments of public API functions
-- Missing `LV_CHECK_OBJ(obj, cls, action)` for `lv_obj_t *` parameters in public API functions
+- Missing `LV_CHECK_OBJ(obj, cls, action)` for `lv_obj_t *`/`const lv_obj_t *` parameters in public API functions
 
 ## Argument Checking Contract
 - Public API functions use `LV_CHECK_ARG`/`LV_CHECK_OBJ` as the sole argument-safety mechanism
-- When `LV_USE_CHECK_ARG=0` checks compile out by design. Do not flag missing unconditional `NULL` guards; passing invalid args with checks disabled is caller UB, not a library defect
+- When `LV_USE_CHECK_ARG=0` checks compile out by design. Do not flag missing unconditional `NULL` guards; passing invalid args with checks disabled is caller undefined behavior, not a library defect
 
 ## Embedded Performance (flag in hot paths)
 


### PR DESCRIPTION
This is to stop copilot from flagging things like these:

<img width="753" height="167" alt="image" src="https://github.com/user-attachments/assets/5122bde0-0e5b-4e23-82d6-18881e155d83" />
