### PR TITLE
fix(slider/bar): prevent int32 overflow in pixel-position or value (10308)

### DIFF
--- a/src/widgets/bar/lv_bar.c
+++ b/src/widgets/bar/lv_bar.c
@@ -435,9 +435,9 @@ static void draw_indic(lv_event_t * e)
 
     if(LV_BAR_IS_ANIMATING(bar->start_value_anim)) {
         int32_t anim_start_value_start_x =
-            (int32_t)((int32_t)anim_length * (bar->start_value_anim.anim_start - bar->min_value)) / range;
+            (int32_t)(((int64_t)anim_length * (bar->start_value_anim.anim_start - bar->min_value)) / range);
         int32_t anim_start_value_end_x =
-            (int32_t)((int32_t)anim_length * (bar->start_value_anim.anim_end - bar->min_value)) / range;
+            (int32_t)(((int64_t)anim_length * (bar->start_value_anim.anim_end - bar->min_value)) / range);
 
         anim_start_value_x = (((anim_start_value_end_x - anim_start_value_start_x) * bar->start_value_anim.anim_state) /
                               LV_BAR_ANIM_STATE_END);
@@ -445,21 +445,21 @@ static void draw_indic(lv_event_t * e)
         anim_start_value_x += anim_start_value_start_x;
     }
     else {
-        anim_start_value_x = (int32_t)((int32_t)anim_length * (bar->start_value - bar->min_value)) / range;
+        anim_start_value_x = (int32_t)(((int64_t)anim_length * (bar->start_value - bar->min_value)) / range);
     }
 
     if(LV_BAR_IS_ANIMATING(bar->cur_value_anim)) {
         int32_t anim_cur_value_start_x =
-            (int32_t)((int32_t)anim_length * (bar->cur_value_anim.anim_start - bar->min_value)) / range;
+            (int32_t)(((int64_t)anim_length * (bar->cur_value_anim.anim_start - bar->min_value)) / range);
         int32_t anim_cur_value_end_x =
-            (int32_t)((int32_t)anim_length * (bar->cur_value_anim.anim_end - bar->min_value)) / range;
+            (int32_t)(((int64_t)anim_length * (bar->cur_value_anim.anim_end - bar->min_value)) / range);
 
         anim_cur_value_x = anim_cur_value_start_x + (((anim_cur_value_end_x - anim_cur_value_start_x) *
                                                       bar->cur_value_anim.anim_state) /
                                                      LV_BAR_ANIM_STATE_END);
     }
     else {
-        anim_cur_value_x = (int32_t)((int32_t)anim_length * (bar->cur_value - bar->min_value)) / range;
+        anim_cur_value_x = (int32_t)(((int64_t)anim_length * (bar->cur_value - bar->min_value)) / range);
     }
 
     /**

--- a/src/widgets/slider/lv_slider.c
+++ b/src/widgets/slider/lv_slider.c
@@ -602,7 +602,7 @@ static void update_knob_pos(lv_obj_t * obj, bool check_drag)
             new_value = p.x - (obj->coords.x1 + bg_left);
         }
         if(indic_w) {
-            new_value = (new_value * range + indic_w / 2) / indic_w;
+            new_value = (int32_t)(((int64_t)new_value * range + indic_w / 2) / indic_w);
             new_value += slider->bar.min_value;
         }
     }
@@ -621,7 +621,7 @@ static void update_knob_pos(lv_obj_t * obj, bool check_drag)
             new_value = p.y - (obj->coords.y2 + bg_bottom);
             new_value = -new_value;
         }
-        new_value = (new_value * range + indic_h / 2) / indic_h;
+        new_value = (int32_t)(((int64_t)new_value * range + indic_h / 2) / indic_h);
         new_value += slider->bar.min_value;
     }
 

--- a/tests/src/test_cases/widgets/test_bar.c
+++ b/tests/src/test_cases/widgets/test_bar.c
@@ -622,4 +622,80 @@ void test_bar_properties(void)
 #endif
 }
 
+void test_bar_large_range_cur_value_no_overflow(void)
+{
+    /* Prevent int32 overflow when indic_w * (cur-min) > INT32_MAX */
+    lv_obj_set_size(g_bar, 600, 24);
+    lv_bar_set_range(g_bar, 0, 20000000);
+    lv_bar_set_value(g_bar, 16000000, LV_ANIM_OFF);
+    lv_obj_update_layout(g_bar);
+    lv_refr_now(NULL);
+
+    lv_bar_t * ptr = (lv_bar_t *)g_bar;
+    int32_t indic_w = lv_area_get_width(&ptr->indic_area);
+    TEST_ASSERT_TRUE(indic_w > 300);
+}
+
+void test_bar_large_range_start_value_no_overflow(void)
+{
+    /* Prevent int32 overflow for start_value pixel position */
+    lv_obj_set_size(g_bar, 600, 24);
+    lv_bar_set_mode(g_bar, LV_BAR_MODE_RANGE);
+    lv_bar_set_range(g_bar, 0, 20000000);
+    lv_bar_set_value(g_bar, 19000000, LV_ANIM_OFF);
+    lv_bar_set_start_value(g_bar, 12000000, LV_ANIM_OFF);
+    lv_obj_update_layout(g_bar);
+    lv_refr_now(NULL);
+
+    lv_bar_t * ptr = (lv_bar_t *)g_bar;
+    TEST_ASSERT_TRUE(ptr->indic_area.x1 > 200);
+}
+
+void test_bar_safe_values_preserved(void)
+{
+    lv_obj_set_size(g_bar, 600, 24);
+    lv_bar_set_range(g_bar, 0, 20000000);
+    lv_bar_set_value(g_bar, 2000000, LV_ANIM_OFF);
+    lv_obj_update_layout(g_bar);
+    lv_refr_now(NULL);
+
+    lv_bar_t * ptr = (lv_bar_t *)g_bar;
+    int32_t indic_w = lv_area_get_width(&ptr->indic_area);
+    TEST_ASSERT_TRUE(indic_w > 30 && indic_w < 150);
+}
+
+void test_bar_large_range_cur_value_anim_no_overflow(void)
+{
+    /* Prevent int32 overflow during cur_value animation */
+    lv_obj_set_size(g_bar, 600, 24);
+    lv_bar_set_range(g_bar, 0, 20000000);
+    lv_bar_set_value(g_bar, 2000000, LV_ANIM_OFF);
+    lv_refr_now(NULL);
+
+    lv_bar_set_value(g_bar, 14000000, LV_ANIM_ON);
+    lv_obj_update_layout(g_bar);
+    lv_refr_now(NULL);
+
+    lv_bar_t * ptr = (lv_bar_t *)g_bar;
+    TEST_ASSERT_TRUE(lv_area_get_width(&ptr->indic_area) > 300);
+}
+
+void test_bar_large_range_start_value_anim_no_overflow(void)
+{
+    /* Prevent int32 overflow during start_value animation */
+    lv_obj_set_size(g_bar, 600, 24);
+    lv_bar_set_mode(g_bar, LV_BAR_MODE_RANGE);
+    lv_bar_set_range(g_bar, 0, 20000000);
+    lv_bar_set_value(g_bar, 19000000, LV_ANIM_OFF);
+    lv_bar_set_start_value(g_bar, 2000000, LV_ANIM_OFF);
+    lv_refr_now(NULL);
+
+    lv_bar_set_start_value(g_bar, 10000000, LV_ANIM_ON);
+    lv_obj_update_layout(g_bar);
+    lv_refr_now(NULL);
+
+    lv_bar_t * ptr = (lv_bar_t *)g_bar;
+    TEST_ASSERT_TRUE(ptr->indic_area.x1 > 200);
+}
+
 #endif

