### PR TITLE
fix(benchmark): prevent infinite loop in is_optimization_enabled on tickless simulators

### DIFF
--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -1005,6 +1005,16 @@ static bool is_optimization_enabled(void)
             loop_not_optimizable();
         }
         t_unoptimized = lv_tick_elaps(t);
+
+        /*On some simulators (e.g. Zephyr's native_sim "inf_clock" model) the
+         *system tick only advances while the CPU is idle, so a busy loop like
+         *this never sees time elapse. In that case `t_unoptimized` stays 0 no
+         *matter how much work is done and the loop would never terminate.
+         *Detect it (a large amount of work with zero elapsed time) and give up
+         *measuring rather than hanging; assume optimizations are enabled.*/
+        if(t_unoptimized == 0 && max_cnt >= 1024) {
+            return true;
+        }
     } while(t_unoptimized < 50);
 
     /*Run the optimizable loop the same amount of times*/


### PR DESCRIPTION
is_optimization_enabled() (used by the benchmark summary screen) times an "unoptimizable" busy loop and
  keeps doubling the iteration count until lv_tick_elaps() reports at least 50 ms:

  do {
      max_cnt *= 2;
      t = lv_tick_get();
      for(i = 0; i < max_cnt; i++) {
          loop_not_optimizable();
      }
      t_unoptimized = lv_tick_elaps(t);
  } while(t_unoptimized < 50);

  This assumes the system tick advances while application code runs. On simulators where it does not —
  e.g. Zephyr's native_sim, whose "inf_clock" model only advances simulated time while the CPU is idle —
  the busy loop never lets time pass, so lv_tick_elaps() stays 0 and the do/while condition t_unoptimized
  < 50 is never satisfied. The benchmark summary screen hangs forever.

  It cannot even escape by overflow: once max_cnt doubles past UINT32_MAX it wraps to 0, the inner loop
  then runs zero times, and the outer loop keeps spinning.

  Fix

  Detect the pathological case — a large amount of work performed with a zero elapsed tick — and stop
  measuring. Assume optimizations are enabled, as the only use is to show a warning that they are off, and the correct behaviour in this case is to not show the warning.