### PR TITLE
fix(gltf): omit surface normals from vertex data for unlit materials

### DIFF
--- a/src/libs/gltf/gltf_data/lv_gltf_data_injest.cpp
+++ b/src/libs/gltf/gltf_data/lv_gltf_data_injest.cpp
@@ -60,6 +60,16 @@ typedef struct {
     fastgltf::math::fvec4 weights2;
 } vertex_t;
 
+typedef struct {
+    fastgltf::math::fvec3 position;
+    fastgltf::math::fvec2 uv;
+    fastgltf::math::fvec2 uv2;
+    fastgltf::math::fvec4 joints;
+    fastgltf::math::fvec4 joints2;
+    fastgltf::math::fvec4 weights;
+    fastgltf::math::fvec4 weights2;
+} vertex_flat_t;
+
 /**********************
  *  STATIC PROTOTYPES
  **********************/
@@ -91,7 +101,7 @@ static bool check_if_unlit(lv_gltf_model_t * data, fastgltf::Primitive * prim);
 template <typename T, typename Func>
 static size_t injest_vec_attribute(uint8_t vec_size, int32_t current_attrib_index, lv_gltf_model_t * data,
                                    const fastgltf::Primitive * prim, const char * attrib_id, GLuint primitive_vertex_buffer,
-                                   size_t offset, Func && functor);
+                                   size_t offset, bool normals, Func && functor);
 
 static int32_t injest_get_any_image_index(fastgltf::Optional<fastgltf::Texture> tex);
 static bool injest_check_any_image_index_valid(fastgltf::Optional<fastgltf::Texture> tex);
@@ -755,62 +765,108 @@ static bool injest_mesh(lv_gltf_model_t * data, fastgltf::Mesh & mesh)
         GL_CALL(glGenBuffers(1, &primitive.vertexBuffer));
         GL_CALL(glBindBuffer(GL_ARRAY_BUFFER, primitive.vertexBuffer));
 
