### PR TITLE
refactor(array): make lv_array_copy more robust

### DIFF
--- a/src/misc/lv_array.c
+++ b/src/misc/lv_array.c
@@ -68,11 +68,23 @@ void lv_array_deinit(lv_array_t * array)
 
 void lv_array_copy(lv_array_t * target, const lv_array_t * source)
 {
+    LV_ASSERT_NULL(target);
+    LV_ASSERT_NULL(source);
+
+    if(target == source) return;
+
+    lv_array_deinit(target);
+    lv_array_init(target, source->capacity, source->element_size);
+
+    if(target->data == NULL && source->capacity > 0 && source->element_size > 0) {
+        lv_memzero(target, sizeof(lv_array_t));
+        return;
+    }
+
     if(lv_array_is_empty(source)) {
         return;
     }
-    lv_array_deinit(target);
-    lv_array_init(target, source->capacity, source->element_size);
+
     lv_memcpy(target->data, source->data, source->size * source->element_size);
     target->size = source->size;
 }

--- a/src/misc/lv_array.c
+++ b/src/misc/lv_array.c
@@ -74,11 +74,37 @@ void lv_array_copy(lv_array_t * target, const lv_array_t * source)
     if(target == source) return;
 
     lv_array_deinit(target);
-    lv_array_init(target, source->capacity, source->element_size);
 
