### PR TITLE
Feat/irq abstraction layer

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -8,6 +8,8 @@ extend-exclude = [
     "docs/src/_static/jquery.js",
     "libs/",
     "scripts/gen_json/create_fake_lib_c.py",
+    "scripts/generators/config_files.py",
+    "scripts/generators/config_headers/parse.py",
     "src/libs/",
     "zephyr/Kconfig",
 ]

--- a/Kconfig
+++ b/Kconfig
@@ -957,18 +957,6 @@ if LV_USE_DRAW_DMA2D
 config LV_DRAW_DMA2D_HAL_INCLUDE
 	string "the header file for LVGL to include for DMA2D"
 	default "stm32h7xx_hal.h"
-
-config LV_USE_DRAW_DMA2D_INTERRUPT
-	bool "use the DMA2D transfer complete interrupt"
-	default n
-	depends on !LV_OS_NONE
-	help
-		Run DMA2D asynchronously: the transfer-complete interrupt wakes the
-		draw unit instead of busy-polling. Requires an OS (for the completion
-		sync object) and an IRQ backend that provides DMA2D (LV_USE_IRQ). The
-		interrupt is wired by the selected IRQ backend (src/irqal); no manual
-		vector/handler wiring is needed.
-
 endif
 endmenu
 

--- a/Kconfig
+++ b/Kconfig
@@ -20,7 +20,7 @@ config LV_STDLIB_RTTHREAD
 	default 3
 
 config LV_STDLIB_CUSTOM
-	int 
+	int
 	default 255
 
 choice
@@ -254,6 +254,63 @@ config LV_OS_IDLE_PERCENT_CUSTOM
 endmenu
 endif #LV_OS_FREERTOS
 endmenu
+menu "Interrupt Handling (IRQ)"
+choice LV_USE_IRQ
+	prompt "IRQ abstraction backend to use"
+	default LV_IRQ_NONE
+
+	config LV_IRQ_NONE
+		bool "NONE"
+	config LV_IRQ_CMSIS
+		bool "CMSIS"
+	config LV_IRQ_ZEPHYR
+		bool "ZEPHYR"
+endchoice
+
+config LV_USE_IRQ
+	int
+	default 0 if LV_IRQ_NONE
+	default 1 if LV_IRQ_CMSIS
+	default 2 if LV_IRQ_ZEPHYR
+
+if LV_IRQ_CMSIS
+config LV_IRQ_USE_CMSIS_INCLUDE
+	bool "Include a CMSIS/vendor device header to discover IRQ numbers"
+	default n
+	help
+		Enable to pull in a vendor/CMSIS device header (e.g. stm32h7xx.h) that
+		provides the IRQn_Type enumerators (PXP_IRQn, DMA2D_IRQn, ...) and the
+		NVIC_* helpers. Peripheral IRQ support is auto-detected from the symbols
+		this header defines.
+
+config LV_IRQ_CMSIS_INCLUDE
+	string "CMSIS/vendor device header"
+	default ""
+	depends on LV_IRQ_USE_CMSIS_INCLUDE
+
+config LV_IRQ_CMSIS_SET_PRIORITY
+	bool "Set the NVIC priority of irqal-managed interrupts"
+	default n
+	help
+		Enable on RTOS builds (e.g. FreeRTOS, or CMSIS-RTOS2 over an RTOS) where
+		the interrupt priority must sit at or below the kernel's syscall interrupt
+		priority ceiling, so the ISR may safely call the kernel's ...FromISR APIs
+		(lv_thread_sync_signal_isr uses one). Leave disabled on bare-metal, where
+		the reset-default priority is fine.
+
+config LV_IRQ_CMSIS_PRIORITY
+	int "NVIC priority value for irqal-managed interrupts"
+	default 255
+	depends on LV_IRQ_CMSIS_SET_PRIORITY
+	help
+		The value passed to NVIC_SetPriority. Defaults to 255, which NVIC_SetPriority
+		maps to the lowest preemption priority regardless of the implemented priority
+		bits (__NVIC_PRIO_BITS) - always safe to call ...FromISR from, at the cost of
+		latency. For best latency under FreeRTOS set it to
+		configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY + 1 (a hand-written lv_conf.h may
+		define this symbolically; a Kconfig build takes a literal number).
+endif #LV_IRQ_CMSIS
+endmenu
 menu "Rendering Configuration"
 
 menu "Color Settings"
@@ -442,42 +499,42 @@ config LV_DRAW_SW_SUPPORT_RGB565A8
 config LV_DRAW_SW_SUPPORT_RGB888
 	bool "Enable support for RGB888 color format"
 	default y
-	
+
 
 config LV_DRAW_SW_SUPPORT_XRGB8888
 	bool "Enable support for XRGB8888 color format"
 	default y
-	
+
 
 config LV_DRAW_SW_SUPPORT_ARGB8888
 	bool "Enable support for ARGB8888 color format"
 	default y
-	
+
 
 config LV_DRAW_SW_SUPPORT_ARGB8888_PREMULTIPLIED
 	bool "Enable support for ARGB8888 premultiplied color format"
 	default y
-	
+
 
 config LV_DRAW_SW_SUPPORT_L8
 	bool "Enable support for L8 color format"
 	default y
-	
+
 
 config LV_DRAW_SW_SUPPORT_AL88
 	bool "Enable support for AL88 color format"
 	default y
-	
+
 
 config LV_DRAW_SW_SUPPORT_A8
 	bool "Enable support for A8 color format"
 	default y
-	
+
 
 config LV_DRAW_SW_SUPPORT_I1
 	bool "Enable support for I1 color format"
 	default y
-	
+
 
 config LV_DRAW_SW_I1_LUM_THRESHOLD
 	int "Luminance threshold for a pixel to be active"
@@ -521,7 +578,7 @@ config LV_GRADIENT_MAX_STOPS
 config LV_USE_DRAW_SW_COMPLEX_GRADIENTS
 	bool "Enable drawing complex gradients in software"
 	default n
-	
+
 	help
 		0: do not enable complex gradients
 		1: enable complex gradients (linear at an angle, radial or conical)
@@ -548,7 +605,7 @@ config LV_DRAW_SW_CIRCLE_CACHE_SIZE
 choice LV_USE_DRAW_SW_ASM
 	prompt "Asm mode in sw draw"
 	default LV_DRAW_SW_ASM_NONE
-	
+
 	help
 		ASM mode to be used
 
@@ -904,10 +961,13 @@ config LV_DRAW_DMA2D_HAL_INCLUDE
 config LV_USE_DRAW_DMA2D_INTERRUPT
 	bool "use the DMA2D transfer complete interrupt"
 	default n
+	depends on !LV_OS_NONE
 	help
-		if enabled, the user is required to call
-		`lv_draw_dma2d_transfer_complete_interrupt_handler`
-		upon receiving the DMA2D global interrupt
+		Run DMA2D asynchronously: the transfer-complete interrupt wakes the
+		draw unit instead of busy-polling. Requires an OS (for the completion
+		sync object) and an IRQ backend that provides DMA2D (LV_USE_IRQ). The
+		interrupt is wired by the selected IRQ backend (src/irqal); no manual
+		vector/handler wiring is needed.
 
 endif
 endmenu
@@ -1036,7 +1096,7 @@ config LV_USE_DRAW_SDL
 	default n
 	help
 	Uses SDL renderer API
-endmenu 
+endmenu
 endmenu
 menu "Input Devices"
 config LV_USE_GRIDNAV
@@ -1162,7 +1222,7 @@ config LV_USE_LOG
 if LV_USE_LOG
 
 choice
-	bool "Default log verbosity" 
+	bool "Default log verbosity"
 	default LV_LOG_LEVEL_WARN
 	help
 		Specify how important log should be added.
@@ -1191,7 +1251,7 @@ config LV_LOG_LEVEL
 	default 5 if LV_LOG_LEVEL_NONE
 
 config LV_LOG_LEVEL_NUM
-	int 
+	int
 	default 5
 
 config LV_LOG_PRINTF
@@ -1204,47 +1264,47 @@ config LV_LOG_PRINTF
 config LV_LOG_USE_TIMESTAMP
 	bool "Enable print timestamp"
 	default y
-	
+
 config LV_LOG_USE_FILE_LINE
 	bool "Enable print file and line number"
 	default y
-	
+
 config LV_LOG_TRACE_MEM
 	bool "Enable/Disable LV_LOG_TRACE in mem module"
 	default y
-	
+
 config LV_LOG_TRACE_TIMER
 	bool "Enable/Disable LV_LOG_TRACE in timer module"
 	default y
-	
+
 config LV_LOG_TRACE_INDEV
 	bool "Enable/Disable LV_LOG_TRACE in indev module"
 	default y
-	
+
 config LV_LOG_TRACE_DISP_REFR
 	bool "Enable/Disable LV_LOG_TRACE in disp refr module"
 	default y
-	
+
 config LV_LOG_TRACE_EVENT
 	bool "Enable/Disable LV_LOG_TRACE in event module"
 	default y
-	
+
 config LV_LOG_TRACE_OBJ_CREATE
 	bool "Enable/Disable LV_LOG_TRACE in obj create module"
 	default y
-	
+
 config LV_LOG_TRACE_LAYOUT
 	bool "Enable/Disable LV_LOG_TRACE in layout module"
 	default y
-	
+
 config LV_LOG_TRACE_ANIM
 	bool "Enable/Disable LV_LOG_TRACE in anim module"
 	default y
-	
+
 config LV_LOG_TRACE_CACHE
 	bool "Enable/Disable LV_LOG_TRACE in cache module"
 	default y
-	
+
 
 endif
 endmenu
@@ -1554,14 +1614,14 @@ config LV_USE_CUSTOM_FONT_DEFAULT
 		  - in the header given by LV_FONT_CUSTOM_INCLUDE, e.g.
 		        #define LV_FONT_CUSTOM_DECLARE  LV_FONT_DECLARE(my_font_24)
 		        #define LV_FONT_DEFAULT         &my_font_24
-			
+
 		If you do not, LV_FONT_DEFAULT falls back to a builtin font,
 		which is no longer compiled in, causing a link error.
 
 
 choice LV_FONT_DEFAULT
 	prompt "Select theme default text font"
