### PR TITLE
fix(circle_buf): add debug assertions for zero-capacity / empty-buffers

### DIFF
--- a/src/misc/lv_circle_buf.c
+++ b/src/misc/lv_circle_buf.c
@@ -184,16 +184,22 @@ void * lv_circle_buf_head(const lv_circle_buf_t * circle_buf)
 {
     LV_ASSERT_NULL(circle_buf);
 
+    uint32_t capacity = lv_circle_buf_capacity(circle_buf);
+    LV_ASSERT_MSG(capacity > 0, "circle buffer capacity must be > 0");
+
     return lv_array_at(&circle_buf->array,
-                       circle_buf->head % lv_circle_buf_capacity(circle_buf));
+                       circle_buf->head % capacity);
 }
 
 void * lv_circle_buf_tail(const lv_circle_buf_t * circle_buf)
 {
     LV_ASSERT_NULL(circle_buf);
 
+    uint32_t capacity = lv_circle_buf_capacity(circle_buf);
+    LV_ASSERT_MSG(capacity > 0, "circle buffer capacity must be > 0");
+
     return lv_array_at(&circle_buf->array,
-                       circle_buf->tail % lv_circle_buf_capacity(circle_buf));
+                       circle_buf->tail % capacity);
 }
 
 lv_result_t lv_circle_buf_read(lv_circle_buf_t * circle_buf, void * data)
