### PR TITLE
fix(array): add element size validation and overflow checks

### DIFF
--- a/.github/workflows/build_micropython.yml
+++ b/.github/workflows/build_micropython.yml
@@ -75,6 +75,23 @@ jobs:
       if: matrix.port == 'esp32'
       run: |
         source tools/ci.sh && ci_esp32_idf_setup
+        TINYUSB_CONFIG="shared/tinyusb/tusb_config.h"
+        if [ -f "$TINYUSB_CONFIG" ]; then
+          if ! grep -q "CFG_TUD_CDC_EP_BUFSIZE" "$TINYUSB_CONFIG"; then
+            sed -i '/#define CFG_TUD_CDC_TX_BUFSIZE/a #define CFG_TUD_CDC_EP_BUFSIZE 64' "$TINYUSB_CONFIG"
+          fi
+        else
+          TINYUSB_CONFIG=$(find . -name "tusb_config.h" | head -1)
+          if [ -f "$TINYUSB_CONFIG" ]; then
+            if ! grep -q "CFG_TUD_CDC_EP_BUFSIZE" "$TINYUSB_CONFIG"; then
+              if grep -q "CFG_TUD_CDC_TX_BUFSIZE" "$TINYUSB_CONFIG"; then
+                sed -i '/#define CFG_TUD_CDC_TX_BUFSIZE/a #define CFG_TUD_CDC_EP_BUFSIZE 64' "$TINYUSB_CONFIG"
+              else
+                sed -i '/#endif \/\/ MICROPY_INCLUDED_SHARED_TINYUSB_TUSB_CONFIG_H/i #define CFG_TUD_CDC_EP_BUFSIZE 64' "$TINYUSB_CONFIG" || echo "#define CFG_TUD_CDC_EP_BUFSIZE 64" >> "$TINYUSB_CONFIG"
+              fi
+            fi
+          fi
+        fi
         source tools/ci.sh && ci_esp32_build_cmod_spiram_s2
         source tools/ci.sh && ci_esp32_build_s3_c3
 

--- a/.github/workflows/build_micropython.yml
+++ b/.github/workflows/build_micropython.yml
@@ -7,7 +7,7 @@ on:
 # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency
 # Ensure that only one commit will be running tests at a time on each PR
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }} 
+  group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:
@@ -75,23 +75,6 @@ jobs:
       if: matrix.port == 'esp32'
       run: |
         source tools/ci.sh && ci_esp32_idf_setup
-        TINYUSB_CONFIG="shared/tinyusb/tusb_config.h"
-        if [ -f "$TINYUSB_CONFIG" ]; then
-          if ! grep -q "CFG_TUD_CDC_EP_BUFSIZE" "$TINYUSB_CONFIG"; then
-            sed -i '/#define CFG_TUD_CDC_TX_BUFSIZE/a #define CFG_TUD_CDC_EP_BUFSIZE 64' "$TINYUSB_CONFIG"
-          fi
-        else
-          TINYUSB_CONFIG=$(find . -name "tusb_config.h" | head -1)
-          if [ -f "$TINYUSB_CONFIG" ]; then
-            if ! grep -q "CFG_TUD_CDC_EP_BUFSIZE" "$TINYUSB_CONFIG"; then
-              if grep -q "CFG_TUD_CDC_TX_BUFSIZE" "$TINYUSB_CONFIG"; then
-                sed -i '/#define CFG_TUD_CDC_TX_BUFSIZE/a #define CFG_TUD_CDC_EP_BUFSIZE 64' "$TINYUSB_CONFIG"
-              else
-                sed -i '/#endif \/\/ MICROPY_INCLUDED_SHARED_TINYUSB_TUSB_CONFIG_H/i #define CFG_TUD_CDC_EP_BUFSIZE 64' "$TINYUSB_CONFIG" || echo "#define CFG_TUD_CDC_EP_BUFSIZE 64" >> "$TINYUSB_CONFIG"
-              fi
-            fi
-          fi
-        fi
         source tools/ci.sh && ci_esp32_build_cmod_spiram_s2
         source tools/ci.sh && ci_esp32_build_s3_c3
 