-	default LV_FONT_DEFAULT_MONTSERRAT_14 
+	default LV_FONT_DEFAULT_MONTSERRAT_14
 	depends on !LV_USE_CUSTOM_FONT_DEFAULT
 	help
 		Select theme default text font
@@ -1866,7 +1926,7 @@ config LV_USE_CALENDAR_CHINESE
 	default n
 
 endif #LV_USE_CALENDAR
-	
+
 
 
 config LV_USE_CANVAS
@@ -1922,7 +1982,7 @@ config LV_GIF_MAX_WIDTH
 	int "Maximum GIF canvas width in pixels"
 	depends on LV_USE_GIF
 	default 480
-	help 
+	help
 		Increasing this value will consume more memory.
 		GIFs wider than this are rejected
 
@@ -1930,7 +1990,7 @@ config LV_GIF_MAX_HEIGHT
 	int "Maximum GIF canvas height in pixels"
 	depends on LV_USE_GIF
 	default 32768
-	help 
+	help
 		This value has no impact on memory usage
 		GIFs taller than this are rejected
 
@@ -2435,7 +2495,7 @@ config LV_NUTTX_LCD_BUFFER_SIZE
 	depends on LV_NUTTX_LCD_CUSTOM_BUFFER
 	depends on LV_USE_NUTTX_LCD
 	default 60
-	
+
 
 config LV_USE_NUTTX_TOUCHSCREEN
 	bool "Use NuttX touchscreen driver"
@@ -3194,7 +3254,7 @@ config LV_TEST_SCREENSHOT_CREATE_REFERENCE_IMAGE
 	bool "Create a reference image by default if it does not exist"
 	default y
 	depends on LV_USE_TEST_SCREENSHOT_COMPARE
-	
+
 endif #LV_USE_TEST
 
 	config LV_USE_MONKEY

--- a/component.mk
+++ b/component.mk
@@ -10,6 +10,7 @@ COMPONENT_SRCDIRS := . \
                   src/display \
                   src/indev \
                   src/osal \
+                  src/irqal \
                   src/misc \
                   src/misc/cache \
                   src/misc/cache/class \

--- a/include/lvgl/config/lv_conf_internal.h
+++ b/include/lvgl/config/lv_conf_internal.h
@@ -1107,14 +1107,6 @@
     #endif
 #endif
 
-#ifndef LV_USE_DRAW_DMA2D_INTERRUPT
-    #ifdef CONFIG_LV_USE_DRAW_DMA2D_INTERRUPT
-        #define LV_USE_DRAW_DMA2D_INTERRUPT CONFIG_LV_USE_DRAW_DMA2D_INTERRUPT
-    #else
-        #define LV_USE_DRAW_DMA2D_INTERRUPT 0
-    #endif
-#endif
-
 #ifndef LV_USE_DRAW_EVE
     #ifdef CONFIG_LV_USE_DRAW_EVE
         #define LV_USE_DRAW_EVE CONFIG_LV_USE_DRAW_EVE
@@ -5181,10 +5173,6 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
 
 #if LV_USE_PPA_IMG && !(LV_USE_PPA)
     #error "LV_USE_PPA_IMG requires LV_USE_PPA (Kconfig depends on)"
-#endif
-
-#if LV_USE_DRAW_DMA2D_INTERRUPT && !(!(LV_USE_OS == LV_OS_NONE) && LV_USE_DRAW_DMA2D)
-    #error "LV_USE_DRAW_DMA2D_INTERRUPT requires !(LV_USE_OS == LV_OS_NONE) && LV_USE_DRAW_DMA2D (Kconfig depends on)"
 #endif
 
 #if (LV_WAYLAND_BACKEND == LV_WAYLAND_BACKEND_G2D) && !LV_USE_DRAW_G2D

--- a/include/lvgl/config/lv_conf_internal.h
+++ b/include/lvgl/config/lv_conf_internal.h
@@ -57,6 +57,11 @@
 #define LV_OS_SDL2          7
 #define LV_OS_CUSTOM        255
 
+/* IRQ abstraction backend to use */
+#define LV_IRQ_NONE     0
+#define LV_IRQ_CMSIS    1
+#define LV_IRQ_ZEPHYR   2
+
 /* Asm mode in sw draw */
 #define LV_DRAW_SW_ASM_NONE      0
 #define LV_DRAW_SW_ASM_NEON      1
@@ -158,7 +163,7 @@
     #define LV_KCONFIG_PRESENT
 #endif
 
-/* 
+/*
  * Detect if the user is using the new calendar day/month configuration
  * in order to avoid warnings for users that have migrated.
  */
@@ -168,7 +173,7 @@
 #define LV_CALENDAR_DISABLE_DEFAULT_DAY_NAMES 0
 #endif
 
-/* 
+/*
  * Detect if the user is using the new calendar day/month configuration
  * in order to avoid warnings for users that have migrated.
  */
@@ -178,7 +183,7 @@
 #define LV_CALENDAR_DISABLE_DEFAULT_MONTH_NAMES 0
 #endif
 
-/* 
+/*
  * Detect if the user is using the xkb keymap configuration
  * in order to avoid warnings for users that have migrated.
  */
@@ -323,6 +328,52 @@
         #define LV_OS_IDLE_PERCENT_CUSTOM CONFIG_LV_OS_IDLE_PERCENT_CUSTOM
     #else
         #define LV_OS_IDLE_PERCENT_CUSTOM 0
+    #endif
+#endif
+
+
+
+/*============================================================================
+ * INTERRUPT HANDLING (IRQ)
+ *============================================================================*/
+
+#ifndef LV_USE_IRQ
+    #ifdef CONFIG_LV_USE_IRQ
+        #define LV_USE_IRQ CONFIG_LV_USE_IRQ
+    #else
+        #define LV_USE_IRQ LV_IRQ_NONE
+    #endif
+#endif
+
+#ifndef LV_IRQ_USE_CMSIS_INCLUDE
+    #ifdef CONFIG_LV_IRQ_USE_CMSIS_INCLUDE
+        #define LV_IRQ_USE_CMSIS_INCLUDE CONFIG_LV_IRQ_USE_CMSIS_INCLUDE
+    #else
+        #define LV_IRQ_USE_CMSIS_INCLUDE 0
+    #endif
+#endif
+
+#ifndef LV_IRQ_CMSIS_INCLUDE
+    #ifdef CONFIG_LV_IRQ_CMSIS_INCLUDE
+        #define LV_IRQ_CMSIS_INCLUDE CONFIG_LV_IRQ_CMSIS_INCLUDE
+    #else
+        #define LV_IRQ_CMSIS_INCLUDE ""
+    #endif
+#endif
+
+#ifndef LV_IRQ_CMSIS_SET_PRIORITY
+    #ifdef CONFIG_LV_IRQ_CMSIS_SET_PRIORITY
+        #define LV_IRQ_CMSIS_SET_PRIORITY CONFIG_LV_IRQ_CMSIS_SET_PRIORITY
+    #else
+        #define LV_IRQ_CMSIS_SET_PRIORITY 0
+    #endif
+#endif
+
+#ifndef LV_IRQ_CMSIS_PRIORITY
+    #ifdef CONFIG_LV_IRQ_CMSIS_PRIORITY
+        #define LV_IRQ_CMSIS_PRIORITY CONFIG_LV_IRQ_CMSIS_PRIORITY
+    #else
+        #define LV_IRQ_CMSIS_PRIORITY 255
     #endif
 #endif
 
@@ -4623,15 +4674,15 @@
  * Start of compatibility block
  -----------------------------------*/
 
-/*  
+/*
  *  TODO: Remove this for v10.
  */
 
 /*
  *  Before the user selected either LV_USE_LZ4_INTERNAL or LV_USE_LZ4_EXTERNAL
- *  For v9.6 LV_USE_LZ4_EXTERNAL doesn't exist anymore, instead the user 
+ *  For v9.6 LV_USE_LZ4_EXTERNAL doesn't exist anymore, instead the user
  *  enables LV_USE_LZ4 and disables LV_USE_LZ4_INTERNAL
- *  To support users using LV_USE_LZ4_EXTERNAL from before v9.6 we 
+ *  To support users using LV_USE_LZ4_EXTERNAL from before v9.6 we
  *  we enable LV_USE_LZ4 for them
  */
 #if defined(LV_USE_LZ4_EXTERNAL) && LV_USE_LZ4_EXTERNAL
@@ -4642,11 +4693,11 @@
 #endif /*!LV_USE_LZ4*/
 #endif /*defined(LV_USE_LZ4_EXTERNAL) && LV_USE_LZ4_EXTERNAL*/
 
-/*  
+/*
  *  Before the user selected either LV_USE_THORVG_INTERNAL or LV_USE_THORVG_EXTERNAL
- *  For v9.6 LV_USE_THORVG_EXTERNAL doesn't exist anymore, instead the user 
+ *  For v9.6 LV_USE_THORVG_EXTERNAL doesn't exist anymore, instead the user
  *  enables LV_USE_THORVG and disables LV_USE_THORVG_INTERNAL
- *  To support users using LV_USE_THORVG_EXTERNAL from before v9.6 we 
+ *  To support users using LV_USE_THORVG_EXTERNAL from before v9.6 we
  *  we enable LV_USE_THORVG for them
  */
 #if defined(LV_USE_THORVG_EXTERNAL) && LV_USE_THORVG_EXTERNAL
@@ -4657,8 +4708,8 @@
 #endif /*!LV_USE_THORVG*/
 #endif /*defined(LV_USE_THORVG_EXTERNAL) && LV_USE_THORVG_EXTERNAL*/
 
