### PR TITLE
perf(obj): skip subtree refresh for scrollbar-only state changes

### DIFF
--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -1187,7 +1187,8 @@ static void update_obj_state(lv_obj_t * obj, lv_state_t new_state)
 
     lv_state_t prev_state = obj->state;
 
-    lv_style_state_cmp_t cmp_res = lv_obj_style_state_compare(obj, prev_state, new_state);
+    lv_part_t changed_part = LV_PART_ANY;
+    lv_style_state_cmp_t cmp_res = lv_obj_style_state_compare(obj, prev_state, new_state, &changed_part);
     /*If there is no difference in styles there is nothing else to do*/
     if(cmp_res == LV_STYLE_STATE_CMP_SAME) {
         obj->state = new_state;
@@ -1257,7 +1258,14 @@ static void update_obj_state(lv_obj_t * obj, lv_state_t new_state)
 
     lv_free(ts);
 
-    if(cmp_res == LV_STYLE_STATE_CMP_DIFF_REDRAW) {
+    if(cmp_res == LV_STYLE_STATE_CMP_DIFF_REDRAW && changed_part == LV_PART_SCROLLBAR) {
+        /*A redraw-only change confined to the scrollbar: refresh just that part.
+         *lv_obj_refresh_style() skips the child-subtree refresh for
+         *LV_PART_SCROLLBAR, avoiding a full-subtree style cascade. This is safe
+         *because the scrollbar is drawn by lv_obj and has no styled children.*/
+        lv_obj_refresh_style(obj, LV_PART_SCROLLBAR, LV_STYLE_PROP_ANY);
+    }
+    else if(cmp_res == LV_STYLE_STATE_CMP_DIFF_REDRAW) {
         /*Invalidation is not enough, e.g. layer type needs to be updated too*/
         lv_obj_refresh_style(obj, LV_PART_ANY, LV_STYLE_PROP_ANY);
     }

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -511,11 +511,20 @@ lv_style_value_t lv_obj_style_apply_color_filter(const lv_obj_t * obj, lv_part_t
     return v;
 }
 
-lv_style_state_cmp_t lv_obj_style_state_compare(lv_obj_t * obj, lv_state_t state1, lv_state_t state2)
+lv_style_state_cmp_t lv_obj_style_state_compare(lv_obj_t * obj, lv_state_t state1, lv_state_t state2,
+                                                lv_part_t * changed_part)
 {
     LV_CHECK_ARG(obj != NULL, return LV_STYLE_STATE_CMP_SAME);
 
     lv_style_state_cmp_t res = LV_STYLE_STATE_CMP_SAME;
+
+    /*Accumulate which part the differing styles belong to: the lone differing
+     *part, or LV_PART_ANY once styles from more than one part differ. Reported
+     *via changed_part so the caller can scope the refresh to a single part.
+     *diff_part_found is needed as a separate flag because a style's part can
+     *itself be LV_PART_ANY, so LV_PART_ANY can't double as "none seen yet".*/
+    lv_part_t diff_part = LV_PART_ANY;
+    bool diff_part_found = false;
 
     /*Are there any new styles for the new state?*/
     uint32_t i;
@@ -527,6 +536,17 @@ lv_style_state_cmp_t lv_obj_style_state_compare(lv_obj_t * obj, lv_state_t state
         bool valid1 = state_act & (~state1) ? false : true;
         bool valid2 = state_act & (~state2) ? false : true;
         if(valid1 != valid2) {
+            /*Record this differing style's part: keep it if it's the only one
+             *seen so far, otherwise collapse to LV_PART_ANY (more than one part).*/
+            lv_part_t part_act = lv_obj_style_get_selector_part(obj->styles[i].selector);
+            if(!diff_part_found) {
+                diff_part = part_act;
+                diff_part_found = true;
+            }
+            else if(part_act != diff_part) {
+                diff_part = LV_PART_ANY;
+            }
+
             const lv_style_t * style = obj->styles[i].style;
             lv_style_value_t v;
             /*If there is layout difference on the main part, return immediately. There is no more serious difference*/
@@ -549,6 +569,9 @@ lv_style_state_cmp_t lv_obj_style_state_compare(lv_obj_t * obj, lv_state_t state
             else if(lv_style_get_prop(style, LV_STYLE_BORDER_WIDTH, &v)) layout_diff = true;
 
             if(layout_diff) {
+                /*Returning early, so the full set of changed parts is unknown:
+                 *report LV_PART_ANY rather than a possibly-incomplete part.*/
+                if(changed_part) *changed_part = LV_PART_ANY;
                 return LV_STYLE_STATE_CMP_DIFF_LAYOUT;
             }
 
@@ -571,6 +594,7 @@ lv_style_state_cmp_t lv_obj_style_state_compare(lv_obj_t * obj, lv_state_t state
         }
     }
 
+    if(changed_part) *changed_part = diff_part;
     return res;
 }
 

--- a/src/core/lv_obj_style_private.h
+++ b/src/core/lv_obj_style_private.h
@@ -75,9 +75,14 @@ void lv_obj_style_create_transition(lv_obj_t * obj, lv_part_t part, lv_state_t p
  * @param obj
  * @param state1
  * @param state2
+ * @param changed_part  optional (may be NULL) out-param. Receives the part that
+ *                      the differing styles belong to, or `LV_PART_ANY` if more
+ *                      than one part differs (or none does). Lets the caller scope
+ *                      the refresh to a single part when possible.
  * @return
  */
-lv_style_state_cmp_t lv_obj_style_state_compare(lv_obj_t * obj, lv_state_t state1, lv_state_t state2);
+lv_style_state_cmp_t lv_obj_style_state_compare(lv_obj_t * obj, lv_state_t state1, lv_state_t state2,
+                                                lv_part_t * changed_part);
 
 /**
  * Update the layer type of a widget bayed on its current styles.

--- a/tests/src/test_cases/test_obj_style_state_refresh.c
+++ b/tests/src/test_cases/test_obj_style_state_refresh.c
@@ -1,0 +1,137 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+#include "../../lvgl_private.h"
+
+#include "unity/unity.h"
+
+/* Tests that a scrollbar-only redraw-only state change does not refresh the child subtree. */
+
+static uint32_t child_style_changed_count;
+
+static void count_style_changed_cb(lv_event_t * e)
+{
+    if(lv_event_get_code(e) == LV_EVENT_STYLE_CHANGED) child_style_changed_count++;
+}
+
+void setUp(void)
+{
+    child_style_changed_count = 0;
+}
+
+void tearDown(void)
+{
+    lv_obj_clean(lv_screen_active());
+}
+
+/* Build a 2-level subtree with a `LV_EVENT_STYLE_CHANGED` counter on every
+ * descendant (not on `parent`, which gets its own event on a state change).
+ * Render it once: state changes only refresh already-rendered objects, so
+ * without a render the toggles below would be skipped and the tests would pass
+ * for the wrong reason. */
+static lv_obj_t * build_rendered_subtree(void)
+{
+    lv_obj_t * parent = lv_obj_create(lv_screen_active());
+    lv_obj_set_size(parent, 200, 200);
+
+    for(uint32_t i = 0; i < 3; i++) {
+        lv_obj_t * child = lv_obj_create(parent);
+        lv_obj_add_event_cb(child, count_style_changed_cb, LV_EVENT_STYLE_CHANGED, NULL);
+        for(uint32_t j = 0; j < 2; j++) {
+            lv_obj_t * grandchild = lv_obj_create(child);
+            lv_obj_add_event_cb(grandchild, count_style_changed_cb, LV_EVENT_STYLE_CHANGED, NULL);
+        }
+    }
+
+    lv_refr_now(NULL);
+    return parent;
+}
+
+/* A redraw-only, scrollbar-only state change must not reach any descendant. */
+void test_scrollbar_redraw_state_does_not_cascade_to_children(void)
+{
+    lv_obj_t * parent = build_rendered_subtree();
+
+    lv_style_t scrollbar_scrolled;
+    lv_style_init(&scrollbar_scrolled);
+    lv_style_set_bg_opa(&scrollbar_scrolled, LV_OPA_COVER); /* redraw-only property */
+    lv_obj_add_style(parent, &scrollbar_scrolled, LV_PART_SCROLLBAR | LV_STATE_SCROLLED);
+
+    /* Reset after the subtree setup (which emits its own STYLE_CHANGED events)
+     * so the count reflects only the state change below. */
+    child_style_changed_count = 0;
+    lv_obj_add_state(parent, LV_STATE_SCROLLED);
+    lv_obj_remove_state(parent, LV_STATE_SCROLLED);
+
+    TEST_ASSERT_EQUAL(0, child_style_changed_count);
+
+    lv_obj_remove_style(parent, &scrollbar_scrolled, LV_PART_SCROLLBAR | LV_STATE_SCROLLED);
+    lv_style_reset(&scrollbar_scrolled);
+}
+
+/* A main-part state change must still cascade into the subtree. */
+void test_main_part_state_still_cascades_to_children(void)
+{
+    lv_obj_t * parent = build_rendered_subtree();
+
+    lv_style_t main_user_1;
+    lv_style_init(&main_user_1);
+    lv_style_set_pad_all(&main_user_1, 20);
+    lv_obj_add_style(parent, &main_user_1, LV_PART_MAIN | LV_STATE_USER_1);
+
+    child_style_changed_count = 0;
+    lv_obj_add_state(parent, LV_STATE_USER_1);
+
+    TEST_ASSERT_GREATER_THAN(0, child_style_changed_count);
+
+    lv_obj_remove_style(parent, &main_user_1, LV_PART_MAIN | LV_STATE_USER_1);
+    lv_style_reset(&main_user_1);
+}
+
+/* A layout-affecting scrollbar change must not take the redraw fast path: it
+ * classifies as a layout difference and still cascades via the full refresh. */
+void test_scrollbar_layout_state_still_cascades_to_children(void)
+{
+    lv_obj_t * parent = build_rendered_subtree();
+
+    lv_style_t scrollbar_layout;
+    lv_style_init(&scrollbar_layout);
+    lv_style_set_width(&scrollbar_layout, 30); /* layout-affecting property */
+    lv_obj_add_style(parent, &scrollbar_layout, LV_PART_SCROLLBAR | LV_STATE_USER_1);
+
+    child_style_changed_count = 0;
+    lv_obj_add_state(parent, LV_STATE_USER_1);
+
+    TEST_ASSERT_GREATER_THAN(0, child_style_changed_count);
+
+    lv_obj_remove_style(parent, &scrollbar_layout, LV_PART_SCROLLBAR | LV_STATE_USER_1);
+    lv_style_reset(&scrollbar_layout);
+}
+
+/* A redraw-only change spanning more than one part is reported as LV_PART_ANY,
+ * so it must not take the scrollbar fast path and still cascades. */
+void test_multi_part_redraw_state_cascades_to_children(void)
+{
+    lv_obj_t * parent = build_rendered_subtree();
+
+    lv_style_t main_redraw;
+    lv_style_init(&main_redraw);
+    lv_style_set_bg_color(&main_redraw, lv_color_hex(0x123456));
+    lv_obj_add_style(parent, &main_redraw, LV_PART_MAIN | LV_STATE_USER_1);
+
+    lv_style_t scrollbar_redraw;
+    lv_style_init(&scrollbar_redraw);
+    lv_style_set_bg_opa(&scrollbar_redraw, LV_OPA_COVER);
+    lv_obj_add_style(parent, &scrollbar_redraw, LV_PART_SCROLLBAR | LV_STATE_USER_1);
+
+    child_style_changed_count = 0;
+    lv_obj_add_state(parent, LV_STATE_USER_1);
+
+    TEST_ASSERT_GREATER_THAN(0, child_style_changed_count);
+
+    lv_obj_remove_style(parent, &main_redraw, LV_PART_MAIN | LV_STATE_USER_1);
+    lv_obj_remove_style(parent, &scrollbar_redraw, LV_PART_SCROLLBAR | LV_STATE_USER_1);
+    lv_style_reset(&main_redraw);
+    lv_style_reset(&scrollbar_redraw);
+}
+
+#endif


### PR DESCRIPTION
When an object's state changes, `update_obj_state()` refreshes its styling with `lv_obj_refresh_style(LV_PART_ANY, LV_STYLE_PROP_ANY)`. For `LV_PART_ANY`, that re-styles the whole child subtree, sending `LV_EVENT_STYLE_CHANGED` to every descendant — even when the only thing that differs between the two states is the scrollbar.

`lv_obj_style_state_compare()` already classified the *kind* of difference (redraw / draw-pad / layout) but discarded *which part* it was on. With this PR, it also reports the changed part: the single part the differing styles belong to, or `LV_PART_ANY` if more than one part differs. When the difference is redraw-only and confined to the scrollbar, `update_obj_state()` refreshes just `LV_PART_SCROLLBAR` and skips the cascade. Everything else — other parts, multi-part changes, and any layout-affecting change — keeps the existing `LV_PART_ANY` refresh unchanged.

**Measured on an STM32U5G9J-DK2 (800x480), the "Widgets demo" benchmark scene went from 21 to 42 fps** with the NemaGFX GPU draw unit (direct-mode double buffering). With the software draw unit it went from 18 to 31 fps in direct mode and from 11 to 14 fps in partial-buffer mode. This scene drives its scrolling containers by continuously updating the scroll position every frame, which re-fires the scroll start/stop transitions — and therefore the `LV_STATE_SCROLLED` toggle — on every frame. It's a degenerate case, but a realistic one for driving scroll position in-app.

Tests cover the scoping in both directions: a scrollbar redraw-only change does not send `LV_EVENT_STYLE_CHANGED` into the subtree, while a main-part change, a layout-affecting scrollbar change, and a redraw change spanning multiple parts all still cascade.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

