### PR TITLE
build(cmake): fix lv_conf.h installation path and defines

### DIFF
--- a/env_support/cmake/lvgl.pc.in
+++ b/env_support/cmake/lvgl.pc.in
@@ -8,6 +8,6 @@ URL: https://lvgl.io/
 Version: @LVGL_VERSION@
 Requires: @LVGL_PKG_REQUIRES@
 Requires.private: @LVGL_PKG_REQUIRES_PRIVATE@
-Cflags: -I${includedir}
+Cflags: -I${includedir} @LVGL_PKG_CFLAGS@
 Libs: -L${libdir} -llvgl @LVGL_PKG_LIBS@
 Libs.private: @LVGL_PKG_LIBS_PRIVATE@

--- a/env_support/cmake/lvgl_target_definitions.cmake
+++ b/env_support/cmake/lvgl_target_definitions.cmake
@@ -1,0 +1,58 @@
+# Accumulates the compile definitions that are active while BUILDING lvgl.
+set_property(GLOBAL PROPERTY LVGL_BUILD_DEFINES "")
+
+# Accumulates the "-D..." fragments emitted into the pkg-config Cflags line.
+# These mirror the install-interface definitions: both describe what a downstream
+# consumer needs to compile against the installed lvgl, just via different channels
+# (this one is the .pc file, the CMake exported target is the other).
+set_property(GLOBAL PROPERTY LVGL_INSTALL_DEFINES "")
+
+# Parse the [PUBLIC|PRIVATE|INTERFACE] scope keyword, defaulting to PUBLIC.
+# Sets _scope and _defs in the calling function scope.
+macro(_lvgl_parse_definition_scope)
+  set(options PUBLIC PRIVATE INTERFACE)
+  cmake_parse_arguments(ARG "${options}" "" "" ${ARGN})
+
+  set(_scope PUBLIC)
+  if(ARG_PRIVATE)
+    set(_scope PRIVATE)
+  elseif(ARG_INTERFACE)
+    set(_scope INTERFACE)
+  endif()
+
+  set(_defs ${ARG_UNPARSED_ARGUMENTS})
+endmacro()
+
+# Adds compile definitions that apply when BUILDING lvgl.
+# 1. Wraps each definition in $<BUILD_INTERFACE:...> on the lvgl target
+# 2. Records the raw definitions so preprocess_lv_conf_internal.py can consume them
+#
+# Usage: lvgl_build_definitions([PUBLIC|PRIVATE|INTERFACE] <def>...)
+function(lvgl_build_definitions)
+  _lvgl_parse_definition_scope(${ARGN})
+
+  foreach(_def IN LISTS _defs)
+    target_compile_definitions(lvgl ${_scope} $<BUILD_INTERFACE:${_def}>)
+  endforeach()
+
+  get_property(_cur GLOBAL PROPERTY LVGL_BUILD_DEFINES)
+  list(APPEND _cur ${_defs})
+  set_property(GLOBAL PROPERTY LVGL_BUILD_DEFINES "${_cur}")
+endfunction()
+
+# Adds compile definitions that apply when the INSTALLED lvgl is consumed.
+# 1. Wraps each definition in $<INSTALL_INTERFACE:...> on the lvgl target
+#  (delivered to CMake consumers via the exported target)
+# 2. Stores the defines so they can be consumed by pkg-config
+#
+# Usage: lvgl_install_definitions([PUBLIC|PRIVATE|INTERFACE] <def>...)
+function(lvgl_install_definitions)
+  _lvgl_parse_definition_scope(${ARGN})
+
+  get_property(_cflags GLOBAL PROPERTY LVGL_INSTALL_DEFINES)
+  foreach(_def IN LISTS _defs)
+    target_compile_definitions(lvgl ${_scope} $<INSTALL_INTERFACE:${_def}>)
+    list(APPEND _cflags "-D${_def}")
+  endforeach()
+  set_property(GLOBAL PROPERTY LVGL_INSTALL_DEFINES "${_cflags}")
+endfunction()