-        std::vector<vertex_t> vertices_vec(positionAccessor.count);
-        vertex_t * vertices = vertices_vec.data();
-        glBufferData(GL_ARRAY_BUFFER, positionAccessor.count * sizeof(*vertices), nullptr, GL_STATIC_DRAW);
-        {
-            int32_t attr_index = 0;
-            attr_index = injest_vec_attribute<fastgltf::math::fvec3>(
-                             3, attr_index, data, &(*it), "POSITION", primitive.vertexBuffer, offsetof(vertex_t, position),
-            [&](fastgltf::math::fvec3 vec, size_t idx) {
-                vertices[idx].position = vec;
-            });
-            attr_index = injest_vec_attribute<fastgltf::math::fvec4>(
-                             4, attr_index, data, &(*it), "JOINTS_0", primitive.vertexBuffer, offsetof(vertex_t, joints),
-            [&](fastgltf::math::fvec4 vec, size_t idx) {
-                vertices[idx].joints = vec;
-            });
-            attr_index = injest_vec_attribute<fastgltf::math::fvec4>(
-                             4, attr_index, data, &(*it), "JOINTS_1", primitive.vertexBuffer, offsetof(vertex_t, joints2),
-            [&](fastgltf::math::fvec4 vec, std::size_t idx) {
-                vertices[idx].joints2 = vec;
-            });
-            attr_index = injest_vec_attribute<fastgltf::math::fvec4>(
-                             4, attr_index, data, &(*it), "WEIGHTS_0", primitive.vertexBuffer, offsetof(vertex_t, weights),
-            [&](fastgltf::math::fvec4 vec, std::size_t idx) {
-                vertices[idx].weights = vec;
-            });
-            attr_index = injest_vec_attribute<fastgltf::math::fvec4>(
-                             4, attr_index, data, &(*it), "WEIGHTS_1", primitive.vertexBuffer, offsetof(vertex_t, weights2),
-            [&](fastgltf::math::fvec4 vec, size_t idx) {
-                vertices[idx].weights2 = vec;
-            });
-            if(!check_if_unlit(data, &*it)) {
+        if(!check_if_unlit(data, &*it)) {
+            std::vector<vertex_t> vertices_vec(positionAccessor.count);
+            vertex_t * vertices = vertices_vec.data();
+            glBufferData(GL_ARRAY_BUFFER, positionAccessor.count * sizeof(*vertices), nullptr, GL_STATIC_DRAW);
+            {
+                int32_t attr_index = 0;
                 attr_index = injest_vec_attribute<fastgltf::math::fvec3>(
-                                 3, attr_index, data, &(*it), "NORMAL", primitive.vertexBuffer, offsetof(vertex_t, normal),
+                                 3, attr_index, data, &(*it), "POSITION", primitive.vertexBuffer, offsetof(vertex_t, position), true,
+                [&](fastgltf::math::fvec3 vec, size_t idx) {
+                    vertices[idx].position = vec;
+                });
+                attr_index = injest_vec_attribute<fastgltf::math::fvec4>(
+                                 4, attr_index, data, &(*it), "JOINTS_0", primitive.vertexBuffer, offsetof(vertex_t, joints), true,
+                [&](fastgltf::math::fvec4 vec, size_t idx) {
+                    vertices[idx].joints = vec;
+                });
+                attr_index = injest_vec_attribute<fastgltf::math::fvec4>(
+                                 4, attr_index, data, &(*it), "JOINTS_1", primitive.vertexBuffer, offsetof(vertex_t, joints2), true,
+                [&](fastgltf::math::fvec4 vec, std::size_t idx) {
+                    vertices[idx].joints2 = vec;
+                });
+                attr_index = injest_vec_attribute<fastgltf::math::fvec4>(
+                                 4, attr_index, data, &(*it), "WEIGHTS_0", primitive.vertexBuffer, offsetof(vertex_t, weights), true,
+                [&](fastgltf::math::fvec4 vec, std::size_t idx) {
+                    vertices[idx].weights = vec;
+                });
+                attr_index = injest_vec_attribute<fastgltf::math::fvec4>(
+                                 4, attr_index, data, &(*it), "WEIGHTS_1", primitive.vertexBuffer, offsetof(vertex_t, weights2), true,
+                [&](fastgltf::math::fvec4 vec, size_t idx) {
+                    vertices[idx].weights2 = vec;
+                });
+                attr_index = injest_vec_attribute<fastgltf::math::fvec3>(
+                                 3, attr_index, data, &(*it), "NORMAL", primitive.vertexBuffer, offsetof(vertex_t, normal), true,
                 [&](fastgltf::math::fvec3 vec, std::size_t idx) {
                     vertices[idx].normal = vec;
                 });
+                attr_index = injest_vec_attribute<fastgltf::math::fvec4>(
+                                 4, attr_index, data, &(*it), "TANGENT", primitive.vertexBuffer, offsetof(vertex_t, tangent), true,
+                [&](fastgltf::math::fvec4 vec, size_t idx) {
+                    vertices[idx].tangent = vec;
+                });
+                attr_index = injest_vec_attribute<fastgltf::math::fvec2>(
+                                 2, attr_index, data, &(*it), "TEXCOORD_0", primitive.vertexBuffer, offsetof(vertex_t, uv), true,
+                [&](fastgltf::math::fvec2 vec, size_t idx) {
+                    vertices[idx].uv = vec;
+                });
+                attr_index = injest_vec_attribute<fastgltf::math::fvec2>(
+                                 2, attr_index, data, &(*it), "TEXCOORD_1", primitive.vertexBuffer, offsetof(vertex_t, uv2), true,
+                [&](fastgltf::math::fvec2 vec, size_t idx) {
+                    vertices[idx].uv2 = vec;
+                });
             }
-            attr_index = injest_vec_attribute<fastgltf::math::fvec4>(
-                             4, attr_index, data, &(*it), "TANGENT", primitive.vertexBuffer, offsetof(vertex_t, tangent),
-            [&](fastgltf::math::fvec4 vec, size_t idx) {
-                vertices[idx].tangent = vec;
-            });
-            attr_index = injest_vec_attribute<fastgltf::math::fvec2>(
-                             2, attr_index, data, &(*it), "TEXCOORD_0", primitive.vertexBuffer, offsetof(vertex_t, uv),
-            [&](fastgltf::math::fvec2 vec, size_t idx) {
-                vertices[idx].uv = vec;
-            });
-            attr_index = injest_vec_attribute<fastgltf::math::fvec2>(
-                             2, attr_index, data, &(*it), "TEXCOORD_1", primitive.vertexBuffer, offsetof(vertex_t, uv2),
-            [&](fastgltf::math::fvec2 vec, size_t idx) {
-                vertices[idx].uv2 = vec;
-            });
+            glBindVertexArray(vao);
+            glBindBuffer(GL_ARRAY_BUFFER, primitive.vertexBuffer);
+            glBufferData(GL_ARRAY_BUFFER, positionAccessor.count * sizeof(vertex_t), vertices_vec.data(), GL_STATIC_DRAW);
         }
-        glBindVertexArray(vao);
-        glBindBuffer(GL_ARRAY_BUFFER, primitive.vertexBuffer);
-        glBufferData(GL_ARRAY_BUFFER, positionAccessor.count * sizeof(vertex_t), vertices_vec.data(), GL_STATIC_DRAW);
+        else {
+            std::vector<vertex_flat_t> vertices_vec(positionAccessor.count);
+            vertex_flat_t * vertices = vertices_vec.data();
+            glBufferData(GL_ARRAY_BUFFER, positionAccessor.count * sizeof(*vertices), nullptr, GL_STATIC_DRAW);
+            {
+                int32_t attr_index = 0;
+                attr_index = injest_vec_attribute<fastgltf::math::fvec3>(
+                                 3, attr_index, data, &(*it), "POSITION", primitive.vertexBuffer, offsetof(vertex_flat_t, position), false,
+                [&](fastgltf::math::fvec3 vec, size_t idx) {
+                    vertices[idx].position = vec;
+                });
+                attr_index = injest_vec_attribute<fastgltf::math::fvec4>(
+                                 4, attr_index, data, &(*it), "JOINTS_0", primitive.vertexBuffer, offsetof(vertex_flat_t, joints), false,
+                [&](fastgltf::math::fvec4 vec, size_t idx) {
+                    vertices[idx].joints = vec;
+                });
+                attr_index = injest_vec_attribute<fastgltf::math::fvec4>(
+                                 4, attr_index, data, &(*it), "JOINTS_1", primitive.vertexBuffer, offsetof(vertex_flat_t, joints2), false,
+                [&](fastgltf::math::fvec4 vec, std::size_t idx) {
+                    vertices[idx].joints2 = vec;
+                });
+                attr_index = injest_vec_attribute<fastgltf::math::fvec4>(
+                                 4, attr_index, data, &(*it), "WEIGHTS_0", primitive.vertexBuffer, offsetof(vertex_flat_t, weights), false,
+                [&](fastgltf::math::fvec4 vec, std::size_t idx) {
+                    vertices[idx].weights = vec;
+                });
+                attr_index = injest_vec_attribute<fastgltf::math::fvec4>(
+                                 4, attr_index, data, &(*it), "WEIGHTS_1", primitive.vertexBuffer, offsetof(vertex_flat_t, weights2), false,
+                [&](fastgltf::math::fvec4 vec, size_t idx) {
+                    vertices[idx].weights2 = vec;
+                });
+                attr_index = injest_vec_attribute<fastgltf::math::fvec2>(
+                                 2, attr_index, data, &(*it), "TEXCOORD_0", primitive.vertexBuffer, offsetof(vertex_flat_t, uv), false,
+                [&](fastgltf::math::fvec2 vec, size_t idx) {
+                    vertices[idx].uv = vec;
+                });
+                attr_index = injest_vec_attribute<fastgltf::math::fvec2>(
+                                 2, attr_index, data, &(*it), "TEXCOORD_1", primitive.vertexBuffer, offsetof(vertex_flat_t, uv2), false,
+                [&](fastgltf::math::fvec2 vec, size_t idx) {
+                    vertices[idx].uv2 = vec;
+                });
+            }
+            glBindVertexArray(vao);
+            glBindBuffer(GL_ARRAY_BUFFER, primitive.vertexBuffer);
+            glBufferData(GL_ARRAY_BUFFER, positionAccessor.count * sizeof(vertex_flat_t), vertices_vec.data(), GL_STATIC_DRAW);
+        }
 
         // Generate the indirect draw command
         auto & draw = primitive.draw;
@@ -855,7 +911,7 @@ static bool injest_mesh(lv_gltf_model_t * data, fastgltf::Mesh & mesh)
 template <typename T, typename Func>
 static size_t injest_vec_attribute(uint8_t vec_size, int32_t current_attrib_index, lv_gltf_model_t * data,
                                    const fastgltf::Primitive * prim, const char * attrib_id, GLuint primitive_vertex_buffer,
-                                   size_t offset, Func && functor
+                                   size_t offset, bool normals, Func && functor
 
                                   )
 {
@@ -870,7 +926,7 @@ static size_t injest_vec_attribute(uint8_t vec_size, int32_t current_attrib_inde
                                   vec_size, // Number of components per vertex
                                   GL_FLOAT, // Data type
                                   GL_FALSE, // Normalized
-                                  sizeof(vertex_t), // Stride (size of one vertex)
+                                  normals ? sizeof(vertex_t) : sizeof(vertex_flat_t), // Stride (size of one vertex)
                                   (void *)offset); // Offset in the buffer
             glEnableVertexAttribArray(current_attrib_index);
         }

--- a/src/libs/gltf/gltf_data/lv_gltf_data_injest.cpp
+++ b/src/libs/gltf/gltf_data/lv_gltf_data_injest.cpp
@@ -86,6 +86,8 @@ static bool injest_mesh(lv_gltf_model_t * data, fastgltf::Mesh & mesh);
 
 static void make_small_magenta_texture(uint32_t new_magenta_tex);
 
+static bool check_if_unlit(lv_gltf_model_t * data, fastgltf::Primitive * prim);
+
 template <typename T, typename Func>
 static size_t injest_vec_attribute(uint8_t vec_size, int32_t current_attrib_index, lv_gltf_model_t * data,
                                    const fastgltf::Primitive * prim, const char * attrib_id, GLuint primitive_vertex_buffer,
@@ -653,6 +655,28 @@ static void injest_light(lv_gltf_model_t * data, size_t light_index, fastgltf::L
     });
 }
 
+static bool check_if_unlit(lv_gltf_model_t * data, fastgltf::Primitive * prim)
+{
+    const auto & asset = data->asset;
+    if(prim->materialIndex.has_value()) {
+        const auto & material = asset.materials[prim->materialIndex.value()];
+        if(material.unlit) {
+            return true;
+        }
+        else {
+            if(material.pbrData.baseColorFactor.x() == 0.0f
+               && material.pbrData.baseColorFactor.y() == 0.0f
+               && material.pbrData.baseColorFactor.z() == 0.0f
+               && material.pbrData.metallicFactor == 1.0f
+               && material.pbrData.roughnessFactor == 1.0f
+               && material.emissiveStrength > 0.0f) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 static bool injest_mesh(lv_gltf_model_t * data, fastgltf::Mesh & mesh)
 {
     /*const auto &asset = GET_ASSET(data);*/
@@ -761,11 +785,13 @@ static bool injest_mesh(lv_gltf_model_t * data, fastgltf::Mesh & mesh)
             [&](fastgltf::math::fvec4 vec, size_t idx) {
                 vertices[idx].weights2 = vec;
             });
-            attr_index = injest_vec_attribute<fastgltf::math::fvec3>(
-                             3, attr_index, data, &(*it), "NORMAL", primitive.vertexBuffer, offsetof(vertex_t, normal),
-            [&](fastgltf::math::fvec3 vec, std::size_t idx) {
-                vertices[idx].normal = vec;
-            });
+            if(!check_if_unlit(data, &*it)) {
+                attr_index = injest_vec_attribute<fastgltf::math::fvec3>(
+                                 3, attr_index, data, &(*it), "NORMAL", primitive.vertexBuffer, offsetof(vertex_t, normal),
+                [&](fastgltf::math::fvec3 vec, std::size_t idx) {
+                    vertices[idx].normal = vec;
+                });
+            }
             attr_index = injest_vec_attribute<fastgltf::math::fvec4>(
                              4, attr_index, data, &(*it), "TANGENT", primitive.vertexBuffer, offsetof(vertex_t, tangent),
             [&](fastgltf::math::fvec4 vec, size_t idx) {

--- a/src/libs/gltf/gltf_view/lv_gltf_view_shader.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view_shader.cpp
@@ -80,6 +80,7 @@ lv_result_t lv_gltf_view_shader_injest_discover_defines(lv_array_t * result, lv_
     LV_ASSERT_MSG(prim->indicesAccessor.has_value(),
                   "We specify fastgltf::Options::GenerateMeshIndices, so we should always have indices");
 
+    bool unlit = false;
     if(!prim->materialIndex.has_value()) {
         if(add_define(result, "ALPHAMODE", "_OPAQUE", false) == LV_RESULT_INVALID) {
             return LV_RESULT_INVALID;
@@ -91,6 +92,7 @@ lv_result_t lv_gltf_view_shader_injest_discover_defines(lv_array_t * result, lv_
             return LV_RESULT_INVALID;
         }
         if(material.unlit) {
+            unlit = true;
             if(add_define(result, "MATERIAL_UNLIT", NULL, false) == LV_RESULT_INVALID) {
                 return LV_RESULT_INVALID;
             }
@@ -104,6 +106,7 @@ lv_result_t lv_gltf_view_shader_injest_discover_defines(lv_array_t * result, lv_
                && material.emissiveStrength > 0.0f) {
                 /* Special case where settings preclude IBL's ability to have visible effect, so disable it entirely */
                 LV_LOG_TRACE("Special case identified, disabling IBL and enabling UNLIT\n");
+                unlit = true;
                 if(add_define(result, "MATERIAL_UNLIT", NULL, false) == LV_RESULT_INVALID) {
                     return LV_RESULT_INVALID;
                 }
@@ -258,11 +261,13 @@ lv_result_t lv_gltf_view_shader_injest_discover_defines(lv_array_t * result, lv_
             }
         }
     }
-    if(add_define_if_primitive_attribute_exists(result, asset, prim, "NORMAL", "HAS_NORMAL_VEC3") == LV_RESULT_INVALID) {
-        return LV_RESULT_INVALID;
-    }
-    if(add_define_if_primitive_attribute_exists(result, asset, prim, "TANGENT", "HAS_TANGENT_VEC4") == LV_RESULT_INVALID) {
-        return LV_RESULT_INVALID;
+    if(!unlit) {
+        if(add_define_if_primitive_attribute_exists(result, asset, prim, "NORMAL", "HAS_NORMAL_VEC3") == LV_RESULT_INVALID) {
+            return LV_RESULT_INVALID;
+        }
+        if(add_define_if_primitive_attribute_exists(result, asset, prim, "TANGENT", "HAS_TANGENT_VEC4") == LV_RESULT_INVALID) {
+            return LV_RESULT_INVALID;
+        }
     }
     if(add_define_if_primitive_attribute_exists(result, asset, prim, "TEXCOORD_0", "HAS_TEXCOORD_0_VEC2") ==
        LV_RESULT_INVALID) {


### PR DESCRIPTION
Unlit materials do not need surface normals and omit them for performance.  However they were still being allocated within the vertex descriptor because the Blender gltf exporter forces normals either on or off for the entire file being exported, not per-item within the file.  To correct that this PR detects when a primitive is rendered as unlit, and does not allocate a surface normal vector for those primitives.

This corrects inconsistent rendering on some platforms.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

