### PR TITLE
perf(arc): skip knob invalidation when hidden

### DIFF
--- a/src/draw/sw/lv_draw_sw_arc.c
+++ b/src/draw/sw/lv_draw_sw_arc.c
@@ -25,8 +25,6 @@ static void get_rounded_area(int16_t angle, int32_t radius, uint8_t thickness, l
 /*********************
  *      DEFINES
  *********************/
-#define SPLIT_RADIUS_LIMIT 10  /*With radius greater than this the arc will drawn in quarters. A quarter is drawn only if there is arc in it*/
-#define SPLIT_ANGLE_GAP_LIMIT 60  /*With small gaps in the arc don't bother with splitting because there is nothing to skip.*/
 
 /**********************
  *      TYPEDEFS
@@ -82,6 +80,12 @@ void lv_draw_sw_arc(lv_draw_task_t * t, const lv_draw_arc_dsc_t * dsc, const lv_
     area_in.y1 += dsc->width;
     area_in.x2 -= dsc->width;
     area_in.y2 -= dsc->width;
+
+    /*Optimization: Minimize clipped area*/
+    lv_area_t arc_area;
+    lv_draw_arc_get_area(dsc->center.x, dsc->center.y, dsc->radius, dsc->start_angle, dsc->end_angle,
+                         width, dsc->rounded, &arc_area);
+    if(!lv_area_intersect(&clipped_area, &clipped_area, &arc_area)) return;
 
     int32_t start_angle = (int32_t)dsc->start_angle;
     int32_t end_angle = (int32_t)dsc->end_angle;

--- a/src/widgets/arc/lv_arc.c
+++ b/src/widgets/arc/lv_arc.c
@@ -42,7 +42,7 @@ static void lv_arc_draw(lv_event_t * e);
 static void lv_arc_event(const lv_obj_class_t * class_p, lv_event_t * e);
 static void inv_arc_area(lv_obj_t * arc, lv_value_precise_t start_angle, lv_value_precise_t end_angle, lv_part_t part);
 static void inv_knob_area(lv_obj_t * obj);
-static void get_knob_inv_area(lv_obj_t * obj, lv_area_t * area);
+static bool get_knob_inv_area(lv_obj_t * obj, lv_area_t * area);
 static void get_center(const lv_obj_t * obj, lv_point_t * center, int32_t * arc_r);
 static lv_value_precise_t get_angle(const lv_obj_t * obj);
 static void get_knob_area(lv_obj_t * arc, const lv_point_t * center, int32_t r, lv_area_t * knob_area);
@@ -182,18 +182,20 @@ void lv_arc_set_angles(lv_obj_t * obj, lv_value_precise_t start, lv_value_precis
     if(start > 360) start -= 360;
     if(end > 360) end -= 360;
 
+    bool visible = lv_obj_is_visible(obj);
+
     /*Snapshot for invalidation*/
     lv_value_precise_t old_start = arc->indic_angle_start;
     lv_value_precise_t old_end = arc->indic_angle_end;
     lv_area_t old_knob_area;
-    get_knob_inv_area(obj, &old_knob_area);
+    bool knob_visible = visible && get_knob_inv_area(obj, &old_knob_area);
 
     /*Apply the change*/
     arc->indic_angle_start = start;
     arc->indic_angle_end = end;
 
     /*Invalidation*/
-    if(lv_obj_is_visible(obj)) {
+    if(visible) {
         /*Area swept by the start angle*/
         lv_value_precise_t start_old_delta = end - old_start;
         lv_value_precise_t start_new_delta = end - start;
@@ -213,8 +215,10 @@ void lv_arc_set_angles(lv_obj_t * obj, lv_value_precise_t start, lv_value_precis
         else if(end_old_delta < end_new_delta) inv_arc_area(obj, old_end, end, LV_PART_INDICATOR);
 
         /*Knob*/
-        lv_obj_invalidate_area(obj, &old_knob_area);
-        inv_knob_area(obj);
+        if(knob_visible) {
+            lv_obj_invalidate_area(obj, &old_knob_area);
+            inv_knob_area(obj);
+        }
     }
 }
 
@@ -906,8 +910,19 @@ static void inv_arc_area(lv_obj_t * obj, lv_value_precise_t start_angle, lv_valu
     lv_obj_invalidate_area(obj, &inv_area);
 }
 
-static void get_knob_inv_area(lv_obj_t * obj, lv_area_t * area)
+static bool get_knob_inv_area(lv_obj_t * obj, lv_area_t * area)
 {
+    if(lv_obj_get_style_bg_opa(obj, LV_PART_KNOB) <= LV_OPA_MIN &&
+       lv_obj_get_style_bg_image_src(obj, LV_PART_KNOB) == NULL &&
+       lv_obj_get_style_border_opa(obj, LV_PART_KNOB) <= LV_OPA_MIN &&
+       lv_obj_get_style_border_width(obj, LV_PART_KNOB) <= 0 &&
+       lv_obj_get_style_outline_opa(obj, LV_PART_KNOB) <= LV_OPA_MIN &&
+       lv_obj_get_style_outline_width(obj, LV_PART_KNOB) <= 0 &&
+       lv_obj_get_style_shadow_opa(obj, LV_PART_KNOB) <= LV_OPA_MIN &&
+       lv_obj_get_style_shadow_width(obj, LV_PART_KNOB) <= 0) {
+        return false;
+    }
+
     lv_point_t c;
     int32_t r;
     get_center(obj, &c, &r);
@@ -919,13 +934,14 @@ static void get_knob_inv_area(lv_obj_t * obj, lv_area_t * area)
     if(knob_extra_size > 0) {
         lv_area_increase(area, knob_extra_size, knob_extra_size);
     }
+
+    return true;
 }
 
 static void inv_knob_area(lv_obj_t * obj)
 {
     lv_area_t a;
-    get_knob_inv_area(obj, &a);
-    lv_obj_invalidate_area(obj, &a);
+    if(get_knob_inv_area(obj, &a)) lv_obj_invalidate_area(obj, &a);
 }
 
 static void get_center(const lv_obj_t * obj, lv_point_t * center, int32_t * arc_r)


### PR DESCRIPTION
* For hidden arcs, do not even compute the old knob position.
* By default, spinners do not have a knob. Optimize arc invalidation for that common case.
* Optimize software arc rendering by trying to minimize the clip area: Splitting the arc was removed in the [parallel render refactoring](https://github.com/lvgl/lvgl/commit/f753265a799bdd910881238cb36f8d731f6d8727). This at least helps when the arc naturally only covers 1 or 2 quadrants (common for spinners).

In total, measuring ~10% reduced instruction count in direct rendering for spinners.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