--- a/env_support/cmake/main.cmake
+++ b/env_support/cmake/main.cmake
@@ -95,11 +95,12 @@ add_library(lvgl ${SOURCES})
 add_library(lvgl::lvgl ALIAS lvgl)
 
 set(CONF_PATH)
-
+include(${CMAKE_CURRENT_LIST_DIR}/lvgl_target_definitions.cmake)
 if (NOT LV_BUILD_USE_KCONFIG)
 
     # Default - use the lv_conf.h configuration file
-    target_compile_definitions(lvgl PUBLIC LV_KCONFIG_IGNORE)
+    lvgl_build_definitions(LV_KCONFIG_IGNORE)
+    lvgl_install_definitions(LV_KCONFIG_IGNORE)
 
     message(STATUS ${LV_BUILD_CONF_PATH})
 
@@ -115,7 +116,7 @@ if (NOT LV_BUILD_USE_KCONFIG)
 
         get_filename_component(CONF_INC_DIR ${CONF_PATH} DIRECTORY)
 
-        target_compile_definitions(lvgl PUBLIC LV_CONF_PATH="${CONF_PATH}")
+        lvgl_build_definitions("LV_CONF_PATH=\"${CONF_PATH}\"")
 
     elseif(LV_BUILD_CONF_DIR)
 
@@ -133,7 +134,7 @@ if (NOT LV_BUILD_USE_KCONFIG)
 
         set(CONF_PATH ${CONF_INC_DIR}/lv_conf.h)
 
-        target_compile_definitions(lvgl PUBLIC LV_CONF_INCLUDE_SIMPLE)
+        lvgl_build_definitions(LV_CONF_INCLUDE_SIMPLE)
 
     else()
 
@@ -144,7 +145,7 @@ if (NOT LV_BUILD_USE_KCONFIG)
         set(CONF_INC_DIR ${CMAKE_SOURCE_DIR})
         set(CONF_PATH ${CONF_INC_DIR}/lv_conf.h)
 
-        target_compile_definitions(lvgl PUBLIC LV_CONF_INCLUDE_SIMPLE)
+        lvgl_build_definitions(LV_CONF_INCLUDE_SIMPLE)
 
     endif()
 
@@ -152,6 +153,10 @@ if (NOT LV_BUILD_USE_KCONFIG)
     if (NOT EXISTS ${CONF_PATH})
         message(FATAL_ERROR "Configuration file: ${CONF_PATH} - not found")
     endif()
+
+    # The lv_conf.h used during the build is installed to <includedir>/lvgl/lv_conf.h
+    # (see the installation section), so the installed library is self-contained and
+    # consumers resolve it the same way as in the Kconfig case, via LV_CONF_PATH.
 
 else()
 
@@ -164,24 +169,29 @@ else()
     # generate_cmake_variables.py script.
     set(GEN_VARS_KCONFIG_MODE_FLAG --kconfig)
 
-    # If using Kconfig, we need to define additional definitions
-    target_compile_definitions(lvgl PUBLIC
-        "LV_CONF_SKIP"
-        "LV_CONF_KCONFIG_EXTERNAL_INCLUDE=\"${KCONFIG_EXTERNAL_INCLUDE}\"")
-
+    # If using Kconfig, we need to define additional build definitions
+    lvgl_build_definitions(
+      LV_CONF_SKIP
+      "LV_CONF_KCONFIG_EXTERNAL_INCLUDE=\"${KCONFIG_EXTERNAL_INCLUDE}\"")
 endif()
 
+
+
 if (LV_BUILD_LVGL_H_SYSTEM_INCLUDE)
-    target_compile_definitions(lvgl PUBLIC LV_LVGL_H_INCLUDE_SYSTEM)
+    lvgl_build_definitions(LV_LVGL_H_INCLUDE_SYSTEM)
 elseif(LV_BUILD_LVGL_H_SIMPLE_INCLUDE)
-    target_compile_definitions(lvgl PUBLIC LV_LVGL_H_INCLUDE_SIMPLE)
+    lvgl_build_definitions(LV_LVGL_H_INCLUDE_SIMPLE)
 endif()
 
 
 if (LV_BUILD_SET_CONFIG_OPTS)
     # Use the portable pcpp to preprocess lv_conf_internal.h
 
