### PR TITLE
fix(demo/benchmark): reuse the first active screen across every scene

### DIFF
--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -56,7 +56,7 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static void load_scene(uint32_t scene);
+static void load_scene(lv_obj_t * scr, uint32_t scene);
 static void next_scene_timer_cb(lv_timer_t * timer);
 
 #if LV_USE_PERF_MONITOR
@@ -78,30 +78,30 @@ static void scroll_anim_y_cb(void * var, int32_t v);
 static void color_anim_cb(void * var, int32_t v);
 static void color_anim(lv_obj_t * obj);
 static void arc_anim(lv_obj_t * obj);
-static void add_warnings(void);
+static void add_warnings(lv_obj_t * scr);
 
-static lv_obj_t * card_create(void);
+static lv_obj_t * card_create(lv_obj_t * scr);
 
-static void empty_screen_cb(void)
+static void empty_screen_cb(lv_obj_t * screen)
 {
-    color_anim(lv_screen_active());
+    color_anim(screen);
 }
 
-static void moving_wallpaper_cb(void)
+static void moving_wallpaper_cb(lv_obj_t * scr)
 {
-    lv_obj_set_style_pad_all(lv_screen_active(), 0, 0);
+    lv_obj_set_style_pad_all(scr, 0, 0);
     LV_IMAGE_DECLARE(img_benchmark_lvgl_logo_rgb);
 
-    lv_obj_t * img = lv_image_create(lv_screen_active());
+    lv_obj_t * img = lv_image_create(scr);
     lv_obj_set_size(img, lv_pct(150), lv_pct(150));
     lv_image_set_src(img, &img_benchmark_lvgl_logo_rgb);
     lv_image_set_inner_align(img, LV_IMAGE_ALIGN_TILE);
     fall_anim(img, - lv_display_get_vertical_resolution(NULL) / 3);
 }
 
-static void single_rectangle_cb(void)
+static void single_rectangle_cb(lv_obj_t * scr)
 {
-    lv_obj_t * obj = lv_obj_create(lv_screen_active());
+    lv_obj_t * obj = lv_obj_create(scr);
     lv_obj_remove_style_all(obj);
     lv_obj_set_style_bg_opa(obj, LV_OPA_COVER, 0);
     lv_obj_center(obj);
@@ -111,14 +111,14 @@ static void single_rectangle_cb(void)
 
 }
 
-static void multiple_rectangles_cb(void)
+static void multiple_rectangles_cb(lv_obj_t * scr)
 {
-    lv_obj_set_flex_flow(lv_screen_active(), LV_FLEX_FLOW_ROW_WRAP);
-    lv_obj_set_flex_align(lv_screen_active(), LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_EVENLY);
+    lv_obj_set_flex_flow(scr, LV_FLEX_FLOW_ROW_WRAP);
+    lv_obj_set_flex_align(scr, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_EVENLY);
 
     uint32_t i;
     for(i = 0; i < 9; i++) {
-        lv_obj_t * obj = lv_obj_create(lv_screen_active());
+        lv_obj_t * obj = lv_obj_create(scr);
         lv_obj_remove_style_all(obj);
         lv_obj_set_style_bg_opa(obj, LV_OPA_COVER, 0);
         lv_obj_set_size(obj, lv_pct(25), lv_pct(25));
@@ -127,9 +127,8 @@ static void multiple_rectangles_cb(void)
     }
 }
 
