### PR TITLE
fix(bar,slider): prevent int32 overflow in pixel-position mapping

### DIFF
--- a/src/widgets/bar/lv_bar.c
+++ b/src/widgets/bar/lv_bar.c
@@ -435,9 +435,9 @@ static void draw_indic(lv_event_t * e)
 
     if(LV_BAR_IS_ANIMATING(bar->start_value_anim)) {
         int32_t anim_start_value_start_x =
-            (int32_t)((int32_t)anim_length * (bar->start_value_anim.anim_start - bar->min_value)) / range;
+            (int32_t)(((int64_t)anim_length * (bar->start_value_anim.anim_start - bar->min_value)) / range);
         int32_t anim_start_value_end_x =
-            (int32_t)((int32_t)anim_length * (bar->start_value_anim.anim_end - bar->min_value)) / range;
+            (int32_t)(((int64_t)anim_length * (bar->start_value_anim.anim_end - bar->min_value)) / range);
 
         anim_start_value_x = (((anim_start_value_end_x - anim_start_value_start_x) * bar->start_value_anim.anim_state) /
                               LV_BAR_ANIM_STATE_END);
@@ -445,21 +445,21 @@ static void draw_indic(lv_event_t * e)
         anim_start_value_x += anim_start_value_start_x;
     }
     else {
-        anim_start_value_x = (int32_t)((int32_t)anim_length * (bar->start_value - bar->min_value)) / range;
+        anim_start_value_x = (int32_t)(((int64_t)anim_length * (bar->start_value - bar->min_value)) / range);
     }
 
     if(LV_BAR_IS_ANIMATING(bar->cur_value_anim)) {
         int32_t anim_cur_value_start_x =
-            (int32_t)((int32_t)anim_length * (bar->cur_value_anim.anim_start - bar->min_value)) / range;
+            (int32_t)(((int64_t)anim_length * (bar->cur_value_anim.anim_start - bar->min_value)) / range);
         int32_t anim_cur_value_end_x =
-            (int32_t)((int32_t)anim_length * (bar->cur_value_anim.anim_end - bar->min_value)) / range;
+            (int32_t)(((int64_t)anim_length * (bar->cur_value_anim.anim_end - bar->min_value)) / range);
 
         anim_cur_value_x = anim_cur_value_start_x + (((anim_cur_value_end_x - anim_cur_value_start_x) *
                                                       bar->cur_value_anim.anim_state) /
                                                      LV_BAR_ANIM_STATE_END);
     }
     else {
-        anim_cur_value_x = (int32_t)((int32_t)anim_length * (bar->cur_value - bar->min_value)) / range;
+        anim_cur_value_x = (int32_t)(((int64_t)anim_length * (bar->cur_value - bar->min_value)) / range);
     }
 
     /**

--- a/src/widgets/slider/lv_slider.c
+++ b/src/widgets/slider/lv_slider.c
@@ -602,7 +602,7 @@ static void update_knob_pos(lv_obj_t * obj, bool check_drag)
             new_value = p.x - (obj->coords.x1 + bg_left);
         }
         if(indic_w) {
-            new_value = (new_value * range + indic_w / 2) / indic_w;
+            new_value = (int32_t)(((int64_t)new_value * range + indic_w / 2) / indic_w);
             new_value += slider->bar.min_value;
         }
     }
@@ -621,7 +621,7 @@ static void update_knob_pos(lv_obj_t * obj, bool check_drag)
             new_value = p.y - (obj->coords.y2 + bg_bottom);
             new_value = -new_value;
         }
-        new_value = (new_value * range + indic_h / 2) / indic_h;
+        new_value = (int32_t)(((int64_t)new_value * range + indic_h / 2) / indic_h);
         new_value += slider->bar.min_value;
     }
 


### PR DESCRIPTION
The intermediate multiplication `pixel × range` could exceed<br>INT32_MAX (2,147,483,647), causing the value to wrap to a negative<br>number and the indicator to jump to the wrong position.

Cast `anim_length` / pixel coordinate to `int64_t` before the<br>multiplication so the intermediate result stays within bounds.

Fixes: lvgl/lvgl#10308

### Description

When a slider or bar has a large value range (e.g. 0..10,000,000)<br>and a narrow indicator (e.g. 600 px), the intermediate multiplication<br>`pixel_position × range` during the value-to-position mapping can<br>exceed 2,147,483,647, causing the int32 result to wrap to a negative<br>number. The indicator then jumps back to the minimum position.

**Affected code paths (8 sites):**

<!-- linear:table-colwidths:266,266,266 -->
| File | Lines | Context |
| -- | -- | -- |
| `lv_slider.c` | L606, L625 | pixel-to-value conversion |
| `lv_bar.c` | L439, L441, L449 | start_value animation + draw |
| `lv_bar.c` | L454, L456, L463 | cur_value animation + draw |

**Fix:** Cast the first operand to `int64_t` so the multiplication<br>stays in 64-bit:

```c
// Before
(int32_t)((int32_t)anim_length * (value - min_value)) / range

// After
(int32_t)(((int64_t)anim_length * (value - min_value)) / range)
Notes
No API or ABI change.
int64_t provides ~6 orders of magnitude headroom over worst case.
Reproduced on Windows with LV_USE_WINDOWS driver.
```