### PR TITLE
fix(examples): include bezier chart endpoint

### DIFF
--- a/examples/anim/lv_example_anim_3.c
+++ b/examples/anim/lv_example_anim_3.c
@@ -78,8 +78,8 @@ static int32_t anim_path_bezier3_cb(const lv_anim_t * a)
 
 static void refer_chart_cubic_bezier(void)
 {
-    for(uint16_t i = 0; i <= CHART_POINTS_NUM; i ++) {
-        int32_t t = i * (1024 / CHART_POINTS_NUM);
+    for(uint16_t i = 0; i < CHART_POINTS_NUM; i ++) {
+        int32_t t = (int32_t)i * 1024 / (CHART_POINTS_NUM - 1);
         int32_t step = lv_bezier3(t, 0, ginfo.p1, ginfo.p2, 1024);
         lv_chart_set_series_value_by_id2(ginfo.chart, ginfo.ser1, i, t, step);
     }


### PR DESCRIPTION
### Description of the feature or fix

lv_example_anim_3 sets the chart point count to CHART_POINTS_NUM, but the bezier refresh loop iterated through i == CHART_POINTS_NUM. lv_chart_set_series_value_by_id2() ignores that id because valid point ids are 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

