### PR TITLE
fix(draw): fix busy loop if layer draw buffer alloc failed

### DIFF
--- a/include/lvgl/draw/lv_draw.h
+++ b/include/lvgl/draw/lv_draw.h
@@ -90,6 +90,9 @@ typedef enum {
     /** The draw task is rendered. It will be removed from the draw task list of the layer
      * and freed automatically. */
     LV_DRAW_TASK_STATE_FINISHED,
+
+    /*Task cannot be completed. E.g. OOM during layer buf alloc*/
+    LV_DRAW_TASK_STATE_FAILED,
 } lv_draw_task_state_t;
 
 struct _lv_layer_t  {

--- a/scripts/gdb/lvglgdb/lvgl/draw/lv_draw_consts.py
+++ b/scripts/gdb/lvglgdb/lvgl/draw/lv_draw_consts.py
@@ -30,6 +30,7 @@ DRAW_TASK_STATE_NAMES = {
     2: "QUEUED",
     3: "IN_PROGRESS",
     4: "FINISHED",
+    5: "FAILED",
 }
 
 DRAW_UNIT_TYPE_NAMES = {

--- a/src/draw/dma2d/lv_draw_dma2d.c
+++ b/src/draw/dma2d/lv_draw_dma2d.c
@@ -418,6 +418,7 @@ static int32_t dispatch_cb(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 
     void * buf = lv_draw_layer_alloc_buf(layer);
     if(buf == NULL) {
+        t->state = LV_DRAW_TASK_STATE_FAILED;
         return LV_DRAW_UNIT_IDLE;
     }
 

--- a/src/draw/espressif/ppa/lv_draw_ppa.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa.c
@@ -150,7 +150,10 @@ static int32_t ppa_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 
     lv_draw_task_t * t = lv_draw_get_available_task(layer, NULL, DRAW_UNIT_ID_PPA);
     if(!t || t->preferred_draw_unit_id != DRAW_UNIT_ID_PPA) return LV_DRAW_UNIT_IDLE;
-    if(lv_draw_layer_alloc_buf(layer) == NULL) return LV_DRAW_UNIT_IDLE;
+    if(lv_draw_layer_alloc_buf(layer) == NULL) {
+        t->state = LV_DRAW_TASK_STATE_FAILED;
+        return LV_DRAW_UNIT_IDLE;
+    }
 
     t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
     u->task_act = t;

--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -237,7 +237,11 @@ bool lv_draw_dispatch_layer(lv_display_t * disp, lv_layer_t * layer)
     bool remove_task = false;
     while(t) {
         t_next = t->next;
-        if(t->state == LV_DRAW_TASK_STATE_FINISHED) {
+        if(t->state == LV_DRAW_TASK_STATE_FINISHED || t->state == LV_DRAW_TASK_STATE_FAILED) {
+            if(t->state == LV_DRAW_TASK_STATE_FAILED) {
+                LV_LOG_ERROR("draw task failed, type: %d", (int)t->type);
+            }
+
             cleanup_task(t, disp);
             remove_task = true;
             if(t_prev != NULL)

--- a/src/draw/nema_gfx/lv_draw_nema_gfx.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx.c
@@ -294,8 +294,10 @@ static int32_t nema_gfx_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
         return LV_DRAW_UNIT_IDLE;
 
     void * buf = lv_draw_layer_alloc_buf(layer);
-    if(buf == NULL)
+    if(buf == NULL) {
+        t->state = LV_DRAW_TASK_STATE_FAILED;
         return LV_DRAW_UNIT_IDLE;
+    }
 
     t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
     draw_nema_gfx_unit->task_act = t;

--- a/src/draw/nxp/g2d/lv_draw_g2d.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d.c
@@ -248,8 +248,10 @@ static int32_t _g2d_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
     if(t == NULL || t->preferred_draw_unit_id != DRAW_UNIT_ID_G2D)
         return LV_DRAW_UNIT_IDLE;
 
-    if(lv_draw_layer_alloc_buf(layer) == NULL)
+    if(lv_draw_layer_alloc_buf(layer) == NULL) {
+        t->state = LV_DRAW_TASK_STATE_FAILED;
         return LV_DRAW_UNIT_IDLE;
+    }
 
     t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
     t->draw_unit = draw_unit;

--- a/src/draw/nxp/pxp/lv_draw_pxp.c
+++ b/src/draw/nxp/pxp/lv_draw_pxp.c
@@ -327,8 +327,10 @@ static int32_t _pxp_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
     if(t == NULL || t->preferred_draw_unit_id != DRAW_UNIT_ID_PXP)
         return LV_DRAW_UNIT_IDLE;
 
-    if(lv_draw_layer_alloc_buf(layer) == NULL)
+    if(lv_draw_layer_alloc_buf(layer) == NULL) {
+        t->state = LV_DRAW_TASK_STATE_FAILED;
         return LV_DRAW_UNIT_IDLE;
+    }
 
     t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
     draw_pxp_unit->task_act = t;

--- a/src/draw/renesas/dave2d/lv_draw_dave2d.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d.c
@@ -400,7 +400,10 @@ static int32_t lv_draw_dave2d_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * 
     if(!lv_draw_dave2d_is_dest_cf_supported(layer->color_format)) return LV_DRAW_UNIT_IDLE;
 
     void * buf = lv_draw_layer_alloc_buf(layer);
-    if(buf == NULL) return LV_DRAW_UNIT_IDLE;
+    if(buf == NULL) {
+        t->state = LV_DRAW_TASK_STATE_FAILED;
+        return LV_DRAW_UNIT_IDLE;
+    }
 
     /*Disable the command buffer as a temporary fix to rendering issues. */
 #if 0

--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -153,7 +153,10 @@ static int32_t dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
     SDL_Texture * texture = layer_get_texture(layer);
     if(layer != disp->layer_head && texture == NULL) {
         void * buf = lv_draw_layer_alloc_buf(layer);
-        if(buf == NULL) return -1;
+        if(buf == NULL) {
+            t->state = LV_DRAW_TASK_STATE_FAILED;
+            return -1;
+        }
 
         SDL_Renderer * renderer = lv_sdl_window_get_renderer(disp);
         int32_t w = lv_area_get_width(&layer->buf_area);

--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -320,6 +320,7 @@ static int32_t dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 
     void * buf = lv_draw_layer_alloc_buf(layer);
     if(buf == NULL) {
+        t->state = LV_DRAW_TASK_STATE_FAILED;
         LV_PROFILER_DRAW_END;
         return LV_DRAW_UNIT_IDLE;  /*Couldn't start rendering*/
     }

--- a/src/draw/sw/lv_draw_sw.c
+++ b/src/draw/sw/lv_draw_sw.c
@@ -288,7 +288,10 @@ static int32_t dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
         /*Allocate a buffer if not done yet.*/
         void * buf = lv_draw_layer_alloc_buf(layer);
         /*Do not return is failed. The other thread might already have a buffer can do something. */
-        if(buf == NULL) continue;
+        if(buf == NULL) {
+            t->state = LV_DRAW_TASK_STATE_FAILED;
+            continue;
+        }
 
         /*Take the task*/
         all_idle = false;

--- a/src/draw/vg_lite/lv_draw_vg_lite.c
+++ b/src/draw/vg_lite/lv_draw_vg_lite.c
@@ -215,6 +215,7 @@ static int32_t draw_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 
     void * buf = lv_draw_layer_alloc_buf(layer);
     if(!buf) {
+        t->state = LV_DRAW_TASK_STATE_FAILED;
         return LV_DRAW_UNIT_IDLE;
     }
 

--- a/tests/src/test_cases/draw/test_draw_layer.c
+++ b/tests/src/test_cases/draw/test_draw_layer.c
@@ -127,7 +127,7 @@ void test_draw_layer_alloc_failed_no_deadlock(void)
 
     /*Hook buf_malloc_cb to always fail*/
     lv_draw_buf_handlers_t * handlers = lv_draw_buf_get_handlers();
-    lv_draw_buf_malloc_cb original_malloc_cb = handlers->buf_malloc_cb;
+    lv_draw_buf_malloc_cb_t original_malloc_cb = handlers->buf_malloc_cb;
     handlers->buf_malloc_cb = fake_buf_malloc_fail;
 
     /*This must return without deadlock - the FAILED state allows the

--- a/tests/src/test_cases/draw/test_draw_layer.c
+++ b/tests/src/test_cases/draw/test_draw_layer.c
@@ -96,4 +96,46 @@ void test_draw_layer_dispatch(void)
     TEST_ASSERT_EQUAL_SCREENSHOT("draw/draw_layer_dispatch.png");
 }
 
+/**
+ * Test that rendering completes without deadlock when layer buffer
+ * allocation fails due to memory exhaustion.
+ *
+ * Before the fix, lv_draw_layer_alloc_buf returning NULL left the draw
+ * task in WAITING state forever, causing draw_buf_flush to spin in an
+ * infinite loop. The fix sets the task to LV_DRAW_TASK_STATE_FAILED so
+ * it gets cleaned up and rendering proceeds.
+ *
+ * Strategy: temporarily replace buf_malloc_cb with a stub that always
+ * returns NULL, create a rotated widget to trigger layer allocation,
+ * then call lv_refr_now(). If it returns, the fix works.
+ */
+static void * fake_buf_malloc_fail(size_t size, lv_color_format_t cf)
+{
+    LV_UNUSED(size);
+    LV_UNUSED(cf);
+    return NULL;
+}
+
+void test_draw_layer_alloc_failed_no_deadlock(void)
+{
+    /*Create a widget with transform_rotation to force LV_LAYER_TYPE_TRANSFORM path*/
+    lv_obj_t * obj = lv_obj_create(lv_screen_active());
+    lv_obj_set_size(obj, 200, 200);
+    lv_obj_center(obj);
+    lv_obj_set_style_transform_rotation(obj, 450, 0); /*45 degrees*/
+    lv_obj_set_style_opa_layered(obj, LV_OPA_50, 0); /*Force layer even with matrix path*/
+
+    /*Hook buf_malloc_cb to always fail*/
+    lv_draw_buf_handlers_t * handlers = lv_draw_buf_get_handlers();
+    lv_draw_buf_malloc_cb original_malloc_cb = handlers->buf_malloc_cb;
+    handlers->buf_malloc_cb = fake_buf_malloc_fail;
+
+    /*This must return without deadlock - the FAILED state allows the
+     *render pipeline to clean up the failed task and proceed.*/
+    lv_refr_now(NULL);
+
+    /*Restore original handler*/
+    handlers->buf_malloc_cb = original_malloc_cb;
+}
+
 #endif


### PR DESCRIPTION
## Summary

When a draw unit attempts to allocate a layer draw buffer via `lv_draw_layer_alloc_buf()` and the allocation fails (returns `NULL` due to OOM), the draw task was left in the `LV_DRAW_TASK_STATE_WAITING` state indefinitely. This caused `lv_draw_dispatch_layer()` to never clean up the task, resulting in an infinite busy loop in the render pipeline (e.g., `lv_refr_now()` / `draw_buf_flush` spinning forever).

This PR introduces a new draw task state — `LV_DRAW_TASK_STATE_FAILED` — and updates all hardware-accelerated and software draw unit dispatch callbacks to set this state when buffer allocation fails. The dispatch layer function then treats `FAILED` tasks the same as `FINISHED` tasks (cleanup + remove), allowing the render pipeline to proceed gracefully instead of deadlocking.

## Root Cause

1. A draw task that requires a layer (e.g., transformed/layered objects with `transform_rotation`, `opa_layered`, etc.) calls `lv_draw_layer_alloc_buf()` during dispatch.
2. If memory is exhausted and the allocation returns `NULL`, the dispatch callback returns `LV_DRAW_UNIT_IDLE` but **does not change the task state** — it remains `WAITING`.
3. On the next dispatch cycle, the same task is picked up again, allocation fails again, and the cycle repeats forever.
4. The caller (e.g., `lv_refr_now()`) blocks waiting for all tasks to be finished, causing a **busy loop / deadlock**.

## Changes

### 1. New task state: `LV_DRAW_TASK_STATE_FAILED`

**File:** `include/lvgl/draw/lv_draw.h`

Added a new enum value to `lv_draw_task_state_t`:

```c
/*Task cannot be completed. E.g. OOM during layer buf alloc*/
LV_DRAW_TASK_STATE_FAILED,
```

### 2. Dispatch layer cleanup logic

**File:** `src/draw/lv_draw.c`

Updated `lv_draw_dispatch_layer()` to treat `FAILED` tasks the same as `FINISHED` — they are cleaned up and removed from the task list. An error log is emitted for failed tasks:

```c
if(t->state == LV_DRAW_TASK_STATE_FINISHED || t->state == LV_DRAW_TASK_STATE_FAILED) {
    if(t->state == LV_DRAW_TASK_STATE_FAILED) {
        LV_LOG_ERROR("draw task failed, type: %d", (int)t->type);
    }
    cleanup_task(t, disp);
    ...
}
```

### 3. Draw unit dispatch callbacks updated

All draw unit dispatch functions now set `t->state = LV_DRAW_TASK_STATE_FAILED` when `lv_draw_layer_alloc_buf()` returns `NULL`:

| File | Draw Unit |
|------|-----------|
| `src/draw/sw/lv_draw_sw.c` | Software renderer |
| `src/draw/dma2d/lv_draw_dma2d.c` | STM32 DMA2D |
| `src/draw/vg_lite/lv_draw_vg_lite.c` | NXP VG-Lite |
| `src/draw/nxp/g2d/lv_draw_g2d.c` | NXP G2D |
| `src/draw/nxp/pxp/lv_draw_pxp.c` | NXP PXP |
| `src/draw/renesas/dave2d/lv_draw_dave2d.c` | Renesas Dave2D |
| `src/draw/sdl/lv_draw_sdl.c` | SDL |
| `src/draw/espressif/ppa/lv_draw_ppa.c` | Espressif PPA |
| `src/draw/nema_gfx/lv_draw_nema_gfx.c` | Nema GFX |

### 4. Unit test

**File:** `tests/src/test_cases/draw/test_draw_layer.c`

Added `test_draw_layer_alloc_failed_no_deadlock()`:
- Creates a widget with `transform_rotation` and `opa_layered` to force the layer allocation path.
- Replaces `buf_malloc_cb` with a stub that always returns `NULL` to simulate OOM.
- Calls `lv_refr_now(NULL)` — if the fix works, it returns without deadlock.
- Restores the original handler.

## Behavior After Fix

| Scenario | Before | After |
|----------|--------|-------|
| Layer buffer alloc fails (OOM) | Task stays `WAITING` → infinite busy loop | Task set to `FAILED` → cleaned up → rendering proceeds |
| Normal rendering (alloc succeeds) | No change | No change |
| Error visibility | Silent hang | `LV_LOG_ERROR` with task type |

## Impact

- **No API breaking changes** — only a new enum value is added; existing code continues to work.
- **Graceful degradation** — under memory pressure, the affected draw task is skipped (visual artifact possible) but the system does not freeze.
- **All draw backends covered** — software and all hardware-accelerated dispatch paths are patched consistently.

## Testing

- `test_draw_layer_alloc_failed_no_deadlock` — verifies no deadlock when buffer allocation fails.
- Existing draw layer tests remain unaffected.

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
