### PR TITLE
fix(mem): guard against integer overflow in lv_calloc

### DIFF
--- a/include/lvgl/stdlib/lv_mem.h
+++ b/include/lvgl/stdlib/lv_mem.h
@@ -70,7 +70,7 @@ void * lv_malloc(size_t size);
  * Allocate a block of zeroed memory dynamically
  * @param num requested number of element to be allocated.
  * @param size requested size of each element in bytes.
- * @return pointer to allocated zeroed memory, or NULL on failure
+ * @return pointer to allocated zeroed memory, or NULL on failure or overflow
  */
 void * lv_calloc(size_t num, size_t size);
 

--- a/src/stdlib/lv_mem.c
+++ b/src/stdlib/lv_mem.c
@@ -116,6 +116,10 @@ void * lv_malloc_zeroed(size_t size)
 void * lv_calloc(size_t num, size_t size)
 {
     LV_TRACE_MEM("allocating number of %zu each %zu bytes", num, size);
+    if (num != 0 && size > ((size_t)-1) / num) {
+        LV_LOG_WARN("lv_calloc: overflow detected (num=%zu, size=%zu)", num, size);
+        return NULL;
+    }
     return lv_malloc_zeroed(num * size);
 }
 

--- a/src/stdlib/lv_mem.c
+++ b/src/stdlib/lv_mem.c
@@ -116,7 +116,7 @@ void * lv_malloc_zeroed(size_t size)
 void * lv_calloc(size_t num, size_t size)
 {
     LV_TRACE_MEM("allocating number of %zu each %zu bytes", num, size);
-    if (num != 0 && size > ((size_t)-1) / num) {
+    if(num != 0 && size > ((size_t) -1) / num) {
         LV_LOG_WARN("lv_calloc: overflow detected (num=%zu, size=%zu)", num, size);
         return NULL;
     }

--- a/tests/src/test_cases/test_mem.c
+++ b/tests/src/test_cases/test_mem.c
@@ -45,7 +45,7 @@ void test_calloc(void)
 
 void test_calloc_overflow(void)
 {
-    const size_t max_half = ((size_t)-1) / 2 + 1;
+    const size_t max_half = ((size_t) -1) / 2 + 1;
     TEST_ASSERT_NULL(lv_calloc(max_half, 2));
     TEST_ASSERT_NULL(lv_calloc(2, max_half));
 }

--- a/tests/src/test_cases/test_mem.c
+++ b/tests/src/test_cases/test_mem.c
@@ -43,6 +43,13 @@ void test_calloc(void)
     TEST_ASSERT_MEM_LEAK_LESS_THAN(mem, 0);
 }
 
+void test_calloc_overflow(void)
+{
+    const size_t max_half = ((size_t)-1) / 2 + 1;
+    TEST_ASSERT_NULL(lv_calloc(max_half, 2));
+    TEST_ASSERT_NULL(lv_calloc(2, max_half));
+}
+
 void test_zalloc(void)
 {
     uint32_t mem = lv_test_get_free_mem();


### PR DESCRIPTION
While going through src/stdlib/lv_mem.c I noticed that lv_calloc does lv_malloc_zeroed(num * size) without an overflow check. If num * size wraps around, you get a buffer smaller than expected – a classic heap overflow. Added a lightweight, portable bounds check using (size_t)-1, a warning log, and a regression test. Minimal, safe, and follows the coding style.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

