### PR TITLE
fix(utils): fix implicit int conversion warning

### DIFF
--- a/src/misc/lv_utils.h
+++ b/src/misc/lv_utils.h
@@ -76,7 +76,7 @@ static inline uint32_t lv_swap_bytes_32(uint32_t x)
  */
 static inline uint16_t lv_swap_bytes_16(uint16_t x)
 {
-    return (x << 8) | (x >> 8);
+    return (uint16_t)(x << 8) | (x >> 8);
 }
 
 /**********************


### PR DESCRIPTION
Found on e2Studio:

```bash
warning: implicit conversion loses integer precision: 'int' to 'uint16_t' (aka 'unsigned short') [-Wimplicit-int-conversion]
   80 |     return (x << 8) | (x >> 8);
      |     ~~~~~~ ~~~~~~~~~^~~~~~~~~~
```
