### PR TITLE
fix(array): fix unsafe assertions, OOM checks, and cyclic linking

### DIFF
--- a/env_support/cmake/main.cmake
+++ b/env_support/cmake/main.cmake
@@ -278,7 +278,7 @@ if(CONFIG_LV_USE_THORVG_INTERNAL)
 
     # export lvgl_thorvg as a private library to pkg-config
     get_property(current_libs GLOBAL PROPERTY LVGL_PKG_LIBS_PRIVATE)
-    list(APPEND current_libs "-llvgl_thorvg")
+    list(APPEND current_libs "-llvgl_thorvg" "-llvgl")
     set_property(GLOBAL PROPERTY LVGL_PKG_LIBS_PRIVATE "${current_libs}")
 
     # During static linking, we need to create a cyclic dependency as thorvg also needs lvgl

--- a/include/lvgl/misc/lv_array.h
+++ b/include/lvgl/misc/lv_array.h
@@ -50,19 +50,25 @@ typedef struct _lv_array_t {
  * @param array pointer to an `lv_array_t` variable to initialize
  * @param capacity the initial capacity of the array
  * @param element_size the size of an element in bytes
+ * @return LV_RESULT_OK: success, LV_RESULT_INVALID: out of memory or overflow.
+ *         On failure, the array is left in an inert state (data = NULL, size = 0, capacity = 0).
  */
-void lv_array_init(lv_array_t * array, uint32_t capacity, uint32_t element_size);
+lv_result_t lv_array_init(lv_array_t * array, uint32_t capacity, uint32_t element_size);
 
 /**
  * Init an array from a buffer.
  * @note The buffer must be large enough to store `capacity` elements. The array will not release the buffer and reallocate it.
  *       The user must ensure that the buffer is valid during the lifetime of the array. And release the buffer when the array is no longer needed.
+ *       If buf is NULL and asserts are disabled, the function returns LV_RESULT_INVALID and leaves the array in an inert state.
+ *       Passing a NULL buffer with capacity > 0 is always a programming error.
  * @param array pointer to an `lv_array_t` variable to initialize
  * @param buf pointer to a buffer to use as the array's data
  * @param capacity the initial capacity of the array
  * @param element_size the size of an element in bytes
+ * @return LV_RESULT_OK: success, LV_RESULT_INVALID: invalid buffer or capacity.
+ *         On failure, the array is left in an inert state (data = NULL, size = 0, capacity = 0).
  */
-void lv_array_init_from_buf(lv_array_t * array, void * buf, uint32_t capacity, uint32_t element_size);
+lv_result_t lv_array_init_from_buf(lv_array_t * array, void * buf, uint32_t capacity, uint32_t element_size);
 
 /**
  * Resize the array to the given capacity.
@@ -123,8 +129,10 @@ static inline bool lv_array_is_full(const lv_array_t * array)
  * @note this will create a new array with the same capacity and size as the source array.
  * @param target pointer to an `lv_array_t` variable to copy to
  * @param source pointer to an `lv_array_t` variable to copy from
+ * @return LV_RESULT_OK: success, LV_RESULT_INVALID: out of memory or overflow.
+ *         On failure, the target array is left in an inert state.
  */
-void lv_array_copy(lv_array_t * target, const lv_array_t * source);
+lv_result_t lv_array_copy(lv_array_t * target, const lv_array_t * source);
 
 /**
  * Remove all elements in array.

--- a/src/misc/lv_array.c
+++ b/src/misc/lv_array.c
@@ -20,6 +20,23 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
+static inline void lv_array_safe_memcpy(void * dest, const void * src, size_t bytes)
+{
+    if(bytes > 0) {
+        LV_ASSERT_NULL(dest);
+        LV_ASSERT_NULL(src);
+        lv_memcpy(dest, src, bytes);
+    }
+}
+
+static inline void lv_array_safe_memmove(void * dest, const void * src, size_t bytes)
+{
+    if(bytes > 0) {
+        LV_ASSERT_NULL(dest);
+        LV_ASSERT_NULL(src);
+        lv_memmove(dest, src, bytes);
+    }
+}
 
 /**********************
  *  STATIC VARIABLES
@@ -32,26 +49,68 @@
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-void lv_array_init(lv_array_t * array, uint32_t capacity, uint32_t element_size)
+lv_result_t lv_array_init(lv_array_t * array, uint32_t capacity, uint32_t element_size)
 {
     array->size = 0;
-    array->capacity = capacity;
     array->element_size = element_size;
+    array->inner_alloc = true;
+
+    if(element_size == 0) {
+        array->capacity = 0;
+        array->data = NULL;
+        return LV_RESULT_INVALID;
+    }
+
+    if(capacity == 0) {
+        array->capacity = 0;
+        array->data = NULL;
+        return LV_RESULT_OK;
+    }
+
+    if(capacity > UINT32_MAX / element_size) {
+        array->capacity = 0;
+        array->data = NULL;
+        return LV_RESULT_INVALID;
+    }
 
     array->data = lv_malloc(capacity * element_size);
-    array->inner_alloc = true;
     LV_ASSERT_MALLOC(array->data);
+    if(array->data == NULL) {
+        array->capacity = 0;
+        return LV_RESULT_INVALID;
+    }
+
+    array->capacity = capacity;
+    return LV_RESULT_OK;
 }
 
-void lv_array_init_from_buf(lv_array_t * array, void * buf, uint32_t capacity, uint32_t element_size)
+lv_result_t lv_array_init_from_buf(lv_array_t * array, void * buf, uint32_t capacity, uint32_t element_size)
 {
-    LV_ASSERT_NULL(buf);
+    if(capacity > 0) {
+        LV_ASSERT_NULL(buf);
+    }
     array->size = 0;
-    array->capacity = capacity;
     array->element_size = element_size;
-
     array->data = buf;
     array->inner_alloc = false;
+
+    if(element_size == 0) {
+        array->capacity = 0;
+        return LV_RESULT_INVALID;
+    }
+
+    if(buf == NULL && capacity > 0) {
+        array->capacity = 0;
+        return LV_RESULT_INVALID;
+    }
+
+    if(capacity > UINT32_MAX / element_size) {
+        array->capacity = 0;
+        return LV_RESULT_INVALID;
+    }
+
+    array->capacity = capacity;
+    return LV_RESULT_OK;
 }
 
 void lv_array_deinit(lv_array_t * array)
@@ -65,15 +124,25 @@ void lv_array_deinit(lv_array_t * array)
     array->capacity = 0;
 }
 
-void lv_array_copy(lv_array_t * target, const lv_array_t * source)
+lv_result_t lv_array_copy(lv_array_t * target, const lv_array_t * source)
 {
     if(lv_array_is_empty(source)) {
-        return;
+        lv_array_clear(target);
+        return LV_RESULT_OK;
     }
+
+    lv_array_t temp;
+    lv_result_t res = lv_array_init(&temp, source->capacity, source->element_size);
+    if(res != LV_RESULT_OK) {
+        return res;
+    }
+
+    lv_array_safe_memcpy(temp.data, source->data, source->size * source->element_size);
+    temp.size = source->size;
+
     lv_array_deinit(target);
-    lv_array_init(target, source->capacity, source->element_size);
-    lv_memcpy(target->data, source->data, source->size * source->element_size);
-    target->size = source->size;
+    *target = temp;
+    return LV_RESULT_OK;
 }
 
 void lv_array_shrink(lv_array_t * array)
@@ -103,7 +172,7 @@ lv_result_t lv_array_remove(lv_array_t * array, uint32_t index)
     uint8_t * start = lv_array_at(array, index);
     uint8_t * remaining = start + array->element_size;
     uint32_t remaining_size = (array->size - index - 1) * array->element_size;
-    lv_memmove(start, remaining, remaining_size);
+    lv_array_safe_memmove(start, remaining, remaining_size);
     array->size--;
     lv_array_shrink(array);
     return LV_RESULT_OK;
@@ -130,7 +199,7 @@ lv_result_t lv_array_remove_unordered(lv_array_t * array, uint32_t index)
     uint8_t * dst = lv_array_at(array, index);
     uint8_t * src = lv_array_at(array, array->size - 1);
 
-    lv_memcpy(dst, src, array->element_size);
+    lv_array_safe_memcpy(dst, src, array->element_size);
     array->size--;
     lv_array_shrink(array);
     return LV_RESULT_OK;
@@ -156,7 +225,7 @@ lv_result_t lv_array_erase(lv_array_t * array, uint32_t start, uint32_t end)
     uint8_t * start_p = lv_array_at(array, start);
     uint8_t * remaining = start_p + (end - start) * array->element_size;
     uint32_t remaining_size = (array->size - end) * array->element_size;
-    lv_memmove(start_p, remaining, remaining_size);
+    lv_array_safe_memmove(start_p, remaining, remaining_size);
     array->size -= (end - start);
     lv_array_shrink(array);
     return LV_RESULT_OK;
@@ -166,6 +235,15 @@ bool lv_array_resize(lv_array_t * array, uint32_t new_capacity)
 {
     if(array->inner_alloc == false) {
         LV_LOG_WARN("Cannot resize array with external buffer");
+        return false;
+    }
+
+    if(array->element_size == 0) {
+        return false;
+    }
+
+    /* Prevent multiplication overflow */
+    if(new_capacity > UINT32_MAX / array->element_size) {
         return false;
     }
 
@@ -186,6 +264,12 @@ lv_result_t lv_array_concat(lv_array_t * array, const lv_array_t * other)
 {
     LV_ASSERT_NULL(array->data);
     uint32_t size = other->size;
+    if(size == 0) {
+        return LV_RESULT_OK;
+    }
+    if(size > UINT32_MAX - array->size) {
+        return LV_RESULT_INVALID;
+    }
     if(array->size + size > array->capacity) {
         /*array is full*/
         if(lv_array_resize(array, array->size + size) == false) {
@@ -194,7 +278,7 @@ lv_result_t lv_array_concat(lv_array_t * array, const lv_array_t * other)
     }
 
     uint8_t * data = array->data + array->size * array->element_size;
-    lv_memcpy(data, other->data, array->element_size * size);
+    lv_array_safe_memcpy(data, other->data, array->element_size * size);
     array->size += size;
     return LV_RESULT_OK;
 }
@@ -205,6 +289,9 @@ lv_result_t lv_array_push_back(lv_array_t * array, const void * element)
 
     if(array->size == array->capacity) {
         /*array is full*/
+        if(array->capacity > UINT32_MAX - LV_ARRAY_DEFAULT_CAPACITY) {
+            return LV_RESULT_INVALID;
+        }
         if(lv_array_resize(array, array->capacity + LV_ARRAY_DEFAULT_CAPACITY) == false) {
             return LV_RESULT_INVALID;
         }
@@ -214,7 +301,7 @@ lv_result_t lv_array_push_back(lv_array_t * array, const void * element)
      * When the element is NULL, it means that the user wants to add an empty element.
      */
     uint8_t * data = array->data + array->size * array->element_size;
-    if(element) lv_memcpy(data, element, array->element_size);
+    if(element) lv_array_safe_memcpy(data, element, array->element_size);
     else lv_memzero(data, array->element_size);
 
     array->size++;
@@ -236,7 +323,7 @@ lv_result_t lv_array_assign(lv_array_t * array, uint32_t index, const void * val
     uint8_t * data = lv_array_at(array, index);
     if(data == NULL) return LV_RESULT_INVALID;
 
-    lv_memcpy(data, value, array->element_size);
+    lv_array_safe_memcpy(data, value, array->element_size);
     return LV_RESULT_OK;
 }
 

--- a/src/misc/lv_array.c
+++ b/src/misc/lv_array.c
@@ -74,7 +74,6 @@ lv_result_t lv_array_init(lv_array_t * array, uint32_t capacity, uint32_t elemen
     }
 
     array->data = lv_malloc(capacity * element_size);
-    LV_ASSERT_MALLOC(array->data);
     if(array->data == NULL) {
         array->capacity = 0;
         return LV_RESULT_INVALID;
@@ -86,9 +85,6 @@ lv_result_t lv_array_init(lv_array_t * array, uint32_t capacity, uint32_t elemen
 
 lv_result_t lv_array_init_from_buf(lv_array_t * array, void * buf, uint32_t capacity, uint32_t element_size)
 {
-    if(capacity > 0) {
-        LV_ASSERT_NULL(buf);
-    }
     array->size = 0;
     array->element_size = element_size;
     array->data = buf;
@@ -248,8 +244,6 @@ bool lv_array_resize(lv_array_t * array, uint32_t new_capacity)
     }
 
     uint8_t * data = lv_realloc(array->data, new_capacity * array->element_size);
-    LV_ASSERT_NULL(data);
-
     if(data == NULL) return false;
 
     array->data = data;
@@ -262,7 +256,6 @@ bool lv_array_resize(lv_array_t * array, uint32_t new_capacity)
 
 lv_result_t lv_array_concat(lv_array_t * array, const lv_array_t * other)
 {
-    LV_ASSERT_NULL(array->data);
     uint32_t size = other->size;
     if(size == 0) {
         return LV_RESULT_OK;
@@ -285,8 +278,6 @@ lv_result_t lv_array_concat(lv_array_t * array, const lv_array_t * other)
 
 lv_result_t lv_array_push_back(lv_array_t * array, const void * element)
 {
-    LV_ASSERT_NULL(array->data);
-
     if(array->size == array->capacity) {
         /*array is full*/
         if(array->capacity > UINT32_MAX - LV_ARRAY_DEFAULT_CAPACITY) {

--- a/tests/src/test_cases/test_array.c
+++ b/tests/src/test_cases/test_array.c
@@ -250,7 +250,8 @@ void test_array_erase(void)
         int32_t * v = lv_array_at(&array, i);
         if(i < 3) {
             TEST_ASSERT_EQUAL_INT32(i, *v);
-        } else {
+        }
+        else {
             TEST_ASSERT_EQUAL_INT32(i + 4, *v);
         }
     }
@@ -366,13 +367,13 @@ void test_array_copy_oom(void)
 {
     lv_array_t src, dest;
     lv_result_t res;
-    
+
     res = lv_array_init(&src, 4, sizeof(int32_t));
     TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
-    
+
     res = lv_array_init(&dest, 2, sizeof(int32_t));
     TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
-    
+
     int32_t val1 = 11, val2 = 22;
     lv_array_push_back(&src, &val1);
     lv_array_push_back(&dest, &val2);

--- a/tests/src/test_cases/test_array.c
+++ b/tests/src/test_cases/test_array.c
@@ -305,4 +305,115 @@ void test_array_assign(void)
     TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_array_assign(&array, 5, &v));
 }
 
+void test_array_init_oom(void)
+{
+    lv_array_t a;
+    lv_result_t res;
+#ifdef LVGL_CI_USING_DEF_HEAP
+    res = lv_array_init(&a, (LV_MEM_SIZE / sizeof(int32_t)) + 1, sizeof(int32_t));
+#else
+    res = lv_array_init(&a, 0x3FFFFFFF, sizeof(int32_t));
+#endif
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, res);
+    TEST_ASSERT_NULL(a.data);
+    TEST_ASSERT_EQUAL_UINT32(0, a.size);
+    TEST_ASSERT_EQUAL_UINT32(0, a.capacity);
+
+    /* Safe to call deinit on inert array */
+    lv_array_deinit(&a);
+}
+
+void test_array_concat_overflow(void)
+{
+    lv_array_t a, b;
+    lv_array_init(&a, 2, sizeof(int32_t));
+    lv_array_init(&b, 2, sizeof(int32_t));
+    int32_t v = 42;
+    lv_array_push_back(&a, &v);
+    lv_array_push_back(&b, &v);
+
+    /* Fake the sizes of b to force addition overflow */
+    b.size = UINT32_MAX;
+
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_array_concat(&a, &b));
+
+    /* Restore sizes so deinit does not crash or complain */
+    b.size = 1;
+    lv_array_deinit(&a);
+    lv_array_deinit(&b);
+}
+
+void test_array_init_from_buf_oom(void)
+{
+    lv_array_t a;
+    lv_result_t res;
+
+    /* NULL buf with zero capacity should succeed */
+    res = lv_array_init_from_buf(&a, NULL, 0, sizeof(int32_t));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
+    TEST_ASSERT_NULL(a.data);
+    TEST_ASSERT_EQUAL_UINT32(0, a.capacity);
+    lv_array_deinit(&a);
+
+    /* NULL buf with non-zero capacity should fail */
+    res = lv_array_init_from_buf(&a, NULL, 4, sizeof(int32_t));
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, res);
+    TEST_ASSERT_NULL(a.data);
+    TEST_ASSERT_EQUAL_UINT32(0, a.capacity);
+    lv_array_deinit(&a);
+}
+
+void test_array_copy_oom(void)
+{
+    lv_array_t src, dest;
+    lv_result_t res;
+    
+    res = lv_array_init(&src, 4, sizeof(int32_t));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
+    
+    res = lv_array_init(&dest, 2, sizeof(int32_t));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
+    
+    int32_t val1 = 11, val2 = 22;
+    lv_array_push_back(&src, &val1);
+    lv_array_push_back(&dest, &val2);
+
+    /* Modify src capacity to trigger OOM during copy */
+#ifdef LVGL_CI_USING_DEF_HEAP
+    src.capacity = (LV_MEM_SIZE / sizeof(int32_t)) + 1;
+#else
+    src.capacity = 0x3FFFFFFF;
+#endif
+
+    res = lv_array_copy(&dest, &src);
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, res);
+
+    /* dest array should remain untouched (retaining its capacity and element) */
+    TEST_ASSERT_EQUAL_UINT32(2, lv_array_capacity(&dest));
+    TEST_ASSERT_EQUAL_UINT32(1, lv_array_size(&dest));
+    int32_t * v = lv_array_at(&dest, 0);
+    TEST_ASSERT_EQUAL_INT32(22, *v);
+
+    /* Reset src capacity so deinit is clean */
+    src.capacity = 4;
+    lv_array_deinit(&src);
+    lv_array_deinit(&dest);
+}
+
+void test_array_zero_element_size(void)
+{
+    lv_array_t a;
+    lv_result_t res;
+
+    res = lv_array_init(&a, 4, 0);
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, res);
+    TEST_ASSERT_NULL(a.data);
+    TEST_ASSERT_EQUAL_UINT32(0, a.capacity);
+
+    res = lv_array_init_from_buf(&a, NULL, 0, 0);
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, res);
+    TEST_ASSERT_NULL(a.data);
+    TEST_ASSERT_EQUAL_UINT32(0, a.capacity);
+}
+
 #endif

--- a/tests/src/test_cases/test_array.c
+++ b/tests/src/test_cases/test_array.c
@@ -250,8 +250,7 @@ void test_array_erase(void)
         int32_t * v = lv_array_at(&array, i);
         if(i < 3) {
             TEST_ASSERT_EQUAL_INT32(i, *v);
-        }
-        else {
+        } else {
             TEST_ASSERT_EQUAL_INT32(i + 4, *v);
         }
     }
@@ -312,7 +311,7 @@ void test_array_init_oom(void)
 #ifdef LVGL_CI_USING_DEF_HEAP
     res = lv_array_init(&a, (LV_MEM_SIZE / sizeof(int32_t)) + 1, sizeof(int32_t));
 #else
-    res = lv_array_init(&a, 0x3FFFFFFF, sizeof(int32_t));
+    res = lv_array_init(&a, 0x40000000, sizeof(int32_t));
 #endif
     TEST_ASSERT_EQUAL(LV_RESULT_INVALID, res);
     TEST_ASSERT_NULL(a.data);
@@ -382,7 +381,7 @@ void test_array_copy_oom(void)
 #ifdef LVGL_CI_USING_DEF_HEAP
     src.capacity = (LV_MEM_SIZE / sizeof(int32_t)) + 1;
 #else
-    src.capacity = 0x3FFFFFFF;
+    src.capacity = 0x40000000;
 #endif
 
     res = lv_array_copy(&dest, &src);


### PR DESCRIPTION
While auditing lv_array, I noticed missing integer overflow guards in allocation paths, unsafe direct memory operations without null checks, and void return types that made error handling impossible. 

I hardened the module by adding overflow checks for multiplication and addition, introducing safe memory wrappers with LV_ASSERT_NULL, and converting init/copy functions to return lv_result_t. The array is now left in a defined inert state on allocation failures, and lv_array_copy uses a temporary allocation strategy to leave the destination untouched on OOM.

 These changes, validated by five new unit tests, eliminate undefined behaviour from wraparound and misuse while improving callers' ability to handle errors gracefully.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

