### PR TITLE
fix(lottie): use source animation duration

### DIFF
--- a/src/widgets/lottie/lv_lottie.c
+++ b/src/widgets/lottie/lv_lottie.c
@@ -136,7 +136,7 @@ void lv_lottie_set_src_data(lv_obj_t * obj, const void * src, size_t src_size)
     float duration;
     tvg_animation_get_total_frame(lottie->tvg_anim, &f_total);
     tvg_animation_get_duration(lottie->tvg_anim, &duration);
-    lv_anim_set_duration(lottie->anim, (uint32_t)(duration * 1000.0f + 0.5f));
+    lv_anim_set_duration(lottie->anim, (uint32_t)(duration * 1000.0f + 0.5f)); /*0.5f rounds to the nearest ms*/
     lottie->anim->act_time = 0;
     lottie->anim->end_value = (int32_t)f_total;
     lottie->anim->reverse_play_in_progress = false;
@@ -156,7 +156,7 @@ void lv_lottie_set_src_file(lv_obj_t * obj, const char * src)
     float duration;
     tvg_animation_get_total_frame(lottie->tvg_anim, &f_total);
     tvg_animation_get_duration(lottie->tvg_anim, &duration);
-    lv_anim_set_duration(lottie->anim, (uint32_t)(duration * 1000.0f + 0.5f));
+    lv_anim_set_duration(lottie->anim, (uint32_t)(duration * 1000.0f + 0.5f)); /*0.5f rounds to the nearest ms*/
     lottie->anim->act_time = 0;
     lottie->anim->end_value = (int32_t)f_total;
     lottie->anim->reverse_play_in_progress = false;

--- a/src/widgets/lottie/lv_lottie.c
+++ b/src/widgets/lottie/lv_lottie.c
@@ -133,8 +133,10 @@ void lv_lottie_set_src_data(lv_obj_t * obj, const void * src, size_t src_size)
     }
 
     float f_total;
+    float duration;
     tvg_animation_get_total_frame(lottie->tvg_anim, &f_total);
-    lv_anim_set_duration(lottie->anim, (int32_t)f_total * 1000 / 60); /*60 FPS*/
+    tvg_animation_get_duration(lottie->tvg_anim, &duration);
+    lv_anim_set_duration(lottie->anim, (uint32_t)(duration * 1000.0f + 0.5f));
     lottie->anim->act_time = 0;
     lottie->anim->end_value = (int32_t)f_total;
     lottie->anim->reverse_play_in_progress = false;
@@ -151,8 +153,10 @@ void lv_lottie_set_src_file(lv_obj_t * obj, const char * src)
     }
 
     float f_total;
+    float duration;
     tvg_animation_get_total_frame(lottie->tvg_anim, &f_total);
-    lv_anim_set_duration(lottie->anim, (int32_t)f_total * 1000 / 60); /*60 FPS*/
+    tvg_animation_get_duration(lottie->tvg_anim, &duration);
+    lv_anim_set_duration(lottie->anim, (uint32_t)(duration * 1000.0f + 0.5f));
     lottie->anim->act_time = 0;
     lottie->anim->end_value = (int32_t)f_total;
     lottie->anim->reverse_play_in_progress = false;

--- a/tests/src/test_cases/widgets/test_lottie.c
+++ b/tests/src/test_cases/widgets/test_lottie.c
@@ -5,6 +5,8 @@
 
 
 static uint32_t buf[LV_TEST_WIDTH_TO_STRIDE(100, 4) * 100 + LV_DRAW_BUF_ALIGN];
+static const char lottie_30_fps[] =
+    "{\"v\":\"5.7.4\",\"fr\":30,\"ip\":0,\"op\":60,\"w\":1,\"h\":1,\"layers\":[]}";
 extern const uint8_t test_lottie_approve[];
 extern const size_t test_lottie_approve_size;
 
@@ -73,6 +75,14 @@ void test_lottie_load_from_file(void)
     /*Should reset automatically*/
     lv_test_fast_forward(200);
     TEST_ASSERT_EQUAL_SCREENSHOT("widgets/lottie_2.png");
+}
+
+void test_lottie_uses_source_duration(void)
+{
+    lv_obj_t * lottie = lv_lottie_create(lv_screen_active());
+    lv_lottie_set_src_data(lottie, lottie_30_fps, sizeof(lottie_30_fps) - 1);
+
+    TEST_ASSERT_EQUAL_UINT32(2000, lv_lottie_get_anim(lottie)->duration);
 }
 
 void test_lottie_missing_settings(void)


### PR DESCRIPTION
The Lottie widget currently assumes a fixed 60 FPS when calculating animation duration. As a result, animations authored at other frame rates play too fast or too slowly.
Use `tvg_animation_get_duration()` to obtain the duration calculated from the source animation metadata.

Added a unit test using a 30 FPS, 60-frame Lottie animation and verified that its LVGL animation duration is set to 2000 ms.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

