### PR TITLE
feat(cache): expose decoded image cache metrics

### DIFF
--- a/docs/src/main-modules/images/caching.mdx
+++ b/docs/src/main-modules/images/caching.mdx
@@ -28,6 +28,20 @@ The size of cache can be changed at run-time with
 <ApiLink name="lv_cache_set_max_size" display="lv_cache_set_max_size(size_t size)" />,
 and retrieved with <ApiLink name="lv_cache_get_max_size" />.
 
+## Cache Metrics
+
+The decoded image cache exposes three byte metrics for the current LVGL global context:
+
+- <ApiLink name="lv_image_cache_get_max_size" />: configured cache quota in bytes.
+- <ApiLink name="lv_image_cache_get_size" />: cache-accounted decoded payload bytes for
+  currently indexed entries, not resident memory.
+- <ApiLink name="lv_image_cache_get_free_size" />: `max(max_size - size, 0)` in bytes.
+
+The metrics do not report system heap usage, cache metadata, or GPU cache usage. They are
+valid only after `lv_init()` and before `lv_deinit()`. The three calls are not atomic
+snapshots; follow LVGL's thread rules and use `lv_lock()`/`lv_unlock()` when calling them
+across threads.
+
 ## Value of Images
 
 When you use more images than available cache size, LVGL can't cache all the

--- a/include/lvgl/image/lv_image_cache.h
+++ b/include/lvgl/image/lv_image_cache.h
@@ -1,0 +1,75 @@
+/**
+ * @file lv_image_cache.h
+ *
+ */
+
+#ifndef LV_IMAGE_CACHE_H
+#define LV_IMAGE_CACHE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "../lv_types.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**
+ * @note This is the configured quota for the current LVGL global context.
+ * @note Valid only after lv_init() and before lv_deinit().
+ * @note This getter is not an atomic snapshot. Follow LVGL's thread rules and use
+ *       lv_lock() and lv_unlock() when calling it across threads.
+ * @return the configured maximum image cache size.
+ */
+size_t lv_image_cache_get_max_size(void);
+
+/**
+ * Get the cache-accounted decoded payload size for currently indexed entries.
+ * This is not the resident memory usage of the image cache.
+ * @note This getter reads the current LVGL global context.
+ * @note Valid only after lv_init() and before lv_deinit().
+ * @note This getter is not an atomic snapshot. Follow LVGL's thread rules and use
+ *       lv_lock() and lv_unlock() when calling it across threads.
+ * @return the cache-accounted decoded payload size in bytes.
+ */
+size_t lv_image_cache_get_size(void);
+
+/**
+ * Get the remaining decoded image cache capacity in bytes.
+ * The result is `max(max_size - size, 0)` and is saturated at 0 when a deferred
+ * resize temporarily leaves the cache overcommitted.
+ * @note This getter reads the current LVGL global context.
+ * @note Valid only after lv_init() and before lv_deinit().
+ * @note This getter is not an atomic snapshot. Follow LVGL's thread rules and use
+ *       lv_lock() and lv_unlock() when calling it across threads.
+ * @return the remaining image cache capacity in bytes.
+ */
+size_t lv_image_cache_get_free_size(void);
+
+/*************************
+ *    GLOBAL VARIABLES
+ *************************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_IMAGE_CACHE_H*/

--- a/include/lvgl/lvgl.h
+++ b/include/lvgl/lvgl.h
@@ -137,6 +137,7 @@
 #include "image/lv_libpng.h"
 #include "image/lv_libwebp.h"
 #include "image/lv_lodepng.h"
+#include "image/lv_image_cache.h"
 #include "image/lv_image_decoder.h"
 #include "image/lv_svg.h"
 #include "image/lv_tjpgd.h"

--- a/src/image/lv_image_decoder.c
+++ b/src/image/lv_image_decoder.c
@@ -10,7 +10,7 @@
 #include "lv_image_decoder_private.h"
 #include "../core/lv_global.h"
 #include "../misc/cache/lv_cache.h"
-#include "../misc/cache/instance/lv_image_cache.h"
+#include "../misc/cache/instance/lv_image_cache_private.h"
 #include "../misc/cache/instance/lv_image_header_cache.h"
 #include "../misc/cache/lv_cache_entry.h"
 

--- a/src/lvgl_private.h
+++ b/src/lvgl_private.h
@@ -149,7 +149,7 @@
 #include "misc/cache/class/lv_cache_lru_rb.h"
 #include "misc/cache/class/lv_cache_sc_da.h"
 #include "misc/cache/instance/lv_cache_instance.h"
