### PR TITLE
fix(snapshot): bound the draw dispatch loop to avoid livelock without an OS

### DIFF
--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -32,7 +32,6 @@
  *  STATIC PROTOTYPES
  **********************/
 static bool is_independent(lv_layer_t * layer, lv_draw_task_t * t_check, uint8_t draw_unit_id);
-static void cleanup_task(lv_draw_task_t * t, lv_display_t * disp);
 static inline size_t get_draw_dsc_size(lv_draw_task_type_t type);
 static lv_draw_task_t * get_first_available_task(lv_layer_t * layer);
 
@@ -242,7 +241,7 @@ bool lv_draw_dispatch_layer(lv_display_t * disp, lv_layer_t * layer)
                 LV_LOG_ERROR("draw task failed, type: %d", (int)t->type);
             }
 
-            cleanup_task(t, disp);
+            lv_draw_cleanup_task(t, disp);
             remove_task = true;
             if(t_prev != NULL)
                 t_prev->next = t_next;
@@ -676,7 +675,7 @@ static inline size_t get_draw_dsc_size(lv_draw_task_type_t type)
  * @param t         pointer to a draw task
  * @param disp      pointer to a display on which the task was drawn
  */
-static void cleanup_task(lv_draw_task_t * t, lv_display_t * disp)
+void lv_draw_cleanup_task(lv_draw_task_t * t, lv_display_t * disp)
 {
     LV_PROFILER_DRAW_BEGIN;
     if(t->type == LV_DRAW_TASK_TYPE_LINE) {

--- a/src/draw/lv_draw_private.h
+++ b/src/draw/lv_draw_private.h
@@ -200,6 +200,18 @@ typedef struct {
  * GLOBAL PROTOTYPES
  **********************/
 
+/**
+ * Free a draw task and everything it owns: any descriptor-owned allocation
+ * (line points, locally-copied label text), and, for a `LV_DRAW_TASK_TYPE_LAYER`
+ * task, the sub-layer it targets (its draw buffer, layer-memory accounting and
+ * `LV_EVENT_CHILD_DELETED`/`layer_deinit` bookkeeping included).  Used both by
+ * the normal dispatch path and to unwind a redraw that is being abandoned.
+ * @param  t      draw task to free
+ * @param  disp   display the task belongs to, needed to release a sub-layer.
+ *                May be `NULL`, in which case sub-layer bookkeeping is skipped.
+ */
+void lv_draw_cleanup_task(lv_draw_task_t * t, lv_display_t * disp);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/draw/snapshot/lv_snapshot.c
+++ b/src/draw/snapshot/lv_snapshot.c
@@ -21,6 +21,14 @@
  *      DEFINES
  *********************/
 
+/*Consecutive `lv_draw_dispatch()` calls tolerated without the pending task
+ *count changing. A layer allocation that fails leaves its draw task queued
+ *("Try later" in `lv_draw_layer_alloc_buf()`), and without an OS the loop below
+ *would retry it forever: a fragmented heap turns a snapshot into a livelock
+ *that hangs the whole application. 512 is roughly 100 ms of failing retries on
+ *a low-end target, far above any legitimate stall.*/
+#define LV_SNAPSHOT_MAX_STALLED_DISPATCHES 512U
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -28,6 +36,8 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
+static uint32_t snapshot_pending_task_count(const lv_layer_t * layer);
+static void snapshot_discard_layer_tasks(lv_layer_t * layer, lv_display_t * disp);
 
 /**********************
  *  STATIC VARIABLES
@@ -173,9 +183,33 @@ lv_result_t lv_snapshot_take_to_draw_buf(lv_obj_t * obj, lv_color_format_t cf, l
 
     layer.all_tasks_added = true;
 
+    uint32_t stalled_dispatches = 0;
+    uint32_t last_task_count = snapshot_pending_task_count(&layer);
+
     while(layer.draw_task_head) {
+#if LV_USE_OS
+        /*Without an OS this busy-spins on `_draw_info.dispatch_req`, so the
+         *stall counter below would never be reached.*/
         lv_draw_dispatch_wait_for_request();
+#endif
         lv_draw_dispatch();
+
+        uint32_t task_count = snapshot_pending_task_count(&layer);
+        if(task_count != last_task_count) {
+            last_task_count = task_count;
+            stalled_dispatches = 0;
+        }
+        else if(++stalled_dispatches > LV_SNAPSHOT_MAX_STALLED_DISPATCHES) {
+            LV_LOG_WARN("Snapshot draw queue stalled, aborting");
+            snapshot_discard_layer_tasks(&layer, disp_new);
+            disp_new->layer_head = layer_old;
+            lv_refr_set_disp_refreshing(disp_old);
+
+            /*Balance the CHILD_CREATED sent for the top layer above; sub-layers
+             *were already balanced by lv_draw_cleanup_task().*/
+            lv_draw_unit_send_event(NULL, LV_EVENT_CHILD_DELETED, &layer);
+            return LV_RESULT_INVALID;
+        }
     }
 
     disp_new->layer_head = layer_old;
@@ -224,5 +258,69 @@ lv_result_t lv_snapshot_take_to_buf(lv_obj_t * obj, lv_color_format_t cf, lv_ima
 /**********************
  *   STATIC FUNCTIONS
  **********************/
+
+/**
+ * Count the draw tasks still pending for a snapshot, across every layer the
+ * redraw created.
+ *
+ * Counting only the top layer would miss all progress made inside a sub-layer:
+ * a task leaves the top layer's list only once it is `READY`, so rendering a
+ * sub-layer keeps the top count constant and would look like a stall.
+ * @param  layer   the snapshot's top layer, which is the head of the chain
+ * @return         number of pending draw tasks
+ */
+static uint32_t snapshot_pending_task_count(const lv_layer_t * layer)
+{
+    uint32_t count = 0;
+
+    while(layer) {
+        const lv_draw_task_t * task = layer->draw_task_head;
+        while(task) {
+            count++;
+            task = task->next;
+        }
+        layer = layer->next;
+    }
+
+    return count;
+}
+
+/**
+ * Release every draw task a stalled snapshot left queued, freeing the sub-layers
+ * they created along the way.
+ *
+ * `lv_draw_dispatch_layer()` only cleans up tasks that reached
+ * `LV_DRAW_TASK_STATE_READY`, and a sub-layer is freed only when its parent's
+ * LAYER task is cleaned up, so abandoning the redraw would otherwise leak both
+ * the queued tasks and every sub-layer allocated for them - on the one path that
+ * runs when memory is already short.  `lv_draw_cleanup_task()` frees a LAYER
+ * task's sub-layer but not the tasks still queued inside it, so those are
+ * released first by recursing into the sub-layer.
+ * @param  layer   layer whose queued tasks are released.  Its own draw buffer
+ *                 is left untouched: for the snapshot's top layer it belongs to
+ *                 the caller, and a sub-layer's buffer is freed by the parent
+ *                 LAYER task that owns it.
+ * @param  disp    display being refreshed, needed to release the sub-layers
+ */
+static void snapshot_discard_layer_tasks(lv_layer_t * layer, lv_display_t * disp)
+{
+    lv_draw_task_t * task = layer->draw_task_head;
+
+    while(task) {
+        lv_draw_task_t * task_next = task->next;
+
+        if(task->type == LV_DRAW_TASK_TYPE_LAYER) {
+            lv_draw_image_dsc_t * image_dsc = task->draw_dsc;
+            lv_layer_t * sub_layer = (lv_layer_t *)image_dsc->src;
+            if(sub_layer) snapshot_discard_layer_tasks(sub_layer, disp);
+        }
+
+        lv_draw_cleanup_task(task, disp);
+
+        task = task_next;
+    }
+
+    layer->draw_task_head = NULL;
+}
 
 #endif /*LV_USE_SNAPSHOT*/


### PR DESCRIPTION
<!-- No related issue filed upstream yet. If a maintainer prefers a tracking
     issue first, I'm happy to open one and reference it here as `Fixes #xxxx`. -->

`lv_snapshot_take_to_draw_buf()` can livelock and hang the whole application when a layer buffer allocation fails and there is no OS to free memory concurrently. This PR bounds the draw-dispatch loop, so an unrecoverable stall becomes a clean `LV_RESULT_INVALID` (already a valid return of this function) instead of an infinite loop.

## Problem Description

`lv_snapshot_take_to_draw_buf()` renders a widget into an off-screen buffer with an unbounded loop:

```c
while(layer.draw_task_head) {
    lv_draw_dispatch_wait_for_request();
    lv_draw_dispatch();
}
```

The loop assumes every dispatch makes progress and that the queue eventually drains. It does not when a layer buffer cannot be allocated. When `lv_draw_layer_alloc_buf()` fails it logs `"Allocating layer buffer failed. Try later"` and **leaves the draw task on the queue** so it can be retried once memory frees up. `lv_draw_dispatch()` therefore returns having done nothing, the task is still at the head, and the loop dispatches the exact same failing allocation again — forever.

With `LV_USE_OS == LV_OS_NONE` there is no second thread that could free memory in the meantime, so the retry can never succeed. The function never returns: the whole application hangs until the device is rebooted.

The trigger in our case is a receipt screen containing labels with `transform_angle` set. In LVGL 9 a rotated label forces an intermediate `ARGB8888` layer that cannot be rendered in bands, so it requires a full contiguous layer buffer. On a fragmented, nearly-exhausted heap that allocation fails and the snapshot livelocks.

## Hardware Context & Environment

Reproduced on a payment terminal where RAM is the binding constraint:

- **Device:** POS PAX S915 — <https://www.transire.com/meios-de-pagamento/pax-by-transire/s915>
- **CPU:** 32-bit ARM
- **Display:** 2.4", 320 x 240
- **Memory:** 16 MB Flash + 1 MB RAM
- **Config:** `LV_USE_OS = LV_OS_NONE` (no RTOS scheduler behind LVGL)

Instrumenting the failing path on the device measured **226,628 failed layer allocations in 46 seconds** while reprinting a receipt with rotated labels, with the screen and keypad fully unresponsive for the whole window.

## Root Cause & Justification

This is a structural issue in LVGL itself, not a misuse on the application side:

1. **The loop has no termination guarantee.** It relies on the queue always draining, but the documented, intended behaviour of `lv_draw_layer_alloc_buf()` on allocation failure is to keep the task queued for a later retry. Under memory pressure those two behaviours combine into an infinite loop. The caller passes a perfectly valid object and color format — there is no API contract it violated.

2. **`LV_OS_NONE` is a first-class, documented configuration.** The retry model only makes sense when another context can free memory concurrently. With no OS there is no such context, so the "try later" path can never make progress. Any single-threaded port on a tight heap hits this, not just ours.

3. **`LV_RESULT_INVALID` is already part of this function's contract.** It is returned for an unsupported color format and for a failing `lv_snapshot_reshape_draw_buf()`. `lv_snapshot_take()` already destroys the draw buffer and returns `NULL` on that result, and callers already handle `NULL`. Turning an unrecoverable stall into that same already-handled failure is the natural, non-breaking behaviour — an infinite hang is strictly worse than a clean error return.

## Proposed Solution

Changes `src/draw/snapshot/lv_snapshot.c` plus a small exposure of an existing internal helper in `src/draw/lv_draw.c` / `src/draw/lv_draw_private.h`. The happy path is behaviourally identical — the new logic only engages once the queue stops making progress.

1. **Bound the loop.**
   Abort after `LV_SNAPSHOT_MAX_STALLED_DISPATCHES` (512) consecutive dispatches that do not change the number of pending draw tasks, returning `LV_RESULT_INVALID`. 512 is ~100 ms of failing retries on the measured target — far above any legitimate transient stall, so a healthy render is never cut short.

2. **Measure progress across the whole layer chain.**
   `snapshot_pending_task_count()` sums the pending tasks of every layer created by the redraw, not only the top one. A task leaves the top layer's list only once it is `READY`, so work happening inside a sub-layer would keep the top count constant and look like a false stall.

3. **Free everything on the abort path by reusing the canonical teardown.**
   `lv_draw_dispatch_layer()` only frees tasks that reached `LV_DRAW_TASK_STATE_READY`, and only frees a sub-layer when its parent's `LAYER` task is cleaned up. Returning early would therefore leak both the queued tasks and every  sub-layer — precisely on the one path that runs when memory is already short. Rather than hand-rolling the teardown (which is easy to get wrong: a draw task is a *single* allocation whose `draw_dsc` points inside the task block, so freeing `draw_dsc` separately corrupts the heap; the layer-memory accounting, the `LV_EVENT_CHILD_DELETED` notification and `LINE` point buffers must all be handled), the static `cleanup_task()` in `lv_draw.c` is exposed as `lv_draw_cleanup_task()`. `snapshot_discard_layer_tasks()` walks the snapshot's layer tree and calls it on every queued task, recursing into a `LAYER` task's sub-layer before cleaning the parent (the parent's cleanup frees the sub-layer struct, but not the tasks still queued inside it). The top layer's `draw_buf` belongs to the caller and is left untouched; its `CHILD_CREATED` is balanced with an explicit `CHILD_DELETED` since it is not freed via a `LAYER` task.

4. **Guard `lv_draw_dispatch_wait_for_request()` with `#if LV_USE_OS`.**
   Without an OS that call busy-spins on `_draw_info.dispatch_req`, so the stall counter would never be reached in the very configuration this fix targets.

### Notes

- [ ] Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed — no public API or behaviour doc change (`LV_RESULT_INVALID` was already a documented return).
- [ ] Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant — not applicable.
- [ ] Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable — the failure requires a genuinely exhausted heap during layer allocation; happy to add a test if maintainers can point me to a preferred way to inject allocation failure for the snapshot path.
- [x] No new options added to `lv_conf_template.h` (the new `LV_SNAPSHOT_MAX_STALLED_DISPATCHES` is an internal `#define`, not a user-facing config), so no `lv_conf_internal_gen.py` / `Kconfig` regeneration is required.
- [x] Ran `scripts/code-format.py` (astyle) and followed the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- [ ] I'll open this as a **Draft** first and mark it *Ready* once CI is green.
- When changes are requested I'll re-request review to notify maintainers.
- Help us review this Pull Request! Anyone can approve or request changes.