--- a/include/lvgl/misc/lv_array.h
+++ b/include/lvgl/misc/lv_array.h
@@ -175,11 +175,12 @@ lv_result_t lv_array_remove_unordered(lv_array_t * array, uint32_t index);
 lv_result_t lv_array_erase(lv_array_t * array, uint32_t start, uint32_t end);
 
 /**
- * Concatenate two arrays. Adds new elements to the end of the array.
- * @note The destination array is automatically expanded as necessary.
- * @param array pointer to an `lv_array_t` variable
- * @param other pointer to the array to concatenate
- * @return LV_RESULT_OK: success, otherwise: error
+ * Concatenate two arrays. Adds new elements from `other` to the end of `array`.
+ * @note Destination array capacity is automatically expanded as necessary.
+ * @note Both arrays must have matching element sizes.
+ * @param array pointer to destination `lv_array_t` variable
+ * @param other pointer to source `lv_array_t` variable to concatenate
+ * @return LV_RESULT_OK: success, LV_RESULT_INVALID: error (NULL pointer, size overflow, element size mismatch)
  */
 lv_result_t lv_array_concat(lv_array_t * array, const lv_array_t * other);
 

--- a/src/misc/lv_array.c
+++ b/src/misc/lv_array.c
@@ -229,8 +229,30 @@ bool lv_array_resize(lv_array_t * array, uint32_t new_capacity)
 
 lv_result_t lv_array_concat(lv_array_t * array, const lv_array_t * other)
 {
-    LV_ASSERT_NULL(array->data);
+    LV_ASSERT_NULL(array);
+    LV_ASSERT_NULL(other);
+
+    if(array == NULL || other == NULL) {
+        LV_LOG_ERROR("NULL pointer passed to lv_array_concat");
+        return LV_RESULT_INVALID;
+    }
+
+    if(array->element_size != other->element_size) {
+        LV_LOG_ERROR("Element size mismatch: %u vs %u",
+                     (unsigned int)array->element_size, (unsigned int)other->element_size);
+        return LV_RESULT_INVALID;
+    }
+
     uint32_t size = other->size;
+    if(size == 0) {
+        return LV_RESULT_OK;
+    }
+
+    if(UINT32_MAX - array->size < size) {
+        LV_LOG_ERROR("Array size overflow");
+        return LV_RESULT_INVALID;
+    }
+
     if(array->size + size > array->capacity) {
         /*array is full*/
         if(lv_array_resize(array, array->size + size) == false) {

--- a/src/misc/lv_array.c
+++ b/src/misc/lv_array.c
@@ -184,8 +184,30 @@ bool lv_array_resize(lv_array_t * array, uint32_t new_capacity)
 
 lv_result_t lv_array_concat(lv_array_t * array, const lv_array_t * other)
 {
-    LV_ASSERT_NULL(array->data);
+    LV_ASSERT_NULL(array);
+    LV_ASSERT_NULL(other);
+
+    if(array == NULL || other == NULL) {
+        LV_LOG_ERROR("NULL pointer passed to lv_array_concat");
+        return LV_RESULT_INVALID;
+    }
+
+    if(array->element_size != other->element_size) {
+        LV_LOG_ERROR("Element size mismatch: %u vs %u",
+                     (unsigned int)array->element_size, (unsigned int)other->element_size);
+        return LV_RESULT_INVALID;
+    }
+
     uint32_t size = other->size;
+    if(size == 0) {
+        return LV_RESULT_OK;
+    }
+
+    if(UINT32_MAX - array->size < size) {
+        LV_LOG_ERROR("Array size overflow");
+        return LV_RESULT_INVALID;
+    }
+
     if(array->size + size > array->capacity) {
         /*array is full*/
         if(lv_array_resize(array, array->size + size) == false) {

--- a/src/misc/lv_array.c
+++ b/src/misc/lv_array.c
@@ -229,14 +229,11 @@ bool lv_array_resize(lv_array_t * array, uint32_t new_capacity)
 
 lv_result_t lv_array_concat(lv_array_t * array, const lv_array_t * other)
 {
-    if(array == NULL || other == NULL) {
-        LV_LOG_ERROR("NULL pointer passed to lv_array_concat");
-        return LV_RESULT_INVALID;
-    }
+    LV_ASSERT(array);
+    LV_ASSERT(other);
 
     if(array->element_size != other->element_size) {
-        LV_LOG_ERROR("Element size mismatch: %u vs %u",
-                     (unsigned int)array->element_size, (unsigned int)other->element_size);
+        LV_LOG_ERROR("Element size mismatch: %"LV_PRIu32" vs %"LV_PRIu32, array->element_size, other->element_size);
         return LV_RESULT_INVALID;
     }
 

--- a/src/misc/lv_array.c
+++ b/src/misc/lv_array.c
@@ -209,7 +209,7 @@ lv_result_t lv_array_erase(lv_array_t * array, uint32_t start, uint32_t end)
 
 bool lv_array_resize(lv_array_t * array, uint32_t new_capacity)
 {
-    if(array == NULL) return false;
+    LV_ASSERT(array);
 
     if(array->inner_alloc == false) {
         LV_LOG_WARN("Cannot resize array with external buffer");

--- a/src/misc/lv_array.c
+++ b/src/misc/lv_array.c
@@ -209,14 +209,14 @@ lv_result_t lv_array_erase(lv_array_t * array, uint32_t start, uint32_t end)
 
 bool lv_array_resize(lv_array_t * array, uint32_t new_capacity)
 {
+    if(array == NULL) return false;
+
     if(array->inner_alloc == false) {
         LV_LOG_WARN("Cannot resize array with external buffer");
         return false;
     }
 
     uint8_t * data = lv_realloc(array->data, new_capacity * array->element_size);
-    LV_ASSERT_NULL(data);
-
     if(data == NULL) return false;
 
     array->data = data;
@@ -229,9 +229,6 @@ bool lv_array_resize(lv_array_t * array, uint32_t new_capacity)
 
 lv_result_t lv_array_concat(lv_array_t * array, const lv_array_t * other)
 {
-    LV_ASSERT_NULL(array);
-    LV_ASSERT_NULL(other);
-
     if(array == NULL || other == NULL) {
         LV_LOG_ERROR("NULL pointer passed to lv_array_concat");
         return LV_RESULT_INVALID;

--- a/src/misc/lv_array.c
+++ b/src/misc/lv_array.c
@@ -164,14 +164,14 @@ lv_result_t lv_array_erase(lv_array_t * array, uint32_t start, uint32_t end)
 
 bool lv_array_resize(lv_array_t * array, uint32_t new_capacity)
 {
+    if(array == NULL) return false;
+
     if(array->inner_alloc == false) {
         LV_LOG_WARN("Cannot resize array with external buffer");
         return false;
     }
 
     uint8_t * data = lv_realloc(array->data, new_capacity * array->element_size);
-    LV_ASSERT_NULL(data);
-
     if(data == NULL) return false;
 
     array->data = data;
@@ -184,9 +184,6 @@ bool lv_array_resize(lv_array_t * array, uint32_t new_capacity)
 
 lv_result_t lv_array_concat(lv_array_t * array, const lv_array_t * other)
 {
-    LV_ASSERT_NULL(array);
-    LV_ASSERT_NULL(other);
-
     if(array == NULL || other == NULL) {
         LV_LOG_ERROR("NULL pointer passed to lv_array_concat");
         return LV_RESULT_INVALID;

--- a/src/misc/lv_array.h
+++ b/src/misc/lv_array.h
@@ -175,8 +175,8 @@ lv_result_t lv_array_remove_unordered(lv_array_t * array, uint32_t index);
  */
 lv_result_t lv_array_erase(lv_array_t * array, uint32_t start, uint32_t end);
 
-
-/** Concatenate two arrays. Adds new elements from `other` to the end of `array`.
+/**
+ * Concatenate two arrays. Adds new elements from `other` to the end of `array`.
  * @note Destination array capacity is automatically expanded as necessary.
  * @note Both arrays must have matching element sizes.
  * @param array pointer to destination `lv_array_t` variable
@@ -184,6 +184,7 @@ lv_result_t lv_array_erase(lv_array_t * array, uint32_t start, uint32_t end);
  * @return LV_RESULT_OK: success, LV_RESULT_INVALID: error (NULL pointer, size overflow, element size mismatch)
  */
 lv_result_t lv_array_concat(lv_array_t * array, const lv_array_t * other);
+
 /**
  * Push back element. Adds a new element to the end of the array.
  * If the array capacity is not enough for the new element, the array will be resized automatically.

--- a/src/misc/lv_array.h
+++ b/src/misc/lv_array.h
@@ -175,15 +175,15 @@ lv_result_t lv_array_remove_unordered(lv_array_t * array, uint32_t index);
  */
 lv_result_t lv_array_erase(lv_array_t * array, uint32_t start, uint32_t end);
 
-/**
- * Concatenate two arrays. Adds new elements to the end of the array.
- * @note The destination array is automatically expanded as necessary.
- * @param array pointer to an `lv_array_t` variable
- * @param other pointer to the array to concatenate
- * @return LV_RESULT_OK: success, otherwise: error
+
+/** Concatenate two arrays. Adds new elements from `other` to the end of `array`.
+ * @note Destination array capacity is automatically expanded as necessary.
+ * @note Both arrays must have matching element sizes.
+ * @param array pointer to destination `lv_array_t` variable
+ * @param other pointer to source `lv_array_t` variable to concatenate
+ * @return LV_RESULT_OK: success, LV_RESULT_INVALID: error (NULL pointer, size overflow, element size mismatch)
  */
 lv_result_t lv_array_concat(lv_array_t * array, const lv_array_t * other);
-
 /**
  * Push back element. Adds a new element to the end of the array.
  * If the array capacity is not enough for the new element, the array will be resized automatically.

--- a/tests/src/test_cases/test_array.c
+++ b/tests/src/test_cases/test_array.c
@@ -80,16 +80,10 @@ void test_array_copy(void)
 
 void test_array_concat(void)
 {
-    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_array_concat(NULL, NULL));
-
     lv_array_t a, b, c;
     lv_array_init(&a, 4, sizeof(int32_t));
     lv_array_init(&b, 4, sizeof(int32_t));
     lv_array_init(&c, 4, sizeof(int16_t)); /* Mismatched element size */
-
-    /* NULL input validation */
-    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_array_concat(&a, NULL));
-    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_array_concat(NULL, &b));
 
     /* Element size mismatch validation */
     TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_array_concat(&a, &c));

--- a/tests/src/test_cases/test_array.c
+++ b/tests/src/test_cases/test_array.c
@@ -80,9 +80,25 @@ void test_array_copy(void)
 
 void test_array_concat(void)
 {
-    lv_array_t a, b;
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_array_concat(NULL, NULL));
+
+    lv_array_t a, b, c;
     lv_array_init(&a, 4, sizeof(int32_t));
     lv_array_init(&b, 4, sizeof(int32_t));
+    lv_array_init(&c, 4, sizeof(int16_t)); /* Mismatched element size */
+
+    /* NULL input validation */
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_array_concat(&a, NULL));
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_array_concat(NULL, &b));
+
+    /* Element size mismatch validation */
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_array_concat(&a, &c));
+
+    /* Empty source array concatenation */
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_array_concat(&a, &b));
+    TEST_ASSERT_EQUAL_UINT32(0, lv_array_size(&a));
+
+    /* Populate and test successful concatenation with capacity expansion */
     for(int32_t i = 0; i < 4; i++) {
         lv_array_push_back(&a, &i);
         lv_array_push_back(&b, &i);
@@ -98,6 +114,7 @@ void test_array_concat(void)
 
     lv_array_deinit(&a);
     lv_array_deinit(&b);
+    lv_array_deinit(&c);
 }
 
 void test_array_init_from_buf(void)


### PR DESCRIPTION
While working with the lv_array module in the codebase, I noticed lv_array_concat lacked defensive checks present in other array functions. It could dereference NULL pointers, silently corrupt data when concatenating arrays with different element sizes, or trigger integer overflows on size addition. I added LV_ASSERT debug macros, runtime checks with error logging, integer overflow protection, updated the header documentation, and expanded the unit test suite to cover these edge cases.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

