### PR TITLE
refactor(obj/style): rewrite loop to avoid realloc every iteration

### DIFF
--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -1352,6 +1352,7 @@ static lv_style_res_t get_selector_style_prop(const lv_obj_t * obj, lv_style_sel
 
 static void remove_style_core(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector, bool theme_only)
 {
+    LV_ASSERT(obj != NULL);
     lv_state_t state = lv_obj_style_get_selector_state(selector);
     lv_part_t part = lv_obj_style_get_selector_part(selector);
     lv_style_prop_t prop = LV_STYLE_PROP_ANY;
@@ -1361,47 +1362,58 @@ static void remove_style_core(lv_obj_t * obj, const lv_style_t * style, lv_style
         lv_obj_invalidate(obj);
     }
 
-    uint32_t i = 0;
+    uint32_t style_count = 0;
     bool deleted = false;
-    while(i <  obj->style_cnt) {
+
+    for(uint32_t i = 0; i < obj->style_cnt; i++) {
         lv_state_t state_act = lv_obj_style_get_selector_state(obj->styles[i].selector);
         lv_part_t part_act = lv_obj_style_get_selector_part(obj->styles[i].selector);
+
+        bool should_remove = true;
         if(theme_only && !obj->styles[i].is_theme) {
-            i++;
-            continue;
+            should_remove = false;
         }
-        if((state != LV_STATE_ANY && state_act != state) ||
-           (part != LV_PART_ANY && part_act != part) ||
-           (style != NULL && style != obj->styles[i].style)) {
-            i++;
+        else if((state != LV_STATE_ANY && state_act != state) ||
+                (part != LV_PART_ANY && part_act != part) ||
+                (style != NULL && style != obj->styles[i].style)) {
+            should_remove = false;
+        }
+
+        if(!should_remove) {
+            /*Keep this entry: copy it down to the current write position if needed*/
+            if(style_count != i) {
+                obj->styles[style_count] = obj->styles[i];
+            }
+            style_count++;
             continue;
         }
 
+        /*This entry is being removed*/
         if(obj->styles[i].is_trans) {
             trans_delete(obj, part, LV_STYLE_PROP_ANY, NULL);
         }
-
         if(obj->styles[i].is_local || obj->styles[i].is_trans) {
             if(obj->styles[i].style) lv_style_reset((lv_style_t *)obj->styles[i].style);
             lv_free((lv_style_t *)obj->styles[i].style);
             obj->styles[i].style = NULL;
         }
-
-        /*Shift the styles after `i` by one*/
-        uint32_t j;
-        for(j = i; j < (uint32_t)obj->style_cnt - 1 ; j++) {
-            obj->styles[j] = obj->styles[j + 1];
-        }
-
-        obj->style_cnt--;
-        obj->styles = lv_realloc(obj->styles, obj->style_cnt * sizeof(lv_obj_style_t));
-
         deleted = true;
-        /*The style from the current `i` index is removed, so `i` points to the next style.
-         *Therefore it doesn't needs to be incremented*/
     }
 
-    if(deleted && prop != LV_STYLE_PROP_INV) {
+    if(!deleted) {
+        return;
+    }
+
+    obj->style_cnt = style_count;
+    if(style_count > 0) {
+        obj->styles = lv_realloc(obj->styles, style_count * sizeof(lv_obj_style_t));
+    }
+    else {
+        lv_free(obj->styles);
+        obj->styles = NULL;
+    }
+
+    if(prop != LV_STYLE_PROP_INV) {
         full_cache_refresh(obj, part);
         lv_obj_refresh_style(obj, part, prop);
     }


### PR DESCRIPTION
Simple refactor to avoid calling `lv_realloc` every loop
