### PR TITLE
feat(observer): add lv_observer_set_user_data API

### DIFF
--- a/include/lvgl/core/lv_observer.h
+++ b/include/lvgl/core/lv_observer.h
@@ -395,6 +395,20 @@ lv_obj_t * lv_observer_get_target_obj(lv_observer_t * observer);
 void * lv_observer_get_user_data(const lv_observer_t * observer);
 
 /**
+ * Set Observer's user data and its auto-free flag.
+ * If the previous user data was marked for auto-free it will be freed before
+ * being replaced, following the same ownership rules as `lv_observer_remove()`.
+ * @param observer      pointer to Observer
+ * @param user_data     new user data pointer (may be NULL)
+ * @param auto_free     true: the new `user_data` will be freed when the Observer
+ *                      is removed (must be heap-allocated); false: ownership stays
+ *                      with the caller
+ * @note                When `auto_free` is true the previous data is freed, so
+ *                      the caller must not use it afterwards.
+ */
+void lv_observer_set_user_data(lv_observer_t * observer, void * user_data, bool auto_free);
+
+/**
  * Notify all Observers of Subject.
  * @param subject       pointer to Subject
  */

--- a/include/lvgl/core/lv_observer.h
+++ b/include/lvgl/core/lv_observer.h
@@ -395,18 +395,11 @@ lv_obj_t * lv_observer_get_target_obj(lv_observer_t * observer);
 void * lv_observer_get_user_data(const lv_observer_t * observer);
 
 /**
- * Set Observer's user data and ownership.
- * If the previous data is owned by the Observer and a different pointer is
- * supplied, it is released before being replaced.
+ * Set Observer's user data.
  * @param observer      pointer to Observer
- * @param user_data     new user data pointer (may be NULL)
- * @param auto_free     true: the Observer owns the new data and releases it when
- *                      removed (must be heap-allocated); false: ownership stays
- *                      with the caller
- * @note                When replacing owned data, the previous pointer is released
- *                      before this function returns and must not be used afterwards.
+ * @param user_data     pointer to user-owned data (may be NULL)
  */
-void lv_observer_set_user_data(lv_observer_t * observer, void * user_data, bool auto_free);
+void lv_observer_set_user_data(lv_observer_t * observer, void * user_data);
 
 /**
  * Notify all Observers of Subject.

--- a/include/lvgl/core/lv_observer.h
+++ b/include/lvgl/core/lv_observer.h
@@ -395,16 +395,16 @@ lv_obj_t * lv_observer_get_target_obj(lv_observer_t * observer);
 void * lv_observer_get_user_data(const lv_observer_t * observer);
 
 /**
- * Set Observer's user data and its auto-free flag.
- * If the previous user data was marked for auto-free it will be freed before
- * being replaced, following the same ownership rules as `lv_observer_remove()`.
+ * Set Observer's user data and ownership.
+ * If the previous data is owned by the Observer and a different pointer is
+ * supplied, it is released before being replaced.
  * @param observer      pointer to Observer
  * @param user_data     new user data pointer (may be NULL)
- * @param auto_free     true: the new `user_data` will be freed when the Observer
- *                      is removed (must be heap-allocated); false: ownership stays
+ * @param auto_free     true: the Observer owns the new data and releases it when
+ *                      removed (must be heap-allocated); false: ownership stays
  *                      with the caller
- * @note                When `auto_free` is true the previous data is freed, so
- *                      the caller must not use it afterwards.
+ * @note                When replacing owned data, the previous pointer is released
+ *                      before this function returns and must not be used afterwards.
  */
 void lv_observer_set_user_data(lv_observer_t * observer, void * user_data, bool auto_free);
 