-    get_target_property(CONF_DEFINES lvgl COMPILE_DEFINITIONS)
+    # Use the definitions active during the build (recorded by
+    # lvgl_build_definitions). We can't use get_target_property(...
+    # COMPILE_DEFINITIONS) here because it returns raw generator-expression
+    # syntax (e.g. "$<BUILD_INTERFACE:LV_CONF_SKIP>") that pcpp can't parse.
+    get_property(CONF_DEFINES GLOBAL PROPERTY LVGL_BUILD_DEFINES)
 
     execute_process(
         COMMAND ${Python_EXECUTABLE} ${LVGL_ROOT_DIR}/scripts/preprocess_lv_conf_internal.py
@@ -336,11 +346,20 @@ if(CONFIG_LV_USE_PRIVATE_API)
     ")
 endif()
 
-# When KConfig is used, copy the expanded conf header and rename it to lv_conf.h
+# Install lv_conf.h inside lvgl/config so its next to lv_conf_internal.h
+# and define LV_CONF_INCLUDE_SIMPLE so that it can be found
+lvgl_install_definitions(LV_CONF_INCLUDE_SIMPLE)
 if(LV_BUILD_USE_KCONFIG)
+    # Kconfig: install the expanded configuration header
     install(
         FILES "${CMAKE_CURRENT_BINARY_DIR}/lv_conf_expanded.h"
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/lvgl/config"
+        RENAME lv_conf.h)
+else()
+    # Non-kconfig: install the actual lv_conf.h used during the build
+    install(
+        FILES "${CONF_PATH}"
+	DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/lvgl/config"
         RENAME lv_conf.h)
 endif()
 
@@ -351,7 +370,9 @@ get_property(PKG_LIBS_PRIVATE GLOBAL PROPERTY LVGL_PKG_LIBS_PRIVATE)
 get_property(CMAKE_PUBLIC_DEPS GLOBAL PROPERTY LVGL_CMAKE_PUBLIC_DEPS)
 get_property(CMAKE_PRIVATE_DEPS GLOBAL PROPERTY LVGL_CMAKE_PRIVATE_DEPS)
 get_property(CMAKE_RAW_LIBS GLOBAL PROPERTY LVGL_CMAKE_RAW_LIBS)
+get_property(PKG_CFLAGS GLOBAL PROPERTY LVGL_INSTALL_DEFINES)
 
+list(JOIN PKG_CFLAGS " " LVGL_PKG_CFLAGS)
 list(JOIN PKG_LIBS_PRIVATE " " LVGL_PKG_LIBS_PRIVATE)
 list(JOIN PKG_REQUIRES " " LVGL_PKG_REQUIRES)
 list(JOIN PKG_REQUIRES_PRIVATE " " LVGL_PKG_REQUIRES_PRIVATE)

--- a/include/lvgl/config/lv_conf_internal.h
+++ b/include/lvgl/config/lv_conf_internal.h
@@ -162,7 +162,7 @@
  * Detect if the user is using the new calendar day/month configuration
  * in order to avoid warnings for users that have migrated.
  */
-#ifdef LV_MONDAY_STR
+#if defined(LV_MONDAY_STR) || defined(CONFIG_LV_MONDAY_STR)
 #define LV_CALENDAR_DISABLE_DEFAULT_DAY_NAMES 1
 #else
 #define LV_CALENDAR_DISABLE_DEFAULT_DAY_NAMES 0
@@ -172,7 +172,7 @@
  * Detect if the user is using the new calendar day/month configuration
  * in order to avoid warnings for users that have migrated.
  */
-#ifdef LV_JANUARY_STR
+#if defined(LV_JANUARY_STR) || defined(CONFIG_LV_JANUARY_STR)
 #define LV_CALENDAR_DISABLE_DEFAULT_MONTH_NAMES 1
 #else
 #define LV_CALENDAR_DISABLE_DEFAULT_MONTH_NAMES 0
@@ -181,12 +181,22 @@
 /* 
  * Detect if the user is using the xkb keymap configuration
  * in order to avoid warnings for users that have migrated.
+ * we only need to check for it if LV_LIBINPUT_XKB is enabled
+ * so evaluate it first and undef it afterwards
  */
-#ifdef LV_LIBINPUT_XKB_RULES
+#ifndef LV_LIBINPUT_XKB
+    #ifdef CONFIG_LV_LIBINPUT_XKB
+        #define LV_LIBINPUT_XKB CONFIG_LV_LIBINPUT_XKB
+    #else
+        #define LV_LIBINPUT_XKB 0
+    #endif
+#endif
+#if LV_LIBINPUT_XKB && (defined(LV_LIBINPUT_XKB_RULES) || defined(CONFIG_LV_LIBINPUT_XKB_RULES))
 #define LV_LIBINPUT_XKB_DISABLE_KEY_MAP 1
 #else
 #define LV_LIBINPUT_XKB_DISABLE_KEY_MAP 0
 #endif
+#undef LV_LIBINPUT_XKB
 
 /*----------------------------------
  * Start parsing lv_conf_template.h

--- a/scripts/generators/config_headers/templates.py
+++ b/scripts/generators/config_headers/templates.py
@@ -102,7 +102,7 @@ __CONFIG_OPTIONS__
  * Detect if the user is using the new calendar day/month configuration
  * in order to avoid warnings for users that have migrated.
  */
-#ifdef LV_MONDAY_STR
+#if defined(LV_MONDAY_STR) || defined(CONFIG_LV_MONDAY_STR)
 #define LV_CALENDAR_DISABLE_DEFAULT_DAY_NAMES 1
 #else
 #define LV_CALENDAR_DISABLE_DEFAULT_DAY_NAMES 0
@@ -112,7 +112,7 @@ __CONFIG_OPTIONS__
  * Detect if the user is using the new calendar day/month configuration
  * in order to avoid warnings for users that have migrated.
  */
-#ifdef LV_JANUARY_STR
+#if defined(LV_JANUARY_STR) || defined(CONFIG_LV_JANUARY_STR)
 #define LV_CALENDAR_DISABLE_DEFAULT_MONTH_NAMES 1
 #else
 #define LV_CALENDAR_DISABLE_DEFAULT_MONTH_NAMES 0
@@ -121,12 +121,22 @@ __CONFIG_OPTIONS__
 /* 
  * Detect if the user is using the xkb keymap configuration
  * in order to avoid warnings for users that have migrated.
+ * we only need to check for it if LV_LIBINPUT_XKB is enabled
+ * so evaluate it first and undef it afterwards
  */
-#ifdef LV_LIBINPUT_XKB_RULES
+#ifndef LV_LIBINPUT_XKB
+    #ifdef CONFIG_LV_LIBINPUT_XKB
+        #define LV_LIBINPUT_XKB CONFIG_LV_LIBINPUT_XKB
+    #else
+        #define LV_LIBINPUT_XKB 0
+    #endif
+#endif
+#if LV_LIBINPUT_XKB && (defined(LV_LIBINPUT_XKB_RULES) || defined(CONFIG_LV_LIBINPUT_XKB_RULES))
 #define LV_LIBINPUT_XKB_DISABLE_KEY_MAP 1
 #else
 #define LV_LIBINPUT_XKB_DISABLE_KEY_MAP 0
 #endif
+#undef LV_LIBINPUT_XKB
 
 /*----------------------------------
  * Start parsing lv_conf_template.h


### PR DESCRIPTION
Fixes two issues:

1. First off, lv_conf.h would get installed as a sibling of lvgl meaning that when doing a system installation it would end up inside `usr/include` directly

2. LV_CONF_KCONFIG_EXTERNAL_INCLUDE would point to a build path which would break after the installation as the same path wouldn't exist, this hardcodes the installation path to `lvgl/lv_conf.h` which is where we end up putting `lv_conf.h` after the fix mentioned in point 1
