### PR TITLE
fix(draw): prevent rounded image memory growth during screen transitions

### DIFF
--- a/src/draw/sw/lv_draw_sw_img.c
+++ b/src/draw/sw/lv_draw_sw_img.c
@@ -381,6 +381,7 @@ static void radius_only(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc
         blend_area.y1 ++;
         blend_area.y2 ++;
     }
+    lv_draw_sw_mask_free_param(&mask_param);
     lv_free(mask_buf);
 
 }


### PR DESCRIPTION
### Description
Repeatedly switching between two screens using `lv_screen_load_anim()`
causes LVGL memory usage to grow after each transition.

The issue does not occur with `LV_SCREEN_LOAD_ANIM_NONE`.

### Allocation path

This issue is triggered when the software renderer exhausts the rounded
mask circle cache during an animated screen transition.

The allocation path is:

1. A rounded image is rendered by `lv_draw_sw_img.c`.
2. `radius_only()` calls `lv_draw_sw_mask_radius_init()`.
3. `lv_draw_sw_mask_radius_init()` searches `_circle_cache`.
4. The default cache contains only four entries:

   ```c
   #define LV_DRAW_SW_CIRCLE_CACHE_SIZE 4
During a MOVE transition, both the old and new screens are rendered.
Together they contain more distinct corner radii than the cache can hold.

When all cache entries have a non-zero used_cnt, LVGL enters the
temporary allocation path:
/*There is no unused entry. Allocate one temporarily*/
entry = lv_malloc_zeroed(sizeof(lv_draw_sw_mask_radius_circle_dsc_t));
entry->life = -1;

circ_calc_aa4() then allocates the corresponding circle buffer.

The code intends to release temporary entries from
lv_draw_sw_mask_free_param() when life < 0. However, in this
screen-transition scenario, the observed allocations are not balanced after
rendering becomes idle. Repeated transitions therefore continuously reduce
available LVGL memory.
This is not simply the expected persistent memory used by _circle_cache.
The number of used allocations continues growing after the cache has already
been initialized.

**Reproduction Method**

```markdown
### Steps to reproduce

Configuration:

```c
#define LV_USE_DRAW_SW 1
#define LV_DRAW_SW_COMPLEX 1
#define LV_DRAW_SW_CIRCLE_CACHE_SIZE 4
Create two persistent screens, screen A and screen B.

Add at least three image-backed widgets to each screen.

Give the images different non-zero corner radii.
Example radii:
Screen A: 8, 12, 16
Screen B: 20, 24, 28

Load screen A.

Repeatedly switch between the two screens:
lv_screen_load_anim(screen_b,
                    LV_SCREEN_LOAD_ANIM_MOVE_LEFT,
                    200,
                    0,
                    false);

lv_screen_load_anim(screen_a,
                    LV_SCREEN_LOAD_ANIM_MOVE_RIGHT,
                    200,
                    0,
                    false);

Wait about 300 ms between transitions so that the previous animation can
finish.

Repeat the transition at least 100 times.

Record lv_mem_monitor() before and after the transition loop.

Stop all transitions and wait several seconds before recording memory
again.

Actual result
free_size continuously decreases.
The number of used allocations continuously increases.
The memory is not recovered after all animations stop.
Frequently observed growing allocation sizes include 28, 68, and 116 bytes.
Control tests
The memory growth does not occur when:
LV_SCREEN_LOAD_ANIM_NONE is used.
The corner radii are removed.
When switching between two pages with an animation,
you need to make sure that the total demand for rounded corner masks on both screens doesn’t exceed the capacity of the circular cache.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

