### PR TITLE
fix(refr): Fixes for triple buffering

### DIFF
--- a/include/lvgl/display/lv_display.h
+++ b/include/lvgl/display/lv_display.h
@@ -335,7 +335,7 @@ void lv_display_set_flush_wait_cb(lv_display_t * disp, lv_display_flush_wait_cb_
 /**
  * Set the sync callback which will be called to synchronize invalidated areas between frame buffers pre-render.
  * @param disp     pointer to a display
- * @param sync_cb  the sync callback (pointer to `area` needing to be synchronized)
+ * @param sync_cb  the sync callback (`dest` to copy the area to, `src` to copy the area from, pointer to the `area` needing to be synchronized)
  */
 void lv_display_set_sync_cb(lv_display_t * disp, lv_display_sync_cb_t sync_cb);
 

--- a/include/lvgl/display/lv_display.h
+++ b/include/lvgl/display/lv_display.h
@@ -80,7 +80,7 @@ typedef enum {
 
 typedef void (*lv_display_flush_cb_t)(lv_display_t * disp, const lv_area_t * area, uint8_t * px_map);
 typedef void (*lv_display_flush_wait_cb_t)(lv_display_t * disp);
-typedef void (*lv_display_sync_cb_t)(lv_display_t * disp, const lv_area_t * area);
+typedef void (*lv_display_sync_cb_t)(lv_display_t * disp, uint8_t *dest, const uint8_t *src, const lv_area_t * area);
 typedef void (*lv_display_sync_wait_cb_t)(lv_display_t * disp);
 
 /**********************

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -717,17 +717,17 @@ static void refr_sync_areas(void)
     lv_draw_buf_t * queued_screen = NULL;
     /*The next buffer that still might be on-screen, modifying this before
       the queued screen is activated might cause tearing*/
-    lv_draw_buf_t * on_screen = NULL;
+    /*lv_draw_buf_t * on_screen = NULL;*/
 
     if(off_screen == disp_refr->buf_3) {
         queued_screen = disp_refr->buf_2;
-        on_screen = disp_refr->buf_1;
+        /*on_screen = disp_refr->buf_1;*/
     } else if(off_screen == disp_refr->buf_2) {
         queued_screen = disp_refr->buf_1;
-        on_screen = disp_refr->buf_3 ? disp_refr->buf_3 : off_screen;
+        /*on_screen = disp_refr->buf_3 ? disp_refr->buf_3 : off_screen;*/
     } else {
         queued_screen = disp_refr->buf_3 ? disp_refr->buf_3 : disp_refr->buf_2;
-        on_screen = disp_refr->buf_3 ? disp_refr->buf_2 : off_screen;
+        /*on_screen = disp_refr->buf_3 ? disp_refr->buf_2 : off_screen;*/
     }
 
     uint32_t hor_res = lv_display_get_horizontal_resolution(disp_refr);

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -43,7 +43,7 @@ static uint32_t get_max_row(lv_display_t * disp, int32_t area_w, int32_t area_h)
 static void draw_buf_flush(lv_display_t * disp);
 static void call_flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_map);
 static void wait_for_flushing(lv_display_t * disp);
-static void call_sync_cb(lv_display_t * disp, const lv_area_t * area);
+static void call_sync_cb(lv_display_t * disp, uint8_t *dest, const uint8_t *src, const lv_area_t * area);
 static void wait_for_syncing(lv_display_t * disp);
 static lv_result_t layer_get_area(lv_layer_t * layer, lv_obj_t * obj, lv_layer_type_t layer_type,
                                   lv_area_t * layer_area_out, lv_area_t * obj_draw_size_out);
@@ -712,21 +712,22 @@ static void refr_sync_areas(void)
     /*The buffers are already swapped.
      *So the active buffer is the off screen buffer where LVGL will render*/
     lv_draw_buf_t * off_screen = disp_refr->buf_act;
-    /*Triple buffer sync buffer for off-screen2 updates.*/
-    lv_draw_buf_t * off_screen2 = NULL;
+    /*The previous buffer that flushed recently, might be on-screen only
+     *after the next VSYNC, shall not be modified*/
+    lv_draw_buf_t * queued_screen = NULL;
+    /*The next buffer that still might be on-screen, modifying this before
+      the queued screen is activated might cause tearing*/
     lv_draw_buf_t * on_screen = NULL;
 
-    if(disp_refr->buf_act == disp_refr->buf_1) {
-        off_screen2 = disp_refr->buf_2;
-        on_screen = disp_refr->buf_3 ? disp_refr->buf_3 : disp_refr->buf_2;
-    }
-    else if(disp_refr->buf_act == disp_refr->buf_2) {
-        off_screen2 = disp_refr->buf_3 ? disp_refr->buf_3 : disp_refr->buf_1;
+    if(off_screen == disp_refr->buf_3) {
+        queued_screen = disp_refr->buf_2;
         on_screen = disp_refr->buf_1;
-    }
-    else {
-        off_screen2 = disp_refr->buf_1;
-        on_screen = disp_refr->buf_2;
+    } else if(off_screen == disp_refr->buf_2) {
+        queued_screen = disp_refr->buf_1;
+        on_screen = disp_refr->buf_3 ? disp_refr->buf_3 : off_screen;
+    } else {
+        queued_screen = disp_refr->buf_3 ? disp_refr->buf_3 : disp_refr->buf_2;
+        on_screen = disp_refr->buf_3 ? disp_refr->buf_2 : off_screen;
     }
 
     uint32_t hor_res = lv_display_get_horizontal_resolution(disp_refr);
@@ -754,16 +755,19 @@ static void refr_sync_areas(void)
             disp_refr->syncing_last = lv_ll_get_tail(&disp_refr->sync_areas) == sync_area;
 
             /*Call sync callback and wait for sync to complete*/
-            call_sync_cb(disp_refr, sync_area);
+            call_sync_cb(disp_refr, off_screen->data, queued_screen->data, sync_area);
             wait_for_syncing(disp_refr);
         }
         /*Fallback to internal double buffered direct mode sync*/
         else {
-            lv_draw_buf_copy(off_screen, sync_area, on_screen, sync_area);
-            if(off_screen2 != on_screen)
-                lv_draw_buf_copy(off_screen2, sync_area, on_screen, sync_area);
+            lv_draw_buf_copy(off_screen, sync_area, queued_screen, sync_area);
         }
     }
