### PR TITLE
fix(fs): use uintptr format for buffer paths

### DIFF
--- a/include/lvgl/stdlib/lv_sprintf.h
+++ b/include/lvgl/stdlib/lv_sprintf.h
@@ -47,6 +47,16 @@
 
 #include "../lv_types.h"
 
+#ifndef LV_PRIuPTR
+    #ifdef PRIuPTR
+        #define LV_PRIuPTR PRIuPTR
+    #elif defined(LV_ARCH_64)
+        #define LV_PRIuPTR LV_PRIu64
+    #else
+        #define LV_PRIuPTR LV_PRIu32
+    #endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/fs/lv_fs.c
+++ b/src/fs/lv_fs.c
@@ -147,11 +147,12 @@ void lv_fs_make_path_from_buffer(lv_fs_path_ex_t * path, char letter, const void
 
     /*Don't add the '.' and the extension if the extension is NULL*/
     if(ext == NULL) {
-        lv_snprintf(path->path, sizeof(path->path), "%c:%zu-%" LV_PRIu32, letter, (size_t) buf, size);
+        lv_snprintf(path->path, sizeof(path->path), "%c:%" LV_PRIuPTR "-%" LV_PRIu32, letter,
+                    (lv_uintptr_t)buf, size);
     }
     else {
-        lv_snprintf(path->path, sizeof(path->path), "%c:%zu-%" LV_PRIu32 ".%s", letter,
-                    (size_t) buf, size, ext);
+        lv_snprintf(path->path, sizeof(path->path), "%c:%" LV_PRIuPTR "-%" LV_PRIu32 ".%s", letter,
+                    (lv_uintptr_t)buf, size, ext);
     }
 }
 

--- a/tests/src/test_cases/widgets/test_image.c
+++ b/tests/src/test_cases/widgets/test_image.c
@@ -787,6 +787,12 @@ void test_image_raw_data_as_file(void)
     lv_fs_path_ex_t mempath;
     lv_fs_make_path_from_buffer(&mempath, LV_FS_MEMFS_LETTER, img_bin, sizeof(img_bin), "bin");
 
+    void * decoded_buf = NULL;
+    uint32_t decoded_size = 0;
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_fs_get_buffer_from_path(&mempath, &decoded_buf, &decoded_size));
+    TEST_ASSERT_EQUAL_PTR(img_bin, decoded_buf);
+    TEST_ASSERT_EQUAL_UINT32(sizeof(img_bin), decoded_size);
+
     lv_obj_t * img_1 = lv_image_create(lv_screen_active());
     lv_image_set_src(img_1, (const char *)&mempath);
     lv_obj_center(img_1);


### PR DESCRIPTION
## Summary

* add `LV_PRIuPTR` for pointer-sized printf formatting
* use it when encoding buffer-backed file paths instead of `%zu`
* assert the buffer path round-trips through `lv_fs_get_buffer_from_path`

Fixes lvgl/lvgl#9877.

## Testing

* `git diff --check HEAD~1..HEAD`
* static check that `lv_fs_make_path_from_buffer` no longer uses `%zu`

Not run locally:

* `python tests\main.py test --test-suite test_image_raw_data_as_file` (local environment is missing `pypng`; this machine also lacks `cmake`, `ninja`, and a C compiler)

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)