### PR TITLE
ci(perf): pin SO3 perf images to the 6.2.0 nested-layout digests

### DIFF
--- a/.github/workflows/perf_emulation.yml
+++ b/.github/workflows/perf_emulation.yml
@@ -42,14 +42,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Pinned by digest to the SO3 6.2.0 nested-layout images (built from the
+        # :lvgl Dockerfiles). The digests and the /so3/so3/usr mount paths in the
+        # "Run Benchmark Demo" step below must always change together.
         include:
         - image_type: 32b
           image_version : |
-            main@sha256:61e287d63b19a503cc4505c13bd93f5e05e19513a947feb048d75662c398c862
+            latest@sha256:f4326e11c63004b8d6ded8a30a8b9bf96bca5f2d70f926b90231a4d80bd58208
           config : lv_conf_perf32b
         - image_type: 64b
           image_version: |
-            main@sha256:e8663d9c138e98b78d12cc8ad056b7d4b0cc4ad233c6f54202e40ce7606c2670
+            latest@sha256:681d5a7f099305b500d24f83350b68ff49758100137e9c09c01233d9c08a013b
           config : lv_conf_perf64b
     steps:
       - name: Checkout
@@ -69,8 +72,8 @@ jobs:
           docker run -t --privileged \
             --name so3-lvperf \
             -v /dev:/dev \
-            -v $(pwd)/configs/ci/perf/lv_conf_perf.h:/so3/usr/lib/lv_conf.h \
-            -v $(pwd):/so3/usr/lib/lvgl \
+            -v $(pwd)/configs/ci/perf/lv_conf_perf.h:/so3/so3/usr/lib/lv_conf.h \
+            -v $(pwd):/so3/so3/usr/lib/lvgl \
             -v $(pwd)/scripts/perf/lvperf_dependencies.sh:/so3/install_dependencies.sh \
             ghcr.io/smartobjectoriented/so3-lvperf${{matrix.image_type}}:${{matrix.image_version}}
 

--- a/.github/workflows/perf_emulation.yml
+++ b/.github/workflows/perf_emulation.yml
@@ -48,11 +48,11 @@ jobs:
         include:
         - image_type: 32b
           image_version : |
-            latest@sha256:f4326e11c63004b8d6ded8a30a8b9bf96bca5f2d70f926b90231a4d80bd58208
+            latest@sha256:8d977ad76d3893bae23e9bfda3217390afe24ba448852edd7579fb8e5fa38a23
           config : lv_conf_perf32b
         - image_type: 64b
           image_version: |
-            latest@sha256:681d5a7f099305b500d24f83350b68ff49758100137e9c09c01233d9c08a013b
+            latest@sha256:1d3674adb634be728d79ffeff37e55183d3d9d228cd536266fa5db444ee0ce77
           config : lv_conf_perf64b
     steps:
       - name: Checkout

--- a/tests/benchmark_emu.py
+++ b/tests/benchmark_emu.py
@@ -9,12 +9,12 @@ import subprocess
 benchmark_configs = {
     "perf32b": {
         "description": "Benchmark config ARM (so3) Emulated - 32 bit",
-        "image_name": "ghcr.io/smartobjectoriented/so3-lvperf32b@sha256:f4326e11c63004b8d6ded8a30a8b9bf96bca5f2d70f926b90231a4d80bd58208",
+        "image_name": "ghcr.io/smartobjectoriented/so3-lvperf32b@sha256:8d977ad76d3893bae23e9bfda3217390afe24ba448852edd7579fb8e5fa38a23",
         "defaults_file": "lv_conf_perf32b.defaults",
     },
     "perf64b": {
         "description": "Benchmark config ARM (so3) Emulated - 64 bit",
-        "image_name": "ghcr.io/smartobjectoriented/so3-lvperf64b@sha256:681d5a7f099305b500d24f83350b68ff49758100137e9c09c01233d9c08a013b",
+        "image_name": "ghcr.io/smartobjectoriented/so3-lvperf64b@sha256:1d3674adb634be728d79ffeff37e55183d3d9d228cd536266fa5db444ee0ce77",
         "defaults_file": "lv_conf_perf64b.defaults",
     },
 }

--- a/tests/benchmark_emu.py
+++ b/tests/benchmark_emu.py
@@ -9,12 +9,12 @@ import subprocess
 benchmark_configs = {
     "perf32b": {
         "description": "Benchmark config ARM (so3) Emulated - 32 bit",
-        "image_name": "ghcr.io/smartobjectoriented/so3-lvperf32b:main",
+        "image_name": "ghcr.io/smartobjectoriented/so3-lvperf32b@sha256:f4326e11c63004b8d6ded8a30a8b9bf96bca5f2d70f926b90231a4d80bd58208",
         "defaults_file": "lv_conf_perf32b.defaults",
     },
     "perf64b": {
         "description": "Benchmark config ARM (so3) Emulated - 64 bit",
-        "image_name": "ghcr.io/smartobjectoriented/so3-lvperf64b:main",
+        "image_name": "ghcr.io/smartobjectoriented/so3-lvperf64b@sha256:681d5a7f099305b500d24f83350b68ff49758100137e9c09c01233d9c08a013b",
         "defaults_file": "lv_conf_perf64b.defaults",
     },
 }
@@ -221,10 +221,12 @@ def run_benchmark(config_name: str, pull: bool) -> None:
     def volume(src, dst):
         return ["-v", f"{src}:{dst}"]
 
+    # The Infrabase images nest the repo at /so3, so the user space lives at
+    # /so3/so3/usr (kernel at /so3/so3/so3). All mount targets use that path.
     def so3_usr_lib(path):
-        return f"/so3/usr/lib/{path}"
+        return f"/so3/so3/usr/lib/{path}"
 
-    so3_usr_build = "/so3/usr/build"
+    so3_usr_build = "/so3/so3/usr/build"
     persistence_dir = "/persistence"
     container_name = get_container_name(config_name)
     build_dir = get_build_dir(config_name)

--- a/tests/perf.py
+++ b/tests/perf.py
@@ -12,12 +12,12 @@ from typing import Optional
 perf_test_options = {
     "OPTIONS_TEST_PERF_32B": {
         "description": "Perf test config ARM (so3) Emulated - 32 bit",
-        "image_name": "ghcr.io/smartobjectoriented/so3-lvperf32b@sha256:f4326e11c63004b8d6ded8a30a8b9bf96bca5f2d70f926b90231a4d80bd58208",
+        "image_name": "ghcr.io/smartobjectoriented/so3-lvperf32b@sha256:8d977ad76d3893bae23e9bfda3217390afe24ba448852edd7579fb8e5fa38a23",
         "config": "lv_test_perf_conf.h",
     },
     "OPTIONS_TEST_PERF_64B": {
         "description": "Perf test config ARM (so3) Emulated - 64 bit",
-        "image_name": "ghcr.io/smartobjectoriented/so3-lvperf64b@sha256:681d5a7f099305b500d24f83350b68ff49758100137e9c09c01233d9c08a013b",
+        "image_name": "ghcr.io/smartobjectoriented/so3-lvperf64b@sha256:1d3674adb634be728d79ffeff37e55183d3d9d228cd536266fa5db444ee0ce77",
         "config": "lv_test_perf_conf.h",
     },
 }

--- a/tests/perf.py
+++ b/tests/perf.py
@@ -12,12 +12,12 @@ from typing import Optional
 perf_test_options = {
     "OPTIONS_TEST_PERF_32B": {
         "description": "Perf test config ARM (so3) Emulated - 32 bit",
-        "image_name": "ghcr.io/smartobjectoriented/so3-lvperf32b:main",
+        "image_name": "ghcr.io/smartobjectoriented/so3-lvperf32b@sha256:f4326e11c63004b8d6ded8a30a8b9bf96bca5f2d70f926b90231a4d80bd58208",
         "config": "lv_test_perf_conf.h",
     },
     "OPTIONS_TEST_PERF_64B": {
         "description": "Perf test config ARM (so3) Emulated - 64 bit",
-        "image_name": "ghcr.io/smartobjectoriented/so3-lvperf64b:main",
+        "image_name": "ghcr.io/smartobjectoriented/so3-lvperf64b@sha256:681d5a7f099305b500d24f83350b68ff49758100137e9c09c01233d9c08a013b",
         "config": "lv_test_perf_conf.h",
     },
 }
@@ -499,16 +499,18 @@ def run_tests(
     def volume(src, dst):
         return ["-v", f"{src}:{dst}"]
 
+    # The Infrabase images nest the repo at /so3, so the user space lives at
+    # /so3/so3/usr (kernel at /so3/so3/so3). All mount targets use that path.
     def so3_usr_src(path):
-        return f"/so3/usr/src/{path}"
+        return f"/so3/so3/usr/src/{path}"
 
     def so3_usr_lib(path):
-        return f"/so3/usr/lib/{path}"
+        return f"/so3/so3/usr/lib/{path}"
 
     def so3_usr_out(path):
-        return f"/so3/usr/out/{path}"
+        return f"/so3/so3/usr/out/{path}"
 
-    so3_usr_build = f"/so3/usr/build"
+    so3_usr_build = f"/so3/so3/usr/build"
     persistence_dir = f"/persistence"
     container_name = get_container_name(options_name)
     build_dir = get_build_dir(options_name)
@@ -539,7 +541,7 @@ def run_tests(
         volume(lvgl_private_h_path, so3_usr_lib("lvgl/lvgl_private.h")),
         # We also need to add the current "lvgl.h" and mount it in the correct path
         # As there's a `#include "../../lvgl.h"` in the `unity_support.h` file
-        volume(lvgl_h_path, "/so3/usr/lvgl.h"),
+        volume(lvgl_h_path, "/so3/so3/usr/lvgl.h"),
         # Mount the test sources (test cases and runners)
         volume(test_src_dir, so3_usr_src("test_src")),
         # Mount the test framework


### PR DESCRIPTION
## What

SO3 — the emulated runtime behind the perf CI — was migrated to its **6.2.0** release, now built with Infrabase. The new build **nests the repository under `/so3`**, so the user space lives at `/so3/so3/usr` instead of the old flat `/so3/usr`.

This aligns all three SO3 perf entry points on the nested layout and **pins them by digest** to the new 6.2.0 images:

- `tests/perf.py` — run by `perf_tests.yml`
- `tests/benchmark_emu.py` — local scene-benchmark helper
- `.github/workflows/perf_emulation.yml` — CI scene-benchmark `docker run`

## Why pin by digest

The image layout and the mount paths must change together. Pinning by `@sha256` (instead of the floating `:main` tag) couples them in this single PR: nothing changes for the perf CI until this merges, and at merge the image and the `/so3/so3/usr` paths switch atomically. `install_dependencies.sh` stays at the repo root (`/so3`) since the Dockerfile creates it there.

## Effect on the benchmark

The 6.2.0 images drive `lv_tick` from the ARM generic timer (a microsecond-resolution clock) instead of a coarse 10 ms helper thread. `lv_tick` still advances in milliseconds, but **accurately** — so the benchmark **FPS is no longer pinned flat at ~24** and reflects real per-scene performance.

Verified locally on both targets against the exact pinned digests (LVGL `master`):

| Arch | Avg FPS | Avg render (ms) | Old image |
|------|---------|-----------------|-----------|
| 32b  | 40      | 20              | 24 / 8    |
| 64b  | 42      | 18              | 24 / 6    |

Per-scene FPS now spreads across 14–60 instead of sitting flat at ~24 (the old coarse-tick artifact).

## Note for reviewers

The emulated-benchmark baseline (`emulated-benchmark-latest`) was recorded with the **old** coarse tick, so the first comparison comment will show a large apparent delta (FPS ~24 → ~40). This is a **measurement-accuracy change, not a perf regression**; the baseline re-seeds on the next `master` push.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