@@ -274,6 +280,7 @@ lv_result_t lv_circle_buf_peek_at(const lv_circle_buf_t * circle_buf, const uint
 {
     LV_ASSERT_NULL(circle_buf);
     LV_ASSERT_NULL(data);
+    LV_ASSERT_MSG(lv_circle_buf_size(circle_buf) > 0, "can't peek into an empty buffer");
 
     const uint32_t real_index = (index % lv_circle_buf_size(circle_buf) + circle_buf->head) % lv_circle_buf_capacity(
                                     circle_buf);

--- a/src/misc/lv_circle_buf.c
+++ b/src/misc/lv_circle_buf.c
@@ -182,9 +182,11 @@ void lv_circle_buf_reset(lv_circle_buf_t * circle_buf)
 
 void * lv_circle_buf_head(const lv_circle_buf_t * circle_buf)
 {
+    uint32_t capacity;
+
     LV_ASSERT_NULL(circle_buf);
 
-    uint32_t capacity = lv_circle_buf_capacity(circle_buf);
+    capacity = lv_circle_buf_capacity(circle_buf);
     LV_ASSERT_MSG(capacity > 0, "circle buffer capacity must be > 0");
 
     return lv_array_at(&circle_buf->array,
@@ -193,9 +195,11 @@ void * lv_circle_buf_head(const lv_circle_buf_t * circle_buf)
 
 void * lv_circle_buf_tail(const lv_circle_buf_t * circle_buf)
 {
+    uint32_t capacity;
+
     LV_ASSERT_NULL(circle_buf);
 
-    uint32_t capacity = lv_circle_buf_capacity(circle_buf);
+    capacity = lv_circle_buf_capacity(circle_buf);
     LV_ASSERT_MSG(capacity > 0, "circle buffer capacity must be > 0");
 
     return lv_array_at(&circle_buf->array,
@@ -278,11 +282,13 @@ lv_result_t lv_circle_buf_peek(const lv_circle_buf_t * circle_buf, void * data)
 
 lv_result_t lv_circle_buf_peek_at(const lv_circle_buf_t * circle_buf, const uint32_t index, void * data)
 {
+    uint32_t real_index;
+
     LV_ASSERT_NULL(circle_buf);
     LV_ASSERT_NULL(data);
     LV_ASSERT_MSG(lv_circle_buf_size(circle_buf) > 0, "can't peek into an empty buffer");
 
-    const uint32_t real_index = (index % lv_circle_buf_size(circle_buf) + circle_buf->head) % lv_circle_buf_capacity(
+    real_index = (index % lv_circle_buf_size(circle_buf) + circle_buf->head) % lv_circle_buf_capacity(
                                     circle_buf);
     lv_memcpy(data, lv_array_at(&circle_buf->array, real_index), circle_buf->array.element_size);
 

--- a/src/misc/lv_circle_buf.c
+++ b/src/misc/lv_circle_buf.c
@@ -182,11 +182,9 @@ void lv_circle_buf_reset(lv_circle_buf_t * circle_buf)
 
 void * lv_circle_buf_head(const lv_circle_buf_t * circle_buf)
 {
-    uint32_t capacity;
-
     LV_ASSERT_NULL(circle_buf);
 
-    capacity = lv_circle_buf_capacity(circle_buf);
+    uint32_t capacity = lv_circle_buf_capacity(circle_buf);
     LV_ASSERT_MSG(capacity > 0, "circle buffer capacity must be > 0");
 
     return lv_array_at(&circle_buf->array,
@@ -195,11 +193,9 @@ void * lv_circle_buf_head(const lv_circle_buf_t * circle_buf)
 
 void * lv_circle_buf_tail(const lv_circle_buf_t * circle_buf)
 {
-    uint32_t capacity;
-
     LV_ASSERT_NULL(circle_buf);
 
-    capacity = lv_circle_buf_capacity(circle_buf);
+    uint32_t capacity = lv_circle_buf_capacity(circle_buf);
     LV_ASSERT_MSG(capacity > 0, "circle buffer capacity must be > 0");
 
     return lv_array_at(&circle_buf->array,
@@ -282,13 +278,11 @@ lv_result_t lv_circle_buf_peek(const lv_circle_buf_t * circle_buf, void * data)
 
 lv_result_t lv_circle_buf_peek_at(const lv_circle_buf_t * circle_buf, const uint32_t index, void * data)
 {
-    uint32_t real_index;
-
     LV_ASSERT_NULL(circle_buf);
     LV_ASSERT_NULL(data);
     LV_ASSERT_MSG(lv_circle_buf_size(circle_buf) > 0, "can't peek into an empty buffer");
 
-    real_index = (index % lv_circle_buf_size(circle_buf) + circle_buf->head) % lv_circle_buf_capacity(
+    const uint32_t real_index = (index % lv_circle_buf_size(circle_buf) + circle_buf->head) % lv_circle_buf_capacity(
                                     circle_buf);
     lv_memcpy(data, lv_array_at(&circle_buf->array, real_index), circle_buf->array.element_size);
 

--- a/src/misc/lv_circle_buf_private.h
+++ b/src/misc/lv_circle_buf_private.h
@@ -114,6 +114,7 @@ void lv_circle_buf_reset(lv_circle_buf_t * circle_buf);
 
 /**
  * Get the head of the buffer
+ * @note The capacity of the buffer must be greater than 0.
  * @param circle_buf pointer to buffer
  * @return pointer to the head of the buffer
  */
@@ -121,6 +122,7 @@ void * lv_circle_buf_head(const lv_circle_buf_t * circle_buf);
 
 /**
  * Get the tail of the buffer
+ * @note The capacity of the buffer must be greater than 0.
  * @param circle_buf pointer to buffer
  * @return pointer to the tail of the buffer
  */
@@ -170,6 +172,7 @@ lv_result_t lv_circle_buf_peek(const lv_circle_buf_t * circle_buf, void * data);
 
 /**
  * Peek a value at an index
+ * @note The size of the buffer must be greater than 0.
  * @param circle_buf pointer to buffer
  * @param index the index of the value to peek, if the index is greater than the size of the buffer, it will return looply.
  * @param data pointer to a variable to store the peeked value


### PR DESCRIPTION
Added LV_ASSERT_MSG guards in lv_circle_buf_head, lv_circle_buf_tail, and lv_circle_buf_peek_at to catch zero-capacity or empty-buffer access in debug builds, preventing silent division‑by‑zero without runtime overhead.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

