### PR TITLE
docs(api): add title to API meta.json

### DIFF
--- a/docs/src/api/meta.json
+++ b/docs/src/api/meta.json
@@ -1,4 +1,5 @@
 {
+  "title": "API",
   "pages": [
     "public",
     "private",


### PR DESCRIPTION
Add a `"title"` field ("API") to `docs/src/api/meta.json` so the API section has an explicit title.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