-#include "misc/cache/instance/lv_image_cache.h"
+#include "misc/cache/instance/lv_image_cache_private.h"
 #include "misc/cache/instance/lv_image_header_cache.h"
 #include "misc/cache/lv_cache.h"
 #include "misc/cache/lv_cache_entry.h"

--- a/src/misc/cache/instance/lv_cache_instance.h
+++ b/src/misc/cache/instance/lv_cache_instance.h
@@ -11,6 +11,6 @@
  *********************/
 
 #include "lv_image_header_cache.h"
-#include "lv_image_cache.h"
+#include "lv_image_cache_private.h"
 
 #endif //LV_CACHE_INSTANCE_H

--- a/src/misc/cache/instance/lv_image_cache.c
+++ b/src/misc/cache/instance/lv_image_cache.c
@@ -11,7 +11,7 @@
 #include "../../../core/lv_global.h"
 #include "../../../misc/lv_iter_private.h"
 
-#include "lv_image_cache.h"
+#include "lv_image_cache_private.h"
 #include "lv_image_header_cache.h"
 #include "../lv_cache_entry.h"
 
@@ -102,6 +102,24 @@ void lv_image_cache_drop(const void * src)
 bool lv_image_cache_is_enabled(void)
 {
     return lv_cache_is_enabled(img_cache_p);
+}
+
+size_t lv_image_cache_get_max_size(void)
+{
+    return lv_cache_get_max_size(img_cache_p, NULL);
+}
+
+size_t lv_image_cache_get_size(void)
+{
+    return lv_cache_get_size(img_cache_p, NULL);
+}
+
+size_t lv_image_cache_get_free_size(void)
+{
+    size_t max_size = lv_cache_get_max_size(img_cache_p, NULL);
+    size_t size = lv_cache_get_size(img_cache_p, NULL);
+
+    return max_size > size ? max_size - size : 0;
 }
 
 lv_iter_t * lv_image_cache_iter_create(void)

--- a/src/misc/cache/instance/lv_image_cache_private.h
+++ b/src/misc/cache/instance/lv_image_cache_private.h
@@ -1,10 +1,10 @@
 /**
-* @file lv_image_cache.h
+ * @file lv_image_cache_private.h
 *
  */
 
-#ifndef LV_IMAGE_CACHE_H
-#define LV_IMAGE_CACHE_H
+#ifndef LV_IMAGE_CACHE_PRIVATE_H
+#define LV_IMAGE_CACHE_PRIVATE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -80,4 +80,4 @@ void lv_image_cache_dump(void);
 } /*extern "C"*/
 #endif
 
-#endif /*LV_IMAGE_CACHE_H*/
+#endif /*LV_IMAGE_CACHE_PRIVATE_H*/

