### PR TITLE
fix(api_map): fix sign conversion warning

### DIFF
--- a/include/lvgl/api_map/lv_api_map_v8.h
+++ b/include/lvgl/api_map/lv_api_map_v8.h
@@ -95,7 +95,7 @@ static inline void lv_obj_move_foreground(lv_obj_t * obj)
         return;
     }
 
-    lv_obj_move_to_index(obj, lv_obj_get_child_count(parent) - 1);
+    lv_obj_move_to_index(obj, (int32_t)lv_obj_get_child_count(parent) - 1);
 }
 
 /**


### PR DESCRIPTION
Found on e2Studio:

```bash
warning: implicit conversion changes signedness: 'uint32_t' (aka 'unsigned int') to 'int32_t' (aka 'int') [-Wsign-conversion]
   94 |     lv_obj_move_to_index(obj, lv_obj_get_child_count(parent) - 1);
      |     ~~~~~~~~~~~~~~~~~~~~      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
```