-    if(target->data == NULL && source->capacity > 0 && source->element_size > 0) {
-        lv_memzero(target, sizeof(lv_array_t));
-        return;
+    /* Guard against multiplication overflow during allocation */
+    if(source->capacity > 0 && source->element_size > 0) {
+        if(source->capacity > UINT32_MAX / source->element_size) {
+            lv_memzero(target, sizeof(lv_array_t));
+            return;
+        }
+
+        void * data = lv_malloc(source->capacity * source->element_size);
+        if(data == NULL) {
+            lv_memzero(target, sizeof(lv_array_t));
+            return;
+        }
+
+        target->data = data;
+        target->capacity = source->capacity;
+        target->element_size = source->element_size;
+        target->inner_alloc = true;
+        target->size = 0;
+    }
+    else {
+        void * data = lv_malloc(0);
+        if(data == NULL) {
+            lv_memzero(target, sizeof(lv_array_t));
+            return;
+        }
+        target->data = data;
+        target->capacity = source->capacity;
+        target->element_size = source->element_size;
+        target->inner_alloc = true;
+        target->size = 0;
     }
 
     if(lv_array_is_empty(source)) {

--- a/src/misc/lv_array.h
+++ b/src/misc/lv_array.h
@@ -119,7 +119,9 @@ static inline bool lv_array_is_full(const lv_array_t * array)
 
 /**
  * Copy an array to another.
- * @note this will create a new array with the same capacity and size as the source array.
+ * @note target is always made an exact copy of source. Any existing content in target is
+ *       deinitialized. If source is empty, target will also be empty. If target's previous
+ *       contents need to be preserved when source is empty, check `lv_array_is_empty` first.
  * @param target pointer to an `lv_array_t` variable to copy to
  * @param source pointer to an `lv_array_t` variable to copy from
  */

--- a/tests/src/test_cases/test_array.c
+++ b/tests/src/test_cases/test_array.c
@@ -307,6 +307,8 @@ void test_array_assign(void)
 
 void test_array_copy_empty_to_uninitialized(void)
 {
+    uint32_t mem_before = lv_test_get_free_mem();
+
     lv_array_t target = {0};
     lv_array_t source;
     lv_array_init(&source, 2, sizeof(int32_t));
@@ -319,10 +321,13 @@ void test_array_copy_empty_to_uninitialized(void)
 
     lv_array_deinit(&target);
     lv_array_deinit(&source);
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem_before, 0);
 }
 
 void test_array_copy_empty_to_populated(void)
 {
+    uint32_t mem_before = lv_test_get_free_mem();
+
     lv_array_t target;
     lv_array_init(&target, 4, sizeof(int32_t));
     int32_t val = 42;
@@ -331,7 +336,6 @@ void test_array_copy_empty_to_populated(void)
     lv_array_t source;
     lv_array_init(&source, 2, sizeof(int32_t));
 
-    uint32_t mem_before = lv_test_get_free_mem();
     lv_array_copy(&target, &source);
 
     /* Verify old target memory was freed and new empty capacity was allocated */
@@ -346,6 +350,8 @@ void test_array_copy_empty_to_populated(void)
 
 void test_array_copy_zero_capacity(void)
 {
+    uint32_t mem_before = lv_test_get_free_mem();
+
     lv_array_t target = {0};
     lv_array_t source;
     lv_array_init(&source, 0, 0);
@@ -358,11 +364,14 @@ void test_array_copy_zero_capacity(void)
 
     lv_array_deinit(&target);
     lv_array_deinit(&source);
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem_before, 0);
 }
 
 void test_array_copy_allocation_failure(void)
 {
 #if LV_USE_STDLIB_MALLOC == LV_STDLIB_BUILTIN && !LV_USE_ASSERT_MALLOC
+    uint32_t mem_before = lv_test_get_free_mem();
+
     lv_array_t target;
     lv_array_init(&target, 2, sizeof(int32_t));
     int32_t val = 42;
@@ -371,8 +380,6 @@ void test_array_copy_allocation_failure(void)
     lv_array_t source;
     uint8_t dummy_buf[4];
     lv_array_init_from_buf(&source, dummy_buf, LV_MEM_SIZE + 1, 1);
-
-    uint32_t mem_before = lv_test_get_free_mem();
 
     /* Copying source with huge capacity should cause allocation failure in init */
     lv_array_copy(&target, &source);
@@ -389,12 +396,12 @@ void test_array_copy_allocation_failure(void)
 
 void test_array_copy_self(void)
 {
+    uint32_t mem_before = lv_test_get_free_mem();
+
     lv_array_t target;
     lv_array_init(&target, 4, sizeof(int32_t));
     int32_t val = 42;
     lv_array_push_back(&target, &val);
-
-    uint32_t mem_before = lv_test_get_free_mem();
 
     /* Copying to self should be a no-op */
     lv_array_copy(&target, &target);

--- a/tests/src/test_cases/test_array.c
+++ b/tests/src/test_cases/test_array.c
@@ -394,6 +394,31 @@ void test_array_copy_allocation_failure(void)
 #endif
 }
 
+void test_array_copy_overflow(void)
+{
+    uint32_t mem_before = lv_test_get_free_mem();
+
+    lv_array_t target;
+    lv_array_init(&target, 2, sizeof(int32_t));
+    int32_t val = 42;
+    lv_array_push_back(&target, &val);
+
+    lv_array_t source;
+    uint8_t dummy_buf[4];
+    /* Initialize source with capacity and element_size that overflows 32-bit multiplication */
+    lv_array_init_from_buf(&source, dummy_buf, UINT32_MAX / 2 + 2, 2);
+
+    /* Copying should overflow and be handled gracefully (zeroed out) */
+    lv_array_copy(&target, &source);
+
+    TEST_ASSERT_NULL(target.data);
+    TEST_ASSERT_EQUAL_UINT32(0, lv_array_size(&target));
+    TEST_ASSERT_EQUAL_UINT32(0, lv_array_capacity(&target));
+
+    lv_array_deinit(&target);
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem_before, 0);
+}
+
 void test_array_copy_self(void)
 {
     uint32_t mem_before = lv_test_get_free_mem();

--- a/tests/src/test_cases/test_array.c
+++ b/tests/src/test_cases/test_array.c
@@ -362,7 +362,7 @@ void test_array_copy_zero_capacity(void)
 
 void test_array_copy_allocation_failure(void)
 {
-#if LV_USE_STDLIB_MALLOC == LV_STDLIB_BUILTIN
+#if LV_USE_STDLIB_MALLOC == LV_STDLIB_BUILTIN && !LV_USE_ASSERT_MALLOC
     lv_array_t target;
     lv_array_init(&target, 2, sizeof(int32_t));
     int32_t val = 42;

--- a/tests/src/test_cases/test_array.c
+++ b/tests/src/test_cases/test_array.c
@@ -305,4 +305,107 @@ void test_array_assign(void)
     TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_array_assign(&array, 5, &v));
 }
 
+void test_array_copy_empty_to_uninitialized(void)
+{
+    lv_array_t target = {0};
+    lv_array_t source;
+    lv_array_init(&source, 2, sizeof(int32_t));
+
+    lv_array_copy(&target, &source);
+
+    TEST_ASSERT_EQUAL_UINT32(0, lv_array_size(&target));
+    TEST_ASSERT_EQUAL_UINT32(2, lv_array_capacity(&target));
+    TEST_ASSERT_NOT_NULL(target.data);
+
+    lv_array_deinit(&target);
+    lv_array_deinit(&source);
+}
+
+void test_array_copy_empty_to_populated(void)
+{
+    lv_array_t target;
+    lv_array_init(&target, 4, sizeof(int32_t));
+    int32_t val = 42;
+    lv_array_push_back(&target, &val);
+
+    lv_array_t source;
+    lv_array_init(&source, 2, sizeof(int32_t));
+
+    uint32_t mem_before = lv_test_get_free_mem();
+    lv_array_copy(&target, &source);
+
+    /* Verify old target memory was freed and new empty capacity was allocated */
+    TEST_ASSERT_EQUAL_UINT32(0, lv_array_size(&target));
+    TEST_ASSERT_EQUAL_UINT32(2, lv_array_capacity(&target));
+    TEST_ASSERT_NOT_NULL(target.data);
+
+    lv_array_deinit(&target);
+    lv_array_deinit(&source);
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem_before, 0);
+}
+
+void test_array_copy_zero_capacity(void)
+{
+    lv_array_t target = {0};
+    lv_array_t source;
+    lv_array_init(&source, 0, 0);
+
+    lv_array_copy(&target, &source);
+
+    TEST_ASSERT_EQUAL_UINT32(0, lv_array_size(&target));
+    TEST_ASSERT_EQUAL_UINT32(0, lv_array_capacity(&target));
+    TEST_ASSERT_NOT_NULL(target.data);
+
+    lv_array_deinit(&target);
+    lv_array_deinit(&source);
+}
+
+void test_array_copy_allocation_failure(void)
+{
+#if LV_USE_STDLIB_MALLOC == LV_STDLIB_BUILTIN
+    lv_array_t target;
+    lv_array_init(&target, 2, sizeof(int32_t));
+    int32_t val = 42;
+    lv_array_push_back(&target, &val);
+
+    lv_array_t source;
+    uint8_t dummy_buf[4];
+    lv_array_init_from_buf(&source, dummy_buf, LV_MEM_SIZE + 1, 1);
+
+    uint32_t mem_before = lv_test_get_free_mem();
+
+    /* Copying source with huge capacity should cause allocation failure in init */
+    lv_array_copy(&target, &source);
+
+    /* Verify target was zeroed/safe-to-deinit, and no memory was leaked */
+    TEST_ASSERT_NULL(target.data);
+    TEST_ASSERT_EQUAL_UINT32(0, lv_array_size(&target));
+    TEST_ASSERT_EQUAL_UINT32(0, lv_array_capacity(&target));
+
+    lv_array_deinit(&target);
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem_before, 0);
+#endif
+}
+
+void test_array_copy_self(void)
+{
+    lv_array_t target;
+    lv_array_init(&target, 4, sizeof(int32_t));
+    int32_t val = 42;
+    lv_array_push_back(&target, &val);
+
+    uint32_t mem_before = lv_test_get_free_mem();
+
+    /* Copying to self should be a no-op */
+    lv_array_copy(&target, &target);
+
+    TEST_ASSERT_EQUAL_UINT32(1, lv_array_size(&target));
+    TEST_ASSERT_EQUAL_UINT32(4, lv_array_capacity(&target));
+    int32_t * r = lv_array_at(&target, 0);
+    TEST_ASSERT_EQUAL_INT32(42, *r);
+
+    lv_array_deinit(&target);
+    TEST_ASSERT_MEM_LEAK_LESS_THAN(mem_before, 0);
+}
+
 #endif


### PR DESCRIPTION
While stepping through lv_array_copy, I saw that an empty source causes an early return – without deinitialising the target. That leaks memory if the target was already allocated and leaves it in a completely wrong state. 

The function also lacked our standard null-pointer assertions and a self‑assignment guard. I restructured the logic to always deinit‑then‑init the target, added the missing assertions, a safe self‑copy path, and graceful handling for allocation failures. The header now documents the behaviour change, and new tests lock down all the edge cases.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

