### PR TITLE
build(cmake): rerun cmake config when lvgl's config changes

### DIFF
--- a/env_support/cmake/kconfig.cmake
+++ b/env_support/cmake/kconfig.cmake
@@ -5,30 +5,22 @@ set(OUTPUT_DOTCONFIG ${CMAKE_CURRENT_SOURCE_DIR}/.config)
 set(KCONFIG_LIST_OUT ${CMAKE_CURRENT_BINARY_DIR}/kconfig_list)
 set(AUTO_CONF_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
+# Normalizes INPUT_PATH to an absolute path (relative to CMAKE_SOURCE_DIR)
+macro(lv_normalize_config_path INPUT_PATH LABEL OUTPUT_VAR)
+    message(STATUS "Using ${LABEL}: ${${INPUT_PATH}}")
+    if(NOT IS_ABSOLUTE ${${INPUT_PATH}})
+        file(REAL_PATH ${${INPUT_PATH}} ${OUTPUT_VAR} BASE_DIRECTORY ${CMAKE_SOURCE_DIR})
+        message(STATUS "Converted to absolute path: ${${OUTPUT_VAR}}")
+    else()
+        set(${OUTPUT_VAR} ${${INPUT_PATH}})
+    endif()
+endmacro()
+
 # Check if the user wants to use a defconfig, using the -DLV_BUILD_DEFCONFIG_PATH option
 if(LV_BUILD_DEFCONFIG_PATH)
-    # The supplied path can be relative - normalize it to absolute
-    message(STATUS "Using defconfig: ${LV_BUILD_DEFCONFIG_PATH}")
-
-    if (NOT IS_ABSOLUTE ${LV_BUILD_DEFCONFIG_PATH})
-        file(REAL_PATH ${LV_BUILD_DEFCONFIG_PATH}
-            DOTCONFIG BASE_DIRECTORY ${CMAKE_SOURCE_DIR})
-        message(STATUS "Converted to absolute path: ${DOTCONFIG}")
-
-    else()
-        set(DOTCONFIG ${LV_BUILD_DEFCONFIG_PATH})
-    endif()
+    lv_normalize_config_path(LV_BUILD_DEFCONFIG_PATH "defconfig" DOTCONFIG)
 elseif(LV_BUILD_DOTCONFIG_PATH)
-    message(STATUS "Using .config: ${LV_BUILD_DOTCONFIG_PATH}")
-
-    if (NOT IS_ABSOLUTE ${LV_BUILD_DOTCONFIG_PATH})
-        file(REAL_PATH ${LV_BUILD_DOTCONFIG_PATH}
-            DOTCONFIG BASE_DIRECTORY ${CMAKE_SOURCE_DIR})
-        message(STATUS "Converted to absolute path: ${DOTCONFIG}")
-
-    else()
-        set(DOTCONFIG ${LV_BUILD_DOTCONFIG_PATH})
-    endif()
+    lv_normalize_config_path(LV_BUILD_DOTCONFIG_PATH ".config" DOTCONFIG)
 else()
     # Fallback - This will attempt to use a .config file inside of the LVGL directory
     set(DOTCONFIG ${CMAKE_CURRENT_SOURCE_DIR}/.config)

--- a/env_support/cmake/kconfig.cmake
+++ b/env_support/cmake/kconfig.cmake
@@ -47,8 +47,9 @@ if(NOT "${ret}" STREQUAL "0")
     message(FATAL_ERROR "command failed with return code: ${ret}")
 endif()
 
-# Re-configure (Re-execute all CMakeLists.txt code) when autoconf.h changes
-set_target_properties(lvgl PROPERTIES CMAKE_CONFIGURE_DEPENDS ${AUTOCONF_H})
+# Re-run CMake configuration (which regenerates autoconf.h) when the input
+# .config/defconfig changes, so that `cmake --build` picks up config edits.
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${DOTCONFIG})
 
 # Set the variable that can be used by the CMakeLists.txt including this file
 set(KCONFIG_EXTERNAL_INCLUDE ${AUTOCONF_H})

