### PR TITLE
feat(widgets): Modify lv_scale_set_line_needle_value for counter clockwise round scales

### DIFF
--- a/src/widgets/scale/lv_scale.c
+++ b/src/widgets/scale/lv_scale.c
@@ -309,14 +309,27 @@ void lv_scale_set_line_needle_value(lv_obj_t * obj, lv_obj_t * needle_line, int3
         actual_needle_length = scale_width / 2 + needle_length;
     }
 
-    if(value < scale->range_min) {
+    /* Changed to support scales which grow numerically counter clockwise (i.e. the min is greater than the max). */
+    bool inverse = (scale->range_min > scale->range_max) ? true : false;
+    if (inverse && (value > scale->range_min))
+    {
         angle = 0;
     }
-    else if(value > scale->range_max) {
+    else if (inverse && (value < scale->range_max))
+    {
         angle = scale->angle_range;
     }
-    else {
-        angle = scale->angle_range * (value - scale->range_min) / (scale->range_max - scale->range_min);
+    else if (!inverse && (value < scale->range_min))
+    {
+        angle = 0;
+    }
+    else if (!inverse && (value > scale->range_max))
+    {
+        angle = scale->angle_range;
+    }
+    else
+    {
+        angle = (int32_t)((int32_t)scale->angle_range * (value - scale->range_min)) / (scale->range_max - scale->range_min);
     }
 
     needle_length_x = (actual_needle_length * lv_trigo_cos(scale->rotation + angle)) >> LV_TRIGO_SHIFT;


### PR DESCRIPTION
A scale can be created to be counter clockwise by setting the min value greater than the max value but the needle line value could not be set. This allows the needle line value to be set when the scale min value is greater than the scale max value.


### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

