### PR TITLE
fix(demo): update Sales and Costs labels in scale1 animation callbacks

### DIFF
--- a/demos/widgets/lv_demo_widgets_analytics.c
+++ b/demos/widgets/lv_demo_widgets_analytics.c
@@ -24,6 +24,8 @@
  **********************/
 
 static void scale1_indic1_anim_cb(void * var, int32_t v);
+static void scale1_indic2_anim_cb(void * var, int32_t v);
+static void scale1_indic3_anim_cb(void * var, int32_t v);
 static void scale2_timer_cb(lv_timer_t * timer);
 static void scale3_anim_cb(void * var, int32_t v);
 static void scale3_size_changed_event_cb(lv_event_t * e);
@@ -174,7 +176,7 @@ void lv_demo_widgets_analytics_create(lv_obj_t * parent)
     lv_obj_remove_flag(arc, LV_OBJ_FLAG_CLICKABLE);
     lv_obj_center(arc);
 
-    lv_anim_set_exec_cb(&a, scale1_indic1_anim_cb);
+    lv_anim_set_exec_cb(&a, scale1_indic2_anim_cb);
     lv_anim_set_var(&a, arc);
     lv_anim_set_duration(&a, 2600);
     lv_anim_set_reverse_duration(&a, 3200);
@@ -190,7 +192,7 @@ void lv_demo_widgets_analytics_create(lv_obj_t * parent)
     lv_obj_remove_flag(arc, LV_OBJ_FLAG_CLICKABLE);
     lv_obj_center(arc);
 
-    lv_anim_set_exec_cb(&a, scale1_indic1_anim_cb);
+    lv_anim_set_exec_cb(&a, scale1_indic3_anim_cb);
     lv_anim_set_var(&a, arc);
     lv_anim_set_duration(&a, 2800);
     lv_anim_set_reverse_duration(&a, 1800);
@@ -355,6 +357,24 @@ static void scale1_indic1_anim_cb(void * var, int32_t v)
     lv_obj_t * card = lv_obj_get_parent(scale1);
     lv_obj_t * label = lv_obj_get_child(card, -5);
     lv_label_set_text_fmt(label, "Revenue: %"LV_PRId32" %%", v);
+}
+
+static void scale1_indic2_anim_cb(void * var, int32_t v)
+{
+    lv_arc_set_value(var, v);
+
+    lv_obj_t * card = lv_obj_get_parent(scale1);
+    lv_obj_t * label = lv_obj_get_child(card, -3);
+    lv_label_set_text_fmt(label, "Sales: %"LV_PRId32" %%", v);
+}
+
+static void scale1_indic3_anim_cb(void * var, int32_t v)
+{
+    lv_arc_set_value(var, v);
+
+    lv_obj_t * card = lv_obj_get_parent(scale1);
+    lv_obj_t * label = lv_obj_get_child(card, -1);
+    lv_label_set_text_fmt(label, "Costs: %"LV_PRId32" %%", v);
 }
 
 static void scale2_timer_cb(lv_timer_t * timer)


### PR DESCRIPTION
On the Analytics tab, the `scale1` card animates three arcs with Revenue, Sales, and Costs labels. All three arcs were wired to the same callback, `scale1_indic1_anim_cb`, which only updates the Revenue label — so Sales and Costs stayed frozen on their initial text while their arcs moved.

This adds `scale1_indic2_anim_cb` and `scale1_indic3_anim_cb` so each arc updates its own label. It's a pre-existing bug in the demo rather than a regression, and the change is confined to the demo — no library code is touched.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

