### PR TITLE
fix(roller): fix single-option roller stuck in edit mode with encoder

### DIFF
--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -441,8 +441,12 @@ static void lv_roller_event(const lv_obj_class_t * class_p, lv_event_t * e)
         }
     }
     else if(code == LV_EVENT_RELEASED || code == LV_EVENT_PRESS_LOST) {
-        if(roller->option_cnt <= 1) return;
-
+        /* Unlike PRESSED/PRESSING/KEY/ROTARY (which are only meaningful when there is
+         * more than one option to scroll/select between), release_handler() is also
+         * responsible for leaving edit mode on an encoder release. That part doesn't
+         * depend on option_cnt, so it must run even for a single-option roller -
+         * otherwise a roller with only one option can never leave edit mode once
+         * entered via the encoder. */
         release_handler(obj);
     }
     else if(code == LV_EVENT_FOCUSED) {

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -431,8 +431,12 @@ static void lv_roller_event(const lv_obj_class_t * class_p, lv_event_t * e)
         }
     }
     else if(code == LV_EVENT_RELEASED || code == LV_EVENT_PRESS_LOST) {
-        if(roller->option_cnt <= 1) return;
-
+        /* Unlike PRESSED/PRESSING/KEY/ROTARY (which are only meaningful when there is
+         * more than one option to scroll/select between), release_handler() is also
+         * responsible for leaving edit mode on an encoder release. That part doesn't
+         * depend on option_cnt, so it must run even for a single-option roller -
+         * otherwise a roller with only one option can never leave edit mode once
+         * entered via the encoder. */
         release_handler(obj);
     }
     else if(code == LV_EVENT_FOCUSED) {

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -441,12 +441,6 @@ static void lv_roller_event(const lv_obj_class_t * class_p, lv_event_t * e)
         }
     }
     else if(code == LV_EVENT_RELEASED || code == LV_EVENT_PRESS_LOST) {
-        /* Unlike PRESSED/PRESSING/KEY/ROTARY (which are only meaningful when there is
-         * more than one option to scroll/select between), release_handler() is also
-         * responsible for leaving edit mode on an encoder release. That part doesn't
-         * depend on option_cnt, so it must run even for a single-option roller -
-         * otherwise a roller with only one option can never leave edit mode once
-         * entered via the encoder. */
         release_handler(obj);
     }
     else if(code == LV_EVENT_FOCUSED) {

--- a/tests/src/test_cases/widgets/test_roller.c
+++ b/tests/src/test_cases/widgets/test_roller.c
@@ -415,4 +415,25 @@ void test_roller_properties(void)
 #endif
 }
 
+void test_roller_single_option_should_leave_edit_mode_if_released(void)
+{
+    lv_obj_t * roller_one_opt = lv_roller_create(active_screen);
+    lv_roller_set_options(roller_one_opt, "Single", LV_ROLLER_MODE_NORMAL);
+
+    lv_group_t * temp_g = lv_group_create();
+    lv_indev_set_group(lv_test_indev_get_indev(LV_INDEV_TYPE_ENCODER), temp_g);
+    lv_group_add_obj(temp_g, roller_one_opt);
+
+    lv_group_set_editing(temp_g, true);
+    TEST_ASSERT_TRUE(lv_group_get_editing(temp_g));
+
+    lv_test_encoder_click();
+
+    /* A roller with a single option must still be able to leave edit mode on
+     * release, just like a roller with multiple options. */
+    TEST_ASSERT_FALSE(lv_group_get_editing(temp_g));
+
+    lv_group_delete(temp_g);
+}
+
 #endif


### PR DESCRIPTION
Fixes #9979.

## Problem

A roller with only one option gets permanently stuck in edit mode when navigated with an encoder: the first encoder press enters edit mode as expected, but a subsequent press cannot leave it.

**Root cause**: `lv_roller_event()`'s `LV_EVENT_RELEASED`/`LV_EVENT_PRESS_LOST` handler short-circuits with `if(roller->option_cnt <= 1) return;` before ever calling `release_handler(obj)`. This guard makes sense for the other early-return sites in the same function (`PRESSED`, `PRESSING`, `KEY`, `ROTARY`), which are all about scrolling/selecting between options - meaningless with a single option. But `release_handler()` is not just about option selection: for an `LV_INDEV_TYPE_ENCODER`, it is the **only** place that calls `lv_group_set_editing(g, false)` to leave edit mode:

```c
if(indev_type == LV_INDEV_TYPE_ENCODER) {
    lv_group_t * g = lv_obj_get_group(obj);
    if(lv_group_get_editing(g)) {
        lv_group_set_editing(g, false);
    }
}
```

That part has nothing to do with `option_cnt`, so skipping the whole call for a single-option roller means there is no code path left that can ever clear the group's editing flag once it's set (via `lv_group_set_editing(g, true)` on encoder ENTER, in `src/indev/lv_indev.c`) - the roller is stuck in edit mode permanently.

## Fix

Drop the `option_cnt <= 1` early return in the `RELEASED`/`PRESS_LOST` handler and always call `release_handler(obj)`. I checked the rest of `release_handler()` for any other issue triggered by `option_cnt == 1`:

- The KEYPAD/ENCODER path only touches `sel_opt_id_ori` and the group's editing flag - independent of `option_cnt`.
- The POINTER/BUTTON path computes `new_opt` from either the clicked letter position or (if dragged) a clamped index (`if(id >= (int32_t)roller->option_cnt) id = roller->option_cnt - 1;`), which for a single option always safely resolves to `new_opt = 0`.

So `release_handler()` is safe to call unconditionally regardless of `option_cnt`; the early return in this one branch was simply too broad, conflating "nothing to scroll/select" with "nothing to do on release".

## Verification

I don't have vcpkg set up in this environment (`tests/CMakeLists.txt` unconditionally requires `$ENV{VCPKG_INSTALLATION_ROOT}` on Windows, which is only present on LVGL's CI runners), so I couldn't run the full test suite locally. Instead:

1. Traced the exact event/state-machine path by reading `src/indev/lv_indev.c`'s `indev_encoder_proc()` alongside `src/widgets/roller/lv_roller.c` and `src/core/lv_group.c`, confirming `lv_group_set_editing(g, false)` inside `release_handler()` is the only code path that can clear a group's editing flag for an `LV_INDEV_TYPE_ENCODER`.
2. Added a regression test (`test_roller_single_option_should_leave_edit_mode_if_released`) following the exact same pattern as the existing `test_slider_range_mode_should_leave_edit_mode_if_released` test: create a single-option roller in its own group, force `lv_group_set_editing(true)`, simulate one `lv_test_encoder_click()`, and assert `lv_group_get_editing()` is now `false`.

## Disclosure

Generative AI (Claude) was used to help investigate this issue, implement, and verify this fix. All changes were reviewed by me before submission.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

