### PR TITLE
fix(nema_gfx): use float literal to avoid double-precision soft-float

### DIFF
--- a/src/draw/nema_gfx/lv_draw_nema_gfx_label.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_label.c
@@ -372,7 +372,7 @@ static void _draw_nema_gfx_letter(lv_draw_task_t * t, lv_draw_glyph_dsc_t * glyp
             if(is_raw_bitmap && (glyph_draw_dsc->format <= LV_FONT_GLYPH_FORMAT_A4)) {
                 nema_bind_src_tex((uintptr_t)(mask_buf), w * h, 1, src_cf, glyph_draw_dsc->g->stride, NEMA_FILTER_PS);
                 nema_matrix3x3_t m = {
-                    {1,    w,   -x - (y * w) - (0.5 * w)},
+                    {1,    w,   -x - (y * w) - (0.5f * w)},
                     {0,    1,                   0},
                     {0,    0,                   1}
                 };


### PR DESCRIPTION
The 3x3 matrix literal in the NemaGFX label draw used `0.5` (a `double`), which promotes the whole expression to double precision. On a Cortex-M33, whose FPU is single-precision only, that pulls in software double-emulation routines (`__adddf3`, `__aeabi_dmul`, etc.) on every glyph — even though `nema_matrix3x3_t` is `float[3][3]`, so the result is immediately truncated back to `float`. Changing the literal to `0.5f` keeps the expression in hardware float.

On an STM32U5G9J-DK2 (NemaGFX GPU2D, 800x480), this soft-float emulation was ~9% of total CPU in the "Screen sized text" benchmark scene, and the fix raised it from 38 to 42 fps.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

