### PR TITLE
perf(draw): skip transparent ARGB8888 additive blends to RGB565

### DIFF
--- a/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c
@@ -1236,9 +1236,13 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
     }
     else {
         uint16_t res = 0;
+        bool skip_transparent = mask_buf == NULL && dsc->blend_mode == LV_BLEND_MODE_ADDITIVE;
         for(y = 0; y < h; y++) {
             lv_color16_t * dest_buf_c16 = (lv_color16_t *) dest_buf_u16;
             for(dest_x = 0, src_x = 0; dest_x < w; dest_x++, src_x += 4) {
+                lv_opa_t src_opa = src_buf_u8[src_x + 3];
+                if(skip_transparent && src_opa == LV_OPA_TRANSP) continue;
+
                 switch(dsc->blend_mode) {
                     case LV_BLEND_MODE_ADDITIVE:
                         res = (LV_MIN(dest_buf_c16[dest_x].red + (src_buf_u8[src_x + 2] >> 3), 31)) << 11;
@@ -1266,15 +1270,15 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
                 }
 
                 if(mask_buf == NULL && opa >= LV_OPA_MAX) {
-                    dest_buf_u16[dest_x] = lv_color_16_16_mix(res, dest_buf_u16[dest_x], src_buf_u8[src_x + 3]);
+                    dest_buf_u16[dest_x] = lv_color_16_16_mix(res, dest_buf_u16[dest_x], src_opa);
                 }
                 else if(mask_buf == NULL && opa < LV_OPA_MAX) {
-                    dest_buf_u16[dest_x] = lv_color_16_16_mix(res, dest_buf_u16[dest_x], LV_OPA_MIX2(opa, src_buf_u8[src_x + 3]));
+                    dest_buf_u16[dest_x] = lv_color_16_16_mix(res, dest_buf_u16[dest_x], LV_OPA_MIX2(opa, src_opa));
                 }
                 else {
                     if(opa >= LV_OPA_MAX) dest_buf_u16[dest_x] = lv_color_16_16_mix(res, dest_buf_u16[dest_x], mask_buf[dest_x]);
                     else dest_buf_u16[dest_x] = lv_color_16_16_mix(res, dest_buf_u16[dest_x], LV_OPA_MIX3(mask_buf[dest_x], opa,
-                                                                                                              src_buf_u8[src_x + 3]));
+                                                                                                              src_opa));
                 }
             }
 

