### PR TITLE
fix(osal): coalesce RT-Thread sync signals

### DIFF
--- a/src/osal/lv_rtthread.c
+++ b/src/osal/lv_rtthread.c
@@ -135,6 +135,14 @@ lv_result_t lv_thread_sync_init(lv_thread_sync_t * sync)
         LV_LOG_WARN("create semaphore failed");
         return LV_RESULT_INVALID;
     }
+
+    rt_err_t ret = rt_sem_control(sync->sem, RT_IPC_CMD_SET_VLIMIT, (void *)1);
+    if(ret) {
+        LV_LOG_WARN("Error: %d", ret);
+        rt_sem_delete(sync->sem);
+        sync->sem = RT_NULL;
+        return LV_RESULT_INVALID;
+    }
     else {
         return LV_RESULT_OK;
     }
@@ -155,7 +163,7 @@ lv_result_t lv_thread_sync_wait(lv_thread_sync_t * sync)
 lv_result_t lv_thread_sync_signal(lv_thread_sync_t * sync)
 {
     rt_err_t ret = rt_sem_release(sync->sem);
-    if(ret) {
+    if(ret && ret != -RT_EFULL) {
         LV_LOG_WARN("Error: %d", ret);
         return LV_RESULT_INVALID;
     }


### PR DESCRIPTION
\### Summary

This changes the RT-Thread OSAL thread sync semaphore to behave as a pending wake-up signal instead of an accumulating counter.

`lv_thread_sync_signal()` can be called repeatedly before the waiting thread consumes the signal. With RT-Thread's default semaphore limit, repeated `rt_sem_release()` calls can accumulate until the semaphore reaches its maximum value, then `rt_sem_release()` returns `-RT_EFULL` and LVGL logs repeated errors.

### What changed

* Limit the RT-Thread sync semaphore to a value of 1 with `RT_IPC_CMD_SET_VLIMIT` after creation.
* Treat `-RT_EFULL` from `rt_sem_release()` as success because it means a signal is already pending.
* Delete the semaphore and fail initialization if the value-limit setup fails.

This matches the coalescing sync behavior used by the pthread and FreeRTOS OSAL implementations.

Closes lvgl/lvgl#10246

### Validation

* `git diff --check origin/master..HEAD`
* `rg -n "RT_IPC_CMD_SET_VLIMIT|RT_EFULL|lv_thread_sync_signal|lv_thread_sync_init" src/osal/lv_rtthread.c`
* `git diff --stat origin/master..HEAD`

Full local LVGL tests were not run in this Windows environment because `cmake` and `ninja` are not installed, and `python tests/main.py --help` currently fails due to the missing `pypng` package.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)