-static void multiple_rgb_images_cb(void)
+static void multiple_rgb_images_cb(lv_obj_t * scr)
 {
-    lv_obj_t * scr = lv_screen_active();
     lv_obj_set_flex_flow(scr, LV_FLEX_FLOW_ROW_WRAP);
     lv_obj_set_flex_align(scr, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_SPACE_EVENLY);
     lv_obj_set_style_pad_bottom(scr, FALL_HEIGHT + PAD_BASIC, 0);
@@ -145,7 +144,7 @@ static void multiple_rgb_images_cb(void)
     for(y = 0; y < ver_cnt; y++) {
         int32_t x;
         for(x = 0; x < hor_cnt; x++) {
-            lv_obj_t * obj = lv_image_create(lv_screen_active());
+            lv_obj_t * obj = lv_image_create(scr);
             lv_image_set_src(obj, &img_benchmark_lvgl_logo_rgb);
             if(x == 0) lv_obj_set_flex_in_new_track(obj, true);
 
@@ -154,9 +153,8 @@ static void multiple_rgb_images_cb(void)
     }
 }
 
-static void multiple_argb_images_cb(void)
+static void multiple_argb_images_cb(lv_obj_t * scr)
 {
-    lv_obj_t * scr = lv_screen_active();
     lv_obj_set_flex_flow(scr, LV_FLEX_FLOW_ROW_WRAP);
     lv_obj_set_flex_align(scr, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_SPACE_EVENLY);
     lv_obj_set_style_pad_bottom(scr, FALL_HEIGHT + PAD_BASIC, 0);
@@ -172,7 +170,7 @@ static void multiple_argb_images_cb(void)
     for(y = 0; y < ver_cnt; y++) {
         int32_t x;
         for(x = 0; x < hor_cnt; x++) {
-            lv_obj_t * obj = lv_image_create(lv_screen_active());
+            lv_obj_t * obj = lv_image_create(scr);
             lv_image_set_src(obj, &img_benchmark_lvgl_logo_argb);
             if(x == 0) lv_obj_set_flex_in_new_track(obj, true);
 
@@ -181,9 +179,8 @@ static void multiple_argb_images_cb(void)
     }
 }
 
-static void rotated_argb_image_cb(void)
+static void rotated_argb_image_cb(lv_obj_t * scr)
 {
-    lv_obj_t * scr = lv_screen_active();
     lv_obj_set_flex_flow(scr, LV_FLEX_FLOW_ROW_WRAP);
     lv_obj_set_flex_align(scr, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_SPACE_EVENLY);
     lv_obj_set_style_pad_bottom(scr, FALL_HEIGHT + PAD_BASIC, 0);
@@ -199,7 +196,7 @@ static void rotated_argb_image_cb(void)
     for(y = 0; y < ver_cnt; y++) {
         int32_t x;
         for(x = 0; x < hor_cnt; x++) {
-            lv_obj_t * obj = lv_image_create(lv_screen_active());
+            lv_obj_t * obj = lv_image_create(scr);
             lv_image_set_src(obj, &img_benchmark_lvgl_logo_argb);
             if(x == 0) lv_obj_set_flex_in_new_track(obj, true);
 
@@ -209,9 +206,8 @@ static void rotated_argb_image_cb(void)
     }
 }
 
-static void multiple_labels_cb(void)
+static void multiple_labels_cb(lv_obj_t * scr)
 {
-    lv_obj_t * scr = lv_screen_active();
     lv_obj_set_flex_flow(scr, LV_FLEX_FLOW_ROW_WRAP);
     lv_obj_set_flex_align(scr, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_SPACE_EVENLY);
 
@@ -241,7 +237,7 @@ static void multiple_labels_cb(void)
     for(y = 0; y < ver_cnt; y++) {
         int32_t x;
         for(x = 0; x < hor_cnt; x++) {
-            lv_obj_t * obj = lv_label_create(lv_screen_active());
+            lv_obj_t * obj = lv_label_create(scr);
             if(x == 0) lv_obj_set_flex_in_new_track(obj, true);
             lv_label_set_text_static(obj, "Hello LVGL!");
             color_anim(obj);
@@ -249,7 +245,7 @@ static void multiple_labels_cb(void)
     }
 }
 
-static void screen_sized_text_cb(void)
+static void screen_sized_text_cb(lv_obj_t * scr)
 {
     const char * txt =
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque fringilla, lorem dapibus fringilla feugiat, justo arcu volutpat magna, vitae ultricies metus tortor nec est. Fusce ut tellus arcu. Fusce eu rutrum metus, nec porta felis. Sed sed ligula laoreet, sodales lacus blandit, elementum justo. Sed posuere quam ut pellentesque ullamcorper. In quis consequat magna. Etiam quis turpis nec lorem dictum finibus. Donec mattis enim dolor, consequat lacinia nisi scelerisque id. Nulla euismod, purus sit amet accumsan tempus, lorem lectus euismod dolor, sit amet facilisis nisl quam elementum nisi. Curabitur et massa eget lorem lacinia scelerisque eget vitae felis. Nulla facilisi.\n\n"
@@ -260,7 +256,6 @@ static void screen_sized_text_cb(void)
         "Morbi erat libero, commodo sit amet turpis eget, efficitur pulvinar dolor. Pellentesque vehicula, velit eget auctor scelerisque, sem risus aliquam lectus, sit amet dapibus massa ex non magna. Donec magna leo, laoreet quis erat vitae, consequat aliquet tellus. Etiam vitae lectus erat. Mauris interdum feugiat aliquet. Nunc justo augue, mattis id finibus eu, sagittis id enim. Vivamus malesuada mauris sed nibh luctus, porta bibendum quam ornare. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Vivamus malesuada magna nec diam tempus, laoreet imperdiet magna faucibus. Aliquam erat volutpat.\n\n"
         "Aenean mattis lobortis quam in venenatis. Sed euismod convallis lectus vel euismod. Vestibulum consequat luctus neque. Quisque consequat bibendum neque eget mollis. Vivamus viverra vehicula eros vel dapibus. Nullam id lectus aliquam, sagittis mi efficitur, interdum mauris. Nunc at felis lobortis, lobortis erat a, euismod augue. In id purus malesuada, tempus magna at, porta mi. Sed tristique nunc eget placerat luctus. Pellentesque posuere non purus vitae malesuada. Curabitur hendrerit dolor metus, nec posuere orci placerat ac.\n\n";
 
-    lv_obj_t * scr = lv_screen_active();
     int32_t hor_res = lv_display_get_horizontal_resolution(NULL);
     int32_t ver_res = lv_display_get_vertical_resolution(NULL);
 
@@ -283,9 +278,8 @@ static void screen_sized_text_cb(void)
     scroll_anim(scr, lv_obj_get_scroll_bottom(scr));
 }
 
-static void multiple_arcs_cb(void)
+static void multiple_arcs_cb(lv_obj_t * scr)
 {
-    lv_obj_t * scr = lv_screen_active();
     lv_obj_set_flex_flow(scr, LV_FLEX_FLOW_ROW_WRAP);
     lv_obj_set_flex_align(scr, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_SPACE_EVENLY);
 
@@ -302,7 +296,7 @@ static void multiple_arcs_cb(void)
         int32_t x;
         for(x = 0; x < hor_cnt; x++) {
 
-            lv_obj_t * obj = lv_arc_create(lv_screen_active());
+            lv_obj_t * obj = lv_arc_create(scr);
             if(x == 0) lv_obj_set_flex_in_new_track(obj, true);
             lv_obj_set_size(obj, 100, 100);
             lv_obj_center(obj);
@@ -319,9 +313,8 @@ static void multiple_arcs_cb(void)
     }
 }
 
-static void containers_cb(void)
+static void containers_cb(lv_obj_t * scr)
 {
-    lv_obj_t * scr = lv_screen_active();
     lv_obj_set_flex_flow(scr, LV_FLEX_FLOW_ROW_WRAP);
     lv_obj_set_flex_align(scr, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_SPACE_EVENLY);
     lv_obj_set_style_pad_bottom(scr, FALL_HEIGHT + PAD_BASIC, 0);
@@ -336,16 +329,15 @@ static void containers_cb(void)
     for(y = 0; y < ver_cnt; y++) {
         int32_t x;
         for(x = 0; x < hor_cnt; x++) {
-            lv_obj_t * card = card_create();
+            lv_obj_t * card = card_create(scr);
             if(x == 0) lv_obj_set_flex_in_new_track(card, true);
             fall_anim(card, 30);
         }
     }
 }
 
-static void containers_with_overlay_cb(void)
+static void containers_with_overlay_cb(lv_obj_t * scr)
 {
-    lv_obj_t * scr = lv_screen_active();
     lv_obj_set_flex_flow(scr, LV_FLEX_FLOW_ROW_WRAP);
     lv_obj_set_flex_align(scr, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_SPACE_EVENLY);
     lv_obj_set_style_pad_bottom(scr, FALL_HEIGHT + PAD_BASIC, 0);
@@ -360,7 +352,7 @@ static void containers_with_overlay_cb(void)
     for(y = 0; y < ver_cnt; y++) {
         int32_t x;
         for(x = 0; x < hor_cnt; x++) {
-            lv_obj_t * card = card_create();
+            lv_obj_t * card = card_create(scr);
             if(x == 0) lv_obj_set_flex_in_new_track(card, true);
             fall_anim(card, 30);
         }
@@ -370,9 +362,8 @@ static void containers_with_overlay_cb(void)
     color_anim(lv_layer_top());
 }
 
-static void containers_with_opa_cb(void)
+static void containers_with_opa_cb(lv_obj_t * scr)
 {
-    lv_obj_t * scr = lv_screen_active();
     lv_obj_set_flex_flow(scr, LV_FLEX_FLOW_ROW_WRAP);
     lv_obj_set_flex_align(scr, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_SPACE_EVENLY);
     lv_obj_set_style_pad_bottom(scr, FALL_HEIGHT + PAD_BASIC, 0);
@@ -387,7 +378,7 @@ static void containers_with_opa_cb(void)
     for(y = 0; y < ver_cnt; y++) {
         int32_t x;
         for(x = 0; x < hor_cnt; x++) {
-            lv_obj_t * card = card_create();
+            lv_obj_t * card = card_create(scr);
             if(x == 0) lv_obj_set_flex_in_new_track(card, true);
             lv_obj_set_style_opa(card, LV_OPA_50, 0);
             fall_anim(card, 30);
@@ -395,9 +386,8 @@ static void containers_with_opa_cb(void)
     }
 }
 
-static void containers_with_opa_layer_cb(void)
+static void containers_with_opa_layer_cb(lv_obj_t * scr)
 {
-    lv_obj_t * scr = lv_screen_active();
     lv_obj_set_flex_flow(scr, LV_FLEX_FLOW_ROW_WRAP);
     lv_obj_set_flex_align(scr, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_SPACE_EVENLY);
     lv_obj_set_style_pad_bottom(scr, FALL_HEIGHT + PAD_BASIC, 0);
@@ -412,7 +402,7 @@ static void containers_with_opa_layer_cb(void)
     for(y = 0; y < ver_cnt; y++) {
         int32_t x;
         for(x = 0; x < hor_cnt; x++) {
-            lv_obj_t * card = card_create();
+            lv_obj_t * card = card_create(scr);
             lv_obj_set_style_opa_layered(card, LV_OPA_50, 0);
             if(x == 0) lv_obj_set_flex_in_new_track(card, true);
             fall_anim(card, 30);
@@ -420,9 +410,8 @@ static void containers_with_opa_layer_cb(void)
     }
 }
 
-static void containers_with_scrolling_cb(void)
+static void containers_with_scrolling_cb(lv_obj_t * scr)
 {
-    lv_obj_t * scr = lv_screen_active();
     lv_obj_set_flex_flow(scr, LV_FLEX_FLOW_ROW_WRAP);
     lv_obj_set_flex_align(scr, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
     lv_obj_set_style_pad_row(scr, 32, 0);
@@ -440,7 +429,7 @@ static void containers_with_scrolling_cb(void)
     for(y = 0; y < ver_cnt; y++) {
         int32_t x;
         for(x = 0; x < hor_cnt; x++) {
-            lv_obj_t * card = card_create();
+            lv_obj_t * card = card_create(scr);
             if(x == 0) lv_obj_set_flex_in_new_track(card, true);
         }
     }
@@ -449,9 +438,8 @@ static void containers_with_scrolling_cb(void)
     scroll_anim(scr, lv_obj_get_scroll_bottom(scr));
 }
 
-static void widgets_demo_cb(void)
+static void widgets_demo_cb(lv_obj_t * scr)
 {
-    lv_obj_t * scr = lv_screen_active();
     lv_obj_set_style_pad_hor(scr, 0, 0);
     lv_obj_set_style_pad_bottom(scr, 0, 0);
     lv_demo_widgets();
@@ -507,9 +495,9 @@ void lv_demo_benchmark(void)
     lv_obj_set_style_bg_opa(scr, LV_OPA_COVER, 0);
     lv_obj_set_style_text_color(scr, lv_color_black(), 0);
     lv_obj_set_style_bg_color(scr, lv_palette_lighten(LV_PALETTE_GREY, 4), 0);
-    lv_obj_set_style_pad_all(lv_screen_active(), 8, 0);
-    lv_obj_set_style_pad_top(lv_screen_active(), HEADER_HEIGHT, 0);
-    lv_obj_set_style_pad_gap(lv_screen_active(), 8, 0);
+    lv_obj_set_style_pad_all(scr, 8, 0);
+    lv_obj_set_style_pad_top(scr, HEADER_HEIGHT, 0);
+    lv_obj_set_style_pad_gap(scr, 8, 0);
 
     lv_obj_t * title = lv_label_create(lv_layer_top());
     lv_obj_set_style_bg_opa(title, LV_OPA_COVER, 0);
@@ -517,9 +505,10 @@ void lv_demo_benchmark(void)
     lv_obj_set_style_text_color(title, lv_color_black(), 0);
     lv_obj_set_width(title, lv_pct(100));
 
-    load_scene(scene_act);
+    load_scene(scr, scene_act);
 
-    lv_timer_create(next_scene_timer_cb, scenes[0].scene_time, NULL);
+    /* store the active screen so that we can re-use it for the next scenes*/
+    lv_timer_create(next_scene_timer_cb, scenes[0].scene_time, scr);
 
 #if LV_USE_PERF_MONITOR
     lv_display_t * disp = lv_display_get_default();
@@ -540,13 +529,14 @@ void lv_demo_benchmark_set_end_cb(lv_demo_benchmark_on_end_cb_t cb)
 void lv_demo_benchmark_summary_display(const lv_demo_benchmark_summary_t * summary)
 {
     LV_ASSERT_NULL(summary)
-    lv_obj_clean(lv_screen_active());
-    lv_obj_set_style_pad_hor(lv_screen_active(), 0, 0);
-    lv_obj_set_flex_flow(lv_screen_active(), LV_FLEX_COLUMN);
+    lv_obj_t * scr = summary->screen;
+    lv_obj_clean(scr);
+    lv_obj_set_style_pad_hor(scr, 0, 0);
+    lv_obj_set_flex_flow(scr, LV_FLEX_COLUMN);
 
-    add_warnings();
+    add_warnings(scr);
 
-    lv_obj_t * table = lv_table_create(lv_screen_active());
+    lv_obj_t * table = lv_table_create(scr);
     lv_obj_set_width(table, lv_pct(100));
     lv_obj_set_style_max_height(table, lv_pct(100), 0);
     lv_obj_set_send_draw_task_events(table, true);
@@ -632,9 +622,8 @@ void lv_demo_benchmark_summary_display(const lv_demo_benchmark_summary_t * summa
  *   STATIC FUNCTIONS
  **********************/
 
-static void load_scene(uint32_t scene)
+static void load_scene(lv_obj_t * scr, uint32_t scene)
 {
-    lv_obj_t * scr = lv_screen_active();
     lv_obj_clean(scr);
     lv_obj_set_style_bg_color(scr, lv_palette_lighten(LV_PALETTE_GREY, 4), 0);
     lv_obj_set_style_text_color(scr, lv_color_black(), 0);
@@ -643,7 +632,7 @@ static void load_scene(uint32_t scene)
     lv_obj_set_style_pad_gap(scr, PAD_BASIC, 0);
     lv_obj_set_style_pad_top(scr, HEADER_HEIGHT, 0);
     lv_obj_set_layout(scr, LV_LAYOUT_NONE);
-    lv_obj_set_flex_align(lv_screen_active(), LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+    lv_obj_set_flex_align(scr, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
 
     lv_anim_delete(scr, scroll_anim_y_cb);
     lv_anim_delete(scr, shake_anim_y_cb);
@@ -653,14 +642,15 @@ static void load_scene(uint32_t scene)
     lv_obj_set_style_bg_opa(lv_layer_top(), LV_OPA_TRANSP, 0);
 
     rnd_reset();
-    if(scenes[scene].create_cb) scenes[scene].create_cb();
+    if(scenes[scene].create_cb) scenes[scene].create_cb(scr);
 }
 
 static void next_scene_timer_cb(lv_timer_t * timer)
 {
     scene_act++;
+    lv_obj_t * scr = lv_timer_get_user_data(timer);
 
-    load_scene(scene_act);
+    load_scene(scr, scene_act);
     if(scenes[scene_act].scene_time == 0) {
         lv_demo_benchmark_summary_t summary;
 
@@ -860,9 +850,9 @@ static void fall_anim(lv_obj_t * obj, int32_t y_max)
     lv_anim_start(&a);
 }
 
-static lv_obj_t * card_create(void)
+static lv_obj_t * card_create(lv_obj_t * scr)
 {
-    lv_obj_t * panel = lv_obj_create(lv_screen_active());
+    lv_obj_t * panel = lv_obj_create(scr);
     lv_obj_set_size(panel, 270, 120);
     lv_obj_set_style_pad_all(panel, 8, 0);
 
@@ -1029,11 +1019,11 @@ static bool is_optimization_enabled(void)
     return t_optimized * 5 < t_unoptimized;
 }
 
-static lv_obj_t * add_warning_label(const char * text)
+static lv_obj_t * add_warning_label(lv_obj_t * scr, const char * text)
 {
     LV_LOG("%s\n", text);
 
-    lv_obj_t * label = lv_label_create(lv_screen_active());
+    lv_obj_t * label = lv_label_create(scr);
     lv_label_set_recolor(label, true);
     lv_label_set_text_fmt(label, "#ffc000 " LV_SYMBOL_WARNING "# %s", text);
     lv_obj_set_style_pad_left(label, 12, 0);
@@ -1042,21 +1032,21 @@ static lv_obj_t * add_warning_label(const char * text)
     return label;
 }
 
-static void add_warnings(void)
+static void add_warnings(lv_obj_t * scr)
 {
 #if LV_USE_ASSERT_OBJ
-    add_warning_label("LV_USE_ASSERT_OBJ is enabled making rendering slower");
+    add_warning_label(scr, "LV_USE_ASSERT_OBJ is enabled making rendering slower");
 #endif
 
 #if LV_USE_ASSERT_MEM_INTEGRITY
-    add_warning_label("LV_USE_ASSERT_MEM_INTEGRITY is enabled making rendering slower");
+    add_warning_label(scr, "LV_USE_ASSERT_MEM_INTEGRITY is enabled making rendering slower");
 #endif
 
     lv_color_format_t cf = lv_display_get_color_format(NULL);
     uint32_t screen_size_byte = LV_HOR_RES * LV_VER_RES * lv_color_format_get_size(cf);
     uint32_t draw_buf_size = lv_display_get_draw_buf_size(NULL);
     if(draw_buf_size < screen_size_byte / 10) {
-        add_warning_label("The draw buffer's size is smaller than 1/10 screen size making rendering slower");
+        add_warning_label(scr, "The draw buffer's size is smaller than 1/10 screen size making rendering slower");
     }
 
     uint32_t ideal_layer_size = screen_size_byte / 20;
@@ -1065,15 +1055,15 @@ static void add_warnings(void)
         lv_snprintf(buf, sizeof(buf),
                     "LV_DRAW_LAYER_SIMPLE_BUF_SIZE is small making opa_layered slow. Consider 1/20 screen size for it (> %"LV_PRIu32"kB)",
                     LV_ALIGN_UP(ideal_layer_size, 1024) / 1024);
-        add_warning_label(buf);
+        add_warning_label(scr, buf);
     }
 
     if(LV_USE_LOG && LV_LOG_LEVEL < LV_LOG_LEVEL_WARN) {
-        add_warning_label("Set LV_LOG_LEVEL at least to LV_LOG_LEVEL_WARN");
+        add_warning_label(scr, "Set LV_LOG_LEVEL at least to LV_LOG_LEVEL_WARN");
     }
 
     if(is_optimization_enabled() == false) {
-        add_warning_label("Compiler optimization is not enabled.");
+        add_warning_label(scr, "Compiler optimization is not enabled.");
     }
 
 }

--- a/demos/benchmark/lv_demo_benchmark.h
+++ b/demos/benchmark/lv_demo_benchmark.h
@@ -50,7 +50,7 @@ LV_FONT_DECLARE(lv_font_benchmark_montserrat_26_aligned)
 
 typedef struct {
     const char * name;
-    void (*create_cb)(void);
+    void (*create_cb)(lv_obj_t * screen);
     uint32_t scene_time;
     uint32_t cpu_avg_usage;
     uint32_t fps_avg;
@@ -67,6 +67,7 @@ typedef struct {
      * Must not be free'd
      */
     lv_demo_benchmark_scene_dsc_t * scenes;
+    lv_obj_t * screen;
 
     int32_t total_avg_fps;
     int32_t total_avg_cpu;


### PR DESCRIPTION
Caught this issue while using multiple diplays:

```c
    lv_display_set_default(disp1);
    lv_demo_benchmark();

    lv_display_set_default(disp2);
    lv_demo_widgets();
    while(1) {
        uint32_t ms = lv_timer_handler();
        if(ms == LV_NO_TIMER_READY) {
            ms = LV_DEF_REFR_PERIOD;
        }
        usleep(ms * 1000);
    }
```

After the benchmark demo is created, the new scenes continued to use `lv_screen_active()` but at that point the active screen was in disp2 and not disp1
