### PR TITLE
chore(ports_branch_updater): register the EK-RA8D1 LLVM and EK-RA8D2 ports

### DIFF
--- a/scripts/release_branch_updater_port_urls.txt
+++ b/scripts/release_branch_updater_port_urls.txt
@@ -16,6 +16,8 @@ https://github.com/lvgl/lv_port_renesas_rz-g2ul-evkit
 https://github.com/lvgl/lv_port_renesas_ek-ra6m3g
 https://github.com/lvgl/lv_port_renesas-ek-rz_a3m
 https://github.com/lvgl/lv_port_renesas_ek_ra8p1
+https://github.com/lvgl/lv_port_renesas_ek-ra8d1_llvm
+https://github.com/lvgl/lv_port_renesas_ek-ra8d2
 https://github.com/lvgl/lv_port_riverdi_stm32u5
 https://github.com/lvgl/lv_port_riverdi_101-stm32h7
 https://github.com/lvgl/lv_port_riverdi_70-stm32h7


### PR DESCRIPTION
`lv_port_renesas_ek-ra8d1_llvm` and `lv_port_renesas_ek-ra8d2` both exist under the lvgl organisation but are absent from `scripts/release_branch_updater_port_urls.txt`.

Two consequences:

- Neither port gets release branches created by the updater.
- Their `completeness_check` workflow has a step asserting the repo's own URL appears in this file, so CI fails on those repos regardless of the change being tested. `lv_port_renesas_ek-ra8d2`'s `master` has been red on this since May.

The EK-RA8D1 GCC port is already listed, so only these two are added.

### Note for maintainers

The existing entry on the line above is `lv_port_renesas_ek_ra8p1`, but the repository is actually `lv_port_renesas_ek-ra8p1` (hyphen, not underscore). It resolves only via GitHub's rename redirect. Because the CI step matches with `grep -Fxq` against the repo's real URL, the RA8P1 port will fail that same check. I left it alone to keep this change scoped, but it looks like a typo worth fixing.
