### PR TITLE
fix(thorvg): free RLE span buffers on the rleRender() error path

### DIFF
--- a/src/libs/thorvg/tvgSwRle.cpp
+++ b/src/libs/thorvg/tvgSwRle.cpp
@@ -970,7 +970,7 @@ SwRle* rleRender(SwRle* rle, const SwOutline* outline, const SwBBox& renderRegio
     return rw.rle;
 
 error:
-    lv_free(rw.rle);
+    rleFree(rw.rle);
     return nullptr;
 }
 


### PR DESCRIPTION
Fixes lvgl/lvgl#10412

Opening this as invited by @AndreCostaaa in the issue.

`rleRender()` frees only the `SwRle` structure on its error path, but `rw.rle->spans` may already have been allocated or grown by `lv_realloc()` at that point, so the span buffer leaks. This switches the error path to the existing `rleFree()`, which releases both the span buffer and the structure.

A few notes from verifying the change:

* All callers (`tvgSwShape.cpp`, `tvgSwImage.cpp`) overwrite their stored pointer with the `nullptr` return value, so freeing the spans introduces no dangling pointer or double free.
* When the structure was freshly allocated with `lv_zalloc()`, `spans` is null and `rleFree()` handles that.
* Built and ran the vector test suite locally (`tests/main.py --build-options OPTIONS_TEST_SYSHEAP --test-suite vector`); all tests pass. I did not add a unit test for the leak itself, since the error path only triggers on a pathologically complex path that cannot be reduced to a single scanline, which is impractical to construct reliably through the public API.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)