### PR TITLE
perf(refr): defer blur invalidation expansion to once per frame

### DIFF
--- a/src/core/lv_global.h
+++ b/src/core/lv_global.h
@@ -80,6 +80,9 @@ typedef struct _lv_global_t {
 
     lv_ll_t style_trans_ll;
     bool style_refresh;
+    /** Number of widgets that currently have blur or a drop shadow (see
+     * lv_obj_t::has_blur). If it is zero lv_obj_invalidate_expand_blur() is skipped. */
+    uint32_t blur_obj_cnt;
     uint32_t style_custom_table_size;
     uint32_t style_last_custom_prop_id;
     uint8_t * style_custom_prop_flag_lookup_table;

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -2015,6 +2015,7 @@ static void update_obj_state(lv_obj_t * obj, lv_state_t new_state)
 
     obj->state = new_state;
     lv_obj_update_layer_type(obj);
+    lv_obj_update_blur_status(obj);
 
     /*Skip transitions if the widget is not rendered yet. */
     if(!obj->rendered) {

--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -36,8 +36,7 @@ static void layout_update_core(lv_obj_t * obj);
 static void transform_point_array(const lv_obj_t * obj, lv_point_t * p, size_t p_count, bool inv);
 static bool is_transformed(const lv_obj_t * obj);
 static lv_result_t invalidate_area_core(const lv_obj_t * obj, lv_area_t * area_tmp);
-static lv_result_t obj_invalidate_area_internal(const lv_display_t * disp, const lv_obj_t * obj,
-                                                const lv_area_t * area);
+static lv_result_t obj_invalidate_area_internal(const lv_obj_t * obj, const lv_area_t * area);
 static bool has_blur(const lv_obj_t * obj);
 static int32_t calc_dynamic_width(lv_obj_t * obj, lv_style_prop_t prop, int32_t * content_width);
 static int32_t calc_dynamic_height(lv_obj_t * obj, lv_style_prop_t prop, int32_t * content_height);
@@ -1015,18 +1014,20 @@ void lv_obj_get_transformed_area(const lv_obj_t * obj, lv_area_t * area, lv_obj_
     area->y2 = LV_MAX4(p[0].y, p[1].y, p[2].y, p[3].y);
 }
 
-typedef struct {
-    const lv_obj_t * requester_obj;
-    const lv_area_t * inv_area;
-} blur_walk_data_t;
+/*
+ * Deferred blur invalidation expansion. A blur object samples the pixels
+ * behind it, so when anything behind it changes the blur object must be
+ * redrawn too. Once per frame, after all invalidations are collected, walk
+ * the tree and add the full extent of any blur object overlapping a dirty
+ * area. The walk repeats until a pass adds no new areas, which catches
+ * transitive cases (a blur object overlapping another blur object that
+ * overlaps a dirty area).
+ */
 
-static lv_obj_tree_walk_res_t blur_walk_cb(lv_obj_t * obj, void * user_data)
+static lv_obj_tree_walk_res_t blur_expand_walk_cb(lv_obj_t * obj, void * user_data)
 {
-    blur_walk_data_t * blur_data = user_data;
-    /*The requester obj was checked already*/
-    if(blur_data->requester_obj == obj) return LV_OBJ_TREE_WALK_SKIP_CHILDREN;
+    if(!has_blur(obj)) return LV_OBJ_TREE_WALK_NEXT;
 
-    /*Truncate the area to the object*/
     lv_area_t obj_coords;
     int32_t ext_size = lv_obj_get_ext_draw_size(obj);
     lv_area_copy(&obj_coords, &obj->coords);
@@ -1036,32 +1037,43 @@ static lv_obj_tree_walk_res_t blur_walk_cb(lv_obj_t * obj, void * user_data)
         lv_obj_get_transformed_area(obj, &obj_coords, LV_OBJ_POINT_TRANSFORM_FLAG_RECURSIVE);
     }
 
-    /*If the widget has blur set, invalidate it*/
-    if(lv_area_is_on(blur_data->inv_area, &obj_coords)) {
-        if(has_blur(obj)) {
-            ext_size = lv_obj_get_ext_draw_size(obj);
-            lv_area_copy(&obj_coords, &obj->coords);
-            obj_coords.x1 -= ext_size;
-            obj_coords.y1 -= ext_size;
-            obj_coords.x2 += ext_size;
-            obj_coords.y2 += ext_size;
-
+    lv_display_t * disp = user_data;
+    uint32_t i;
+    for(i = 0; i < disp->inv_p; i++) {
+        /*Join state is always zero here (the join pass runs after this), but
+         *guard anyway to match the other inv_areas consumers in lv_refr.c.*/
+        if(disp->inv_area_joined[i]) continue;
+        if(lv_area_is_on(&disp->inv_areas[i], &obj_coords)) {
             invalidate_area_core(obj, &obj_coords);
 
             /*No need to check the children as the widget is already invalidated
              *which will redraw the children too*/
             return LV_OBJ_TREE_WALK_SKIP_CHILDREN;
         }
-        else {
-            /*Check the next child, maybe it's blurred*/
-            return LV_OBJ_TREE_WALK_NEXT;
-        }
-    }
-    else {
-        /*Not on the area of interest, skip it*/
-        return LV_OBJ_TREE_WALK_SKIP_CHILDREN;
     }
 
+    return LV_OBJ_TREE_WALK_NEXT;
+}
+
+void lv_obj_invalidate_expand_blur(lv_display_t * disp)
+{
+    if(disp->inv_p == 0) return;
+
+    uint32_t prev_inv_p;
+    do {
+        prev_inv_p = disp->inv_p;
+
+        lv_obj_tree_walk(disp->act_scr, blur_expand_walk_cb, disp);
+        if(disp->prev_scr) lv_obj_tree_walk(disp->prev_scr, blur_expand_walk_cb, disp);
+        lv_obj_tree_walk(disp->sys_layer, blur_expand_walk_cb, disp);
+        lv_obj_tree_walk(disp->top_layer, blur_expand_walk_cb, disp);
+        lv_obj_tree_walk(disp->bottom_layer, blur_expand_walk_cb, disp);
+
+        /*Repeat while new areas keep being added. An overflow in lv_inv_area()
+         *can instead shrink inv_p (it collapses to a single whole-screen area);
+         *the loop then exits, which is correct -- the whole screen is a superset
+         *that covers every blur object.*/
+    } while(disp->inv_p > prev_inv_p);
 }
 
 lv_result_t lv_obj_invalidate_area(const lv_obj_t * obj, const lv_area_t * area)
@@ -1075,7 +1087,7 @@ lv_result_t lv_obj_invalidate_area(const lv_obj_t * obj, const lv_area_t * area)
     /*If there are blurred or drop-shadow parts the whole widget needs to be invalidated
      *as these can't be calculated partially. */
     if(has_blur(obj)) return lv_obj_invalidate(obj);
-    else return obj_invalidate_area_internal(disp, obj, area);
+    else return obj_invalidate_area_internal(obj, area);
 }
 
 
@@ -1095,7 +1107,7 @@ lv_result_t lv_obj_invalidate(const lv_obj_t * obj)
     obj_coords.x2 += ext_size;
     obj_coords.y2 += ext_size;
 
-    lv_result_t res = obj_invalidate_area_internal(disp, obj, &obj_coords);
+    lv_result_t res = obj_invalidate_area_internal(obj, &obj_coords);
 
     return res;
 }
@@ -1321,30 +1333,15 @@ const lv_matrix_t * lv_obj_get_transform(const lv_obj_t * obj)
  *   STATIC FUNCTIONS
  **********************/
 
-static lv_result_t obj_invalidate_area_internal(const lv_display_t * disp, const lv_obj_t * obj,
-                                                const lv_area_t * area)
+static lv_result_t obj_invalidate_area_internal(const lv_obj_t * obj, const lv_area_t * area)
 {
-    LV_ASSERT_NULL(disp);
     LV_ASSERT_NULL(obj);
     LV_ASSERT_NULL(area);
 
     lv_area_t area_tmp;
     lv_area_copy(&area_tmp, area);
 
-    lv_result_t res = invalidate_area_core(obj, &area_tmp);
-    if(res == LV_RESULT_INVALID) return res;
-
-    /*If this area is on a blurred widget, invalidate that widget too*/
-    blur_walk_data_t blur_walk_data;
-    blur_walk_data.requester_obj = obj;
-    blur_walk_data.inv_area = &area_tmp;
-    lv_obj_tree_walk(disp->act_scr, blur_walk_cb, &blur_walk_data);
-    if(disp->prev_scr) lv_obj_tree_walk(disp->prev_scr, blur_walk_cb, &blur_walk_data);
-    lv_obj_tree_walk(disp->sys_layer, blur_walk_cb, &blur_walk_data);
-    lv_obj_tree_walk(disp->top_layer, blur_walk_cb, &blur_walk_data);
-    lv_obj_tree_walk(disp->bottom_layer, blur_walk_cb, &blur_walk_data);
-
-    return res;
+    return invalidate_area_core(obj, &area_tmp);
 }
 
 static bool is_transformed(const lv_obj_t * obj)

--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -48,7 +48,6 @@ static void transform_point_array(const lv_obj_t * obj, lv_point_t * p, size_t p
 static bool is_transformed(const lv_obj_t * obj);
 static lv_result_t invalidate_area_core(const lv_obj_t * obj, lv_area_t * area_tmp);
 static lv_result_t obj_invalidate_area_internal(const lv_obj_t * obj, const lv_area_t * area);
-static bool has_blur(const lv_obj_t * obj);
 static int32_t calc_dynamic_width(lv_obj_t * obj, lv_style_prop_t prop, int32_t * content_width);
 static int32_t calc_dynamic_height(lv_obj_t * obj, lv_style_prop_t prop, int32_t * content_height);
 static bool size_in_effect_is_pct(int32_t unclamped, int32_t min, int32_t max, int32_t size_style,
@@ -1035,11 +1034,16 @@ void lv_obj_get_transformed_area(const lv_obj_t * obj, lv_area_t * area, lv_obj_
  * invalidated area. The walk repeats until a pass adds no new areas, which
  * catches transitive cases (a blur object overlapping another blur object
  * that overlaps an invalidated area).
+ *
+ * Each widget's blur status is cached in obj->has_blur and counted globally in
+ * blur_obj_cnt (see lv_obj_update_blur_status()), so the walk is skipped
+ * entirely while no widget has blur and costs one bit test per widget when it
+ * does run.
  */
 
 static lv_obj_tree_walk_res_t blur_expand_walk_cb(lv_obj_t * obj, void * user_data)
 {
-    if(!has_blur(obj)) return LV_OBJ_TREE_WALK_NEXT;
+    if(!obj->has_blur) return LV_OBJ_TREE_WALK_NEXT;
 
     /*invalidate_area_core() expects untransformed coordinates and applies the
      *transform itself*/
@@ -1077,6 +1081,9 @@ void lv_obj_invalidate_expand_blur(lv_display_t * disp)
 {
     if(disp->inv_p == 0) return;
 
+    /*There is nothing to expand if no widget has blur or drop shadow*/
+    if(LV_GLOBAL_DEFAULT()->blur_obj_cnt == 0) return;
+
     uint32_t prev_inv_p;
     do {
         prev_inv_p = disp->inv_p;
@@ -1104,7 +1111,7 @@ lv_result_t lv_obj_invalidate_area(const lv_obj_t * obj, const lv_area_t * area)
 
     /*If there are blurred or drop-shadow parts the whole widget needs to be invalidated
      *as these can't be calculated partially. */
-    if(has_blur(obj)) return lv_obj_invalidate(obj);
+    if(obj->has_blur) return lv_obj_invalidate(obj);
     else return obj_invalidate_area_internal(obj, area);
 }
 
@@ -1651,34 +1658,6 @@ static lv_result_t invalidate_area_core(const lv_obj_t * obj, lv_area_t * area_t
 
     lv_result_t res = lv_inv_area(lv_obj_get_display(obj), area_tmp);
     return res;
-}
-
-static bool has_blur(const lv_obj_t * obj)
-{
-    const uint32_t group_blur = (uint32_t)1 << lv_style_get_prop_group(LV_STYLE_BLUR_RADIUS);
-    const uint32_t group_dropshadow = (uint32_t)1 << lv_style_get_prop_group(LV_STYLE_DROP_SHADOW_OPA);
-    const lv_state_t state = lv_obj_style_get_selector_state(lv_obj_get_state(obj));
-    const lv_state_t state_inv = ~state;
-    lv_style_value_t v;
-    uint32_t i;
-    for(i = 0; i < obj->style_cnt; i++) {
-        lv_obj_style_t * obj_style = &obj->styles[i];
-        if(obj_style->is_disabled) continue;
-
-        lv_state_t state_style = lv_obj_style_get_selector_state(obj->styles[i].selector);
-        if((state_style & state_inv)) continue;
-
-        if((obj_style->style->has_group & group_blur) &&
-           lv_style_get_prop_internal(obj_style->style, LV_STYLE_BLUR_RADIUS, &v)) {
-            if(v.num > 0) return true;
-        }
-        if((obj_style->style->has_group & group_dropshadow) &&
-           lv_style_get_prop_internal(obj_style->style, LV_STYLE_DROP_SHADOW_OPA, &v)) {
-            if(v.num > 0) return true;
-        }
-    }
-
-    return false;
 }
 
 /**

--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -47,8 +47,7 @@ static void layout_update_core(lv_obj_t * obj);
 static void transform_point_array(const lv_obj_t * obj, lv_point_t * p, size_t p_count, bool inv);
 static bool is_transformed(const lv_obj_t * obj);
 static lv_result_t invalidate_area_core(const lv_obj_t * obj, lv_area_t * area_tmp);
-static lv_result_t obj_invalidate_area_internal(const lv_display_t * disp, const lv_obj_t * obj,
-                                                const lv_area_t * area);
+static lv_result_t obj_invalidate_area_internal(const lv_obj_t * obj, const lv_area_t * area);
 static bool has_blur(const lv_obj_t * obj);
 static int32_t calc_dynamic_width(lv_obj_t * obj, lv_style_prop_t prop, int32_t * content_width);
 static int32_t calc_dynamic_height(lv_obj_t * obj, lv_style_prop_t prop, int32_t * content_height);
@@ -1028,53 +1027,71 @@ void lv_obj_get_transformed_area(const lv_obj_t * obj, lv_area_t * area, lv_obj_
     area->y2 = LV_MAX4(p[0].y, p[1].y, p[2].y, p[3].y);
 }
 
-typedef struct {
-    const lv_obj_t * requester_obj;
-    const lv_area_t * inv_area;
-} blur_walk_data_t;
+/*
+ * Deferred blur invalidation expansion. A blur object samples the pixels
+ * behind it, so when anything behind it changes the blur object must be
+ * redrawn too. Once per frame, after all invalidations are collected, walk
+ * the tree and add the full extent of any blur object overlapping an
+ * invalidated area. The walk repeats until a pass adds no new areas, which
+ * catches transitive cases (a blur object overlapping another blur object
+ * that overlaps an invalidated area).
+ */
 
-static lv_obj_tree_walk_res_t blur_walk_cb(lv_obj_t * obj, void * user_data)
+static lv_obj_tree_walk_res_t blur_expand_walk_cb(lv_obj_t * obj, void * user_data)
 {
-    blur_walk_data_t * blur_data = user_data;
-    /*The requester obj was checked already*/
-    if(blur_data->requester_obj == obj) return LV_OBJ_TREE_WALK_SKIP_CHILDREN;
+    if(!has_blur(obj)) return LV_OBJ_TREE_WALK_NEXT;
 
-    /*Truncate the area to the object*/
+    /*invalidate_area_core() expects untransformed coordinates and applies the
+     *transform itself*/
     lv_area_t obj_coords;
     int32_t ext_size = lv_obj_get_ext_draw_size(obj);
     obj_coords = obj->coords;
     lv_area_increase(&obj_coords, ext_size, ext_size);
 
+    /*The invalidated areas are in screen coordinates so check the overlap
+     *against the transformed area*/
+    lv_area_t scr_coords;
+    scr_coords = obj_coords;
     if(is_transformed(obj)) {
-        lv_obj_get_transformed_area(obj, &obj_coords, LV_OBJ_POINT_TRANSFORM_FLAG_RECURSIVE);
+        lv_obj_get_transformed_area(obj, &scr_coords, LV_OBJ_POINT_TRANSFORM_FLAG_RECURSIVE);
     }
 
-    /*If the widget has blur set, invalidate it*/
-    if(lv_area_is_on(blur_data->inv_area, &obj_coords)) {
-        if(has_blur(obj)) {
-            ext_size = lv_obj_get_ext_draw_size(obj);
-            obj_coords = obj->coords;
-            obj_coords.x1 -= ext_size;
-            obj_coords.y1 -= ext_size;
-            obj_coords.x2 += ext_size;
-            obj_coords.y2 += ext_size;
-
+    lv_display_t * disp = user_data;
+    uint32_t i;
+    for(i = 0; i < disp->inv_p; i++) {
+        /*The join pass runs after this and its state is reset each frame*/
+        LV_ASSERT(!disp->inv_area_joined[i]);
+        if(lv_area_is_on(&disp->inv_areas[i], &scr_coords)) {
             invalidate_area_core(obj, &obj_coords);
 
             /*No need to check the children as the widget is already invalidated
              *which will redraw the children too*/
             return LV_OBJ_TREE_WALK_SKIP_CHILDREN;
         }
-        else {
-            /*Check the next child, maybe it's blurred*/
-            return LV_OBJ_TREE_WALK_NEXT;
-        }
-    }
-    else {
-        /*Not on the area of interest, skip it*/
-        return LV_OBJ_TREE_WALK_SKIP_CHILDREN;
     }
 
+    return LV_OBJ_TREE_WALK_NEXT;
+}
+
+void lv_obj_invalidate_expand_blur(lv_display_t * disp)
+{
+    if(disp->inv_p == 0) return;
+
+    uint32_t prev_inv_p;
+    do {
+        prev_inv_p = disp->inv_p;
+
+        lv_obj_tree_walk(disp->act_scr, blur_expand_walk_cb, disp);
+        if(disp->prev_scr) lv_obj_tree_walk(disp->prev_scr, blur_expand_walk_cb, disp);
+        lv_obj_tree_walk(disp->sys_layer, blur_expand_walk_cb, disp);
+        lv_obj_tree_walk(disp->top_layer, blur_expand_walk_cb, disp);
+        lv_obj_tree_walk(disp->bottom_layer, blur_expand_walk_cb, disp);
+
+        /*Repeat while new areas keep being added. An overflow in lv_inv_area()
+         *can instead shrink inv_p (it collapses to a single whole-screen area)
+         *and the loop exits, which is correct because the whole screen covers
+         *every blur object.*/
+    } while(disp->inv_p > prev_inv_p);
 }
 
 lv_result_t lv_obj_invalidate_area(const lv_obj_t * obj, const lv_area_t * area)
@@ -1088,7 +1105,7 @@ lv_result_t lv_obj_invalidate_area(const lv_obj_t * obj, const lv_area_t * area)
     /*If there are blurred or drop-shadow parts the whole widget needs to be invalidated
      *as these can't be calculated partially. */
     if(has_blur(obj)) return lv_obj_invalidate(obj);
-    else return obj_invalidate_area_internal(disp, obj, area);
+    else return obj_invalidate_area_internal(obj, area);
 }
 
 
@@ -1108,7 +1125,7 @@ lv_result_t lv_obj_invalidate(const lv_obj_t * obj)
     obj_coords.x2 += ext_size;
     obj_coords.y2 += ext_size;
 
-    lv_result_t res = obj_invalidate_area_internal(disp, obj, &obj_coords);
+    lv_result_t res = obj_invalidate_area_internal(obj, &obj_coords);
 
     return res;
 }
@@ -1334,30 +1351,15 @@ const lv_matrix_t * lv_obj_get_transform(const lv_obj_t * obj)
  *   STATIC FUNCTIONS
  **********************/
 
-static lv_result_t obj_invalidate_area_internal(const lv_display_t * disp, const lv_obj_t * obj,
-                                                const lv_area_t * area)
+static lv_result_t obj_invalidate_area_internal(const lv_obj_t * obj, const lv_area_t * area)
 {
-    LV_ASSERT_NULL(disp);
     LV_ASSERT_NULL(obj);
     LV_ASSERT_NULL(area);
 
     lv_area_t area_tmp;
     area_tmp = *area;
 
-    lv_result_t res = invalidate_area_core(obj, &area_tmp);
-    if(res == LV_RESULT_INVALID) return res;
-
-    /*If this area is on a blurred widget, invalidate that widget too*/
-    blur_walk_data_t blur_walk_data;
-    blur_walk_data.requester_obj = obj;
-    blur_walk_data.inv_area = &area_tmp;
-    lv_obj_tree_walk(disp->act_scr, blur_walk_cb, &blur_walk_data);
-    if(disp->prev_scr) lv_obj_tree_walk(disp->prev_scr, blur_walk_cb, &blur_walk_data);
-    lv_obj_tree_walk(disp->sys_layer, blur_walk_cb, &blur_walk_data);
-    lv_obj_tree_walk(disp->top_layer, blur_walk_cb, &blur_walk_data);
-    lv_obj_tree_walk(disp->bottom_layer, blur_walk_cb, &blur_walk_data);
-
-    return res;
+    return invalidate_area_core(obj, &area_tmp);
 }
 
 static bool is_transformed(const lv_obj_t * obj)

--- a/src/core/lv_obj_private.h
+++ b/src/core/lv_obj_private.h
@@ -104,6 +104,15 @@ lv_obj_spec_attr_t * lv_obj_allocate_spec_attr(lv_obj_t * obj);
 lv_result_t lv_obj_add_child(lv_obj_t * parent, lv_obj_t * child);
 void lv_obj_remove_child(lv_obj_t * parent, lv_obj_t * child);
 
+/**
+ * Expand the display's invalidated areas to cover blur objects whose background
+ * changed. Run once per frame: for each blur object that overlaps an
+ * already-invalidated area, invalidates the object's full extent, repeating the
+ * walk until a pass adds no new areas (to cover transitive blur-over-blur cases).
+ * @param disp  pointer to a display
+ */
+void lv_obj_invalidate_expand_blur(lv_display_t * disp);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/core/lv_obj_private.h
+++ b/src/core/lv_obj_private.h
@@ -159,6 +159,11 @@ struct _lv_obj_t {
     /** The widget is rendered at least once already.
      * It's used to skip initial animations and transitions. */
     uint16_t rendered : 1;
+
+    /** The widget has blur or a drop shadow in its current state, so a change
+     * behind it must invalidate its full extent. It's updated by
+     * lv_obj_update_blur_status() and counted in blur_obj_cnt in lv_global_t. */
+    uint16_t has_blur : 1;
 };
 
 /**********************
@@ -180,6 +185,7 @@ void lv_obj_remove_child(lv_obj_t * parent, lv_obj_t * child);
  * changed. It's called once per frame and invalidates the full extent of every
  * blur object that overlaps an invalidated area, repeating the walk until a
  * pass adds no new areas to cover transitive blur-over-blur cases.
+ * Does nothing while no widget has blur (blur_obj_cnt in lv_global_t is zero).
  * @param disp  pointer to a display
  */
 void lv_obj_invalidate_expand_blur(lv_display_t * disp);

--- a/src/core/lv_obj_private.h
+++ b/src/core/lv_obj_private.h
@@ -175,6 +175,15 @@ lv_obj_spec_attr_t * lv_obj_allocate_spec_attr(lv_obj_t * obj);
 lv_result_t lv_obj_add_child(lv_obj_t * parent, lv_obj_t * child);
 void lv_obj_remove_child(lv_obj_t * parent, lv_obj_t * child);
 
+/**
+ * Expand the display's invalidated areas to cover blur objects whose background
+ * changed. It's called once per frame and invalidates the full extent of every
+ * blur object that overlaps an invalidated area, repeating the walk until a
+ * pass adds no new areas to cover transitive blur-over-blur cases.
+ * @param disp  pointer to a display
+ */
+void lv_obj_invalidate_expand_blur(lv_display_t * disp);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -68,6 +68,7 @@ static void trans_anim_cb(void * _tr, int32_t v);
 static void trans_anim_start_cb(lv_anim_t * a);
 static void trans_anim_completed_cb(lv_anim_t * a);
 static lv_layer_type_t calculate_layer_type(lv_obj_t * obj);
+static bool calculate_has_blur(lv_obj_t * obj);
 static void full_cache_refresh(lv_obj_t * obj, lv_part_t part);
 static void fade_anim_cb(void * obj, int32_t v);
 static void fade_in_anim_completed(lv_anim_t * a);
@@ -281,6 +282,11 @@ void lv_obj_refresh_style(lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop)
     /*Cache the layer type*/
     if((part == LV_PART_ANY || part == LV_PART_MAIN) && is_layer_refr) {
         lv_obj_update_layer_type(obj);
+    }
+
+    /*Cache whether the widget has blur or drop shadow*/
+    if(prop == LV_STYLE_PROP_ANY || prop == LV_STYLE_BLUR_RADIUS || prop == LV_STYLE_DROP_SHADOW_OPA) {
+        lv_obj_update_blur_status(obj);
     }
 
     if(prop == LV_STYLE_PROP_ANY || is_ext_draw) {
@@ -709,6 +715,26 @@ void lv_obj_update_layer_type(lv_obj_t * obj)
             return;
         }
         obj->spec_attr->layer_type = layer_type;
+    }
+}
+
+void lv_obj_update_blur_status(lv_obj_t * obj)
+{
+    LV_CHECK_ARG(obj != NULL, return);
+
+    /*Deletion releases the count itself (see obj_delete_core())*/
+    if(obj->is_deleting) return;
+
+    bool has_blur = calculate_has_blur(obj);
+    if(has_blur == (bool)obj->has_blur) return;
+
+    obj->has_blur = has_blur;
+    if(has_blur) {
+        LV_GLOBAL_DEFAULT()->blur_obj_cnt++;
+    }
+    else {
+        LV_ASSERT(LV_GLOBAL_DEFAULT()->blur_obj_cnt > 0);
+        LV_GLOBAL_DEFAULT()->blur_obj_cnt--;
     }
 }
 
@@ -1305,6 +1331,37 @@ static lv_layer_type_t calculate_layer_type(lv_obj_t * obj)
     if(lv_obj_get_style_bitmap_mask_src_internal(obj, LV_PART_MAIN) != NULL) return LV_LAYER_TYPE_SIMPLE;
     if(lv_obj_get_style_blend_mode_internal(obj, LV_PART_MAIN) != LV_BLEND_MODE_NORMAL) return LV_LAYER_TYPE_SIMPLE;
     return LV_LAYER_TYPE_NONE;
+}
+
+/*True if any style attached to the widget enables blur or a drop shadow in the
+ *widget's current state. The per-style has_group bitmask makes the common
+ *no-blur case a cheap scan.*/
+static bool calculate_has_blur(lv_obj_t * obj)
+{
+    const uint32_t group_blur = (uint32_t)1 << lv_style_get_prop_group(LV_STYLE_BLUR_RADIUS);
+    const uint32_t group_dropshadow = (uint32_t)1 << lv_style_get_prop_group(LV_STYLE_DROP_SHADOW_OPA);
+    const lv_state_t state = lv_obj_style_get_selector_state(lv_obj_get_state(obj));
+    const lv_state_t state_inv = ~state;
+    lv_style_value_t v;
+    uint32_t i;
+    for(i = 0; i < obj->style_cnt; i++) {
+        lv_obj_style_t * obj_style = &obj->styles[i];
+        if(obj_style->is_disabled) continue;
+
+        lv_state_t state_style = lv_obj_style_get_selector_state(obj->styles[i].selector);
+        if((state_style & state_inv)) continue;
+
+        if((obj_style->style->has_group & group_blur) &&
+           lv_style_get_prop(obj_style->style, LV_STYLE_BLUR_RADIUS, &v)) {
+            if(v.num > 0) return true;
+        }
+        if((obj_style->style->has_group & group_dropshadow) &&
+           lv_style_get_prop(obj_style->style, LV_STYLE_DROP_SHADOW_OPA, &v)) {
+            if(v.num > 0) return true;
+        }
+    }
+
+    return false;
 }
 
 static void full_cache_refresh(lv_obj_t * obj, lv_part_t part)

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -720,7 +720,7 @@ void lv_obj_update_layer_type(lv_obj_t * obj)
 
 void lv_obj_update_blur_status(lv_obj_t * obj)
 {
-    LV_CHECK_ARG(obj != NULL, return);
+    LV_ASSERT_NULL(obj);
 
     /*Deletion releases the count itself (see obj_delete_core())*/
     if(obj->is_deleting) return;

--- a/src/core/lv_obj_style_private.h
+++ b/src/core/lv_obj_style_private.h
@@ -104,6 +104,14 @@ lv_style_value_t lv_obj_get_style_prop_internal(const lv_obj_t * obj, lv_part_t 
  */
 lv_style_value_t lv_obj_style_apply_color_filter_internal(const lv_obj_t * obj, lv_part_t part, lv_style_value_t v);
 
+/**
+ * Update the cached blur status of a widget based on its current styles and
+ * state, and maintain the global count of widgets with blur (blur_obj_cnt in
+ * lv_global_t). The result will be stored in `obj->has_blur`.
+ * @param obj       the object whose blur status should be updated
+ */
+void lv_obj_update_blur_status(lv_obj_t * obj);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -676,6 +676,14 @@ static void obj_delete_core(lv_obj_t * obj)
         return;
     }
 
+    /*Release the blur bookkeeping now: the style teardown below doesn't go
+     *through lv_obj_update_blur_status()*/
+    if(obj->has_blur) {
+        obj->has_blur = 0;
+        LV_ASSERT(LV_GLOBAL_DEFAULT()->blur_obj_cnt > 0);
+        LV_GLOBAL_DEFAULT()->blur_obj_cnt--;
+    }
+
     /*Clean registered event_cb*/
     if(obj->spec_attr) lv_event_remove_all(&(obj->spec_attr->event_list));
 

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -618,11 +618,17 @@ void lv_obj_refr(lv_layer_t * layer, lv_obj_t * obj)
  **********************/
 
 /**
- * Join the areas which has got common parts
+ * Expand the invalidated areas for blur objects, then join the areas which have
+ * got common parts
  */
 static void lv_refr_join_area(void)
 {
     LV_PROFILER_REFR_BEGIN;
+
+    /*Expand before joining so any blur object whose background changed is
+     *invalidated and then merged in along with the rest.*/
+    lv_obj_invalidate_expand_blur(disp_refr);
+
     uint32_t join_from;
     uint32_t join_in;
     lv_area_t joined_area;

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -414,6 +414,8 @@ void lv_display_refr_timer(lv_timer_t * tmr)
         goto refr_finish;
     }
 
+    /*Expand the invalidated areas for blur objects before joining them*/
+    lv_obj_invalidate_expand_blur(disp_refr);
     lv_refr_join_area();
     refr_sync_areas();
     refr_invalid_areas();
@@ -618,17 +620,11 @@ void lv_obj_refr(lv_layer_t * layer, lv_obj_t * obj)
  **********************/
 
 /**
- * Expand the invalidated areas for blur objects, then join the areas which have
- * got common parts
+ * Join the areas which has got common parts
  */
 static void lv_refr_join_area(void)
 {
     LV_PROFILER_REFR_BEGIN;
-
-    /*Expand before joining so any blur object whose background changed is
-     *invalidated and then merged in along with the rest.*/
-    lv_obj_invalidate_expand_blur(disp_refr);
-
     uint32_t join_from;
     uint32_t join_in;
     lv_area_t joined_area;

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -625,11 +625,17 @@ void lv_obj_refr(lv_layer_t * layer, lv_obj_t * obj)
  **********************/
 
 /**
- * Join the areas which has got common parts
+ * Expand the invalidated areas for blur objects, then join the areas which have
+ * got common parts
  */
 static void lv_refr_join_area(void)
 {
     LV_PROFILER_REFR_BEGIN;
+
+    /*Expand before joining so any blur object whose background changed is
+     *invalidated and then merged in along with the rest.*/
+    lv_obj_invalidate_expand_blur(disp_refr);
+
     uint32_t join_from;
     uint32_t join_in;
     lv_area_t joined_area;

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -418,6 +418,8 @@ void lv_display_refr_timer(lv_timer_t * timer)
         goto refr_finish;
     }
 
+    /*Expand the invalidated areas for blur objects before joining them*/
+    lv_obj_invalidate_expand_blur(disp_refr);
     lv_refr_join_area();
     refr_sync_areas();
     refr_invalid_areas();
@@ -625,17 +627,11 @@ void lv_obj_refr(lv_layer_t * layer, lv_obj_t * obj)
  **********************/
 
 /**
- * Expand the invalidated areas for blur objects, then join the areas which have
- * got common parts
+ * Join the areas which has got common parts
  */
 static void lv_refr_join_area(void)
 {
     LV_PROFILER_REFR_BEGIN;
-
-    /*Expand before joining so any blur object whose background changed is
-     *invalidated and then merged in along with the rest.*/
-    lv_obj_invalidate_expand_blur(disp_refr);
-
     uint32_t join_from;
     uint32_t join_in;
     lv_area_t joined_area;

--- a/tests/src/test_cases/test_obj_blur_invalidation.c
+++ b/tests/src/test_cases/test_obj_blur_invalidation.c
@@ -1,0 +1,215 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+#include "../../lvgl_private.h"
+
+#include "unity/unity.h"
+
+/* Tests for deferred blur-invalidation expansion.
+ *
+ * A blur object samples the pixels behind it, so when anything behind it
+ * changes it must be redrawn in full. These tests drive the real path: a
+ * normal object behind a blur object is invalidated, a refresh is run (which
+ * runs the once-per-frame expansion), and the areas reported through
+ * LV_EVENT_INVALIDATE_AREA are inspected to confirm the blur object's area was
+ * (or was not) invalidated. */
+
+static lv_display_t * disp;
+
+/* Comfortably larger than the most any test invalidates in one capture window. */
+#define MAX_CAPTURED 64
+static lv_area_t captured[MAX_CAPTURED];
+static uint32_t captured_cnt;
+
+void setUp(void)
+{
+    disp = lv_display_get_default();
+}
+
+void tearDown(void)
+{
+    lv_obj_clean(lv_screen_active());
+}
+
+/* Record every area the display is asked to invalidate while capturing. */
+static void invalidate_area_cb(lv_event_t * e)
+{
+    if(captured_cnt >= MAX_CAPTURED) return; /* keep within bounds; no test gets close */
+    lv_area_t * area = lv_event_get_param(e);
+    captured[captured_cnt++] = *area;
+}
+
+/* Start capturing invalidated areas. The callback is only attached while
+ * capturing, so the captured list holds exactly the areas the action under test
+ * produced -- not the areas from creating and first-rendering the objects. */
+static void start_capture(void)
+{
+    captured_cnt = 0;
+    lv_display_add_event_cb(disp, invalidate_area_cb, LV_EVENT_INVALIDATE_AREA, NULL);
+}
+
+static void stop_capture(void)
+{
+    lv_display_remove_event_cb_with_user_data(disp, invalidate_area_cb, NULL);
+}
+
+/* Invalidate an object and run a refresh (which runs the blur expansion),
+ * capturing the invalidated areas it produces. */
+static void invalidate_and_refresh(lv_obj_t * obj)
+{
+    start_capture();
+    lv_obj_invalidate(obj);
+    lv_refr_now(NULL);
+    stop_capture();
+}
+
+/* True if any captured invalidated area overlaps the given area. */
+static bool area_was_invalidated(const lv_area_t * area)
+{
+    for(uint32_t i = 0; i < captured_cnt; i++) {
+        if(lv_area_is_on(&captured[i], area)) return true;
+    }
+    return false;
+}
+
+/* True if any captured invalidated area overlaps the object's coordinates --
+ * i.e. the object's area was (at least partly) invalidated. */
+static bool obj_area_was_invalidated(const lv_obj_t * obj)
+{
+    return area_was_invalidated(&obj->coords);
+}
+
+/* A normal object at (x, y) of the given size on the active screen. */
+static lv_obj_t * create_obj(int32_t x, int32_t y, int32_t w, int32_t h)
+{
+    lv_obj_t * obj = lv_obj_create(lv_screen_active());
+    lv_obj_remove_style_all(obj);
+    lv_obj_set_pos(obj, x, y);
+    lv_obj_set_size(obj, w, h);
+    return obj;
+}
+
+/* Like create_obj() but with a blur set, so it samples the pixels behind it. */
+static lv_obj_t * create_blur_obj(int32_t x, int32_t y, int32_t w, int32_t h)
+{
+    lv_obj_t * obj = create_obj(x, y, w, h);
+    lv_obj_set_style_blur_radius(obj, 10, 0);
+    return obj;
+}
+
+/* Invalidating an object behind a blur object must, after a refresh, also
+ * invalidate the blur object's *full* extent -- it has to be redrawn because its
+ * background changed. The changed object is small and in one corner; the
+ * assertion checks the opposite corner of the blur object, which only the
+ * full-extent expansion (not the changed object's own area) can invalidate. */
+void test_change_behind_blur_invalidates_the_blur_object(void)
+{
+    lv_obj_t * blur = create_blur_obj(100, 100, 80, 80);  /* ~100..180 */
+    lv_obj_t * behind = create_obj(105, 105, 10, 10);     /* top-left corner, inside blur */
+    lv_refr_now(NULL);
+
+    /* A patch in the blur object's far (bottom-right) corner, away from the
+     * changed object -- not covered by the changed object's own invalidation. */
+    lv_area_t far_corner = {blur->coords.x2 - 10, blur->coords.y2 - 10, blur->coords.x2, blur->coords.y2};
+    TEST_ASSERT_FALSE(lv_area_is_on(&behind->coords, &far_corner));
+
+    invalidate_and_refresh(behind);
+
+    TEST_ASSERT_TRUE(area_was_invalidated(&far_corner));
+}
+
+/* Invalidating an object that does not overlap the blur object must not
+ * invalidate the blur object. */
+void test_change_away_from_blur_leaves_it_untouched(void)
+{
+    lv_obj_t * blur = create_blur_obj(10, 10, 40, 40); /* top-left corner */
+    lv_obj_t * behind = create_obj(300, 250, 20, 20);  /* far away, bottom-right */
+    lv_refr_now(NULL);
+
+    invalidate_and_refresh(behind);
+
+    TEST_ASSERT_FALSE(obj_area_was_invalidated(blur));
+}
+
+/* Transitive chain: blur object b1 sits over the changed object; blur object b2
+ * overlaps b1's right edge but not the changed object. Expanding b1 makes its
+ * area dirty, and the fixed-point loop must then see b2 overlapping b1's
+ * now-dirty area and invalidate b2 too -- a single pass would miss b2.
+ *
+ * The assertion checks b2's far-right region, which lies beyond b1 (and beyond
+ * b1's blur-expanded extent). b1's own invalidation cannot reach there, so that
+ * region is invalidated only if b2 was expanded in its own right -- which is
+ * exactly the transitive behavior under test. */
+void test_blur_over_blur_is_invalidated_transitively(void)
+{
+    lv_obj_t * b1 = create_blur_obj(100, 100, 80, 80);  /* coords ~100..179 */
+    lv_obj_t * b2 = create_blur_obj(175, 100, 80, 80);  /* coords ~175..254, sliver-overlaps b1 */
+    lv_obj_t * behind = create_obj(105, 105, 10, 10);   /* inside b1 only, not b2 */
+    lv_refr_now(NULL);
+
+    /* The changed object is inside b1 but not b2, so b2 can only be reached
+     * transitively through b1. */
+    TEST_ASSERT_TRUE(lv_area_is_on(&behind->coords, &b1->coords));
+    TEST_ASSERT_FALSE(lv_area_is_on(&behind->coords, &b2->coords));
+
+    /* A patch at b2's far-right edge, clear of b1 and its blur-expanded extent,
+     * so only b2's own expansion can invalidate it. */
+    lv_area_t b2_far = {b2->coords.x2 - 10, b2->coords.y1, b2->coords.x2, b2->coords.y1 + 10};
+    TEST_ASSERT_TRUE(b2_far.x1 > b1->coords.x2 + 32); /* clear of b1 + any blur expansion */
+
+    invalidate_and_refresh(behind);
+
+    TEST_ASSERT_TRUE(obj_area_was_invalidated(b1)); /* b1: direct overlap with the change */
+    TEST_ASSERT_TRUE(area_was_invalidated(&b2_far)); /* b2: only reachable via transitive expansion */
+}
+
+/* has_blur() is also true for an object with a drop shadow, so a change behind a
+ * drop-shadow object must invalidate it in full as well. Same far-corner check
+ * as the blur case, but the object carries a drop shadow instead of a blur. */
+void test_change_behind_drop_shadow_invalidates_the_object(void)
+{
+    lv_obj_t * shadow = create_obj(100, 100, 80, 80); /* ~100..180 */
+    lv_obj_set_style_drop_shadow_opa(shadow, LV_OPA_COVER, 0);
+    lv_obj_t * behind = create_obj(105, 105, 10, 10); /* top-left corner, inside shadow */
+    lv_refr_now(NULL);
+
+    lv_area_t far_corner = {shadow->coords.x2 - 10, shadow->coords.y2 - 10, shadow->coords.x2, shadow->coords.y2};
+    TEST_ASSERT_FALSE(lv_area_is_on(&behind->coords, &far_corner));
+
+    invalidate_and_refresh(behind);
+
+    TEST_ASSERT_TRUE(area_was_invalidated(&far_corner));
+}
+
+/* The expansion's purpose is to handle a frame with many invalidations at once,
+ * so the inner loop must scan more than one dirty area. Two disjoint objects in
+ * opposite corners of a blur object are invalidated in the same frame (with
+ * these coordinates they stay separate rather than being joined), and the blur
+ * object's center, covered by neither, must still be invalidated -- which only
+ * the full-extent expansion can do. */
+void test_multiple_disjoint_changes_behind_blur(void)
+{
+    lv_obj_t * blur = create_blur_obj(100, 100, 120, 120); /* ~100..220 */
+    lv_obj_t * behind_tl = create_obj(105, 105, 10, 10);   /* top-left */
+    lv_obj_t * behind_br = create_obj(205, 205, 10, 10);   /* bottom-right */
+    lv_refr_now(NULL);
+
+    /* Center patch, covered by neither changed object. */
+    int32_t cx = (blur->coords.x1 + blur->coords.x2) / 2;
+    int32_t cy = (blur->coords.y1 + blur->coords.y2) / 2;
+    lv_area_t center = {cx - 5, cy - 5, cx + 5, cy + 5};
+    TEST_ASSERT_FALSE(lv_area_is_on(&behind_tl->coords, &center));
+    TEST_ASSERT_FALSE(lv_area_is_on(&behind_br->coords, &center));
+
+    start_capture();
+    lv_obj_invalidate(behind_tl);
+    lv_obj_invalidate(behind_br);
+    /* Both invalidations were recorded as separate dirty areas, so the expansion
+     * runs with more than one area to scan (its inner loop). */
+    TEST_ASSERT_GREATER_THAN_UINT32(1, captured_cnt);
+    lv_refr_now(NULL);
+    stop_capture();
+
+    TEST_ASSERT_TRUE(area_was_invalidated(&center));
+}
+
+#endif

--- a/tests/src/test_cases/test_obj_blur_invalidation.c
+++ b/tests/src/test_cases/test_obj_blur_invalidation.c
@@ -1,0 +1,302 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+#include "../../lvgl_private.h"
+
+#include "unity/unity.h"
+
+/* Tests for deferred blur-invalidation expansion.
+ *
+ * A blur object samples the pixels behind it, so when anything behind it
+ * changes it must be redrawn in full. These tests drive the real path: a
+ * normal object behind a blur object is invalidated, a refresh is run (which
+ * runs the once-per-frame expansion), and the areas reported through
+ * LV_EVENT_INVALIDATE_AREA are inspected to confirm the blur object's area was
+ * (or was not) invalidated. */
+
+static lv_display_t * disp;
+
+/* Large enough for every test's capture window. */
+#define MAX_CAPTURED 64
+static lv_area_t captured[MAX_CAPTURED];
+static uint32_t captured_cnt;
+
+void setUp(void)
+{
+    disp = lv_display_get_default();
+}
+
+void tearDown(void)
+{
+    lv_obj_clean(lv_screen_active());
+}
+
+/* Record every area the display is asked to invalidate while capturing. */
+static void invalidate_area_cb(lv_event_t * e)
+{
+    TEST_ASSERT_LESS_THAN_UINT32(MAX_CAPTURED, captured_cnt);
+    lv_area_t * area = lv_event_get_param(e);
+    captured[captured_cnt++] = *area;
+}
+
+/* Start capturing invalidated areas. The callback is only attached while
+ * capturing, so the captured list holds exactly the areas the action under test
+ * produced, not the areas from creating and first rendering the objects. */
+static void start_capture(void)
+{
+    captured_cnt = 0;
+    lv_display_add_event_cb(disp, invalidate_area_cb, LV_EVENT_INVALIDATE_AREA, NULL);
+}
+
+static void stop_capture(void)
+{
+    lv_display_remove_event_cb_with_user_data(disp, invalidate_area_cb, NULL);
+}
+
+/* Invalidate an object and run a refresh (which runs the blur expansion),
+ * capturing the invalidated areas it produces. */
+static void invalidate_and_refresh(lv_obj_t * obj)
+{
+    start_capture();
+    lv_obj_invalidate(obj);
+    lv_refr_now(NULL);
+    stop_capture();
+}
+
+/* True if any captured invalidated area overlaps the given area. */
+static bool area_was_invalidated(const lv_area_t * area)
+{
+    for(uint32_t i = 0; i < captured_cnt; i++) {
+        if(lv_area_is_on(&captured[i], area)) return true;
+    }
+    return false;
+}
+
+/* True if any captured invalidated area overlaps the object's coordinates. */
+static bool obj_area_was_invalidated(const lv_obj_t * obj)
+{
+    return area_was_invalidated(&obj->coords);
+}
+
+/* A normal object at (x, y) of the given size on the active screen. */
+static lv_obj_t * create_obj(int32_t x, int32_t y, int32_t w, int32_t h)
+{
+    lv_obj_t * obj = lv_obj_create(lv_screen_active());
+    lv_obj_remove_style_all(obj);
+    lv_obj_set_pos(obj, x, y);
+    lv_obj_set_size(obj, w, h);
+    return obj;
+}
+
+/* Like create_obj() but with a blur set, so it samples the pixels behind it. */
+static lv_obj_t * create_blur_obj(int32_t x, int32_t y, int32_t w, int32_t h)
+{
+    lv_obj_t * obj = create_obj(x, y, w, h);
+    lv_obj_set_style_blur_radius(obj, 10, 0);
+    return obj;
+}
+
+/* In LV_DISPLAY_RENDER_MODE_FULL any change redraws the whole screen and
+ * lv_inv_area() sends no LV_EVENT_INVALIDATE_AREA, so there is no per-area
+ * expansion to observe. */
+static void skip_in_full_render_mode(void)
+{
+    if(lv_display_get_render_mode(disp) == LV_DISPLAY_RENDER_MODE_FULL) {
+        TEST_IGNORE_MESSAGE("No per-area invalidation in LV_DISPLAY_RENDER_MODE_FULL");
+    }
+}
+
+/* Invalidating an object behind a blur object must also invalidate the blur
+ * object's full extent because its background changed. The changed object is
+ * small and in one corner. The assertion checks the opposite corner of the
+ * blur object, which only the full expansion can invalidate. */
+void test_change_behind_blur_invalidates_the_blur_object(void)
+{
+    skip_in_full_render_mode();
+    lv_obj_t * blur = create_blur_obj(100, 100, 80, 80);  /* ~100..180 */
+    lv_obj_t * behind = create_obj(105, 105, 10, 10);     /* top-left corner, inside blur */
+    lv_refr_now(NULL);
+
+    /* A patch in the blur object's far (bottom-right) corner, away from the
+     * changed object so its own invalidation cannot cover it. */
+    lv_area_t far_corner = {blur->coords.x2 - 10, blur->coords.y2 - 10, blur->coords.x2, blur->coords.y2};
+    TEST_ASSERT_FALSE(lv_area_is_on(&behind->coords, &far_corner));
+
+    invalidate_and_refresh(behind);
+
+    TEST_ASSERT_TRUE(area_was_invalidated(&far_corner));
+}
+
+/* Invalidating an object that does not overlap the blur object must not
+ * invalidate the blur object. */
+void test_change_away_from_blur_leaves_it_untouched(void)
+{
+    skip_in_full_render_mode();
+    lv_obj_t * blur = create_blur_obj(10, 10, 40, 40); /* top-left corner */
+    lv_obj_t * behind = create_obj(300, 250, 20, 20);  /* far away, bottom-right */
+    lv_refr_now(NULL);
+
+    invalidate_and_refresh(behind);
+
+    TEST_ASSERT_FALSE(obj_area_was_invalidated(blur));
+}
+
+/* Transitive chain: blur object b1 sits over the changed object and blur object
+ * b2 overlaps b1's right edge but not the changed object. Expanding b1
+ * invalidates b1's area, and the fixed-point loop must then see b2 overlapping
+ * that area and invalidate b2 too. A single pass would miss b2.
+ *
+ * The assertion checks b2's far-right region, beyond b1 and its blur-expanded
+ * extent, so only b2's own expansion can invalidate it. */
+void test_blur_over_blur_is_invalidated_transitively(void)
+{
+    skip_in_full_render_mode();
+    lv_obj_t * b1 = create_blur_obj(100, 100, 80, 80);  /* coords ~100..179 */
+    lv_obj_t * b2 = create_blur_obj(175, 100, 80, 80);  /* coords ~175..254, sliver-overlaps b1 */
+    lv_obj_t * behind = create_obj(105, 105, 10, 10);   /* inside b1 only, not b2 */
+    lv_refr_now(NULL);
+
+    /* The changed object is inside b1 but not b2, so b2 can only be reached
+     * transitively through b1. */
+    TEST_ASSERT_TRUE(lv_area_is_on(&behind->coords, &b1->coords));
+    TEST_ASSERT_FALSE(lv_area_is_on(&behind->coords, &b2->coords));
+
+    /* A patch at b2's far-right edge, clear of b1 and its blur-expanded extent,
+     * so only b2's own expansion can invalidate it. */
+    lv_area_t b2_far = {b2->coords.x2 - 10, b2->coords.y1, b2->coords.x2, b2->coords.y1 + 10};
+    TEST_ASSERT_TRUE(b2_far.x1 > b1->coords.x2 + 32); /* clear of b1 + any blur expansion */
+
+    invalidate_and_refresh(behind);
+
+    TEST_ASSERT_TRUE(obj_area_was_invalidated(b1)); /* b1: direct overlap with the change */
+    TEST_ASSERT_TRUE(area_was_invalidated(&b2_far)); /* b2: only reachable via transitive expansion */
+}
+
+/* A blur object that is a descendant of the invalidated object must be expanded
+ * too. The child's full extent must be redrawn even when the change overlaps
+ * only a corner of it. */
+void test_blur_child_of_invalidated_parent_is_expanded(void)
+{
+    skip_in_full_render_mode();
+    lv_obj_t * parent = create_obj(100, 100, 200, 200);   /* ~100..299 */
+    lv_obj_t * blur_child = lv_obj_create(parent);
+    lv_obj_remove_style_all(blur_child);
+    lv_obj_set_pos(blur_child, 20, 20);                   /* abs ~120..219 */
+    lv_obj_set_size(blur_child, 100, 100);
+    lv_obj_set_style_blur_radius(blur_child, 10, 0);
+    lv_refr_now(NULL);
+
+    /* A small patch of the parent overlapping only the child's top-left corner. */
+    lv_area_t patch = {blur_child->coords.x1 - 5, blur_child->coords.y1 - 5,
+                       blur_child->coords.x1 + 5, blur_child->coords.y1 + 5
+                      };
+
+    /* Far corner of the child, well away from the patch. Only a full expansion
+     * of the child itself can invalidate it. */
+    lv_area_t far_corner = {blur_child->coords.x2 - 10, blur_child->coords.y2 - 10,
+                            blur_child->coords.x2, blur_child->coords.y2
+                           };
+    TEST_ASSERT_FALSE(lv_area_is_on(&patch, &far_corner));
+
+    start_capture();
+    lv_obj_invalidate_area(parent, &patch);
+    lv_refr_now(NULL);
+    stop_capture();
+
+    TEST_ASSERT_TRUE(area_was_invalidated(&far_corner));
+}
+
+/* has_blur() is also true for an object with a drop shadow, so a change behind a
+ * drop-shadow object must invalidate it in full as well. Same far-corner check
+ * as the blur case, but the object carries a drop shadow instead of a blur. */
+void test_change_behind_drop_shadow_invalidates_the_object(void)
+{
+    skip_in_full_render_mode();
+    lv_obj_t * shadow = create_obj(100, 100, 80, 80); /* ~100..180 */
+    lv_obj_set_style_drop_shadow_opa(shadow, LV_OPA_COVER, 0);
+    lv_obj_t * behind = create_obj(105, 105, 10, 10); /* top-left corner, inside shadow */
+    lv_refr_now(NULL);
+
+    lv_area_t far_corner = {shadow->coords.x2 - 10, shadow->coords.y2 - 10, shadow->coords.x2, shadow->coords.y2};
+    TEST_ASSERT_FALSE(lv_area_is_on(&behind->coords, &far_corner));
+
+    invalidate_and_refresh(behind);
+
+    TEST_ASSERT_TRUE(area_was_invalidated(&far_corner));
+}
+
+/* The expansion handles a frame with many invalidations at once, so the inner
+ * loop must scan more than one invalidated area. Two disjoint objects in
+ * opposite corners of a blur object are invalidated in the same frame (with
+ * these coordinates they stay separate rather than being joined), and the blur
+ * object's center, covered by neither, must still be invalidated. Only the
+ * full expansion can do that. */
+void test_multiple_disjoint_changes_behind_blur(void)
+{
+    skip_in_full_render_mode();
+    lv_obj_t * blur = create_blur_obj(100, 100, 120, 120); /* ~100..220 */
+    lv_obj_t * behind_tl = create_obj(105, 105, 10, 10);   /* top-left */
+    lv_obj_t * behind_br = create_obj(205, 205, 10, 10);   /* bottom-right */
+    lv_refr_now(NULL);
+
+    /* Center patch, covered by neither changed object. */
+    int32_t cx = (blur->coords.x1 + blur->coords.x2) / 2;
+    int32_t cy = (blur->coords.y1 + blur->coords.y2) / 2;
+    lv_area_t center = {cx - 5, cy - 5, cx + 5, cy + 5};
+    TEST_ASSERT_FALSE(lv_area_is_on(&behind_tl->coords, &center));
+    TEST_ASSERT_FALSE(lv_area_is_on(&behind_br->coords, &center));
+
+    start_capture();
+    lv_obj_invalidate(behind_tl);
+    lv_obj_invalidate(behind_br);
+    /* Both invalidations were recorded as separate areas, so the expansion
+     * runs with more than one area to scan. */
+    TEST_ASSERT_GREATER_THAN_UINT32(1, captured_cnt);
+    lv_refr_now(NULL);
+    stop_capture();
+
+    TEST_ASSERT_TRUE(area_was_invalidated(&center));
+}
+
+/* A transformed blur object renders at its transformed area, not at its
+ * untransformed coordinates. A change behind the transformed area must
+ * invalidate all of it. */
+void test_change_behind_rotated_blur_invalidates_transformed_extent(void)
+{
+    skip_in_full_render_mode();
+    lv_obj_t * blur = create_blur_obj(300, 200, 120, 120);
+    lv_obj_set_style_transform_pivot_x(blur, 0, 0);
+    lv_obj_set_style_transform_pivot_y(blur, 0, 0);
+    lv_obj_set_style_transform_rotation(blur, 900, 0); /* 90 degrees */
+    lv_refr_now(NULL);
+
+    /* Where the blur object actually renders. */
+    lv_area_t tr;
+    tr = blur->coords;
+    lv_obj_get_transformed_area(blur, &tr, LV_OBJ_POINT_TRANSFORM_FLAG_RECURSIVE);
+
+    /* The rotation must move the transformed area almost fully off the
+     * untransformed coordinates, otherwise this test could pass without any
+     * transform handling at all. */
+    lv_area_t overlap;
+    bool on = lv_area_intersect(&overlap, &tr, &blur->coords);
+    TEST_ASSERT_TRUE(!on || lv_area_get_width(&overlap) <= 2 || lv_area_get_height(&overlap) <= 2);
+
+    /* A change behind the transformed area, near its top-left corner. */
+    lv_obj_t * behind = create_obj(tr.x1 + 16, tr.y1 + 16, 10, 10);
+    lv_refr_now(NULL);
+
+    /* Probe the center of the transformed area. It is away from the changed
+     * object, the area's edges and the untransformed coordinates, so only a
+     * full expansion of the transformed area can invalidate it. */
+    int32_t cx = (tr.x1 + tr.x2) / 2;
+    int32_t cy = (tr.y1 + tr.y2) / 2;
+    lv_area_t probe = {cx - 5, cy - 5, cx + 5, cy + 5};
+    TEST_ASSERT_FALSE(lv_area_is_on(&behind->coords, &probe));
+    TEST_ASSERT_FALSE(lv_area_is_on(&blur->coords, &probe));
+
+    invalidate_and_refresh(behind);
+
+    TEST_ASSERT_TRUE(area_was_invalidated(&probe));
+}
+
+#endif

--- a/tests/src/test_cases/test_obj_blur_tracking.c
+++ b/tests/src/test_cases/test_obj_blur_tracking.c
@@ -1,0 +1,317 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+#include "../../lvgl_private.h"
+
+#include "unity/unity.h"
+
+/* Tests for the cached per-widget blur status (obj->has_blur) and the global
+ * count of widgets with blur (blur_obj_cnt in lv_global_t).
+ *
+ * The cache is recomputed at the same choke points as the layer-type cache
+ * (lv_obj_refresh_style(), state changes) and released on widget deletion, so
+ * the count returns to zero when the last blur user goes away and
+ * lv_obj_invalidate_expand_blur() skips its tree walk again. The tests drive
+ * the transition edges: local properties, style attach/detach/replace,
+ * shared-style mutation, state-selective styles, per-widget style disabling
+ * and subtree deletion. */
+
+static lv_display_t * disp;
+
+/* Large enough for every test's capture window. */
+#define MAX_CAPTURED 64
+static lv_area_t captured[MAX_CAPTURED];
+static uint32_t captured_cnt;
+
+void setUp(void)
+{
+    disp = lv_display_get_default();
+}
+
+void tearDown(void)
+{
+    lv_obj_clean(lv_screen_active());
+}
+
+static uint32_t blur_cnt(void)
+{
+    return LV_GLOBAL_DEFAULT()->blur_obj_cnt;
+}
+
+/* Record every area the display is asked to invalidate while capturing. */
+static void invalidate_area_cb(lv_event_t * e)
+{
+    TEST_ASSERT_LESS_THAN_UINT32(MAX_CAPTURED, captured_cnt);
+    lv_area_t * area = lv_event_get_param(e);
+    captured[captured_cnt++] = *area;
+}
+
+/* Start capturing invalidated areas. The callback is only attached while
+ * capturing, so the captured list holds exactly the areas the action under test
+ * produced, not the areas from creating and first rendering the objects. */
+static void start_capture(void)
+{
+    captured_cnt = 0;
+    lv_display_add_event_cb(disp, invalidate_area_cb, LV_EVENT_INVALIDATE_AREA, NULL);
+}
+
+static void stop_capture(void)
+{
+    lv_display_remove_event_cb_with_user_data(disp, invalidate_area_cb, NULL);
+}
+
+/* True if any captured invalidated area overlaps the given area. */
+static bool area_was_invalidated(const lv_area_t * area)
+{
+    for(uint32_t i = 0; i < captured_cnt; i++) {
+        if(lv_area_is_on(&captured[i], area)) return true;
+    }
+    return false;
+}
+
+/* A normal object at (x, y) of the given size on the active screen. All styles
+ * are removed so only the styles the test sets apply. */
+static lv_obj_t * create_obj(int32_t x, int32_t y, int32_t w, int32_t h)
+{
+    lv_obj_t * obj = lv_obj_create(lv_screen_active());
+    lv_obj_remove_style_all(obj);
+    lv_obj_set_pos(obj, x, y);
+    lv_obj_set_size(obj, w, h);
+    return obj;
+}
+
+/* The baseline: nothing on a plain screen has blur. */
+void test_count_zero_without_blur(void)
+{
+    lv_obj_t * obj = create_obj(10, 10, 50, 50);
+    lv_obj_set_style_bg_opa(obj, LV_OPA_COVER, 0);
+    lv_refr_now(NULL);
+
+    TEST_ASSERT_FALSE(obj->has_blur);
+    TEST_ASSERT_EQUAL_UINT32(0, blur_cnt());
+}
+
+/* The count follows a local blur property up and down, and deletion releases
+ * it. */
+void test_count_follows_local_blur_prop(void)
+{
+    lv_obj_t * obj = create_obj(10, 10, 50, 50);
+    TEST_ASSERT_EQUAL_UINT32(0, blur_cnt());
+
+    lv_obj_set_style_blur_radius(obj, 10, 0);
+    TEST_ASSERT_TRUE(obj->has_blur);
+    TEST_ASSERT_EQUAL_UINT32(1, blur_cnt());
+
+    lv_obj_set_style_blur_radius(obj, 0, 0); /* radius 0 = no blur */
+    TEST_ASSERT_FALSE(obj->has_blur);
+    TEST_ASSERT_EQUAL_UINT32(0, blur_cnt());
+
+    lv_obj_set_style_blur_radius(obj, 5, 0);
+    TEST_ASSERT_EQUAL_UINT32(1, blur_cnt());
+
+    lv_obj_delete(obj);
+    TEST_ASSERT_EQUAL_UINT32(0, blur_cnt());
+}
+
+/* Drop shadow opacity also counts as blur. */
+void test_count_follows_drop_shadow(void)
+{
+    lv_obj_t * obj = create_obj(10, 10, 50, 50);
+
+    lv_obj_set_style_drop_shadow_opa(obj, LV_OPA_COVER, 0);
+    TEST_ASSERT_EQUAL_UINT32(1, blur_cnt());
+
+    lv_obj_set_style_drop_shadow_opa(obj, LV_OPA_TRANSP, 0);
+    TEST_ASSERT_EQUAL_UINT32(0, blur_cnt());
+}
+
+/* Attaching and detaching a shared style with blur moves the count. */
+void test_count_follows_style_attach_detach(void)
+{
+    lv_style_t style;
+    lv_style_init(&style);
+    lv_style_set_blur_radius(&style, 8);
+
+    lv_obj_t * obj = create_obj(10, 10, 50, 50);
+    TEST_ASSERT_EQUAL_UINT32(0, blur_cnt());
+
+    lv_obj_add_style(obj, &style, 0);
+    TEST_ASSERT_EQUAL_UINT32(1, blur_cnt());
+
+    lv_obj_remove_style(obj, &style, 0);
+    TEST_ASSERT_EQUAL_UINT32(0, blur_cnt());
+
+    lv_obj_add_style(obj, &style, 0);
+    TEST_ASSERT_EQUAL_UINT32(1, blur_cnt());
+
+    lv_obj_remove_style_all(obj);
+    TEST_ASSERT_EQUAL_UINT32(0, blur_cnt());
+
+    lv_obj_delete(obj);
+    lv_style_reset(&style);
+}
+
+/* A blur style bound to a state selector only counts while the widget is in
+ * that state. Entering and leaving the state involves no style mutation or
+ * (re)attachment, so this edge is covered only by the update_obj_state() hook. */
+void test_count_follows_state_selective_blur(void)
+{
+    lv_style_t style;
+    lv_style_init(&style);
+    lv_style_set_blur_radius(&style, 8);
+
+    lv_obj_t * obj = create_obj(10, 10, 50, 50);
+    lv_obj_add_style(obj, &style, LV_STATE_PRESSED);
+
+    TEST_ASSERT_FALSE(obj->has_blur); /* default state: the style doesn't apply */
+    TEST_ASSERT_EQUAL_UINT32(0, blur_cnt());
+
+    lv_obj_add_state(obj, LV_STATE_PRESSED);
+    TEST_ASSERT_TRUE(obj->has_blur);
+    TEST_ASSERT_EQUAL_UINT32(1, blur_cnt());
+
+    lv_obj_remove_state(obj, LV_STATE_PRESSED);
+    TEST_ASSERT_FALSE(obj->has_blur);
+    TEST_ASSERT_EQUAL_UINT32(0, blur_cnt());
+
+    lv_obj_delete(obj);
+    lv_style_reset(&style);
+}
+
+/* Disabling an attached blur style stops it from counting, re-enabling counts
+ * it again. */
+void test_count_follows_style_disable(void)
+{
+    lv_style_t style;
+    lv_style_init(&style);
+    lv_style_set_blur_radius(&style, 8);
+
+    lv_obj_t * obj = create_obj(10, 10, 50, 50);
+    lv_obj_add_style(obj, &style, 0);
+    TEST_ASSERT_EQUAL_UINT32(1, blur_cnt());
+
+    lv_obj_style_set_disabled(obj, &style, 0, true);
+    TEST_ASSERT_EQUAL_UINT32(0, blur_cnt());
+
+    lv_obj_style_set_disabled(obj, &style, 0, false);
+    TEST_ASSERT_EQUAL_UINT32(1, blur_cnt());
+
+    lv_obj_delete(obj);
+    lv_style_reset(&style);
+}
+
+/* Mutating a shared style takes effect through lv_obj_report_style_change(),
+ * which refreshes the style's users and updates their cached blur status. */
+void test_count_follows_shared_style_mutation(void)
+{
+    lv_style_t style;
+    lv_style_init(&style);
+    lv_style_set_bg_opa(&style, LV_OPA_COVER);
+
+    lv_obj_t * obj = create_obj(10, 10, 50, 50);
+    lv_obj_add_style(obj, &style, 0);
+    TEST_ASSERT_EQUAL_UINT32(0, blur_cnt());
+
+    lv_style_set_blur_radius(&style, 8);
+    lv_obj_report_style_change(&style);
+    TEST_ASSERT_EQUAL_UINT32(1, blur_cnt());
+
+    lv_style_remove_prop(&style, LV_STYLE_BLUR_RADIUS);
+    lv_obj_report_style_change(&style);
+    TEST_ASSERT_EQUAL_UINT32(0, blur_cnt());
+
+    lv_obj_delete(obj);
+    lv_style_reset(&style);
+}
+
+/* lv_obj_replace_style() swaps style pointers without add/remove, and must
+ * still move the count both ways. The blur style is const to also cover
+ * styles that never pass through lv_style_set_prop(). */
+const lv_style_const_prop_t blur_const_props[] = {
+    LV_STYLE_CONST_BLUR_RADIUS(12),
+    LV_STYLE_CONST_PROPS_END
+};
+LV_STYLE_CONST_INIT(blur_const_style, blur_const_props);
+
+void test_count_follows_replace_style(void)
+{
+    lv_style_t plain;
+    lv_style_init(&plain);
+    lv_style_set_bg_opa(&plain, LV_OPA_COVER);
+
+    lv_obj_t * obj = create_obj(10, 10, 50, 50);
+    lv_obj_add_style(obj, &plain, 0);
+    TEST_ASSERT_EQUAL_UINT32(0, blur_cnt());
+
+    TEST_ASSERT_TRUE(lv_obj_replace_style(obj, &plain, &blur_const_style, 0));
+    TEST_ASSERT_EQUAL_UINT32(1, blur_cnt());
+
+    TEST_ASSERT_TRUE(lv_obj_replace_style(obj, &blur_const_style, &plain, 0));
+    TEST_ASSERT_EQUAL_UINT32(0, blur_cnt());
+
+    lv_obj_delete(obj);
+    lv_style_reset(&plain);
+}
+
+/* Deleting a subtree releases the count of every blur widget inside it. */
+void test_subtree_delete_releases_count(void)
+{
+    lv_obj_t * parent = create_obj(10, 10, 200, 200);
+
+    lv_obj_t * child1 = lv_obj_create(parent);
+    lv_obj_remove_style_all(child1);
+    lv_obj_set_style_blur_radius(child1, 10, 0);
+
+    lv_obj_t * child2 = lv_obj_create(parent);
+    lv_obj_remove_style_all(child2);
+    lv_obj_set_style_drop_shadow_opa(child2, LV_OPA_COVER, 0);
+
+    lv_obj_t * grandchild = lv_obj_create(child1);
+    lv_obj_remove_style_all(grandchild);
+    lv_obj_set_style_blur_radius(grandchild, 4, 0);
+
+    TEST_ASSERT_EQUAL_UINT32(3, blur_cnt());
+
+    lv_obj_delete(parent);
+    TEST_ASSERT_EQUAL_UINT32(0, blur_cnt());
+}
+
+/* End to end: a change behind a blur object expands to its full extent. After
+ * the blur is removed the same change no longer does, because the zero count
+ * skips the expansion walk. */
+void test_expansion_stops_when_blur_removed(void)
+{
+    /* In LV_DISPLAY_RENDER_MODE_FULL there are no per-area invalidations to observe */
+    if(lv_display_get_render_mode(disp) == LV_DISPLAY_RENDER_MODE_FULL) {
+        TEST_IGNORE_MESSAGE("No per-area invalidation in LV_DISPLAY_RENDER_MODE_FULL");
+    }
+    lv_obj_t * blur = create_obj(100, 100, 80, 80);            /* ~100..180 */
+    lv_obj_set_style_blur_radius(blur, 10, 0);
+    lv_obj_t * behind = create_obj(105, 105, 10, 10);          /* top-left corner, inside blur */
+    lv_refr_now(NULL);
+
+    /* A patch in the blur object's far (bottom-right) corner, away from the
+     * changed object -- reachable only through the full-extent expansion. */
+    lv_area_t far_corner = {blur->coords.x2 - 10, blur->coords.y2 - 10, blur->coords.x2, blur->coords.y2};
+    TEST_ASSERT_FALSE(lv_area_is_on(&behind->coords, &far_corner));
+
+    /* With blur: the change behind expands to the blur object's far corner. */
+    start_capture();
+    lv_obj_invalidate(behind);
+    lv_refr_now(NULL);
+    stop_capture();
+    TEST_ASSERT_TRUE(area_was_invalidated(&far_corner));
+
+    /* Remove the blur and let the resulting invalidation drain. */
+    lv_obj_set_style_blur_radius(blur, 0, 0);
+    lv_refr_now(NULL);
+    TEST_ASSERT_EQUAL_UINT32(0, blur_cnt());
+
+    /* Without blur: the same change stays local; the far corner is untouched. */
+    start_capture();
+    lv_obj_invalidate(behind);
+    lv_refr_now(NULL);
+    stop_capture();
+    TEST_ASSERT_FALSE(area_was_invalidated(&far_corner));
+}
+
+#endif


### PR DESCRIPTION
Blur objects sample the pixels behind them, so when anything behind a blur object changes, the blur object has to be redrawn too. This was handled on every single object invalidation: each one walked the whole object tree (across the active and previous screens and layers) looking for blur objects that overlap the dirty area. In a screen with many invalidations and no blur objects at all, this results in a lot of tree walking for no gain.

This PR moves the work into a single deferred pass, `lv_obj_invalidate_expand_blur()`, run once per frame just before the dirty areas are joined. The pass repeats until it adds no new areas, so a blur object overlapping another blur object over a dirty area is expanded too -- the per-invalidation walk missed that transitive case (`test_blur_over_blur_is_invalidated_transitively` fails on master). It also expands blur objects inside the invalidated object's own subtree, which the walk skipped (`test_blur_child_of_invalidated_parent_is_expanded` also fails on master).

To skip the tree entirely when nothing is blurred, each widget caches its blur status in a spare `lv_obj_t` bit, maintained from `lv_obj_refresh_style()` and state changes, plus a global count of widgets with blur or a drop shadow. The expansion returns immediately while the count is zero, and when it does run the per-widget style scan becomes a single bit test.

Tests drive the real path end to end: invalidate a normal object, refresh, and check through `LV_EVENT_INVALIDATE_AREA` what was actually invalidated. Coverage includes the cases above plus rotated (transformed) blur objects, drop shadows, and the blur-status tracking edges (shared styles gaining blur after attach, state-selective blur, style disabling, deletion).

Measured on an STM32U5G9J-DK2 (800x480) against current master: "Multiple labels" (many small, spatially-separated invalidations) rises from 39 to 45 fps with the NemaGFX GPU draw unit and 36 to 42 fps with software rendering in direct mode. The zero-blur gate also makes no-blur scenes cheaper than master -- "Multiple rectangles" drops about 4% CPU in every config I measured. Where the framerate is capped the gain shows as CPU headroom instead (labels at 30 fps: 73% to 63%).