### PR TITLE
fix(obj_pos): correct off-by-one in lv_obj_get_transformed_area

### DIFF
--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -1010,9 +1010,9 @@ void lv_obj_get_transformed_area(const lv_obj_t * obj, lv_area_t * area, lv_obj_
     lv_obj_transform_point_array(obj, p, 4, flags);
 
     area->x1 = LV_MIN4(p[0].x, p[1].x, p[2].x, p[3].x);
-    area->x2 = LV_MAX4(p[0].x, p[1].x, p[2].x, p[3].x);
+    area->x2 = LV_MAX4(p[0].x, p[1].x, p[2].x, p[3].x) - 1;
     area->y1 = LV_MIN4(p[0].y, p[1].y, p[2].y, p[3].y);
-    area->y2 = LV_MAX4(p[0].y, p[1].y, p[2].y, p[3].y);
+    area->y2 = LV_MAX4(p[0].y, p[1].y, p[2].y, p[3].y) - 1;
 }
 
 typedef struct {


### PR DESCRIPTION
## Description

Fixes lvgl/lvgl#10211

`lv_obj_get_transformed_area` converts input inclusive area coordinates to exclusive boundary points by adding +1 to x2/y2 before applying the transformation. However, the resulting bounding box was not converted back to inclusive coordinates, causing the returned area to be 1px wider and 1px taller than the actual transformed region.

This leads to unnecessary display refreshes, especially noticeable on e-ink displays where minimizing the refresh area is important.

## Fix

Subtract 1 from the output x2/y2 values to convert the transformed exclusive boundary back to inclusive coordinates.

## Verification

Local test results with `OPTIONS_TEST_DEFHEAP`:

* **156/156 tests passed, 0 failures**
* `test_obj_pos`: 12/12 passed
* All `test_render_to_*` (12 variants): passed
* All widget tests: passed

Render reference images will need regeneration since the fix changes the bounding box by 1px, affecting `layer_normal` rendering at object edges.

## Analysis

The 4 input corner points are constructed in exclusive coordinate space:

```
p[0] = {x1, y1}          // top-left (same in both systems)
p[1] = {x1, y2 + 1}      // bottom-left exclusive
p[2] = {x2 + 1, y1}      // top-right exclusive
p[3] = {x2 + 1, y2 + 1}  // bottom-right exclusive
```

After transformation, `LV_MAX4` gives the exclusive far boundary. To get the inclusive `x2`/`y2` for `lv_area_t`, we must subtract 1.

Signed-off-by: hanzhijian [hanzhijian@zepp.com](<mailto:hanzhijian@zepp.com>)