-/*  
- *  Backward compatibility. Before the user selected either 
+/*
+ *  Backward compatibility. Before the user selected either
  *  LV_X11_RENDER_MODE_PARTIAL or LV_X11_RENDER_MODE_DIRECT or
  *  LV_X11_RENDER_MODE_FULL. For v9.6, this becomes a single choice:
  *  LV_X11_RENDER_MODE which maps to a LV_DISPLAY_RENDER_MODE value.
@@ -5028,6 +5079,14 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
     #error "LV_OS_IDLE_PERCENT_CUSTOM requires LV_USE_OS == LV_OS_FREERTOS (Kconfig depends on)"
 #endif
 
+#if LV_IRQ_USE_CMSIS_INCLUDE && !(LV_USE_IRQ == LV_IRQ_CMSIS)
+    #error "LV_IRQ_USE_CMSIS_INCLUDE requires LV_USE_IRQ == LV_IRQ_CMSIS (Kconfig depends on)"
+#endif
+
+#if LV_IRQ_CMSIS_SET_PRIORITY && !(LV_USE_IRQ == LV_IRQ_CMSIS)
+    #error "LV_IRQ_CMSIS_SET_PRIORITY requires LV_USE_IRQ == LV_IRQ_CMSIS (Kconfig depends on)"
+#endif
+
 #if (LV_USE_VECTOR_GRAPHIC || LV_USE_DRAW_VG_LITE || LV_USE_DRAW_NANOVG || LV_USE_OPENGLES) && !LV_USE_MATRIX
     #error "LV_USE_MATRIX must be enabled: Kconfig selects it from LV_USE_VECTOR_GRAPHIC || LV_USE_DRAW_VG_LITE || LV_USE_DRAW_NANOVG || LV_USE_OPENGLES"
 #endif
@@ -5124,8 +5183,8 @@ LV_EXPORT_CONST_INT(LV_DRAW_BUF_ALIGN);
     #error "LV_USE_PPA_IMG requires LV_USE_PPA (Kconfig depends on)"
 #endif
 
-#if LV_USE_DRAW_DMA2D_INTERRUPT && !(LV_USE_DRAW_DMA2D)
-    #error "LV_USE_DRAW_DMA2D_INTERRUPT requires LV_USE_DRAW_DMA2D (Kconfig depends on)"
+#if LV_USE_DRAW_DMA2D_INTERRUPT && !(!(LV_USE_OS == LV_OS_NONE) && LV_USE_DRAW_DMA2D)
+    #error "LV_USE_DRAW_DMA2D_INTERRUPT requires !(LV_USE_OS == LV_OS_NONE) && LV_USE_DRAW_DMA2D (Kconfig depends on)"
 #endif
 
 #if (LV_WAYLAND_BACKEND == LV_WAYLAND_BACKEND_G2D) && !LV_USE_DRAW_G2D

--- a/include/lvgl/irqal/lv_irq.h
+++ b/include/lvgl/irqal/lv_irq.h
@@ -24,37 +24,46 @@ extern "C" {
  **********************/
 
 /**
- * Callback invoked by the selected IRQ backend when a registered hardware
- * interrupt fires. The callback runs in interrupt context.
+ * Callback invoked by the provider when a completion event fires (in interrupt
+ * context).
  *
- * No context pointer is passed: each `lv_irq_attach_*()` is peripheral-specific
- * and every peripheral is a singleton, so the callback already knows its context
- * and reads whatever state it needs from its own static storage.
+ * @param user_data  a provider-supplied pointer. Plain hardware-IRQ providers
+ *                    (DMA2D, PXP) pass NULL. The NemaGFX GPU2D provider passes a
+ *                    pointer to the completed command-list id (cast to
+ *                    `uint32_t *` and dereference). `attach` does not take a
+ *                    registration-time user_data yet; keeping this `void *`
+ *                    leaves room to forward one later without changing callers.
  */
-typedef void (*lv_irq_cb_t)(void);
+typedef void (*lv_irq_cb_t)(void * user_data);
 
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
 
-/* One attach/detach pair per known peripheral IRQ, implemented by the selected
- * IRQ backend (LV_USE_IRQ) for the peripherals the target actually provides.
- * These are used mainly by LVGL's own GPU draw units. The declarations are
- * unconditional, but a definition exists only when the selected backend covers
- * that peripheral, so calling one the backend does not provide is a link error.
- * To supply your own backend, select LV_IRQ_NONE and define the attach/detach
- * functions you need (see src/irqal for the reference backends to copy).
+/* One attach/detach pair per known GPU completion source, used mainly by LVGL's
+ * own GPU draw units. `attach` arranges for the callback to be invoked (in
+ * interrupt context) when the source signals completion; `detach` stops it.
+ * `cb` must not be NULL. The declarations are unconditional, but a definition
+ * exists only when something provides that source, so calling an unprovided one
+ * is a link error.
  *
- * `attach` registers/enables the line so `cb()` is invoked when the IRQ fires
- * (in interrupt context); `detach` disables it. `cb` must not be NULL. The
- * interrupt priority is sourced by the backend (device tree on Zephyr, vendor
- * config on CMSIS), not passed here. */
+ * Providers differ by source:
+ *  - DMA2D / PXP: raw hardware IRQs wired by the selected LV_USE_IRQ backend
+ *    (device tree on Zephyr, NVIC on CMSIS); the priority is sourced there, and
+ *    the callback's user_data is NULL. Supply your own by selecting LV_IRQ_NONE
+ *    and defining the attach/detach functions you need (see src/irqal to copy).
+ *  - NemaGFX GPU2D: registered through the vendor GPU2D HAL callback API; its
+ *    irqal backend (src/irqal, built for the NemaGFX STM32 HAL) provides it. The
+ *    callback's user_data is a pointer to the completed command-list id. */
 
 lv_result_t lv_irq_attach_dma2d(lv_irq_cb_t cb);
 lv_result_t lv_irq_detach_dma2d(void);
 
 lv_result_t lv_irq_attach_pxp(lv_irq_cb_t cb);
 lv_result_t lv_irq_detach_pxp(void);
+
+lv_result_t lv_irq_attach_nema_gpu2d(lv_irq_cb_t cb);
+lv_result_t lv_irq_detach_nema_gpu2d(void);
 
 /**********************
  *      MACROS

--- a/include/lvgl/irqal/lv_irq.h
+++ b/include/lvgl/irqal/lv_irq.h
@@ -37,15 +37,18 @@ typedef void (*lv_irq_cb_t)(void);
  * GLOBAL PROTOTYPES
  **********************/
 
-/* One attach/detach pair per known peripheral IRQ. The declarations are
- * unconditional (public API); a definition exists only for peripherals the
- * selected backend actually provides (see LV_IRQ_HAS_* in the backend). Guard
- * call sites with the matching LV_IRQ_HAS_* macro so you never reference a
- * function the backend didn't define.
+/* One attach/detach pair per known peripheral IRQ, implemented by the selected
+ * IRQ backend (LV_USE_IRQ) for the peripherals the target actually provides.
+ * These are used mainly by LVGL's own GPU draw units. The declarations are
+ * unconditional, but a definition exists only when the selected backend covers
+ * that peripheral, so calling one the backend does not provide is a link error.
+ * To supply your own backend, select LV_IRQ_NONE and define the attach/detach
+ * functions you need (see src/irqal for the reference backends to copy).
  *
- * `attach` registers/enables the line so `cb()` is invoked when the IRQ fires;
- * `detach` disables it. The interrupt priority is sourced by the backend
- * (device tree on Zephyr, vendor config on CMSIS), not passed here. */
+ * `attach` registers/enables the line so `cb()` is invoked when the IRQ fires
+ * (in interrupt context); `detach` disables it. `cb` must not be NULL. The
+ * interrupt priority is sourced by the backend (device tree on Zephyr, vendor
+ * config on CMSIS), not passed here. */
 
 lv_result_t lv_irq_attach_dma2d(lv_irq_cb_t cb);
 lv_result_t lv_irq_detach_dma2d(void);

--- a/include/lvgl/irqal/lv_irq.h
+++ b/include/lvgl/irqal/lv_irq.h
@@ -1,0 +1,64 @@
+/**
+ * @file lv_irq.h
+ *
+ */
+
+#ifndef LV_IRQ_H
+#define LV_IRQ_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../lv_types.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**
+ * Callback invoked by the selected IRQ backend when a registered hardware
+ * interrupt fires. The callback runs in interrupt context.
+ *
+ * No context pointer is passed: each `lv_irq_attach_*()` is peripheral-specific
+ * and every peripheral is a singleton, so the callback already knows its context
+ * and reads whatever state it needs from its own static storage.
+ */
+typedef void (*lv_irq_cb_t)(void);
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/* One attach/detach pair per known peripheral IRQ. The declarations are
+ * unconditional (public API); a definition exists only for peripherals the
+ * selected backend actually provides (see LV_IRQ_HAS_* in the backend). Guard
+ * call sites with the matching LV_IRQ_HAS_* macro so you never reference a
+ * function the backend didn't define.
+ *
+ * `attach` registers/enables the line so `cb()` is invoked when the IRQ fires;
+ * `detach` disables it. The interrupt priority is sourced by the backend
+ * (device tree on Zephyr, vendor config on CMSIS), not passed here. */
+
+lv_result_t lv_irq_attach_dma2d(lv_irq_cb_t cb);
+lv_result_t lv_irq_detach_dma2d(void);
+
+lv_result_t lv_irq_attach_pxp(lv_irq_cb_t cb);
+lv_result_t lv_irq_detach_pxp(void);
+
+/**********************
+ *      MACROS
+ **********************/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_IRQ_H*/

--- a/include/lvgl/lvgl.h
+++ b/include/lvgl/lvgl.h
@@ -148,6 +148,7 @@
 #include "layouts/lv_layout.h"
 #include "logging/lv_log.h"
 #include "lv_types.h"