--- a/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c
@@ -1236,9 +1236,13 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
     }
     else {
         uint16_t res = 0;
+        bool skip_transparent = ((mask_buf == NULL) && (dsc->blend_mode == LV_BLEND_MODE_ADDITIVE));
         for(y = 0; y < h; y++) {
             lv_color16_t * dest_buf_c16 = (lv_color16_t *) dest_buf_u16;
             for(dest_x = 0, src_x = 0; dest_x < w; dest_x++, src_x += 4) {
+                lv_opa_t src_opa = src_buf_u8[src_x + 3];
+                if(skip_transparent && src_opa == LV_OPA_TRANSP) continue;
+
                 switch(dsc->blend_mode) {
                     case LV_BLEND_MODE_ADDITIVE:
                         res = (LV_MIN(dest_buf_c16[dest_x].red + (src_buf_u8[src_x + 2] >> 3), 31)) << 11;
@@ -1266,15 +1270,15 @@ static void LV_ATTRIBUTE_FAST_MEM argb8888_image_blend(lv_draw_sw_blend_image_ds
                 }
 
                 if(mask_buf == NULL && opa >= LV_OPA_MAX) {
-                    dest_buf_u16[dest_x] = lv_color_16_16_mix(res, dest_buf_u16[dest_x], src_buf_u8[src_x + 3]);
+                    dest_buf_u16[dest_x] = lv_color_16_16_mix(res, dest_buf_u16[dest_x], src_opa);
                 }
                 else if(mask_buf == NULL && opa < LV_OPA_MAX) {
-                    dest_buf_u16[dest_x] = lv_color_16_16_mix(res, dest_buf_u16[dest_x], LV_OPA_MIX2(opa, src_buf_u8[src_x + 3]));
+                    dest_buf_u16[dest_x] = lv_color_16_16_mix(res, dest_buf_u16[dest_x], LV_OPA_MIX2(opa, src_opa));
                 }
                 else {
                     if(opa >= LV_OPA_MAX) dest_buf_u16[dest_x] = lv_color_16_16_mix(res, dest_buf_u16[dest_x], mask_buf[dest_x]);
                     else dest_buf_u16[dest_x] = lv_color_16_16_mix(res, dest_buf_u16[dest_x], LV_OPA_MIX3(mask_buf[dest_x], opa,
-                                                                                                              src_buf_u8[src_x + 3]));
+                                                                                                              src_opa));
                 }
             }
 

--- a/tests/src/test_cases/draw/test_draw_blend.c
+++ b/tests/src/test_cases/draw/test_draw_blend.c
@@ -5,6 +5,26 @@
 
 #include "unity/unity.h"
 
+static uint16_t make_rgb565(uint8_t red, uint8_t green, uint8_t blue)
+{
+    return (uint16_t)(((red & 0xf8U) << 8) | ((green & 0xfcU) << 3) | (blue >> 3));
+}
+
+static uint16_t add_argb8888_to_rgb565(uint16_t dst, lv_color32_t src)
+{
+    if(src.alpha == 0) return dst;
+
+    uint16_t red = (uint16_t)((dst >> 11) + (src.red >> 3));
+    uint16_t green = (uint16_t)(((dst >> 5) & 0x3fU) + (src.green >> 2));
+    uint16_t blue = (uint16_t)((dst & 0x1fU) + (src.blue >> 3));
+    if(red > 31) red = 31;
+    if(green > 63) green = 63;
+    if(blue > 31) blue = 31;
+
+    uint16_t res = (uint16_t)((red << 11) | (green << 5) | blue);
+    return lv_color_16_16_mix(res, dst, src.alpha);
+}
+
 void setUp(void)
 {
     /* Function run before every test */
@@ -165,6 +185,98 @@ void test_rgb888(void)
 void test_rgb565(void)
 {
     canvas_draw("rgb565", LV_COLOR_FORMAT_RGB565);
+}
+
+void test_argb8888_additive_blend_to_rgb565(void)
+{
+    enum {
+        TEST_W = 4,
+        TEST_H = 2,
+        TEST_STRIDE_PX = 6,
+    };
+
+    uint16_t dest[TEST_H][TEST_STRIDE_PX] = {
+        {
+            make_rgb565(0x10, 0x20, 0x30),
+            make_rgb565(0x21, 0x32, 0x43),
+            make_rgb565(0x40, 0x50, 0x60),
+            make_rgb565(0xf0, 0xe0, 0xd0),
+            0xa55a,
+            0x5aa5,
+        },
+        {
+            make_rgb565(0x01, 0x23, 0x45),
+            make_rgb565(0x67, 0x89, 0xab),
+            make_rgb565(0xcd, 0xef, 0x12),
+            make_rgb565(0x34, 0x56, 0x78),
+            0x33cc,
+            0xcc33,
+        },
+    };
+    const uint16_t original[TEST_H][TEST_STRIDE_PX] = {
+        {
+            dest[0][0],
+            dest[0][1],
+            dest[0][2],
+            dest[0][3],
+            dest[0][4],
+            dest[0][5],
+        },
+        {
+            dest[1][0],
+            dest[1][1],
+            dest[1][2],
+            dest[1][3],
+            dest[1][4],
+            dest[1][5],
+        },
+    };
+    lv_color32_t src[TEST_H][TEST_STRIDE_PX] = {
+        {
+            { .blue = 0x40, .green = 0x20, .red = 0x10, .alpha = 0x00 },
+            { .blue = 0x00, .green = 0x00, .red = 0x00, .alpha = 0xff },
+            { .blue = 0x30, .green = 0x60, .red = 0x90, .alpha = 0x80 },
+            { .blue = 0xff, .green = 0xff, .red = 0xff, .alpha = 0xff },
+            { .blue = 0x7e, .green = 0x7e, .red = 0x7e, .alpha = 0x7e },
+            { .blue = 0x7e, .green = 0x7e, .red = 0x7e, .alpha = 0x7e },
+        },
+        {
+            { .blue = 0x18, .green = 0x28, .red = 0x38, .alpha = 0xff },
+            { .blue = 0x48, .green = 0x58, .red = 0x68, .alpha = 0x40 },
+            { .blue = 0x00, .green = 0x10, .red = 0x20, .alpha = 0x00 },
+            { .blue = 0x90, .green = 0xa0, .red = 0xb0, .alpha = 0xff },
+            { .blue = 0x7e, .green = 0x7e, .red = 0x7e, .alpha = 0x7e },
+            { .blue = 0x7e, .green = 0x7e, .red = 0x7e, .alpha = 0x7e },
+        },
+    };
+
+    lv_draw_sw_blend_image_dsc_t dsc;
+    lv_memzero(&dsc, sizeof(dsc));
+    dsc.dest_buf = dest;
+    dsc.dest_w = TEST_W;
+    dsc.dest_h = TEST_H;
+    dsc.dest_stride = sizeof(dest[0]);
+    dsc.src_buf = src;
+    dsc.src_stride = sizeof(src[0]);
+    dsc.src_color_format = LV_COLOR_FORMAT_ARGB8888;
+    dsc.opa = LV_OPA_COVER;
+    dsc.blend_mode = LV_BLEND_MODE_ADDITIVE;
+
+    lv_draw_sw_blend_image_to_rgb565(&dsc);
+
+    TEST_ASSERT_EQUAL_HEX16(add_argb8888_to_rgb565(original[0][0], src[0][0]), dest[0][0]);
+    TEST_ASSERT_EQUAL_HEX16(add_argb8888_to_rgb565(original[0][1], src[0][1]), dest[0][1]);
+    TEST_ASSERT_EQUAL_HEX16(add_argb8888_to_rgb565(original[0][2], src[0][2]), dest[0][2]);
+    TEST_ASSERT_EQUAL_HEX16(add_argb8888_to_rgb565(original[0][3], src[0][3]), dest[0][3]);
+    TEST_ASSERT_EQUAL_HEX16(add_argb8888_to_rgb565(original[1][0], src[1][0]), dest[1][0]);
+    TEST_ASSERT_EQUAL_HEX16(add_argb8888_to_rgb565(original[1][1], src[1][1]), dest[1][1]);
+    TEST_ASSERT_EQUAL_HEX16(add_argb8888_to_rgb565(original[1][2], src[1][2]), dest[1][2]);
+    TEST_ASSERT_EQUAL_HEX16(add_argb8888_to_rgb565(original[1][3], src[1][3]), dest[1][3]);
+
+    TEST_ASSERT_EQUAL_HEX16(original[0][4], dest[0][4]);
+    TEST_ASSERT_EQUAL_HEX16(original[0][5], dest[0][5]);
+    TEST_ASSERT_EQUAL_HEX16(original[1][4], dest[1][4]);
+    TEST_ASSERT_EQUAL_HEX16(original[1][5], dest[1][5]);
 }
 
 #endif


### PR DESCRIPTION
### Description

Skip fully transparent source pixels in the ARGB8888 to RGB565 additive software blend path when no mask is used.

For transparent ARGB8888 source pixels, the existing path still computes the additive RGB565 result and then mixes it with opacity 0, which leaves the destination unchanged. This patch avoids that work for `LV_BLEND_MODE_ADDITIVE` without changing masked paths or other blend modes.

### Notes

- No documentation update needed; this is an internal software renderer optimization.
- No example update needed.
- The unit test covers transparent source pixels, black source pixels, partial alpha, full alpha, and destination stride padding.

### Local benchmark

Standalone Windows/MinGW microbenchmark mirroring this loop, 700x260 pixels, 500 iterations:

| case | observed speedup range |
| --- | ---: |
| sparse ARGB8888 source | 1.45x - 1.66x |
| sparse ARGB8888 source with stride padding | 1.27x - 1.44x |
| dense ARGB8888 source | 0.96x - 1.00x |

All benchmark runs produced matching output checksums.

### Tests

- `build\astyle\build\gcc\bin\astyle --options=scripts\code-format.cfg src\draw\sw\blend\lv_draw_sw_blend_to_rgb565.c tests\src\test_cases\draw\test_draw_blend.c`
- `git diff --check`
- `cmake --build build\lvgl-gcc-min --target lvgl -j 8`
- `python scripts\commit_msg_check.py --check-title 'perf(draw): skip transparent ARGB8888 additive blends to RGB565'`

Full Docker/Linux perf tests were not run in my local Windows environment.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

