### PR TITLE
build(cmake): handle pkg-config targets without include directories

### DIFF
--- a/env_support/cmake/lvgl_link_libraries.cmake
+++ b/env_support/cmake/lvgl_link_libraries.cmake
@@ -103,7 +103,7 @@ function(lvgl_link_pkg_config)
 
   foreach(_target IN LISTS ARG_TARGETS)
     target_link_libraries(lvgl ${SCOPE} $<BUILD_INTERFACE:${_target}>)
-    get_target_property(_inc_dirs ${_target} INTERFACE_INCLUDE_DIRECTORIES)
+    get_property(_inc_dirs TARGET ${_target} PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
     foreach(_dir IN LISTS _inc_dirs)
       target_include_directories(
         lvgl ${SCOPE} $<BUILD_INTERFACE:${_dir}>


### PR DESCRIPTION
## Problem

CMake configuration fails when a dependency discovered through pkg-config does
not provide an `INTERFACE_INCLUDE_DIRECTORIES` property on its imported target.

This can occur when all of a dependency's headers are installed in compiler
system include directories. For example, Ubuntu installs WebP headers under
`/usr/include`, and `libwebp.pc` reports:

```text
Cflags: -I/usr/include
```

By default, pkg-config removes system include paths from its output because the
compiler already searches them. As a result, CMake creates PkgConfig::WebP
without an INTERFACE_INCLUDE_DIRECTORIES property.
When LVGL tests are configured with WebP enabled, such as with:
./tests/main.py --clean --build-options OPTIONS_TEST_SYSHEAP test
lvgl_link_pkg_config() reads the missing property with
get_target_property(). CMake then assigns the sentinel value
_inc_dirs-NOTFOUND to the result variable. The following loop treats that
sentinel as an actual include directory and adds it to the lvgl target.
CMake generation consequently fails with an error similar to:
Target "lvgl" contains relative path in its INTERFACE_INCLUDE_DIRECTORIES:

  "_inc_dirs-NOTFOUND"
The dependency itself is installed correctly, and no explicit include path is
required because its headers are already available through the compiler's
default system include path.

## Fix

Use get_property() to read INTERFACE_INCLUDE_DIRECTORIES.
Unlike get_target_property(), get_property() returns an empty value when the
property is not set. The existing foreach() therefore performs zero
iterations, while targets that provide include directories continue to be
handled unchanged.
This prevents a CMake NOTFOUND sentinel from being propagated as an include
directory without adding special cases or environment workarounds.

## Testing

Tested on Ubuntu with WebP discovered through pkg-config and without
PKG_CONFIG_ALLOW_SYSTEM_CFLAGS.
env -u PKG_CONFIG_ALLOW_SYSTEM_CFLAGS \
  ./tests/main.py --clean \
  --build-options OPTIONS_TEST_SYSHEAP test
CMake configured successfully, test_libwebp built and passed, and all 158
tests passed.