+
+    /*Now the buffers in sync and the off screen buffer is ready to be updated.
+     *If it is flushed just in time before the queued screen is swapped to at a
+     *VSYNC, it shall override it and be the latest frame. If it is too late to
+     *override, it shall be the next frame (unless overridden by the next flush.*/
 
     /*Clear sync areas*/
     lv_ll_clear(&disp_refr->sync_areas);
@@ -1517,7 +1521,7 @@ static void wait_for_flushing(lv_display_t * disp)
     LV_PROFILER_REFR_END;
 }
 
-static void call_sync_cb(lv_display_t * disp, const lv_area_t * area)
+static void call_sync_cb(lv_display_t * disp, uint8_t *dest, const uint8_t *src, const lv_area_t * area)
 {
     LV_PROFILER_REFR_BEGIN;
 
@@ -1528,13 +1532,14 @@ static void call_sync_cb(lv_display_t * disp, const lv_area_t * area)
     offset_area.y1 += disp->offset_y;
     offset_area.y2 += disp->offset_y;
 
-    LV_TRACE_REFR("Calling sync_cb on (%d;%d)(%d;%d) area",
+    LV_TRACE_REFR("Calling sync_cb on (%d;%d)(%d;%d) area to copy from %p to %p",
                   (int)offset_area.x1, (int)offset_area.y1,
-                  (int)offset_area.x2, (int)offset_area.y2);
+                  (int)offset_area.x2, (int)offset_area.y2,
+                  src, dest);
 
     lv_display_send_event(disp, LV_EVENT_SYNC_START, (void *)&offset_area);
 
-    disp->sync_cb(disp, &offset_area);
+    disp->sync_cb(disp, dest, src, &offset_area);
 
     lv_display_send_event(disp, LV_EVENT_SYNC_FINISH, (void *)&offset_area);
 

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -419,10 +419,9 @@ void lv_display_refr_timer(lv_timer_t * tmr)
     refr_invalid_areas();
 
     if(disp_refr->inv_p == 0) goto refr_finish;
-    /*In double buffered direct mode or if sync callback is set, save the updated areas.
+    /*In double buffered direct mode save the updated areas.
      *They will be used on the next call to synchronize the buffers.*/
-    if((lv_display_is_double_buffered(disp_refr) && disp_refr->render_mode == LV_DISPLAY_RENDER_MODE_DIRECT) ||
-       disp_refr->sync_cb) {
+    if(lv_display_is_double_buffered(disp_refr) && disp_refr->render_mode == LV_DISPLAY_RENDER_MODE_DIRECT) {
         uint32_t i;
         for(i = 0; i < disp_refr->inv_p; i++) {
             if(disp_refr->inv_area_joined[i])
@@ -661,11 +660,11 @@ static void lv_refr_join_area(void)
  */
 static void refr_sync_areas(void)
 {
-    /*Do not sync if not direct double buffered and no sync callback set*/
-    const bool auto_sync = disp_refr->render_mode == LV_DISPLAY_RENDER_MODE_DIRECT &&
-                           lv_display_is_double_buffered(disp_refr);
-    const bool user_sync = disp_refr->sync_cb != NULL;
-    if(!auto_sync && !user_sync) return;
+    /*Do not sync if not direct or double buffered*/
+    if(disp_refr->render_mode != LV_DISPLAY_RENDER_MODE_DIRECT) return;
+
+    /*Do not sync if not double buffered*/
+    if(!lv_display_is_double_buffered(disp_refr)) return;
 
     /*Do not sync if no sync areas*/
     if(lv_ll_is_empty(&disp_refr->sync_areas)) return;
@@ -717,21 +716,17 @@ static void refr_sync_areas(void)
     lv_draw_buf_t * off_screen2 = NULL;
     lv_draw_buf_t * on_screen = NULL;
 
-    /* Only compute buffer relationships when auto_sync (direct double-buffered) is used.
-     * When only user_sync is active, these pointers are not needed. */
-    if(auto_sync) {
-        if(disp_refr->buf_act == disp_refr->buf_1) {
-            off_screen2 = disp_refr->buf_2;
-            on_screen = disp_refr->buf_3 ? disp_refr->buf_3 : disp_refr->buf_2;
-        }
-        else if(disp_refr->buf_act == disp_refr->buf_2) {
-            off_screen2 = disp_refr->buf_3 ? disp_refr->buf_3 : disp_refr->buf_1;
-            on_screen = disp_refr->buf_1;
-        }
-        else {
-            off_screen2 = disp_refr->buf_1;
-            on_screen = disp_refr->buf_2;
-        }
+    if(disp_refr->buf_act == disp_refr->buf_1) {
+        off_screen2 = disp_refr->buf_2;
+        on_screen = disp_refr->buf_3 ? disp_refr->buf_3 : disp_refr->buf_2;
+    }
+    else if(disp_refr->buf_act == disp_refr->buf_2) {
+        off_screen2 = disp_refr->buf_3 ? disp_refr->buf_3 : disp_refr->buf_1;
+        on_screen = disp_refr->buf_1;
+    }
+    else {
+        off_screen2 = disp_refr->buf_1;
+        on_screen = disp_refr->buf_2;
     }
 
     uint32_t hor_res = lv_display_get_horizontal_resolution(disp_refr);


### PR DESCRIPTION
I have started using LVGL recently at my job, and while investigating how things work, the direct mode buffer syncing code looked very strange. The more I have looked at it, the less it made sense. So here is my attempt at getting triple-buffering right, where the on-screen and the queued screen are owned by GPU, and LVGL is only allowed to modify the off-screen buffer, as described here: https://www.4rknova.com/blog/2025/09/12/triple-buffering

Could not find in-tree users of the sync_cb API to see how it was meant to be working, so I have assumed that it only did not receive destination and source buffers because it was assumed that the current buffer should be copied to all others. But that is not true, so I have updated it. Adapting out-of-tree users should be straightforward (either fix your code or ignore the extra parameters).
Anyway, I don't see the point of sync_cb, it should simply be an override for buf_copy_cb.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

