### PR TITLE
perf(draw/sw): use byte-level memset for aligned I1 solid fills

### DIFF
--- a/src/draw/sw/blend/lv_draw_sw_blend_to_i1.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend_to_i1.c
@@ -231,19 +231,28 @@ void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_i1(lv_draw_sw_blend_fill_ds
     uint8_t src_color = lv_color_luminance(dsc->color) / (I1_LUM_THRESHOLD + 1);
     uint8_t * dest_buf = dsc->dest_buf;
 
-    int32_t bit_ofs = dsc->relative_area.x1 % 8;
+    const int32_t bit_ofs = dsc->relative_area.x1 % 8;
 
     /* Simple fill */
     if(mask == NULL && opa >= LV_OPA_MAX) {
         if(LV_RESULT_INVALID == LV_DRAW_SW_COLOR_BLEND_TO_I1(dsc)) {
+            const uint8_t fill_byte = src_color ? 0xFF : 0x00;
             for(int32_t y = 0; y < h; y++) {
-                for(int32_t x = 0; x < w; x++) {
-                    if(src_color) {
-                        set_bit(dest_buf, x + bit_ofs);
-                    }
-                    else {
-                        clear_bit(dest_buf, x + bit_ofs);
-                    }
+                int32_t x = 0;
+                while(x < w && ((x + bit_ofs) % 8) != 0) {
+                    if(src_color) set_bit(dest_buf, x + bit_ofs);
+                    else clear_bit(dest_buf, x + bit_ofs);
+                    x++;
+                }
+                const int32_t full_bytes = (w - x) / 8;
+                if(full_bytes > 0) {
+                    lv_memset(&dest_buf[(x + bit_ofs) / 8], fill_byte, full_bytes);
+                    x += full_bytes * 8;
+                }
+                while(x < w) {
+                    if(src_color) set_bit(dest_buf, x + bit_ofs);
+                    else clear_bit(dest_buf, x + bit_ofs);
+                    x++;
                 }
                 dest_buf = drawbuf_next_row(dest_buf, dest_stride);
             }


### PR DESCRIPTION
### Context

When using LVGL on a small microcontroller with a 1-bit-per-pixel (bpp) display, LVGL natively uses 8 bits per pixel (bpp) and performs a conversion to 1 bpp in the file `src/draw/sw/blend/lv_draw_sw_blend_to_i1.c`. The problem is that this function is very slow.  
This merge request (MR) improves this conversion and makes it 6 times faster.

### Description

`lv_draw_sw_blend_color_to_i1()`'s "simple fill" path (no mask, full opacity) was setting or clearing one bit at a time for the whole fill area. This replaces that with the classic bit-blit alignment trick:
1. handle the leading bits individually until the write position is byte-aligned,
2. `memset()` every fully-covered byte in one call,
3. handle the trailing (`< 8`) bits individually.

This turns an O(w) sequence of single-bit read-modify-write operations into O(w/8) byte writes for the bulk of any reasonably wide fill, useful for I1 (1bpp) displays, where solid fills (backgrounds, status bars, screen clears) are common.

Behavior is unchanged: only bits within the exact fill rectangle are touched, and any bits outside width `w` or partially covered at the row edges are left untouched, exactly as before.

### Notes
- No public API change, no new config option, no docs/example update needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

