### PR TITLE
fix(textarea): skip vertical scroll check for one-line text areas

### DIFF
--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -1416,16 +1416,23 @@ static void lv_textarea_scroll_to_cursor_pos(lv_obj_t * obj, int32_t pos)
     lv_label_get_letter_pos(ta->label, pos, &cur_pos);
 
     /*The text area needs to have it's final size to see if the cursor is out of the area or not*/
-
-    /*Check the top*/
     int32_t font_h = lv_font_get_line_height(font);
-    if(cur_pos.y < lv_obj_get_scroll_top(obj)) {
-        lv_obj_scroll_to_y(obj, cur_pos.y, LV_ANIM_ON);
-    }
-    /*Check the bottom*/
-    int32_t h = lv_obj_get_content_height(obj);
-    if(cur_pos.y + font_h - lv_obj_get_scroll_top(obj) > h) {
-        lv_obj_scroll_to_y(obj, cur_pos.y - h + font_h, LV_ANIM_ON);
+
+    /*A one line text area only ever has a single line of text, so the cursor's vertical
+     *position is always 0 and vertical scrolling can never reveal more of it. Skipping this
+     *check also avoids fighting itself when the text area is shorter than one line of text
+     *(e.g. a compact lv_spinbox), where the top and bottom checks below would otherwise keep
+     *scrolling back and forth forever.*/
+    if(!ta->one_line) {
+        /*Check the top*/
+        if(cur_pos.y < lv_obj_get_scroll_top(obj)) {
+            lv_obj_scroll_to_y(obj, cur_pos.y, LV_ANIM_ON);
+        }
+        /*Check the bottom*/
+        int32_t h = lv_obj_get_content_height(obj);
+        if(cur_pos.y + font_h - lv_obj_get_scroll_top(obj) > h) {
+            lv_obj_scroll_to_y(obj, cur_pos.y - h + font_h, LV_ANIM_ON);
+        }
     }
 
     /*Check the left*/


### PR DESCRIPTION
<!-- No related GitHub issue - this was reported on the forum, not filed as an issue -->

`lv_textarea_scroll_to_cursor_pos()` ran a vertical "keep the cursor in view" check even for one-line text areas, where the cursor's y position is always `0` (there's only ever one line). Once the content height (box height minus padding) became smaller than one line of text — trivial to hit on a compact one-line `lv_spinbox` — the top-check and bottom-check disagreed and kept pushing the vertical scroll offset back and forth. Since this reruns on every value/text update, the scroll offset oscillated continuously, which shows up as the text visibly jumping up and down every time the value changes.

This skips the vertical scroll-into-view check entirely when the text area is in one-line mode, since a single line never needs vertical scrolling in the first place. Multi-line text areas are unaffected.

**Repro:**
- Create an `lv_spinbox` (always one-line) with a height at or below one line of text (or small padding + `LV_SIZE_CONTENT`).
- Repeatedly change its value (e.g. `lv_spinbox_increment()`).
- Before: `scroll_y` oscillates and the text visibly jumps every update.
- After: `scroll_y` stays `0`, text is stable.
