### PR TITLE
build(cmake): skip lvgl's exported link interface for fetched libs

### DIFF
--- a/docs/src/integration/building/cmake.mdx
+++ b/docs/src/integration/building/cmake.mdx
@@ -160,6 +160,13 @@ Dependency resolution is attempted in this order:
 2. `pkg-config` — uses the system's pkg-config tool (Linux/macOS)
 3. `FetchContent` — fetches and builds the dependency from source
 
+<Callout type="warning">
+If a required dependency is resolved via `FetchContent` instead of `find_package` or 
+`pkg-config`, later attempts to link against that library elsewhere on the system may fail. 
+Make sure every package required by your enabled features is available via one of the first 
+two options *before* creating an LVGL installation.
+</Callout>
+
 Each strategy can be disabled globally or per dependency. This is particularly useful for
 cross-compilation environments where system libraries should not be used.
 

--- a/env_support/cmake/dependencies.cmake
+++ b/env_support/cmake/dependencies.cmake
@@ -16,7 +16,7 @@ if(UNIX AND NOT PkgConfig_FOUND)
 endif()
 
 if(UNIX)
-  lvgl_link_raw(TARGETS m PKG_LIB_PRIVATE -lm)
+  lvgl_link_system_lib(TARGETS m PKG_LIB_PRIVATE -lm)
 endif()
 
 # ====== Draw Units ====== #