--- a/env_support/cmake/kconfig.cmake
+++ b/env_support/cmake/kconfig.cmake
@@ -10,7 +10,7 @@ if(LV_BUILD_DEFCONFIG_PATH)
     # The supplied path can be relative - normalize it to absolute
     message(STATUS "Using defconfig: ${LV_BUILD_DEFCONFIG_PATH}")
 
-    if (NOT IS_ABSOLUTE ${CONF_PATH})
+    if (NOT IS_ABSOLUTE ${LV_BUILD_DEFCONFIG_PATH})
         file(REAL_PATH ${LV_BUILD_DEFCONFIG_PATH}
             DOTCONFIG BASE_DIRECTORY ${CMAKE_SOURCE_DIR})
         message(STATUS "Converted to absolute path: ${DOTCONFIG}")
@@ -19,7 +19,16 @@ if(LV_BUILD_DEFCONFIG_PATH)
         set(DOTCONFIG ${LV_BUILD_DEFCONFIG_PATH})
     endif()
 elseif(LV_BUILD_DOTCONFIG_PATH)
-    set(DOTCONFIG ${LV_BUILD_DOTCONFIG_PATH})
+    message(STATUS "Using .config: ${LV_BUILD_DOTCONFIG_PATH}")
+
+    if (NOT IS_ABSOLUTE ${LV_BUILD_DOTCONFIG_PATH})
+        file(REAL_PATH ${LV_BUILD_DOTCONFIG_PATH}
+            DOTCONFIG BASE_DIRECTORY ${CMAKE_SOURCE_DIR})
+        message(STATUS "Converted to absolute path: ${DOTCONFIG}")
+
+    else()
+        set(DOTCONFIG ${LV_BUILD_DOTCONFIG_PATH})
+    endif()
 else()
     # Fallback - This will attempt to use a .config file inside of the LVGL directory
     set(DOTCONFIG ${CMAKE_CURRENT_SOURCE_DIR}/.config)

--- a/env_support/cmake/kconfig.cmake
+++ b/env_support/cmake/kconfig.cmake
@@ -5,7 +5,7 @@ set(OUTPUT_DOTCONFIG ${CMAKE_CURRENT_SOURCE_DIR}/.config)
 set(KCONFIG_LIST_OUT ${CMAKE_CURRENT_BINARY_DIR}/kconfig_list)
 set(AUTO_CONF_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
-# Normalizes INPUT_PATH to an absolute path (relative to CMAKE_SOURCE_DIR)
+# Normalizes INPUT_PATH (which is relative to CMAKE_SOURCE_DIR) to an absolute path 
 macro(lv_normalize_config_path INPUT_PATH LABEL OUTPUT_VAR)
     message(STATUS "Using ${LABEL}: ${${INPUT_PATH}}")
     if(NOT IS_ABSOLUTE ${${INPUT_PATH}})

--- a/env_support/cmake/main.cmake
+++ b/env_support/cmake/main.cmake
@@ -94,6 +94,8 @@ endif()
 add_library(lvgl ${SOURCES})
 add_library(lvgl::lvgl ALIAS lvgl)
 
+set(CONF_PATH)
+
 if (NOT LV_BUILD_USE_KCONFIG)
 
     # Default - use the lv_conf.h configuration file
@@ -220,6 +222,12 @@ if (LV_BUILD_SET_CONFIG_OPTS)
 
     # This will set all CONFIG_LV_USE_* or CONFIG_LV_BUILD_* variables in cmake
     include(${CMAKE_CURRENT_BINARY_DIR}/lv_conf.cmake)
+
+    # Regen lv_conf.cmake when lv_conf.h changes
+    if(CONF_PATH)
+        set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${CONF_PATH})
+    endif()
+
     if(NOT CONFIG_LV_USE_PRIVATE_API AND (CONFIG_LV_BUILD_DEMOS OR CONFIG_LV_BUILD_EXAMPLES))
         message(STATUS "CONFIG_LV_USE_PRIVATE_API forcefully enabled because demos or examples are being built")
         set(CONFIG_LV_USE_PRIVATE_API ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
as the title says

This is to regen lv_conf.cmake so that we don't have stale cmake variables being turned on if lv_conf.h/.config changes