### PR TITLE
feat(wayland): support moving xdg-toplevel windows by dragging

### DIFF
--- a/src/drivers/wayland/lv_wayland_pointer.c
+++ b/src/drivers/wayland/lv_wayland_pointer.c
@@ -195,8 +195,16 @@ static void pointer_handle_enter(void * data, struct wl_pointer * pointer, uint3
                                  wl_fixed_t sx, wl_fixed_t sy)
 {
     LV_UNUSED(data);
-    LV_UNUSED(surface);
     lv_wl_seat_pointer_t * seat_pointer = wl_pointer_get_user_data(pointer);
+    LV_ASSERT_NULL(seat_pointer);
+    seat_pointer->active_window = NULL;
+    lv_wl_window_t * window;
+    LV_LL_READ(&lv_wl_ctx.window_ll, window) {
+        if(window->body == surface) {
+            seat_pointer->active_window = window;
+            break;
+        }
+    }
     int pos_x = wl_fixed_to_int(sx);
     int pos_y = wl_fixed_to_int(sy);
 
@@ -220,6 +228,9 @@ static void pointer_handle_leave(void * data, struct wl_pointer * pointer, uint3
     LV_UNUSED(serial);
     LV_UNUSED(surface);
     LV_UNUSED(pointer);
+    lv_wl_seat_pointer_t * seat_pointer = wl_pointer_get_user_data(pointer);
+    LV_ASSERT_NULL(seat_pointer);
+    seat_pointer->active_window = NULL;
 }
 
 static void pointer_handle_motion(void * data, struct wl_pointer * pointer, uint32_t time, wl_fixed_t sx, wl_fixed_t sy)
@@ -248,6 +259,12 @@ static void pointer_handle_button(void * data, struct wl_pointer * pointer, uint
 
     if(button == BTN_LEFT) {
         seat_pointer->left_btn_state = lv_state;
+        if(state == WL_POINTER_BUTTON_STATE_PRESSED && seat_pointer->active_window) {
+            xdg_toplevel_move(
+                seat_pointer->active_window->xdg.xdg_toplevel,
+                lv_wl_ctx.seat.wl_seat,
+                serial);
+        }
     }
     else if(button == BTN_RIGHT) {
         seat_pointer->right_btn_state = lv_state;

--- a/src/drivers/wayland/lv_wayland_private.h
+++ b/src/drivers/wayland/lv_wayland_private.h
@@ -41,6 +41,7 @@ typedef struct {
     struct wl_pointer * wl_pointer;
     struct wl_surface * cursor_surface;
     struct wl_cursor_theme * cursor_theme;
+    struct _lv_wl_window_t * active_window;
     lv_point_t point;
     lv_indev_state_t left_btn_state;
     lv_indev_state_t right_btn_state;


### PR DESCRIPTION
Fixes #10342

## Description

This PR adds support for moving undecorated Wayland xdg-toplevel windows by dragging.

It tracks the active window on pointer enter/leave events and invokes `xdg_toplevel_move()` when the left mouse button is pressed.

### Changes

- Track the active Wayland window in the pointer state.
- Update the active window on pointer enter/leave events.
- Invoke `xdg_toplevel_move()` on left mouse button press.

### Testing

- Built successfully with the Wayland simulator (`lvglsim`).
- Verified that windows can be moved by dragging with the left mouse button.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