--- a/env_support/cmake/dependencies/fastgltf.cmake
+++ b/env_support/cmake/dependencies/fastgltf.cmake
@@ -57,4 +57,4 @@ set(FASTGLTF_DIFFUSE_TRANSMISSION_SUPPORT
 
 FetchContent_MakeAvailable(fastgltf)
 
-lvgl_link_raw(PRIVATE TARGETS fastgltf::fastgltf PKG_LIB_PRIVATE ${PKG_LIB_PRIVATE})
+lvgl_link_fetched(TARGETS fastgltf::fastgltf PKG_LIB_PRIVATE ${PKG_LIB_PRIVATE})

--- a/env_support/cmake/dependencies/freetype.cmake
+++ b/env_support/cmake/dependencies/freetype.cmake
@@ -80,4 +80,4 @@ set(FT_WITH_ZLIB
     CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(freetype)
-lvgl_link_raw(TARGETS freetype PKG_LIB_PRIVATE ${PKG_LIB_PRIVATE})
+lvgl_link_fetched(TARGETS freetype PKG_LIB_PRIVATE ${PKG_LIB_PRIVATE})

--- a/env_support/cmake/dependencies/g2d.cmake
+++ b/env_support/cmake/dependencies/g2d.cmake
@@ -4,7 +4,7 @@ find_path(G2D_INCLUDE_DIR NAMES g2d.h g2dExt.h QUIET)
 if(G2D_LIBRARY AND G2D_INCLUDE_DIR)
   message(STATUS "lvgl: G2D: found at ${G2D_LIBRARY}")
   target_include_directories(lvgl PRIVATE ${G2D_INCLUDE_DIR})
-  lvgl_link_raw(TARGETS ${G2D_LIBRARY} PKG_LIB_PRIVATE "-lg2d")
+  lvgl_link_system_lib(TARGETS ${G2D_LIBRARY} PKG_LIB_PRIVATE "-lg2d")
   return()
 endif()
 

--- a/env_support/cmake/dependencies/glfw.cmake
+++ b/env_support/cmake/dependencies/glfw.cmake
@@ -69,4 +69,4 @@ set(GLFW_BUILD_EXAMPLES
     CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(glfw)
-lvgl_link_raw(TARGETS glfw PKG_LIB_PRIVATE ${PKG_LIB_PRIVATE})
+lvgl_link_fetched(TARGETS glfw PKG_LIB_PRIVATE ${PKG_LIB_PRIVATE})

--- a/env_support/cmake/dependencies/jpeg.cmake
+++ b/env_support/cmake/dependencies/jpeg.cmake
@@ -76,4 +76,4 @@ set(WITH_CRT_DLL
     CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(libjpeg-turbo)
-lvgl_link_raw(TARGETS jpeg-static PKG_LIB_PRIVATE ${PKG_LIB_PRIVATE})
+lvgl_link_fetched(TARGETS jpeg-static PKG_LIB_PRIVATE ${PKG_LIB_PRIVATE})

--- a/env_support/cmake/dependencies/png.cmake
+++ b/env_support/cmake/dependencies/png.cmake
@@ -74,4 +74,4 @@ set(PNG_TOOLS
     CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(libpng)
-lvgl_link_raw(TARGETS png_static PKG_LIB_PRIVATE ${PKG_LIB_PRIVATE})
+lvgl_link_fetched(TARGETS png_static PKG_LIB_PRIVATE ${PKG_LIB_PRIVATE})

--- a/env_support/cmake/dependencies/sdl2.cmake
+++ b/env_support/cmake/dependencies/sdl2.cmake
@@ -102,4 +102,4 @@ set(SDL_DBUS
     CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(SDL2)
-lvgl_link_raw(TARGETS SDL2::SDL2-static PKG_LIB_PRIVATE ${PKG_LIB_PRIVATE})
+lvgl_link_fetched(TARGETS SDL2::SDL2-static PKG_LIB_PRIVATE ${PKG_LIB_PRIVATE})

--- a/env_support/cmake/dependencies/sdl2_image.cmake
+++ b/env_support/cmake/dependencies/sdl2_image.cmake
@@ -70,4 +70,4 @@ set(SDL2IMAGE_INSTALL
     CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(SDL2_image)
-lvgl_link_raw(TARGETS SDL2_image::SDL2_image-static PKG_LIB_PRIVATE ${PKG_LIB_PRIVATE})
+lvgl_link_fetched(TARGETS SDL2_image::SDL2_image-static PKG_LIB_PRIVATE ${PKG_LIB_PRIVATE})

--- a/env_support/cmake/dependencies/webp.cmake
+++ b/env_support/cmake/dependencies/webp.cmake
@@ -86,4 +86,4 @@ FetchContent_Declare(
   GIT_TAG 4fa21912338357f89e4fd51cf2368325b59e9bd9)
 
 FetchContent_MakeAvailable(webp)
-lvgl_link_raw(TARGETS webp PKG_LIB_PRIVATE ${PKG_LIB_PRIVATE})
+lvgl_link_fetched(TARGETS webp PKG_LIB_PRIVATE ${PKG_LIB_PRIVATE})

--- a/env_support/cmake/lvgl_link_libraries.cmake
+++ b/env_support/cmake/lvgl_link_libraries.cmake
@@ -125,9 +125,38 @@ function(lvgl_link_pkg_config)
   endif()
 endfunction()
 
-# No find_package nor pkgconfig support. Links targets normally 
-# Only registers PKG_LIB_PRIVATE for .pc Libs.private
-function(lvgl_link_raw)
+# Links targets fetched from source (FetchContent). No find_package nor
+# pkgconfig support. Only registers PKG_LIB_PRIVATE for .pc Libs.private.
+#
+# In the cmake path, we only set these for lvgl's BUILD_INTERFACE to
+# exclude them from lvgl's exported link interface.
+function(lvgl_link_fetched)
+  set(multiValueArgs TARGETS PKG_LIB_PRIVATE)
+  cmake_parse_arguments(ARG "" "" "${multiValueArgs}" ${ARGN})
+
+  set(SCOPE PRIVATE)
+  if(CONFIG_LV_USE_PRIVATE_API)
+    set(SCOPE PUBLIC)
+  endif()
+
+  if(ARG_TARGETS)
+    set(_targets)
+    foreach(_target IN LISTS ARG_TARGETS)
+      list(APPEND _targets $<BUILD_INTERFACE:${_target}>)
+    endforeach()
+    target_link_libraries(lvgl ${SCOPE} ${_targets})
+  endif()
+
+  if(ARG_PKG_LIB_PRIVATE)
+    lvgl_add_pkg_libs_private(${ARG_PKG_LIB_PRIVATE})
+  endif()
+endfunction()
+
+# Links a system library that is neither found via find_package/pkg-config nor
+# fetched from source (e.g. m). Unlike lvgl_link_fetched, these must stay
+# in lvgl's exported link interface so consumers of an installed lvgl link
+# against them too. Only registers PKG_LIB_PRIVATE for .pc Libs.private.
+function(lvgl_link_system_lib)
   set(multiValueArgs TARGETS PKG_LIB_PRIVATE)
   cmake_parse_arguments(ARG "" "" "${multiValueArgs}" ${ARGN})
 


### PR DESCRIPTION
As the title says, if we don't restrict the linking to `BUILD_INTERFACE`, cmake will complain about not being able 
to export a fetched library during installation