--- a/tests/src/test_cases/widgets/test_slider.c
+++ b/tests/src/test_cases/widgets/test_slider.c
@@ -610,4 +610,66 @@ void test_slider_range_mode_vertical_rtl_drag_start_value_selection(void)
                                        &ptr_ver->bar.cur_value, -1);
 }
 
+void test_slider_large_range_drag_no_int32_overflow_horiz(void)
+{
+    /* Prevent int32 overflow during horizontal drag.
+     * 600px slider x range 20M → pixel * range > INT32_MAX for pixel > ~107. */
+    lv_obj_set_size(slider, 600, 20);
+    lv_obj_center(slider);
+    lv_slider_set_range(slider, 0, 20000000);
+    lv_slider_set_value(slider, 0, LV_ANIM_OFF);
+    lv_obj_update_layout(slider);
+    lv_refr_now(NULL);
+
+    /* Drag from center to right: pixel ~300 → value should be ~10M (not overflowed) */
+    lv_test_mouse_move_to_obj(slider);
+    lv_test_mouse_press();
+    lv_test_wait(50);
+    lv_test_mouse_move_by(150, 0);  /* drag right ~50% more */
+    lv_test_wait(50);
+    lv_test_mouse_release();
+    lv_test_wait(50);
+
+    int32_t val = lv_slider_get_value(slider);
+    /* Value must NOT be 0 (overflow collapse). Should be in upper half of range. */
+    TEST_ASSERT_TRUE(val > 5000000);
+    TEST_ASSERT_TRUE(val <= 20000000);
+}
+
+void test_slider_large_range_drag_no_int32_overflow_vert(void)
+{
+    /* Prevent int32 overflow during vertical drag. */
+    lv_obj_set_size(slider, 20, 400);
+    lv_obj_center(slider);
+    lv_slider_set_range(slider, 0, 20000000);
+    lv_slider_set_value(slider, 0, LV_ANIM_OFF);
+    lv_obj_update_layout(slider);
+    lv_refr_now(NULL);
+
+    lv_test_mouse_move_to_obj(slider);
+    lv_test_mouse_press();
+    lv_test_wait(50);
+    lv_test_mouse_move_by(0, -100);
+    lv_test_wait(50);
+    lv_test_mouse_release();
+    lv_test_wait(50);
+
+    int32_t val = lv_slider_get_value(slider);
+    TEST_ASSERT_TRUE(val > 5000000);
+    TEST_ASSERT_TRUE(val <= 20000000);
+}
+
+void test_slider_large_range_key_up_increments(void)
+{
+    lv_obj_set_size(slider, 600, 20);
+    lv_slider_set_range(slider, 0, 20000000);
+    lv_slider_set_value(slider, 10000000, LV_ANIM_OFF);
+
+    uint32_t key = LV_KEY_RIGHT;
+    lv_obj_send_event(slider, LV_EVENT_KEY, (void *)&key);
+
+    int32_t val = lv_slider_get_value(slider);
+    TEST_ASSERT_TRUE(val > 10000000);
+}
+
 #endif


### PR DESCRIPTION
### Summary

Fix int32 overflow in `lv_slider` and `lv_bar` pixel-position mapping<br>when indicator size × value range exceeds `INT32_MAX`.

The slider inherits from `lv_bar_class`. Both slider and bar compute<br>pixel positions via `pixel × range` which overflows for large ranges.

This combined PR fixes both. The bar fix is required for the vertical<br>slider test to pass CI (UBSan catches the bar overflow during slider<br>redraw).

### Changes

Cast `int32_t` multiplication to `int64_t` before the division in<br>`lv_slider::update_knob_pos` and `lv_bar::draw_indic`.

### Tests

Slider — 3 tests (mouse-drag + key event, large range).<br>Bar — 5 tests (indicator pixel check: cur/start value, with/without animation).

### Notes

- [X] Add [Tests](<https://github.com/lvgl/lvgl/blob/master/tests/README.md>) if applicable.
- [X] Run `scripts/code-format.py` and follow the [Code Conventions](<https://docs.lvgl.io/master/CODING_STYLE.html>).

Closes lvgl/lvgl#10308