### PR TITLE
Fix: lv_calendar_get_pressed_date() parse error with Chinese calendar

### DIFF
--- a/src/widgets/calendar/lv_calendar.c
+++ b/src/widgets/calendar/lv_calendar.c
@@ -323,7 +323,7 @@ lv_result_t lv_calendar_get_pressed_date(const lv_obj_t * obj, lv_calendar_date_
 
     const char * txt = lv_buttonmatrix_get_button_text(calendar->btnm, lv_buttonmatrix_get_selected_button(calendar->btnm));
 
-    if(txt[1] == 0) date->day = txt[0] - '0';
+    if(txt[1] == '\0' || text[1] == '\n') date->day = txt[0] - '0';
     else date->day = (txt[0] - '0') * 10 + (txt[1] - '0');
 
     date->year = calendar->showed_date.year;


### PR DESCRIPTION
Fix parsing error in lv_calendar_get_pressed_date() when Chinese lunar calendar is enabled.
Add support for newline characters in calendar day text and refactor related parsing logic for robustness.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

