### PR TITLE
ci(stale_bot): add stale bot with no auto stale

### DIFF
--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -1,0 +1,30 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v11
+        with:
+          repo-token: ${{ github.token }}
+          close-issue-message: |
+            As there was no activity here for a while we close this issue. But don't worry, the conversation is still here and you can get back to it at any time.
+
+            Feel free to comment if you have remarks or ideas on this topic.
+          close-pr-message: |
+            As there was no activity here for a while we close this issue. But don't worry, the conversation is still here and you can get back to it at any time.
+
+            Feel free to comment if you have remarks or ideas on this topic.
+          days-before-stale: -1 # don't add the stale symbol automatically
+          days-before-close: 14
+          stale-issue-label: "Waiting for author"
+          stale-pr-label: "Waiting for author"
+          close-issue-reason: 'completed'


### PR DESCRIPTION
This adds the stale bot in close mode only meaning that no issue nor PR is automatic marked as stale
This guarantees that every PR/issue is looked at by a human maintainer
