### PR TITLE
fix(draw/nema_gfx): clip tasks by _real_area so transformed images are drawn

### DIFF
--- a/src/draw/nema_gfx/lv_draw_nema_gfx.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx.c
@@ -328,7 +328,9 @@ static void nema_gfx_execute_drawing(lv_draw_nema_gfx_unit_t * u)
     int32_t x;
     int32_t y;
 
-    if(!lv_area_intersect(&clipped_area,  &t->area, &t->clip_area)) {
+    /* Use _real_area (transformed bounding box), not area, so scaled/rotated
+     * images aren't skipped. _real_area == area for non-transformed tasks. */
+    if(!lv_area_intersect(&clipped_area, &t->_real_area, &t->clip_area)) {
         /* Nothing to do */
         return;
     }

--- a/src/draw/nema_gfx/lv_draw_nema_gfx.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx.c
@@ -328,8 +328,6 @@ static void nema_gfx_execute_drawing(lv_draw_nema_gfx_unit_t * u)
     int32_t x;
     int32_t y;
 
-    /* Use _real_area (transformed bounding box), not area, so scaled/rotated
-     * images aren't skipped. _real_area == area for non-transformed tasks. */
     if(!lv_area_intersect(&clipped_area, &t->_real_area, &t->clip_area)) {
         /* Nothing to do */
         return;


### PR DESCRIPTION
nema_gfx_execute_drawing() decided whether to run a draw task by intersecting t->area with the clip area. For scaled/rotated images t->area is the original, untransformed footprint, while the actual rendered region is the transformed bounding box stored in t->_real_area. When the refresh region overlapped only the transformed area and not the original footprint, the intersection was empty and the whole image draw was skipped, so scaled images disappeared (more easily at larger scale factors).

Use t->_real_area for the intersection. It holds the transformed bounding box and equals t->area for non-transformed tasks, so all task types keep working and the cache flush/invalidate region becomes correct as well.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

