### PR TITLE
fix(bmp): reject truncated files in decoder_info

### DIFF
--- a/src/image/lv_bmp.c
+++ b/src/image/lv_bmp.c
@@ -102,7 +102,12 @@ static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_d
             /*Save the data in the header*/
             uint8_t headers[54];
 
-            lv_fs_read(&dsc->file, headers, 54, NULL);
+            uint32_t rn = 0;
+            lv_fs_res_t res = lv_fs_read(&dsc->file, headers, 54, &rn);
+            if(res != LV_FS_RES_OK || rn < 54) {
+                return LV_RESULT_INVALID;
+            }
+
             uint32_t w;
             uint32_t h;
             lv_memcpy(&w, headers + 18, 4);


### PR DESCRIPTION
### Description

`decoder_info()` in `lv_bmp.c` reads the 54-byte BMP header with
`lv_fs_read(&dsc->file, headers, 54, NULL)`, ignoring how many bytes were
actually read. For a file shorter than 54 bytes the tail of the `headers`
stack buffer stays uninitialized, and that garbage is then copied into
`width`/`height`/`bpp` while the function still returns `LV_RESULT_OK`.

This fix captures the actual read count and returns `LV_RESULT_INVALID`
on a short or failed read, matching how other decoders (e.g. libwebp)
already check `lv_fs_read`.

### How to reproduce / verify

Feed a `.bmp` file smaller than 54 bytes to `lv_image_decoder_get_info()`.
Under Valgrind Memcheck the original code reports a read of uninitialized
values; with this change the truncated file is rejected cleanly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

