### PR TITLE
feat(draw/ppa): support SoCs that expose no L2 cache line size

### DIFF
--- a/env_support/cmake/esp.cmake
+++ b/env_support/cmake/esp.cmake
@@ -55,7 +55,7 @@ else()
 
   set(IDF_COMPONENTS esp_timer log)
 
-  if(${target} STREQUAL "esp32p4")
+  if(${target} STREQUAL "esp32p4" OR ${target} STREQUAL "esp32s31")
     list(APPEND IDF_COMPONENTS esp_driver_ppa esp_mm)
   endif()
 

--- a/src/draw/espressif/ppa/lv_draw_ppa_private.h
+++ b/src/draw/espressif/ppa/lv_draw_ppa_private.h
@@ -31,8 +31,16 @@ extern "C" {
 /* The ppa driver depends heavily on the esp-idf headers*/
 #include <sdkconfig.h>
 
-#if (CONFIG_LV_DRAW_BUF_ALIGN != CONFIG_CACHE_L2_CACHE_LINE_SIZE)
-#error "CONFIG_LV_DRAW_BUF_ALIGN must be equal to CONFIG_CACHE_L2_CACHE_LINE_SIZE!"
+#if defined(CONFIG_CACHE_L2_CACHE_LINE_SIZE)
+#define LV_DRAW_PPA_CACHE_LINE_SIZE CONFIG_CACHE_L2_CACHE_LINE_SIZE
+#elif defined(CONFIG_CACHE_L1_DCACHE_LINE_SIZE)
+#define LV_DRAW_PPA_CACHE_LINE_SIZE CONFIG_CACHE_L1_DCACHE_LINE_SIZE
+#else
+#error "Cannot determine the data cache line size for the PPA draw unit"
+#endif
+
+#if (CONFIG_LV_DRAW_BUF_ALIGN != LV_DRAW_PPA_CACHE_LINE_SIZE)
+#error "CONFIG_LV_DRAW_BUF_ALIGN must be equal to the data cache line size!"
 #endif
 
 


### PR DESCRIPTION
Enabling the PPA draw unit on the ESP32-S31 dev board fails to build. Two
  things get in the way:

  1. `env_support/cmake/esp.cmake` only adds the `esp_driver_ppa` and
     `esp_mm` IDF components when the target is `esp32p4`, so the PPA
     sources cannot find their dependencies on any other SoC.
  2. `lv_draw_ppa_private.h` compares `CONFIG_LV_DRAW_BUF_ALIGN` against
     `CONFIG_CACHE_L2_CACHE_LINE_SIZE` unconditionally. On a SoC that
     exposes no L2 cache that symbol is not defined, so the `#if` sees 0,
     the guard can never pass, and the build aborts with
     `"CONFIG_LV_DRAW_BUF_ALIGN must be equal to CONFIG_CACHE_L2_CACHE_LINE_SIZE!"`
     — pointing the user at a Kconfig option that does not exist for their
     target.