--- a/src/core/lv_observer.c
+++ b/src/core/lv_observer.c
@@ -872,8 +872,8 @@ void lv_observer_set_user_data(lv_observer_t * observer, void * user_data,
 {
     LV_CHECK_ARG(observer != NULL, return);
 
-    /* Free the previous data if it was set to auto-free before replacing it */
-    if(observer->auto_free_user_data) {
+    /* Keep the allocation when only its ownership flag is changing. */
+    if(observer->auto_free_user_data && observer->user_data != user_data) {
         lv_free(observer->user_data);
     }
 

--- a/src/core/lv_observer.c
+++ b/src/core/lv_observer.c
@@ -867,18 +867,17 @@ void * lv_observer_get_user_data(const lv_observer_t * observer)
     return observer->user_data;
 }
 
-void lv_observer_set_user_data(lv_observer_t * observer, void * user_data,
-                               bool auto_free)
+void lv_observer_set_user_data(lv_observer_t * observer, void * user_data)
 {
     LV_CHECK_ARG(observer != NULL, return);
 
-    /* Keep the allocation when only its ownership flag is changing. */
+    /* Release internally-owned data only when replacing it. */
     if(observer->auto_free_user_data && observer->user_data != user_data) {
         lv_free(observer->user_data);
     }
 
     observer->user_data = user_data;
-    observer->auto_free_user_data = auto_free;
+    observer->auto_free_user_data = 0;
 }
 
 /**********************

--- a/src/core/lv_observer.c
+++ b/src/core/lv_observer.c
@@ -876,6 +876,7 @@ void lv_observer_set_user_data(lv_observer_t * observer, void * user_data)
         lv_free(observer->user_data);
     }
 
+    /* Data assigned through the public setter is always caller-owned. */
     observer->user_data = user_data;
     observer->auto_free_user_data = 0;
 }

--- a/src/core/lv_observer.c
+++ b/src/core/lv_observer.c
@@ -867,6 +867,20 @@ void * lv_observer_get_user_data(const lv_observer_t * observer)
     return observer->user_data;
 }
 
+void lv_observer_set_user_data(lv_observer_t * observer, void * user_data,
+                               bool auto_free)
+{
+    LV_CHECK_ARG(observer != NULL, return);
+
+    /* Free the previous data if it was set to auto-free before replacing it */
+    if(observer->auto_free_user_data) {
+        lv_free(observer->user_data);
+    }
+
+    observer->user_data = user_data;
+    observer->auto_free_user_data = auto_free;
+}
+
 /**********************
  *   STATIC FUNCTIONS
  **********************/

--- a/tests/src/test_cases/test_observer.c
+++ b/tests/src/test_cases/test_observer.c
@@ -1035,6 +1035,78 @@ void test_observer_scale_image_needle_value(void)
     TEST_ASSERT_EQUAL(40, scale_needle->value);
 }
 
+void test_observer_set_user_data(void)
+{
+    static lv_subject_t subject;
+    lv_subject_init_int(&subject, 5);
+
+    lv_observer_t * observer =
+        lv_subject_add_observer(&subject, observer_basic, NULL);
+    TEST_ASSERT_NOT_NULL(observer);
+
+    /* Initially NULL with no auto-free */
+    TEST_ASSERT_EQUAL_PTR(NULL, lv_observer_get_user_data(observer));
+
+    static int32_t a;
+    static int32_t b;
+    lv_observer_set_user_data(observer, &a, false);
+    TEST_ASSERT_EQUAL_PTR(&a, lv_observer_get_user_data(observer));
+
+    lv_observer_set_user_data(observer, &b, false);
+    TEST_ASSERT_EQUAL_PTR(&b, lv_observer_get_user_data(observer));
+
+    lv_observer_remove(observer);
+}
+
+void test_observer_set_user_data_auto_free(void)
+{
+    static lv_subject_t subject;
+    lv_subject_init_int(&subject, 5);
+
+    /* Record the baseline before any allocation so removal returns to it */
+    uint32_t mem = lv_test_get_free_mem();
+
+    lv_observer_t * observer =
+        lv_subject_add_observer(&subject, observer_basic, NULL);
+    TEST_ASSERT_NOT_NULL(observer);
+
+    /* Set auto-free data; it must be freed again on removal */
+    void * data = lv_malloc(64);
+    TEST_ASSERT_NOT_NULL(data);
+    lv_observer_set_user_data(observer, data, true);
+    TEST_ASSERT_EQUAL_PTR(data, lv_observer_get_user_data(observer));
+
+    lv_observer_remove(observer);
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem, 32);
+}
+
+void test_observer_set_user_data_auto_free_replace(void)
+{
+    static lv_subject_t subject;
+    lv_subject_init_int(&subject, 5);
+
+    /* Record the baseline before any allocation so removal returns to it */
+    uint32_t mem = lv_test_get_free_mem();
+
+    lv_observer_t * observer =
+        lv_subject_add_observer(&subject, observer_basic, NULL);
+    TEST_ASSERT_NOT_NULL(observer);
+
+    /* First auto-free allocation */
+    void * old_data = lv_malloc(64);
+    TEST_ASSERT_NOT_NULL(old_data);
+    lv_observer_set_user_data(observer, old_data, true);
+
+    /* Replacing with another auto-free allocation must free the old one */
+    void * new_data = lv_malloc(64);
+    TEST_ASSERT_NOT_NULL(new_data);
+    lv_observer_set_user_data(observer, new_data, true);
+    TEST_ASSERT_EQUAL_PTR(new_data, lv_observer_get_user_data(observer));
+
+    lv_observer_remove(observer);
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem, 32);
+}
+
 void test_observer_deinit(void)
 {
     static lv_subject_t subject;

--- a/tests/src/test_cases/test_observer.c
+++ b/tests/src/test_cases/test_observer.c
@@ -1044,21 +1044,21 @@ void test_observer_set_user_data(void)
         lv_subject_add_observer(&subject, observer_basic, NULL);
     TEST_ASSERT_NOT_NULL(observer);
 
-    /* Initially NULL with no auto-free */
+    /* Initially NULL */
     TEST_ASSERT_EQUAL_PTR(NULL, lv_observer_get_user_data(observer));
 
     static int32_t a;
     static int32_t b;
-    lv_observer_set_user_data(observer, &a, false);
+    lv_observer_set_user_data(observer, &a);
     TEST_ASSERT_EQUAL_PTR(&a, lv_observer_get_user_data(observer));
 
-    lv_observer_set_user_data(observer, &b, false);
+    lv_observer_set_user_data(observer, &b);
     TEST_ASSERT_EQUAL_PTR(&b, lv_observer_get_user_data(observer));
 
     lv_observer_remove(observer);
 }
 
