### PR TITLE
refactor(indev): add `static` modifier to definition of `indev_gesture`

### DIFF
--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -1783,7 +1783,7 @@ static void indev_click_focus(lv_indev_t * indev)
 * Handle the gesture of indev_proc_p->pointer.act_obj
 * @param indev pointer to an input device state
 */
-void indev_gesture(lv_indev_t * indev)
+static void indev_gesture(lv_indev_t * indev)
 {
     if(indev->pointer.scroll_obj) return;
     if(indev->pointer.gesture_sent) return;


### PR DESCRIPTION
Although this was already explained in #10289, it is not mandatory.
However, this change helps ensure code consistency.
Other functions in the vicinity are declared and defined with the `static` keyword.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