--- a/src/misc/cache/lv_cache.h
+++ b/src/misc/cache/lv_cache.h
@@ -405,7 +405,7 @@ void lv_cache_entry_init(lv_cache_entry_t * entry, const lv_cache_t * cache, con
 void lv_cache_entry_delete(lv_cache_entry_t * entry);
 
 #include "class/lv_cache_class.h"
-#include "instance/lv_image_cache.h"
+#include "instance/lv_image_cache_private.h"
 
 /*************************
  *    GLOBAL VARIABLES

--- a/tests/src/test_cases/draw/test_draw_vector_detail.c
+++ b/tests/src/test_cases/draw/test_draw_vector_detail.c
@@ -1,6 +1,6 @@
 #if LV_BUILD_TEST
 #include "../lvgl.h"
-#include "src/misc/cache/instance/lv_image_cache.h"
+#include "src/misc/cache/instance/lv_image_cache_private.h"
 #include "unity/unity.h"
 
 static lv_layer_t layer;

--- a/tests/src/test_cases/draw/test_image_cache.c
+++ b/tests/src/test_cases/draw/test_image_cache.c
@@ -4,14 +4,91 @@
 
 #include "unity/unity.h"
 
+static size_t initial_image_cache_max_size;
+static size_t initial_free_mem;
+
 void setUp(void)
 {
-    /* Function run before every test */
+    initial_image_cache_max_size = lv_image_cache_get_max_size();
+    lv_image_cache_drop(NULL);
+    initial_free_mem = lv_test_get_free_mem();
 }
 
 void tearDown(void)
 {
-    /* Function run after every test */
+    lv_image_cache_resize((uint32_t)initial_image_cache_max_size, true);
+    lv_image_cache_drop(NULL);
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(initial_free_mem, 64);
+}
+
+static size_t add_test_image_to_cache(void)
+{
+    static uint8_t image_src;
+    lv_draw_buf_t * decoded = lv_draw_buf_create(4, 4, LV_COLOR_FORMAT_ARGB8888, LV_STRIDE_AUTO);
+    if(decoded == NULL) {
+        TEST_FAIL_MESSAGE("Failed to create test image");
+        return 0;
+    }
+
+    size_t payload_size = decoded->data_size;
+
+    lv_image_cache_data_t search_key = {
+        .slot.size = payload_size,
+        .src = &image_src,
+        .src_type = LV_IMAGE_SRC_VARIABLE,
+    };
+    lv_cache_entry_t * entry = lv_image_decoder_add_to_cache(NULL, &search_key, decoded, NULL);
+    if(entry == NULL) {
+        lv_draw_buf_destroy(decoded);
+        TEST_FAIL_MESSAGE("Failed to add test image to cache");
+        return 0;
+    }
+
+    lv_cache_release(LV_GLOBAL_DEFAULT()->img_cache, entry, NULL);
+    return payload_size;
+}
+
+void test_image_cache_metrics(void)
+{
+    const size_t max_size = 1024;
+    lv_image_cache_resize(max_size, true);
+
+    TEST_ASSERT_EQUAL_SIZE_T(max_size, lv_image_cache_get_max_size());
+    TEST_ASSERT_EQUAL_SIZE_T(0, lv_image_cache_get_size());
+    TEST_ASSERT_EQUAL_SIZE_T(max_size, lv_image_cache_get_free_size());
+
+    size_t payload_size = add_test_image_to_cache();
+
+    TEST_ASSERT_EQUAL_SIZE_T(payload_size, lv_image_cache_get_size());
+    TEST_ASSERT_LESS_OR_EQUAL_SIZE_T(max_size, lv_image_cache_get_size());
+    TEST_ASSERT_EQUAL_SIZE_T(max_size - payload_size, lv_image_cache_get_free_size());
+}
+
+void test_image_cache_metrics_resize_and_disabled(void)
+{
+    lv_image_cache_resize(128, true);
+    TEST_ASSERT_TRUE(lv_image_cache_is_enabled());
+    TEST_ASSERT_EQUAL_SIZE_T(128, lv_image_cache_get_max_size());
+    TEST_ASSERT_EQUAL_SIZE_T(128, lv_image_cache_get_free_size());
+
+    lv_image_cache_resize(0, true);
+    TEST_ASSERT_FALSE(lv_image_cache_is_enabled());
+    TEST_ASSERT_EQUAL_SIZE_T(0, lv_image_cache_get_max_size());
+    TEST_ASSERT_EQUAL_SIZE_T(0, lv_image_cache_get_size());
+    TEST_ASSERT_EQUAL_SIZE_T(0, lv_image_cache_get_free_size());
+}
+
+void test_image_cache_metrics_overcommit_saturates_free_size(void)
+{
+    lv_image_cache_resize(1024, true);
+    size_t payload_size = add_test_image_to_cache();
+
+    TEST_ASSERT_GREATER_THAN(1, payload_size);
+
+    lv_image_cache_resize(1, false);
+    TEST_ASSERT_EQUAL_SIZE_T(1, lv_image_cache_get_max_size());
+    TEST_ASSERT_GREATER_THAN(lv_image_cache_get_max_size(), lv_image_cache_get_size());
+    TEST_ASSERT_EQUAL_SIZE_T(0, lv_image_cache_get_free_size());
 }
 
 void test_image_cache_dump(void)


### PR DESCRIPTION
## Description of the feature or fix

Fixes lvgl/lvgl#10394.

Expose read-only capacity and usage metrics for the decoded image cache without exposing its private `lv_cache_t` instance:

* `lv_image_cache_get_max_size()` reports the configured cache quota.
* `lv_image_cache_get_size()` reports cache-accounted decoded payload bytes for currently indexed entries.
* `lv_image_cache_get_free_size()` reports the remaining quota with saturating subtraction when a deferred resize temporarily leaves the cache overcommitted.

The metrics are provided through a new public image-cache header included by `<lvgl/lvgl.h>`. The existing internal image-cache header is renamed to `lv_image_cache_private.h` so lifecycle, iterator, dump, and cache-control APIs remain private.

The documentation clarifies that these values are cache accounting rather than total resident or heap memory, and that they follow the current LVGL global context and normal LVGL threading rules.

## Notes

* The generic cache API and its existing `free_size` semantics are unchanged.
* The public image-cache facade performs the saturating calculation locally.
* Separate getter calls are not an atomic statistics snapshot.

## Checklist

- [X] Added Doxygen comments for the public APIs.
- [X] Updated image-cache documentation.
- [X] Added tests for empty, populated, disabled, resized, and overcommitted cache states.
- [X] Ran AStyle v3.4.12 and the LVGL template check.
- [X] Ran `test_image_cache` and `test_cache` with both system heap and LVGL heap configurations.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)