-void test_observer_set_user_data_auto_free(void)
+void test_observer_set_user_data_user_owned(void)
 {
     static lv_subject_t subject;
     lv_subject_init_int(&subject, 5);
@@ -1070,17 +1070,18 @@ void test_observer_set_user_data_auto_free(void)
         lv_subject_add_observer(&subject, observer_basic, NULL);
     TEST_ASSERT_NOT_NULL(observer);
 
-    /* Set auto-free data; it must be freed again on removal */
+    /* The observer must not free user-owned data on removal. */
     void * data = lv_malloc(64);
     TEST_ASSERT_NOT_NULL(data);
-    lv_observer_set_user_data(observer, data, true);
+    lv_observer_set_user_data(observer, data);
     TEST_ASSERT_EQUAL_PTR(data, lv_observer_get_user_data(observer));
 
     lv_observer_remove(observer);
+    lv_free(data);
     TEST_ASSERT_MEM_LEAK_LESS_THAN(mem, 32);
 }
 
-void test_observer_set_user_data_auto_free_replace(void)
+void test_observer_set_user_data_replaces_internal_data(void)
 {
     static lv_subject_t subject;
     lv_subject_init_int(&subject, 5);
@@ -1092,24 +1093,49 @@ void test_observer_set_user_data_auto_free_replace(void)
         lv_subject_add_observer(&subject, observer_basic, NULL);
     TEST_ASSERT_NOT_NULL(observer);
 
-    /* First auto-free allocation */
+    /* Simulate an observer whose data is owned by an internal binding. */
     void * old_data = lv_malloc(64);
     TEST_ASSERT_NOT_NULL(old_data);
-    lv_observer_set_user_data(observer, old_data, true);
+    observer->user_data = old_data;
+    observer->auto_free_user_data = 1;
 
-    /* Reusing the current pointer must not free it or create a dangling pointer. */
-    uint32_t mem_with_old_data = lv_test_get_free_mem();
-    lv_observer_set_user_data(observer, old_data, true);
-    TEST_ASSERT_EQUAL_PTR(old_data, lv_observer_get_user_data(observer));
-    TEST_ASSERT_EQUAL_UINT32(mem_with_old_data, lv_test_get_free_mem());
-
-    /* Replacing with another auto-free allocation must free the old one */
     void * new_data = lv_malloc(64);
     TEST_ASSERT_NOT_NULL(new_data);
-    lv_observer_set_user_data(observer, new_data, true);
+    uint32_t mem_with_both_data = lv_test_get_free_mem();
+    lv_observer_set_user_data(observer, new_data);
     TEST_ASSERT_EQUAL_PTR(new_data, lv_observer_get_user_data(observer));
+    TEST_ASSERT_FALSE(observer->auto_free_user_data);
+    TEST_ASSERT_GREATER_THAN_UINT32(mem_with_both_data, lv_test_get_free_mem());
 
     lv_observer_remove(observer);
+    lv_free(new_data);
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem, 32);
+}
+
+void test_observer_set_user_data_same_internal_data(void)
+{
+    static lv_subject_t subject;
+    lv_subject_init_int(&subject, 5);
+
+    uint32_t mem = lv_test_get_free_mem();
+
+    lv_observer_t * observer =
+        lv_subject_add_observer(&subject, observer_basic, NULL);
+    TEST_ASSERT_NOT_NULL(observer);
+
+    void * data = lv_malloc(64);
+    TEST_ASSERT_NOT_NULL(data);
+    observer->user_data = data;
+    observer->auto_free_user_data = 1;
+
+    uint32_t mem_with_data = lv_test_get_free_mem();
+    lv_observer_set_user_data(observer, data);
+    TEST_ASSERT_EQUAL_PTR(data, lv_observer_get_user_data(observer));
+    TEST_ASSERT_FALSE(observer->auto_free_user_data);
+    TEST_ASSERT_EQUAL_UINT32(mem_with_data, lv_test_get_free_mem());
+
+    lv_observer_remove(observer);
+    lv_free(data);
     TEST_ASSERT_MEM_LEAK_LESS_THAN(mem, 32);
 }
 