+#include "irqal/lv_irq.h"
 #include "misc/lv_array.h"
 #include "misc/lv_async.h"
 #include "misc/lv_math.h"

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -124,6 +124,54 @@
 
 
 /*============================================================================
+ * INTERRUPT HANDLING (IRQ)
+ *============================================================================*/
+
+/** IRQ abstraction backend to use
+ *  Possible values:
+ *  - LV_IRQ_NONE
+ *  - LV_IRQ_CMSIS
+ *  - LV_IRQ_ZEPHYR
+ */
+#define LV_USE_IRQ LV_IRQ_NONE
+
+#if LV_USE_IRQ == LV_IRQ_CMSIS
+/** Enable to pull in a vendor/CMSIS device header (e.g. stm32h7xx.h) that
+ *  provides the IRQn_Type enumerators (PXP_IRQn, DMA2D_IRQn, ...) and the
+ *  NVIC_* helpers. Peripheral IRQ support is auto-detected from the symbols
+ *  this header defines.
+ */
+#define LV_IRQ_USE_CMSIS_INCLUDE 0
+
+#if LV_IRQ_USE_CMSIS_INCLUDE
+/** CMSIS/vendor device header */
+#define LV_IRQ_CMSIS_INCLUDE ""
+
+#endif /*LV_IRQ_USE_CMSIS_INCLUDE*/
+
+/** Enable on RTOS builds (e.g. FreeRTOS, or CMSIS-RTOS2 over an RTOS) where
+ *  the interrupt priority must sit at or below the kernel's syscall interrupt
+ *  priority ceiling, so the ISR may safely call the kernel's ...FromISR APIs
+ *  (lv_thread_sync_signal_isr uses one). Leave disabled on bare-metal, where
+ *  the reset-default priority is fine.
+ */
+#define LV_IRQ_CMSIS_SET_PRIORITY 0
+
+#if LV_IRQ_CMSIS_SET_PRIORITY
+/** The value passed to NVIC_SetPriority. Defaults to 255, which NVIC_SetPriority
+ *  maps to the lowest preemption priority regardless of the implemented priority
+ *  bits (__NVIC_PRIO_BITS) - always safe to call ...FromISR from, at the cost of
+ *  latency. For best latency under FreeRTOS set it to
+ *  configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY + 1 (a hand-written lv_conf.h may
+ *  define this symbolically; a Kconfig build takes a literal number).
+ */
+#define LV_IRQ_CMSIS_PRIORITY 255
+
+#endif /*LV_IRQ_CMSIS_SET_PRIORITY*/
+#endif /*LV_USE_IRQ == LV_IRQ_CMSIS*/
+
+
+/*============================================================================
  * RENDERING CONFIGURATION
  *============================================================================*/
 
@@ -518,12 +566,16 @@
 /** the header file for LVGL to include for DMA2D */
 #define LV_DRAW_DMA2D_HAL_INCLUDE "stm32h7xx_hal.h"
 
-/** if enabled, the user is required to call
- *  `lv_draw_dma2d_transfer_complete_interrupt_handler`
- *  upon receiving the DMA2D global interrupt
+#if LV_USE_OS != LV_OS_NONE
+/** Run DMA2D asynchronously: the transfer-complete interrupt wakes the
+ *  draw unit instead of busy-polling. Requires an OS (for the completion
+ *  sync object) and an IRQ backend that provides DMA2D (LV_USE_IRQ). The
+ *  interrupt is wired by the selected IRQ backend (src/irqal); no manual
+ *  vector/handler wiring is needed.
  */
 #define LV_USE_DRAW_DMA2D_INTERRUPT 0
 
+#endif /*LV_USE_OS != LV_OS_NONE*/
 #endif /*LV_USE_DRAW_DMA2D*/
 
 /** Use EVE FT81X GPU. */

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -566,16 +566,6 @@
 /** the header file for LVGL to include for DMA2D */
 #define LV_DRAW_DMA2D_HAL_INCLUDE "stm32h7xx_hal.h"
 
-#if LV_USE_OS != LV_OS_NONE
-/** Run DMA2D asynchronously: the transfer-complete interrupt wakes the
- *  draw unit instead of busy-polling. Requires an OS (for the completion
- *  sync object) and an IRQ backend that provides DMA2D (LV_USE_IRQ). The
- *  interrupt is wired by the selected IRQ backend (src/irqal); no manual
- *  vector/handler wiring is needed.
- */
-#define LV_USE_DRAW_DMA2D_INTERRUPT 0
-
-#endif /*LV_USE_OS != LV_OS_NONE*/
 #endif /*LV_USE_DRAW_DMA2D*/
 
 /** Use EVE FT81X GPU. */

