### PR TITLE
fix(dave2d): disable the command buffer as a temporary fix to rendering issues

### DIFF
--- a/src/draw/renesas/dave2d/lv_draw_dave2d.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d.c
@@ -402,6 +402,8 @@ static int32_t lv_draw_dave2d_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * 
     void * buf = lv_draw_layer_alloc_buf(layer);
     if(buf == NULL) return LV_DRAW_UNIT_IDLE;
 
+    /*Disable the command buffer as a temporal fix to rendering issues. */
+#if 0
     deps = lv_draw_get_dependent_count(t);
     if(deps > 0 || draw_pressure > 0) {
         draw_pressure += deps;
@@ -429,7 +431,9 @@ static int32_t lv_draw_dave2d_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * 
          */
         return LV_DRAW_UNIT_IDLE;
     }
-    else {
+    else
+#endif
+    {
         /* Handles a special case when there is no sufficient draw pressure
          * But the actual task did not carry any extra pressure to get drew
          * in this case, the drawing pipeline have a few set of tasks that

--- a/src/draw/renesas/dave2d/lv_draw_dave2d.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d.c
@@ -402,7 +402,7 @@ static int32_t lv_draw_dave2d_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * 
     void * buf = lv_draw_layer_alloc_buf(layer);
     if(buf == NULL) return LV_DRAW_UNIT_IDLE;
 
-    /*Disable the command buffer as a temporal fix to rendering issues. */
+    /*Disable the command buffer as a temporary fix to rendering issues. */
 #if 0
     deps = lv_draw_get_dependent_count(t);
     if(deps > 0 || draw_pressure > 0) {


### PR DESCRIPTION
As the title says. It didn't cause any change in the benchmark results. 
 
### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