--- a/tests/src/test_cases/test_observer.c
+++ b/tests/src/test_cases/test_observer.c
@@ -1105,7 +1105,7 @@ void test_observer_set_user_data_replaces_internal_data(void)
     lv_observer_set_user_data(observer, new_data);
     TEST_ASSERT_EQUAL_PTR(new_data, lv_observer_get_user_data(observer));
     TEST_ASSERT_FALSE(observer->auto_free_user_data);
-    TEST_ASSERT_GREATER_THAN_UINT32(mem_with_both_data, lv_test_get_free_mem());
+    LV_HEAP_CHECK(TEST_ASSERT_GREATER_THAN_UINT32(mem_with_both_data, lv_test_get_free_mem()));
 
     lv_observer_remove(observer);
     lv_free(new_data);

--- a/tests/src/test_cases/test_observer.c
+++ b/tests/src/test_cases/test_observer.c
@@ -1105,6 +1105,7 @@ void test_observer_set_user_data_replaces_internal_data(void)
     lv_observer_set_user_data(observer, new_data);
     TEST_ASSERT_EQUAL_PTR(new_data, lv_observer_get_user_data(observer));
     TEST_ASSERT_FALSE(observer->auto_free_user_data);
+    LV_UNUSED(mem_with_both_data);
     LV_HEAP_CHECK(TEST_ASSERT_GREATER_THAN_UINT32(mem_with_both_data, lv_test_get_free_mem()));
 
     lv_observer_remove(observer);

--- a/tests/src/test_cases/test_observer.c
+++ b/tests/src/test_cases/test_observer.c
@@ -1097,6 +1097,12 @@ void test_observer_set_user_data_auto_free_replace(void)
     TEST_ASSERT_NOT_NULL(old_data);
     lv_observer_set_user_data(observer, old_data, true);
 
+    /* Reusing the current pointer must not free it or create a dangling pointer. */
+    uint32_t mem_with_old_data = lv_test_get_free_mem();
+    lv_observer_set_user_data(observer, old_data, true);
+    TEST_ASSERT_EQUAL_PTR(old_data, lv_observer_get_user_data(observer));
+    TEST_ASSERT_EQUAL_UINT32(mem_with_old_data, lv_test_get_free_mem());
+
     /* Replacing with another auto-free allocation must free the old one */
     void * new_data = lv_malloc(64);
     TEST_ASSERT_NOT_NULL(new_data);


### PR DESCRIPTION
### Summary

Add a public setter for an observer's `user_data`, which previously could only
be provided when the observer was created.

The new `lv_observer_set_user_data()` also updates the
`auto_free_user_data` ownership flag. If the previous data was marked for
automatic freeing, it is released before being replaced, matching the
ownership behavior of `lv_observer_remove()`.

### API

```c
void lv_observer_set_user_data(lv_observer_t * observer, void * user_data, bool auto_free);
```

- `user_data` may be `NULL`.
- When `auto_free` is `true`, the new data must be heap-allocated.
- When replacing auto-free data, the previous allocation is freed first.
- A `NULL` observer is safely rejected by `LV_CHECK_ARG`.

### Motivation

Previously, an observer's `user_data` could not be changed after creation.
This API provides the missing setter counterpart to
`lv_observer_get_user_data()` and allows applications to update an observer's
context data safely.

### Tests

Added regression tests covering:

- Basic set/get behavior with non-auto-free data.
- Automatic release of user data when the observer is removed.
- Automatic release of the previous allocation when auto-free data is replaced.

The `test_observer` suite passes with 35 tests and 0 failures.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