--- a/scripts/generators/config_files.py
+++ b/scripts/generators/config_files.py
@@ -19,6 +19,7 @@ SCRIPT_PATH = Path(__file__).resolve()
 ROOT_FILES = [
     "src/stdlib/Kconfig",
     "src/osal/Kconfig",
+    "src/irqal/Kconfig",
     "src/draw/Kconfig",
     "src/indev/Kconfig",
     "src/core/Kconfig",

--- a/scripts/generators/config_headers/parse.py
+++ b/scripts/generators/config_headers/parse.py
@@ -56,6 +56,7 @@ from .kconfig_utils import (
 # which breaks embedded users' Kconfig configs.
 MEMBER_IS_TOKEN: set[str] = {
     "LV_USE_OS",  # tokens LV_OS_* are defined into lv_conf_internal.h
+    "LV_USE_IRQ",  # tokens LV_IRQ_* are defined into lv_conf_internal.h
     "LV_LOG_LEVEL",  # LV_LOG_LEVEL_* defined into lv_conf_internal.h
     "LV_USE_DRAW_SW_ASM",  # LV_DRAW_SW_ASM_* defined into lv_conf_internal.h
     "LV_USE_NEMA_LIB",  # LV_NEMA_LIB_*

--- a/src/draw/dma2d/Kconfig
+++ b/src/draw/dma2d/Kconfig
@@ -13,9 +13,12 @@ config LV_DRAW_DMA2D_HAL_INCLUDE
 config LV_USE_DRAW_DMA2D_INTERRUPT
 	bool "use the DMA2D transfer complete interrupt"
 	default n
+	depends on !LV_OS_NONE
 	help
-		if enabled, the user is required to call
-		`lv_draw_dma2d_transfer_complete_interrupt_handler`
-		upon receiving the DMA2D global interrupt
+		Run DMA2D asynchronously: the transfer-complete interrupt wakes the
+		draw unit instead of busy-polling. Requires an OS (for the completion
+		sync object) and an IRQ backend that provides DMA2D (LV_USE_IRQ). The
+		interrupt is wired by the selected IRQ backend (src/irqal); no manual
+		vector/handler wiring is needed.
 
 endif

--- a/src/draw/dma2d/Kconfig
+++ b/src/draw/dma2d/Kconfig
@@ -9,16 +9,4 @@ if LV_USE_DRAW_DMA2D
 config LV_DRAW_DMA2D_HAL_INCLUDE
 	string "the header file for LVGL to include for DMA2D"
 	default "stm32h7xx_hal.h"
-
-config LV_USE_DRAW_DMA2D_INTERRUPT
-	bool "use the DMA2D transfer complete interrupt"
-	default n
-	depends on !LV_OS_NONE
-	help
-		Run DMA2D asynchronously: the transfer-complete interrupt wakes the
-		draw unit instead of busy-polling. Requires an OS (for the completion
-		sync object) and an IRQ backend that provides DMA2D (LV_USE_IRQ). The
-		interrupt is wired by the selected IRQ backend (src/irqal); no manual
-		vector/handler wiring is needed.
-
 endif

--- a/src/draw/dma2d/lv_draw_dma2d.c
+++ b/src/draw/dma2d/lv_draw_dma2d.c
@@ -14,13 +14,8 @@
 #include "../../misc/lv_area_private.h"
 #include "../lv_draw_buf_private.h"
 
-#if defined(__ZEPHYR__) && LV_USE_DRAW_DMA2D_INTERRUPT
-    #include <zephyr/kernel.h>
-    #include <zephyr/irq.h>
-#endif
-
 #if !LV_DRAW_DMA2D_ASYNC && LV_USE_DRAW_DMA2D_INTERRUPT
-    #warning LV_USE_DRAW_DMA2D_INTERRUPT is 1 but has no effect because LV_USE_OS is LV_OS_NONE
+    #warning LV_USE_DRAW_DMA2D_INTERRUPT is 1 but has no effect because LV_USE_OS is LV_OS_NONE or no IRQ backend provides DMA2D (LV_USE_IRQ)
 #endif
 
 /*********************
@@ -44,8 +39,8 @@ static int32_t delete_cb(lv_draw_unit_t * draw_unit);
     static int32_t wait_finish_cb(lv_draw_unit_t * u);
 #endif
 static void post_transfer_tasks(lv_draw_dma2d_unit_t * u);
-#if defined(__ZEPHYR__) && LV_USE_DRAW_DMA2D_INTERRUPT
-    static void zephyr_dma2d_irq_handler(void *);
+#if LV_DRAW_DMA2D_ASYNC
+    static void dma2d_irq_cb(void);
 #endif
 #if LV_DRAW_DMA2D_CACHE
     static void invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
@@ -118,19 +113,18 @@ void lv_draw_dma2d_init(void)
     /* disable dead time */
     DMA2D->AMTCR = 0;
 
-#if defined(__ZEPHYR__) && LV_USE_DRAW_DMA2D_INTERRUPT
-    IRQ_CONNECT(DT_IRQN(DT_NODELABEL(dma2d)), DT_IRQ(DT_NODELABEL(dma2d), priority), zephyr_dma2d_irq_handler, NULL, 0);
-    irq_enable(DT_IRQN(DT_NODELABEL(dma2d)));
-#else
-    /* enable the interrupt */
-    NVIC_EnableIRQ(DMA2D_IRQn);
+#if LV_DRAW_DMA2D_ASYNC
+    /* register the transfer-complete interrupt through the IRQ abstraction layer */
+    lv_irq_attach_dma2d(dma2d_irq_cb);
 #endif
 }
 
 void lv_draw_dma2d_deinit(void)
 {
+#if LV_DRAW_DMA2D_ASYNC
     /* disable the interrupt */
-    NVIC_DisableIRQ(DMA2D_IRQn);
+    lv_irq_detach_dma2d();
+#endif
 
     /* disable the DMA2D clock */
 #if defined(STM32F4) || defined(STM32F7) || defined(STM32U5) || defined(STM32L4)
@@ -339,8 +333,9 @@ static void flush_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area)
 /**********************
  *   STATIC FUNCTIONS
  **********************/
-#if defined(__ZEPHYR__) && LV_USE_DRAW_DMA2D_INTERRUPT
-static void zephyr_dma2d_irq_handler(void *)
+#if LV_DRAW_DMA2D_ASYNC
+/* Called by the IRQ abstraction layer (src/irqal) when the DMA2D interrupt fires */
+static void dma2d_irq_cb(void)
 {
     /* Clear Transfer Complete flag */
     DMA2D->IFCR = DMA2D_IFCR_CTCIF;

--- a/src/draw/dma2d/lv_draw_dma2d.c
+++ b/src/draw/dma2d/lv_draw_dma2d.c
@@ -14,10 +14,6 @@
 #include "../../misc/lv_area_private.h"
 #include "../lv_draw_buf_private.h"
 
-#if !LV_DRAW_DMA2D_ASYNC && LV_USE_DRAW_DMA2D_INTERRUPT
-    #warning LV_USE_DRAW_DMA2D_INTERRUPT is 1 but has no effect because LV_USE_OS is LV_OS_NONE or no IRQ backend provides DMA2D (LV_USE_IRQ)
-#endif
-
 /*********************
  *      DEFINES
  *********************/
@@ -40,7 +36,7 @@ static int32_t delete_cb(lv_draw_unit_t * draw_unit);
 #endif
 static void post_transfer_tasks(lv_draw_dma2d_unit_t * u);
 #if LV_DRAW_DMA2D_ASYNC
-    static void dma2d_irq_cb(void);
+    static void dma2d_irq_cb(void * user_data);
 #endif
 #if LV_DRAW_DMA2D_CACHE
     static void invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
@@ -143,14 +139,12 @@ void lv_draw_dma2d_deinit(void)
 #endif
 }
 
-#if LV_USE_DRAW_DMA2D_INTERRUPT
 void lv_draw_dma2d_transfer_complete_interrupt_handler(void)
 {
 #if LV_DRAW_DMA2D_ASYNC
     lv_thread_sync_signal_isr(&g_unit->interrupt_signal);
 #endif
 }
-#endif
 
 lv_draw_dma2d_output_cf_t lv_draw_dma2d_cf_to_dma2d_output_cf(lv_color_format_t cf)
 {
@@ -263,7 +257,7 @@ void lv_draw_dma2d_configure_and_start_transfer(const lv_draw_dma2d_configuratio
 
     /* start the transfer (also set mode and enable transfer complete interrupt) */
     DMA2D->CR = DMA2D_CR_START | (((uint32_t) conf->mode) << DMA2D_CR_MODE_Pos)
-#if LV_USE_DRAW_DMA2D_INTERRUPT
+#if LV_DRAW_DMA2D_ASYNC
                 | DMA2D_CR_TCIE
 #endif
                 ;
@@ -335,8 +329,10 @@ static void flush_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area)
  **********************/
 #if LV_DRAW_DMA2D_ASYNC
 /* Called by the IRQ abstraction layer (src/irqal) when the DMA2D interrupt fires */
-static void dma2d_irq_cb(void)
+static void dma2d_irq_cb(void * user_data)
 {
+    LV_UNUSED(user_data); /* DMA2D transfer-complete carries no payload */
+
     /* Clear Transfer Complete flag */
     DMA2D->IFCR = DMA2D_IFCR_CTCIF;
 

--- a/src/draw/dma2d/lv_draw_dma2d.h
+++ b/src/draw/dma2d/lv_draw_dma2d.h
@@ -32,9 +32,7 @@ extern "C" {
 void lv_draw_dma2d_init(void);
 void lv_draw_dma2d_deinit(void);
 
-#if LV_USE_DRAW_DMA2D_INTERRUPT
 void lv_draw_dma2d_transfer_complete_interrupt_handler(void);
-#endif
 
 /**********************
  *      MACROS

--- a/src/draw/dma2d/lv_draw_dma2d_private.h
+++ b/src/draw/dma2d/lv_draw_dma2d_private.h
@@ -26,7 +26,7 @@ extern "C" {
  *      DEFINES
  *********************/
 
-#if LV_USE_DRAW_DMA2D_INTERRUPT && LV_USE_OS && LV_IRQ_HAS_DMA2D
+#if LV_USE_OS && LV_IRQ_HAS_DMA2D
 #define LV_DRAW_DMA2D_ASYNC 1
 #else
 #define LV_DRAW_DMA2D_ASYNC 0

--- a/src/draw/dma2d/lv_draw_dma2d_private.h
+++ b/src/draw/dma2d/lv_draw_dma2d_private.h
@@ -19,13 +19,14 @@ extern "C" {
 
 #include "../lv_draw_private.h"
 #include "../sw/lv_draw_sw.h"
+#include "../../irqal/lv_irq_private.h"
 #include LV_DRAW_DMA2D_HAL_INCLUDE
 
 /*********************
  *      DEFINES
  *********************/
 
-#if LV_USE_DRAW_DMA2D_INTERRUPT && LV_USE_OS
+#if LV_USE_DRAW_DMA2D_INTERRUPT && LV_USE_OS && LV_IRQ_HAS_DMA2D
 #define LV_DRAW_DMA2D_ASYNC 1
 #else
 #define LV_DRAW_DMA2D_ASYNC 0

--- a/src/draw/nema_gfx/lv_draw_nema_gfx_stm32_hal.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_stm32_hal.c
@@ -49,9 +49,7 @@ extern GPU2D_HandleTypeDef hgpu2d;
  *  STATIC PROTOTYPES
  **********************/
 
-#if (USE_HAL_GPU2D_REGISTER_CALLBACKS == 1)
-    static void GPU2D_CommandListCpltCallback(GPU2D_HandleTypeDef * hgpu2d, uint32_t CmdListID);
-#endif
+static void nema_gpu2d_completion_cb(void * user_data);
 
 /**********************
  *  STATIC VARIABLES
@@ -76,15 +74,11 @@ static lv_thread_sync_t sync;
  *   GLOBAL FUNCTIONS
  **********************/
 
-#if (USE_HAL_GPU2D_REGISTER_CALLBACKS == 1)
-    static void GPU2D_CommandListCpltCallback(GPU2D_HandleTypeDef * hgpu2d, uint32_t CmdListID)
-#else
-    void HAL_GPU2D_CommandListCpltCallback(GPU2D_HandleTypeDef * hgpu2d, uint32_t CmdListID)
-#endif
+/* NemaGFX-side completion handler passed to lv_irq_attach_nema_gpu2d(): records
+ * which command list finished (from the forwarded pointer) and wakes waiters. */
+static void nema_gpu2d_completion_cb(void * user_data)
 {
-    LV_UNUSED(hgpu2d);
-
-    last_cl_id = CmdListID;
+    last_cl_id = *(uint32_t *)user_data;
     lv_thread_sync_signal_isr(&sync);
 }
 
@@ -94,11 +88,8 @@ int32_t nema_sys_init(void)
 
     lv_thread_sync_init(&sync);
 
-    /* Setup GPU2D Callback */
-#if (USE_HAL_GPU2D_REGISTER_CALLBACKS == 1)
-    /* Register Command List Complete Callback */
-    HAL_GPU2D_RegisterCommandListCpltCallback(&hgpu2d, GPU2D_CommandListCpltCallback);
-#endif
+    /* Route the GPU2D completion interrupt through the IRQ abstraction layer */
+    lv_irq_attach_nema_gpu2d(nema_gpu2d_completion_cb);
 
     /* Initialise Mem Space */
     error_code = tsi_malloc_init_pool_aligned(0, (void *)nemagfx_pool_mem, (uintptr_t)nemagfx_pool_mem,

--- a/src/draw/nxp/pxp/lv_pxp_cfg.h
+++ b/src/draw/nxp/pxp/lv_pxp_cfg.h
@@ -37,9 +37,6 @@ extern "C" {
 /** PXP module instance to use*/
 #define PXP_ID PXP
 
-/** PXP interrupt line ID*/
-#define PXP_IRQ_ID PXP_IRQn
-
 /**********************
  *      TYPEDEFS
  **********************/

--- a/src/draw/nxp/pxp/lv_pxp_osa.c
+++ b/src/draw/nxp/pxp/lv_pxp_osa.c
@@ -60,7 +60,7 @@ static void _pxp_wait(void);
 /**
  * PXP completion callback, invoked by the IRQ abstraction layer (src/irqal).
  */
-static void _pxp_irq_cb(void);
+static void _pxp_irq_cb(void * user_data);
 
 /**********************
  *  STATIC VARIABLES
@@ -97,8 +97,10 @@ pxp_cfg_t * pxp_get_default_cfg(void)
 
 /* Called by the IRQ abstraction layer (src/irqal) when the PXP interrupt fires,
  * regardless of the underlying environment (Zephyr, CMSIS, ...). */
-static void _pxp_irq_cb(void)
+static void _pxp_irq_cb(void * user_data)
 {
+    LV_UNUSED(user_data); /* PXP completion carries no payload */
+
     if(kPXP_CompleteFlag & PXP_GetStatusFlags(PXP_ID)) {
         PXP_ClearStatusFlags(PXP_ID, kPXP_CompleteFlag);
 #if LV_USE_OS

--- a/src/draw/nxp/pxp/lv_pxp_osa.c
+++ b/src/draw/nxp/pxp/lv_pxp_osa.c
@@ -18,15 +18,11 @@
 #if LV_USE_DRAW_PXP
 #include "lv_pxp_utils.h"
 #include "../../../osal/lv_os_private.h"
+#include "../../../irqal/lv_irq_private.h"
 #include <fsl_pxp.h>
 
-#if defined(SDK_OS_FREE_RTOS)
-    #include <FreeRTOS.h>
-#endif
-
-#if defined(__ZEPHYR__)
-    #include <zephyr/kernel.h>
-    #include <zephyr/irq.h>
+#if !LV_IRQ_HAS_PXP
+    #error "PXP needs an IRQ backend that provides PXP (set LV_USE_IRQ to a backend whose platform exposes PXP - e.g. a Zephyr DT node or CMSIS PXP_IRQn - or supply a custom backend defining LV_IRQ_HAS_PXP)"
 #endif
 
 /*********************
@@ -61,12 +57,10 @@ static void _pxp_run(void);
  */
 static void _pxp_wait(void);
 
-#if defined(__ZEPHYR__)
-    /**
-    * Interrupt handler for Zephyr IRQ
-    */
-    static void _pxp_zephyr_irq_handler(void *);
-#endif
+/**
+ * PXP completion callback, invoked by the IRQ abstraction layer (src/irqal).
+ */
+static void _pxp_irq_cb(void);
 
 /**********************
  *  STATIC VARIABLES
@@ -92,7 +86,18 @@ static pxp_cfg_t _pxp_default_cfg = {
  *   GLOBAL FUNCTIONS
  **********************/
 
-void PXP_IRQHandler(void)
+pxp_cfg_t * pxp_get_default_cfg(void)
+{
+    return &_pxp_default_cfg;
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+/* Called by the IRQ abstraction layer (src/irqal) when the PXP interrupt fires,
+ * regardless of the underlying environment (Zephyr, CMSIS, ...). */
+static void _pxp_irq_cb(void)
 {
     if(kPXP_CompleteFlag & PXP_GetStatusFlags(PXP_ID)) {
         PXP_ClearStatusFlags(PXP_ID, kPXP_CompleteFlag);
@@ -104,22 +109,6 @@ void PXP_IRQHandler(void)
     }
 }
 
-pxp_cfg_t * pxp_get_default_cfg(void)
-{
-    return &_pxp_default_cfg;
-}
-
-/**********************
- *   STATIC FUNCTIONS
- **********************/
-
-#if defined(__ZEPHYR__)
-static void _pxp_zephyr_irq_handler(void *)
-{
-    PXP_IRQHandler();
-}
-#endif
-
 static void _pxp_interrupt_init(void)
 {
 #if LV_USE_OS
@@ -128,27 +117,16 @@ static void _pxp_interrupt_init(void)
     }
 #endif
 
-#if defined(__ZEPHYR__)
-    IRQ_CONNECT(DT_IRQN(DT_NODELABEL(pxp)), CONFIG_LV_Z_PXP_INTERRUPT_PRIORITY, _pxp_zephyr_irq_handler, NULL, 0);
-    irq_enable(DT_IRQN(DT_NODELABEL(pxp)));
-#elif defined(SDK_OS_FREE_RTOS)
-    NVIC_SetPriority(PXP_IRQ_ID, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY + 1);
-#endif
-
-#if !defined(__ZEPHYR__)
-    NVIC_EnableIRQ(PXP_IRQ_ID);
-#endif
+    /* register the PXP completion interrupt through the IRQ abstraction layer;
+     * the environment-specific wiring lives in src/irqal, not here */
+    lv_irq_attach_pxp(_pxp_irq_cb);
 
     ucPXPIdle = true;
 }
 
 static void _pxp_interrupt_deinit(void)
 {
-#if defined(__ZEPHYR__)
-    irq_disable(DT_IRQN(DT_NODELABEL(pxp)));
-#else
-    NVIC_DisableIRQ(PXP_IRQ_ID);
-#endif
+    lv_irq_detach_pxp();
 
 #if LV_USE_OS
     lv_thread_sync_delete(&pxp_sync);

--- a/src/draw/nxp/pxp/lv_pxp_osa.h
+++ b/src/draw/nxp/pxp/lv_pxp_osa.h
@@ -38,11 +38,6 @@ extern "C" {
  **********************/
 
 /**
- * PXP device interrupt handler. Used to check PXP task completion status.
- */
-void PXP_IRQHandler(void);
-
-/**
  * Get the PXP default configuration.
  */
 pxp_cfg_t * pxp_get_default_cfg(void);

--- a/src/irqal/Kconfig
+++ b/src/irqal/Kconfig
@@ -1,0 +1,57 @@
+menu "Interrupt Handling (IRQ)"
+choice LV_USE_IRQ
+	prompt "IRQ abstraction backend to use"
+	default LV_IRQ_NONE
+
+	config LV_IRQ_NONE
+		bool "NONE"
+	config LV_IRQ_CMSIS
+		bool "CMSIS"
+	config LV_IRQ_ZEPHYR
+		bool "ZEPHYR"
+endchoice
+
+config LV_USE_IRQ
+	int
+	default 0 if LV_IRQ_NONE
+	default 1 if LV_IRQ_CMSIS
+	default 2 if LV_IRQ_ZEPHYR
+
+if LV_IRQ_CMSIS
+config LV_IRQ_USE_CMSIS_INCLUDE
+	bool "Include a CMSIS/vendor device header to discover IRQ numbers"
+	default n
+	help
+		Enable to pull in a vendor/CMSIS device header (e.g. stm32h7xx.h) that
+		provides the IRQn_Type enumerators (PXP_IRQn, DMA2D_IRQn, ...) and the
+		NVIC_* helpers. Peripheral IRQ support is auto-detected from the symbols
+		this header defines.
+
+config LV_IRQ_CMSIS_INCLUDE
+	string "CMSIS/vendor device header"
+	default ""
+	depends on LV_IRQ_USE_CMSIS_INCLUDE
+
+config LV_IRQ_CMSIS_SET_PRIORITY
+	bool "Set the NVIC priority of irqal-managed interrupts"
+	default n
+	help
+		Enable on RTOS builds (e.g. FreeRTOS, or CMSIS-RTOS2 over an RTOS) where
+		the interrupt priority must sit at or below the kernel's syscall interrupt
+		priority ceiling, so the ISR may safely call the kernel's ...FromISR APIs
+		(lv_thread_sync_signal_isr uses one). Leave disabled on bare-metal, where
+		the reset-default priority is fine.
+
+config LV_IRQ_CMSIS_PRIORITY
+	int "NVIC priority value for irqal-managed interrupts"
+	default 255
+	depends on LV_IRQ_CMSIS_SET_PRIORITY
+	help
+		The value passed to NVIC_SetPriority. Defaults to 255, which NVIC_SetPriority
+		maps to the lowest preemption priority regardless of the implemented priority
+		bits (__NVIC_PRIO_BITS) - always safe to call ...FromISR from, at the cost of
+		latency. For best latency under FreeRTOS set it to
+		configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY + 1 (a hand-written lv_conf.h may
+		define this symbolically; a Kconfig build takes a literal number).
+endif #LV_IRQ_CMSIS
+endmenu

--- a/src/irqal/lv_irq_cmsis.c
+++ b/src/irqal/lv_irq_cmsis.c
@@ -55,12 +55,18 @@ static void cmsis_enable_irq(IRQn_Type irqn)
 }
 #endif
 
+/* The callback is written from thread context (attach/detach) and read from
+ * interrupt context (the vector below), so it is volatile and read once into a
+ * local in the ISR to keep the access well-defined. A pointer-sized store is
+ * atomic on Cortex-M, and detach disables the line before clearing it. */
+
 #if LV_IRQ_HAS_DMA2D
 
-static lv_irq_cb_t dma2d_cb;
+static volatile lv_irq_cb_t dma2d_cb;
 
 lv_result_t lv_irq_attach_dma2d(lv_irq_cb_t cb)
 {
+    LV_CHECK_ARG(cb != NULL, return LV_RESULT_INVALID, "callback must not be NULL");
     dma2d_cb = cb;
     cmsis_enable_irq(DMA2D_IRQn);
     return LV_RESULT_OK;
@@ -76,17 +82,19 @@ lv_result_t lv_irq_detach_dma2d(void)
 void DMA2D_IRQHandler(void);
 void DMA2D_IRQHandler(void)
 {
-    if(dma2d_cb) dma2d_cb();
+    lv_irq_cb_t cb = dma2d_cb;
+    if(cb) cb();
 }
 
 #endif /*LV_IRQ_HAS_DMA2D*/
 
 #if LV_IRQ_HAS_PXP
 
-static lv_irq_cb_t pxp_cb;
+static volatile lv_irq_cb_t pxp_cb;
 
 lv_result_t lv_irq_attach_pxp(lv_irq_cb_t cb)
 {
+    LV_CHECK_ARG(cb != NULL, return LV_RESULT_INVALID, "callback must not be NULL");
     pxp_cb = cb;
     cmsis_enable_irq(PXP_IRQn);
     return LV_RESULT_OK;
@@ -102,7 +110,8 @@ lv_result_t lv_irq_detach_pxp(void)
 void PXP_IRQHandler(void);
 void PXP_IRQHandler(void)
 {
-    if(pxp_cb) pxp_cb();
+    lv_irq_cb_t cb = pxp_cb;
+    if(cb) cb();
 }
 
 #endif /*LV_IRQ_HAS_PXP*/

--- a/src/irqal/lv_irq_cmsis.c
+++ b/src/irqal/lv_irq_cmsis.c
@@ -83,7 +83,7 @@ void DMA2D_IRQHandler(void);
 void DMA2D_IRQHandler(void)
 {
     lv_irq_cb_t cb = dma2d_cb;
-    if(cb) cb();
+    if(cb) cb(NULL);
 }
 
 #endif /*LV_IRQ_HAS_DMA2D*/
@@ -111,7 +111,7 @@ void PXP_IRQHandler(void);
 void PXP_IRQHandler(void)
 {
     lv_irq_cb_t cb = pxp_cb;
-    if(cb) cb();
+    if(cb) cb(NULL);
 }
 
 #endif /*LV_IRQ_HAS_PXP*/

--- a/src/irqal/lv_irq_cmsis.c
+++ b/src/irqal/lv_irq_cmsis.c
@@ -1,0 +1,114 @@
+/**
+ * @file lv_irq_cmsis.c
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "lv_irq_private.h"
+
+#if LV_USE_IRQ == LV_IRQ_CMSIS
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+/* On a static-vector Cortex-M target the handler cannot be registered at runtime,
+ * so this backend *defines* the named IRQ vector (overriding the vendor startup's
+ * weak default at link time) and `attach` only stores the callback and enables the
+ * NVIC line. A project using this backend for a peripheral must NOT also define the
+ * corresponding *_IRQHandler vector. */
+
+/* Enable an IRQ line, first lowering its NVIC priority to a kernel-safe value when
+ * requested. On an RTOS the ISR calls a ...FromISR API (via lv_thread_sync_signal_isr),
+ * which requires the priority to sit at or below the syscall ceiling; that value is
+ * OS-specific, so it comes from config (LV_IRQ_CMSIS_PRIORITY) rather than from any
+ * RTOS header, keeping this backend environment-agnostic. */
+#if LV_IRQ_HAS_DMA2D || LV_IRQ_HAS_PXP
+static void cmsis_enable_irq(IRQn_Type irqn)
+{
+#if LV_IRQ_CMSIS_SET_PRIORITY
+    NVIC_SetPriority(irqn, LV_IRQ_CMSIS_PRIORITY);
+#endif
+    NVIC_EnableIRQ(irqn);
+}
+#endif
+
+#if LV_IRQ_HAS_DMA2D
+
+static lv_irq_cb_t dma2d_cb;
+
+lv_result_t lv_irq_attach_dma2d(lv_irq_cb_t cb)
+{
+    dma2d_cb = cb;
+    cmsis_enable_irq(DMA2D_IRQn);
+    return LV_RESULT_OK;
+}
+
+lv_result_t lv_irq_detach_dma2d(void)
+{
+    NVIC_DisableIRQ(DMA2D_IRQn);
+    dma2d_cb = NULL;
+    return LV_RESULT_OK;
+}
+
+void DMA2D_IRQHandler(void);
+void DMA2D_IRQHandler(void)
+{
+    if(dma2d_cb) dma2d_cb();
+}
+
+#endif /*LV_IRQ_HAS_DMA2D*/
+
+#if LV_IRQ_HAS_PXP
+
+static lv_irq_cb_t pxp_cb;
+
+lv_result_t lv_irq_attach_pxp(lv_irq_cb_t cb)
+{
+    pxp_cb = cb;
+    cmsis_enable_irq(PXP_IRQn);
+    return LV_RESULT_OK;
+}
+
+lv_result_t lv_irq_detach_pxp(void)
+{
+    NVIC_DisableIRQ(PXP_IRQn);
+    pxp_cb = NULL;
+    return LV_RESULT_OK;
+}
+
+void PXP_IRQHandler(void);
+void PXP_IRQHandler(void)
+{
+    if(pxp_cb) pxp_cb();
+}
+
+#endif /*LV_IRQ_HAS_PXP*/
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+#endif /*LV_USE_IRQ == LV_IRQ_CMSIS*/

--- a/src/irqal/lv_irq_cmsis.h
+++ b/src/irqal/lv_irq_cmsis.h
@@ -1,0 +1,66 @@
+/**
+ * @file lv_irq_cmsis.h
+ *
+ */
+
+#ifndef LV_IRQ_CMSIS_H
+#define LV_IRQ_CMSIS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../lvgl_public.h"
+
+#if LV_USE_IRQ == LV_IRQ_CMSIS
+
+/* Vendor/CMSIS device header providing the IRQn_Type enumerators (e.g. PXP_IRQn,
+ * DMA2D_IRQn) and the NVIC_* helpers. Needed both to test peripheral availability
+ * below and to register/enable the lines in lv_irq_cmsis.c. */
+#if LV_IRQ_USE_CMSIS_INCLUDE
+#include LV_IRQ_CMSIS_INCLUDE
+#endif
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/* Per-peripheral capability: available only if the device header exposes the
+ * peripheral. Detection uses the peripheral base-address *macro* (DMA2D_BASE,
+ * PXP_BASE) rather than the *_IRQn enumerators, because the latter are enum
+ * constants and are invisible to the preprocessor. `#ifndef` guards let a user
+ * force a value from lv_conf.h when their device header names things differently. */
+#ifndef LV_IRQ_HAS_DMA2D
+#if defined(DMA2D_BASE)
+#define LV_IRQ_HAS_DMA2D 1
+#else
+#define LV_IRQ_HAS_DMA2D 0
+#endif
+#endif
+
+#ifndef LV_IRQ_HAS_PXP
+#if defined(PXP_BASE)
+#define LV_IRQ_HAS_PXP 1
+#else
+#define LV_IRQ_HAS_PXP 0
+#endif
+#endif
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+#endif /*LV_USE_IRQ == LV_IRQ_CMSIS*/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_IRQ_CMSIS_H*/

--- a/src/irqal/lv_irq_nema_stm32.c
+++ b/src/irqal/lv_irq_nema_stm32.c
@@ -1,0 +1,94 @@
+/**
+ * @file lv_irq_nema_stm32.c
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "lv_irq_private.h"
+
+#if LV_USE_NEMA_GFX && (LV_USE_NEMA_HAL == LV_NEMA_HAL_STM32)
+
+#include LV_NEMA_STM32_HAL_INCLUDE
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+#if (USE_HAL_GPU2D_REGISTER_CALLBACKS == 1)
+    static void nema_gpu2d_hal_trampoline(GPU2D_HandleTypeDef * hgpu2d, uint32_t CmdListID);
+#endif
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/* The GPU2D completion is delivered through the vendor HAL's command-list-complete
+ * callback API, which owns the hardware vector and needs the hgpu2d handle. That
+ * makes this a NemaGFX/STM32-specific irqal backend: it lives with the generic
+ * backends but is gated on the NemaGFX STM32 HAL rather than on LV_USE_IRQ.
+ *
+ * nema_event_code holds the last completed command-list id; a pointer to it is
+ * forwarded to the callback as user_data (the NemaGFX-specific payload). */
+extern GPU2D_HandleTypeDef hgpu2d;
+
+static volatile lv_irq_cb_t nema_gpu2d_cb;
+static uint32_t nema_event_code;
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+lv_result_t lv_irq_attach_nema_gpu2d(lv_irq_cb_t cb)
+{
+    LV_CHECK_ARG(cb != NULL, return LV_RESULT_INVALID, "callback must not be NULL");
+    nema_gpu2d_cb = cb;
+#if (USE_HAL_GPU2D_REGISTER_CALLBACKS == 1)
+    HAL_GPU2D_RegisterCommandListCpltCallback(&hgpu2d, nema_gpu2d_hal_trampoline);
+#endif
+    return LV_RESULT_OK;
+}
+
+lv_result_t lv_irq_detach_nema_gpu2d(void)
+{
+    /* Clearing the stored callback makes the HAL callback a no-op; no dependency
+     * on a HAL un-register API. */
+    nema_gpu2d_cb = NULL;
+    return LV_RESULT_OK;
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+/* Vendor HAL command-list-complete callback: saves the completed command-list id
+ * and forwards a pointer to it as the callback's user_data. Registered at runtime
+ * when USE_HAL_GPU2D_REGISTER_CALLBACKS==1, otherwise it overrides the HAL's weak
+ * symbol. */
+#if (USE_HAL_GPU2D_REGISTER_CALLBACKS == 1)
+    static void nema_gpu2d_hal_trampoline(GPU2D_HandleTypeDef * hgpu2d, uint32_t CmdListID)
+#else
+    void HAL_GPU2D_CommandListCpltCallback(GPU2D_HandleTypeDef * hgpu2d, uint32_t CmdListID)
+#endif
+{
+    lv_irq_cb_t cb = nema_gpu2d_cb;
+    LV_UNUSED(hgpu2d);
+
+    nema_event_code = CmdListID;
+    if(cb) cb(&nema_event_code);
+}
+
+#endif /*LV_USE_NEMA_GFX && LV_USE_NEMA_HAL == LV_NEMA_HAL_STM32*/

--- a/src/irqal/lv_irq_none.h
+++ b/src/irqal/lv_irq_none.h
@@ -1,0 +1,50 @@
+/**
+ * @file lv_irq_none.h
+ *
+ */
+
+#ifndef LV_IRQ_NONE_H
+#define LV_IRQ_NONE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../lvgl_public.h"
+
+#if LV_USE_IRQ == LV_IRQ_NONE
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/* No hardware IRQ backend is compiled in.
+ *
+ * The per-peripheral capability macros (LV_IRQ_HAS_*) are left undefined here and
+ * default to 0 in lv_irq_private.h, so draw units fall back to polling or emit a
+ * compile error when they require an interrupt.
+ *
+ * This selection is also the "bring your own backend" path: define the needed
+ * LV_IRQ_HAS_* macros to 1 in your lv_conf.h and link your own implementation of
+ * the matching lv_irq_attach and lv_irq_detach functions from your build. Because
+ * no in-repo backend .c is compiled for LV_IRQ_NONE, there is no symbol conflict.
+ */
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+#endif /*LV_USE_IRQ == LV_IRQ_NONE*/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_IRQ_NONE_H*/

--- a/src/irqal/lv_irq_private.h
+++ b/src/irqal/lv_irq_private.h
@@ -1,0 +1,59 @@
+/**
+ * @file lv_irq_private.h
+ *
+ * Provides the compile-time per-peripheral capability macros (LV_IRQ_HAS_*).
+ *
+ * This is NOT part of the public API and is deliberately NOT included from
+ * lvgl_private.h: irqal exposes no types embedded in LVGL structs, so it does
+ * not need umbrella-wide visibility. Only the irqal backend .c files and the
+ * few draw units that use irqal (e.g. dma2d, pxp) include this header, because
+ * they need LV_IRQ_HAS_* at compile time (to gate call sites / async paths).
+ * The public API (lv_irq_attach_*, lv_irq_cb_t) lives in include/lvgl/irqal/lv_irq.h.
+ */
+
+#ifndef LV_IRQ_PRIVATE_H
+#define LV_IRQ_PRIVATE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../lvgl_public.h"
+
+/* Include every backend header; each self-guards on LV_USE_IRQ, so only the
+ * selected one contributes its LV_IRQ_HAS_* definitions and vendor includes. */
+#include "lv_irq_none.h"
+#include "lv_irq_cmsis.h"
+#include "lv_irq_zephyr.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/* Capability macros default to 0 when the selected backend didn't define them.
+ * A custom backend (LV_IRQ_NONE + own implementation) can pre-define these to 1
+ * in lv_conf.h; those definitions win because lv_conf is included above. */
+#ifndef LV_IRQ_HAS_DMA2D
+#define LV_IRQ_HAS_DMA2D 0
+#endif
+
+#ifndef LV_IRQ_HAS_PXP
+#define LV_IRQ_HAS_PXP 0
+#endif
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_IRQ_PRIVATE_H*/

--- a/src/irqal/lv_irq_zephyr.c
+++ b/src/irqal/lv_irq_zephyr.c
@@ -43,26 +43,33 @@
  * by the matching attach (the Zephyr analogue of the CMSIS named vector). The
  * interrupt priority comes from the device tree node. */
 
+/* The callback is written from thread context (attach/detach) and read from
+ * interrupt context (the trampoline), so it is volatile and read once into a
+ * local to keep the access well-defined. A pointer-sized store is atomic on
+ * Cortex-M, and detach disables the line before clearing it. */
+
 #if LV_IRQ_HAS_DMA2D
 
-static lv_irq_cb_t dma2d_cb;
+static volatile lv_irq_cb_t dma2d_cb;
 
 static void dma2d_trampoline(void * arg)
 {
+    lv_irq_cb_t cb = dma2d_cb;
     LV_UNUSED(arg);
-    if(dma2d_cb) dma2d_cb();
+    if(cb) cb();
 }
 
 #endif /*LV_IRQ_HAS_DMA2D*/
 
 #if LV_IRQ_HAS_PXP
 
-static lv_irq_cb_t pxp_cb;
+static volatile lv_irq_cb_t pxp_cb;
 
 static void pxp_trampoline(void * arg)
 {
+    lv_irq_cb_t cb = pxp_cb;
     LV_UNUSED(arg);
-    if(pxp_cb) pxp_cb();
+    if(cb) cb();
 }
 
 #endif /*LV_IRQ_HAS_PXP*/
@@ -75,6 +82,7 @@ static void pxp_trampoline(void * arg)
 
 lv_result_t lv_irq_attach_dma2d(lv_irq_cb_t cb)
 {
+    LV_CHECK_ARG(cb != NULL, return LV_RESULT_INVALID, "callback must not be NULL");
     dma2d_cb = cb;
     IRQ_CONNECT(DT_IRQN(DT_NODELABEL(dma2d)), DT_IRQ(DT_NODELABEL(dma2d), priority),
                 dma2d_trampoline, NULL, 0);
@@ -95,6 +103,7 @@ lv_result_t lv_irq_detach_dma2d(void)
 
 lv_result_t lv_irq_attach_pxp(lv_irq_cb_t cb)
 {
+    LV_CHECK_ARG(cb != NULL, return LV_RESULT_INVALID, "callback must not be NULL");
     pxp_cb = cb;
     IRQ_CONNECT(DT_IRQN(DT_NODELABEL(pxp)), DT_IRQ(DT_NODELABEL(pxp), priority),
                 pxp_trampoline, NULL, 0);

--- a/src/irqal/lv_irq_zephyr.c
+++ b/src/irqal/lv_irq_zephyr.c
@@ -1,0 +1,114 @@
+/**
+ * @file lv_irq_zephyr.c
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "lv_irq_private.h"
+
+#if LV_USE_IRQ == LV_IRQ_ZEPHYR
+
+#include <zephyr/kernel.h>
+#include <zephyr/irq.h>
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+/* IRQ_CONNECT is a build-time macro that needs a compile-time-constant ISR symbol,
+ * so it can't be handed the runtime callback passed to attach(). Each peripheral
+ * therefore registers a small fixed trampoline that calls the stored callback set
+ * by the matching attach (the Zephyr analogue of the CMSIS named vector). The
+ * interrupt priority comes from the device tree node. */
+
+#if LV_IRQ_HAS_DMA2D
+
+static lv_irq_cb_t dma2d_cb;
+
+static void dma2d_trampoline(void * arg)
+{
+    LV_UNUSED(arg);
+    if(dma2d_cb) dma2d_cb();
+}
+
+#endif /*LV_IRQ_HAS_DMA2D*/
+
+#if LV_IRQ_HAS_PXP
+
+static lv_irq_cb_t pxp_cb;
+
+static void pxp_trampoline(void * arg)
+{
+    LV_UNUSED(arg);
+    if(pxp_cb) pxp_cb();
+}
+
+#endif /*LV_IRQ_HAS_PXP*/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+#if LV_IRQ_HAS_DMA2D
+
+lv_result_t lv_irq_attach_dma2d(lv_irq_cb_t cb)
+{
+    dma2d_cb = cb;
+    IRQ_CONNECT(DT_IRQN(DT_NODELABEL(dma2d)), DT_IRQ(DT_NODELABEL(dma2d), priority),
+                dma2d_trampoline, NULL, 0);
+    irq_enable(DT_IRQN(DT_NODELABEL(dma2d)));
+    return LV_RESULT_OK;
+}
+
+lv_result_t lv_irq_detach_dma2d(void)
+{
+    irq_disable(DT_IRQN(DT_NODELABEL(dma2d)));
+    dma2d_cb = NULL;
+    return LV_RESULT_OK;
+}
+
+#endif /*LV_IRQ_HAS_DMA2D*/
+
+#if LV_IRQ_HAS_PXP
+
+lv_result_t lv_irq_attach_pxp(lv_irq_cb_t cb)
+{
+    pxp_cb = cb;
+    IRQ_CONNECT(DT_IRQN(DT_NODELABEL(pxp)), DT_IRQ(DT_NODELABEL(pxp), priority),
+                pxp_trampoline, NULL, 0);
+    irq_enable(DT_IRQN(DT_NODELABEL(pxp)));
+    return LV_RESULT_OK;
+}
+
+lv_result_t lv_irq_detach_pxp(void)
+{
+    irq_disable(DT_IRQN(DT_NODELABEL(pxp)));
+    pxp_cb = NULL;
+    return LV_RESULT_OK;
+}
+
+#endif /*LV_IRQ_HAS_PXP*/
+
+#endif /*LV_USE_IRQ == LV_IRQ_ZEPHYR*/

--- a/src/irqal/lv_irq_zephyr.c
+++ b/src/irqal/lv_irq_zephyr.c
@@ -56,7 +56,7 @@ static void dma2d_trampoline(void * arg)
 {
     lv_irq_cb_t cb = dma2d_cb;
     LV_UNUSED(arg);
-    if(cb) cb();
+    if(cb) cb(NULL);
 }
 
 #endif /*LV_IRQ_HAS_DMA2D*/
@@ -69,7 +69,7 @@ static void pxp_trampoline(void * arg)
 {
     lv_irq_cb_t cb = pxp_cb;
     LV_UNUSED(arg);
-    if(cb) cb();
+    if(cb) cb(NULL);
 }
 
 #endif /*LV_IRQ_HAS_PXP*/

--- a/src/irqal/lv_irq_zephyr.h
+++ b/src/irqal/lv_irq_zephyr.h
@@ -1,0 +1,58 @@
+/**
+ * @file lv_irq_zephyr.h
+ *
+ */
+
+#ifndef LV_IRQ_ZEPHYR_H
+#define LV_IRQ_ZEPHYR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../lvgl_public.h"
+
+#if LV_USE_IRQ == LV_IRQ_ZEPHYR
+
+#include <zephyr/devicetree.h>
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/* Per-peripheral capability: available only if the device tree has the node.
+ * `#ifndef` guards let a user force a value from lv_conf.h. */
+#ifndef LV_IRQ_HAS_DMA2D
+#if DT_NODE_EXISTS(DT_NODELABEL(dma2d))
+#define LV_IRQ_HAS_DMA2D 1
+#else
+#define LV_IRQ_HAS_DMA2D 0
+#endif
+#endif
+
+#ifndef LV_IRQ_HAS_PXP
+#if DT_NODE_EXISTS(DT_NODELABEL(pxp))
+#define LV_IRQ_HAS_PXP 1
+#else
+#define LV_IRQ_HAS_PXP 0
+#endif
+#endif
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+#endif /*LV_USE_IRQ == LV_IRQ_ZEPHYR*/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_IRQ_ZEPHYR_H*/


### PR DESCRIPTION
  feat(irqal): add an IRQ abstraction layer for GPU draw units

  Asynchronous GPU draw units (DMA2D, PXP) embedded environment-specific
  interrupt-registration code directly in the unit — `#if __ZEPHYR__ ...
  IRQ_CONNECT` vs `NVIC_EnableIRQ` vs a FreeRTOS priority tweak — which made
  the units non-portable and conflated vector wiring with the draw logic.

  Introduce `src/irqal/`, an IRQ abstraction layer modeled on the OS
  abstraction layer (`src/osal/`) but independent of it:

  - Public API in `include/lvgl/irqal/lv_irq.h`:
    `lv_irq_attach_<periph>(lv_irq_cb_t cb)` / `lv_irq_detach_<periph>()`.
    The backend invokes the `void(*)(void)` callback when the IRQ fires; the
    callback does the peripheral flag-clear and completion signaling.
  - Exactly one backend is compiled in, selected by `LV_USE_IRQ`
    (NONE / CMSIS / ZEPHYR), mirroring `LV_USE_OS`:
      - CMSIS defines the named vectors, enables the NVIC line, and can set
        the NVIC priority (config) so the ISR may safely call `...FromISR`
        under an RTOS.
      - ZEPHYR uses `IRQ_CONNECT`/`irq_enable` with device-tree gating.
      - NONE is also the "bring your own backend" path: define `LV_IRQ_HAS_*`
        in lv_conf.h and link your own implementation (no symbol conflict).
  - Per-peripheral capability macros `LV_IRQ_HAS_*` gate call sites; they are
    auto-detected by the backend (CMSIS peripheral base macros, Zephyr DT
    nodes) and overridable from lv_conf.h.

  Migrate the DMA2D and PXP units onto the layer, so `src/draw/` no longer
  references `__ZEPHYR__`, `IRQ_CONNECT`, `NVIC_*` or `SDK_OS_FREE_RTOS`.
  PXP errors out when its IRQ is unavailable (no polling fallback); DMA2D
  keeps its register-poll path and now gates async mode on `LV_IRQ_HAS_DMA2D`.

  Wire `LV_USE_IRQ` into the Kconfig-driven config generation (ROOT_FILES +
  MEMBER_IS_TOKEN) and gate `LV_USE_DRAW_DMA2D_INTERRUPT` on `LV_USE_OS`.
