### PR TITLE
fix(draw): correct crossed neighbour axes in A8 transform anti-aliasing

### DIFF
--- a/src/draw/sw/lv_draw_sw_transform.c
+++ b/src/draw/sw/lv_draw_sw_transform.c
@@ -933,8 +933,8 @@ static void transform_a8(const uint8_t * src, int32_t src_w, int32_t src_h, int3
            ys_int + y_next >= 0 &&
            ys_int + y_next <= src_h - 1) {
 
-            lv_opa_t a_ver = src_tmp[x_next];
-            lv_opa_t a_hor = src_tmp[y_next * src_stride];
+            lv_opa_t a_hor = src_tmp[x_next];
+            lv_opa_t a_ver = src_tmp[y_next * src_stride];
 
             if(a_ver != abuf[x]) a_ver = ((a_ver * ys_fract) + (abuf[x] * (0x100 - ys_fract))) >> 8;
             if(a_hor != abuf[x]) a_hor = ((a_hor * xs_fract) + (abuf[x] * (0x100 - xs_fract))) >> 8;


### PR DESCRIPTION
The bug was observed as surprisingly jagged edges when rotating an A8 bitmap with AA enabled.

In transform_a8() the horizontal and vertical neighbour samples were assigned to swapped variables, so each was then weighted by the wrong sub-pixel fraction:

    a_ver = src_tmp[x_next];               /* horizontal neighbour */
    a_hor = src_tmp[y_next * src_stride];  /* vertical neighbour   */
    a_ver = (a_ver * ys_fract) + ...       /* horizontal x Y weight */
    a_hor = (a_hor * xs_fract) + ...       /* vertical   x X weight */

transform_al88() and transform_rgb565a8() are structurally identical and bind the neighbours the other way round, which is the correct pairing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

