### PR TITLE
DON'T SQUASH: deprecate using NULL for display args and add arg checks to sysmon and display

### DIFF
--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -89,6 +89,7 @@ static void empty_screen_cb(lv_obj_t * screen)
 
 static void moving_wallpaper_cb(lv_obj_t * scr)
 {
+    lv_display_t * display = lv_obj_get_display(scr);
     lv_obj_set_style_pad_all(scr, 0, 0);
     LV_IMAGE_DECLARE(img_benchmark_lvgl_logo_rgb);
 
@@ -96,7 +97,7 @@ static void moving_wallpaper_cb(lv_obj_t * scr)
     lv_obj_set_size(img, lv_pct(150), lv_pct(150));
     lv_image_set_src(img, &img_benchmark_lvgl_logo_rgb);
     lv_image_set_inner_align(img, LV_IMAGE_ALIGN_TILE);
-    fall_anim(img, - lv_display_get_vertical_resolution(NULL) / 3);
+    fall_anim(img, - lv_display_get_vertical_resolution(display) / 3);
 }
 
 static void single_rectangle_cb(lv_obj_t * scr)
@@ -211,8 +212,9 @@ static void multiple_labels_cb(lv_obj_t * scr)
     lv_obj_set_flex_flow(scr, LV_FLEX_FLOW_ROW_WRAP);
     lv_obj_set_flex_align(scr, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_SPACE_EVENLY);
 
-    int32_t hor_res = lv_display_get_horizontal_resolution(NULL);
-    int32_t ver_res = lv_display_get_vertical_resolution(NULL);
+    lv_display_t * display = lv_obj_get_display(scr);
+    int32_t hor_res = lv_display_get_horizontal_resolution(display);
+    int32_t ver_res = lv_display_get_vertical_resolution(display);
 
 #if LV_DEMO_BENCHMARK_ALIGNED_FONTS
     if(hor_res * ver_res > 800 * 480) lv_obj_set_style_text_font(scr, &lv_font_benchmark_montserrat_26_aligned, 0);
@@ -256,8 +258,9 @@ static void screen_sized_text_cb(lv_obj_t * scr)
         "Morbi erat libero, commodo sit amet turpis eget, efficitur pulvinar dolor. Pellentesque vehicula, velit eget auctor scelerisque, sem risus aliquam lectus, sit amet dapibus massa ex non magna. Donec magna leo, laoreet quis erat vitae, consequat aliquet tellus. Etiam vitae lectus erat. Mauris interdum feugiat aliquet. Nunc justo augue, mattis id finibus eu, sagittis id enim. Vivamus malesuada mauris sed nibh luctus, porta bibendum quam ornare. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Vivamus malesuada magna nec diam tempus, laoreet imperdiet magna faucibus. Aliquam erat volutpat.\n\n"
         "Aenean mattis lobortis quam in venenatis. Sed euismod convallis lectus vel euismod. Vestibulum consequat luctus neque. Quisque consequat bibendum neque eget mollis. Vivamus viverra vehicula eros vel dapibus. Nullam id lectus aliquam, sagittis mi efficitur, interdum mauris. Nunc at felis lobortis, lobortis erat a, euismod augue. In id purus malesuada, tempus magna at, porta mi. Sed tristique nunc eget placerat luctus. Pellentesque posuere non purus vitae malesuada. Curabitur hendrerit dolor metus, nec posuere orci placerat ac.\n\n";
 
-    int32_t hor_res = lv_display_get_horizontal_resolution(NULL);
-    int32_t ver_res = lv_display_get_vertical_resolution(NULL);
+    lv_display_t * display = lv_obj_get_display(scr);
+    int32_t hor_res = lv_display_get_horizontal_resolution(display);
+    int32_t ver_res = lv_display_get_vertical_resolution(display);
 
 #if LV_DEMO_BENCHMARK_ALIGNED_FONTS
     if(hor_res * ver_res > 800 * 480) lv_obj_set_style_text_font(scr, &lv_font_benchmark_montserrat_26_aligned, 0);
@@ -817,7 +820,9 @@ static void scroll_anim_y_cb(void * var, int32_t v)
 
 static void scroll_anim(lv_obj_t * obj, int32_t y_max)
 {
-    uint32_t t = lv_anim_speed(lv_display_get_dpi(NULL));
+    lv_display_t * display = lv_obj_get_display(obj);
+    const int32_t dpi = lv_display_get_dpi(display);
+    uint32_t t = lv_anim_speed(dpi);
 
     lv_anim_t a;
     lv_anim_init(&a);
@@ -1042,10 +1047,10 @@ static void add_warnings(lv_obj_t * scr)
 #if LV_USE_ASSERT_MEM_INTEGRITY
     add_warning_label(scr, "LV_USE_ASSERT_MEM_INTEGRITY is enabled making rendering slower");
 #endif
-
-    lv_color_format_t cf = lv_display_get_color_format(NULL);
+    lv_display_t * display = lv_obj_get_display(scr);
+    lv_color_format_t cf = lv_display_get_color_format(display);
     uint32_t screen_size_byte = LV_HOR_RES * LV_VER_RES * lv_color_format_get_size(cf);
-    uint32_t draw_buf_size = lv_display_get_draw_buf_size(NULL);
+    uint32_t draw_buf_size = lv_display_get_draw_buf_size(display);
     if(draw_buf_size < screen_size_byte / 10) {
         add_warning_label(scr, "The draw buffer's size is smaller than 1/10 screen size making rendering slower");
     }

--- a/demos/widgets/lv_demo_widgets.c
+++ b/demos/widgets/lv_demo_widgets.c
@@ -115,7 +115,7 @@ void lv_demo_widgets_start_slideshow(void)
     lv_obj_t * tab = lv_obj_get_child(cont, 0);
 
     int32_t v = lv_obj_get_scroll_bottom(tab);
-    uint32_t t = lv_anim_speed(lv_display_get_dpi(NULL));
+    uint32_t t = lv_anim_speed(lv_display_get_dpi(lv_display_get_default()));
     lv_anim_t a;
     lv_anim_init(&a);
     lv_anim_set_exec_cb(&a, scroll_anim_y_cb);
@@ -294,7 +294,8 @@ static void slideshow_anim_completed_cb(lv_anim_t * a_old)
     lv_obj_update_layout(tv);
 
     int32_t v = lv_obj_get_scroll_bottom(tab);
-    uint32_t t = lv_anim_speed(lv_display_get_dpi(NULL));
+    int32_t dpi = lv_display_get_dpi(lv_display_get_default());
+    uint32_t t = lv_anim_speed(dpi);
 
     lv_anim_t a;
     lv_anim_init(&a);

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -238,7 +238,7 @@ TAB_SIZE               = 4
 # "Side Effects:". You can put \n's in the value part of an alias to insert
 # newlines.
 
-ALIASES                =
+ALIASES  = "nullable=@b Optional: may be `NULL`."
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"

--- a/docs/src/changelog/migration-v10.mdx
+++ b/docs/src/changelog/migration-v10.mdx
@@ -403,6 +403,66 @@ if you need finer control.
 
 ---
 
+## Display
+
+Calling the following functions with `NULL` as the display parameter is deprecated and will be considered an error in future versions. You can use <ApiLink name="lv_display_get_default"/> to query the default display.
+
+- <ApiLink name="lv_display_set_resolution"/>
+- <ApiLink name="lv_display_set_physical_resolution"/>
+- <ApiLink name="lv_display_set_offset"/>
+- <ApiLink name="lv_display_set_dpi"/>
+- <ApiLink name="lv_display_get_horizontal_resolution"/>
+- <ApiLink name="lv_display_get_vertical_resolution"/>
+- <ApiLink name="lv_display_get_original_horizontal_resolution"/>
+- <ApiLink name="lv_display_get_original_vertical_resolution"/>
+- <ApiLink name="lv_display_get_physical_horizontal_resolution"/>
+- <ApiLink name="lv_display_get_physical_vertical_resolution"/>
+- <ApiLink name="lv_display_get_offset_x"/>
+- <ApiLink name="lv_display_get_offset_y"/>
+- <ApiLink name="lv_display_get_dpi"/>
+- <ApiLink name="lv_display_set_draw_buffers"/>
+- <ApiLink name="lv_display_set_3rd_draw_buffer"/>
+- <ApiLink name="lv_display_set_render_mode"/>
+- <ApiLink name="lv_display_get_flush_cb"/>
+- <ApiLink name="lv_display_set_flush_cb"/>
+- <ApiLink name="lv_display_set_flush_wait_cb"/>
+- <ApiLink name="lv_display_set_sync_cb"/>
+- <ApiLink name="lv_display_set_sync_wait_cb"/>
+- <ApiLink name="lv_display_set_color_format"/>
+- <ApiLink name="lv_display_get_color_format"/>
+- <ApiLink name="lv_display_get_tile_cnt"/>
+- <ApiLink name="lv_display_get_antialiasing"/>
+- <ApiLink name="lv_display_get_render_mode"/>
+- <ApiLink name="lv_display_get_screen_active"/>
+- <ApiLink name="lv_display_get_screen_loading"/>
+- <ApiLink name="lv_display_get_screen_prev"/>
+- <ApiLink name="lv_display_get_layer_top"/>
+- <ApiLink name="lv_display_get_layer_sys"/>
+- <ApiLink name="lv_display_get_layer_bottom"/>
+- <ApiLink name="lv_display_get_screen_by_name"/>
+- <ApiLink name="lv_display_set_rotation"/>
+- <ApiLink name="lv_display_get_rotation"/>
+- <ApiLink name="lv_display_get_matrix_rotation"/>
+- <ApiLink name="lv_display_set_theme"/>
+- <ApiLink name="lv_display_get_theme"/>
+- <ApiLink name="lv_display_trigger_activity"/>
+- <ApiLink name="lv_display_enable_invalidation"/>
+- <ApiLink name="lv_display_is_invalidation_enabled"/>
+- <ApiLink name="lv_display_get_refr_timer"/>
+- <ApiLink name="lv_display_delete_refr_timer"/>
+- <ApiLink name="lv_display_send_vsync_event"/>
+- <ApiLink name="lv_display_register_vsync_event"/>
+- <ApiLink name="lv_display_unregister_vsync_event"/>
+- <ApiLink name="lv_display_set_user_data"/>
+- <ApiLink name="lv_display_set_driver_data"/>
+- <ApiLink name="lv_display_get_user_data"/>
+- <ApiLink name="lv_display_get_driver_data"/>
+- <ApiLink name="lv_display_get_buf_active"/>
+- <ApiLink name="lv_display_get_draw_buf_size"/>
+- <ApiLink name="lv_display_get_invalidated_draw_buf_size"/>
+
+---
+
 ## Widgets
 
 ### lv_qrcode

--- a/docs/src/changelog/migration-v10.mdx
+++ b/docs/src/changelog/migration-v10.mdx
@@ -463,6 +463,21 @@ Calling the following functions with `NULL` as the display parameter is deprecat
 
 ---
 
+## Sysmon
+
+Calling the following functions with `NULL` as the display parameter is deprecated and will be considered an error in future versions. You can use <ApiLink name="lv_display_get_default"/> to query the default display.
+
+- <ApiLink name="lv_sysmon_create"/>
+- <ApiLink name="lv_sysmon_show_performance"/>
+- <ApiLink name="lv_sysmon_hide_performance"/>
+- <ApiLink name="lv_sysmon_performance_dump"/>
+- <ApiLink name="lv_sysmon_performance_resume"/>
+- <ApiLink name="lv_sysmon_performance_pause"/>
+- <ApiLink name="lv_sysmon_show_memory"/>
+- <ApiLink name="lv_sysmon_hide_memory"/>
+
+---
+
 ## Widgets
 
 ### lv_qrcode

--- a/docs/src/debugging/sysmon.mdx
+++ b/docs/src/debugging/sysmon.mdx
@@ -40,13 +40,14 @@ Enable in `lv_conf.h`:
 
 ```c
 /* Create generic monitor */
-lv_obj_t * sysmon = lv_sysmon_create(lv_display_get_default());
+lv_display_t* display = lv_display_get_default();
+lv_obj_t * sysmon = lv_sysmon_create(display);
 
 /* Create performance monitor */
-lv_sysmon_show_performance(NULL);  /* NULL = default display */
+lv_sysmon_show_performance(display);
 
 /* Create memory monitor */
-lv_sysmon_show_memory(NULL);
+lv_sysmon_show_memory(display);
 ```
 
 ### Performance Monitor

--- a/docs/src/integration/overview.mdx
+++ b/docs/src/integration/overview.mdx
@@ -182,7 +182,7 @@ In this case, the main `while(1)` could look like this:
 ```c
 while(1) {
     /* Normal operation (no sleep) if < 5 sec inactivity */
-    if(lv_display_get_inactive_time(NULL) < 5000) {
+    if(lv_display_get_inactive_time(lv_display_get_default()) < 5000) {
         lv_timer_handler();
     }
     /* Sleep after 5 sec inactivity */

--- a/docs/src/main-modules/display/inactivity.mdx
+++ b/docs/src/main-modules/display/inactivity.mdx
@@ -6,12 +6,9 @@ description: "A user's inactivity time is measured and stored with each lv_displ
 A user's inactivity time is measured and stored with each `lv_display_t` object.
 Every use of an [Input Device](/main-modules/indev) counts as activity. To get time elapsed since the last
 activity, use <ApiLink name="lv_display_get_inactive_time" display="lv_display_get_inactive_time(display1)" />. If `NULL` is
-passed, the lowest inactivity time among all displays will be returned (in this case
-NULL does *not* mean the [Default Display](/main-modules/display/setup)).
+passed, the lowest inactivity time among all displays will be returned. 
 
-You can manually trigger an activity using
-<ApiLink name="lv_display_trigger_activity" display="lv_display_trigger_activity(display1)" />.  If `display1` is `NULL`, the
-[Default Display](/main-modules/display/setup) will be used (**not all displays**).
+You can manually trigger an activity using <ApiLink name="lv_display_trigger_activity" display="lv_display_trigger_activity(display1)" />.  
 
 <Callout type="info" title="Further Reading">
 - [lv_port_disp_template.c](https://github.com/lvgl/lvgl/blob/master/examples/porting/lv_port_disp_template.c)

--- a/examples/styles/lv_example_style_gradient_radial.c
+++ b/examples/styles/lv_example_style_gradient_radial.c
@@ -22,8 +22,9 @@ void lv_example_style_gradient_radial(void)
         LV_COLOR_MAKE(0x00, 0x00, 0x00),
     };
 
-    int32_t width = lv_display_get_horizontal_resolution(NULL);
-    int32_t height = lv_display_get_vertical_resolution(NULL);
+    lv_display_t * display = lv_display_get_default();
+    int32_t width = lv_display_get_horizontal_resolution(display);
+    int32_t height = lv_display_get_vertical_resolution(display);
 
     static lv_style_t style;
     lv_style_init(&style);

--- a/examples/styles/lv_example_style_theme.c
+++ b/examples/styles/lv_example_style_theme.c
@@ -35,7 +35,7 @@ static void new_theme_init_and_set(void)
 
     /* Initialize the new theme with the current theme as its parent
      * The user is responsible for freeing the theme when it's no longer needed */
-    lv_theme_t * th_act = lv_display_get_theme(NULL);
+    lv_theme_t * th_act = lv_display_get_theme(display);
     lv_theme_t * th_new = lv_theme_create();
     lv_theme_copy(th_new, th_act);
     lv_theme_set_parent(th_new, th_act);

--- a/examples/styles/lv_example_style_transform_card.c
+++ b/examples/styles/lv_example_style_transform_card.c
@@ -101,7 +101,7 @@ void lv_example_style_transform_card(void)
     card_to_transform = card_create();
     lv_obj_center(card_to_transform);
 
-    int32_t disp_w = lv_display_get_horizontal_resolution(NULL);
+    int32_t disp_w = lv_display_get_horizontal_resolution(lv_display_get_default());
     lv_obj_t * arc = lv_arc_create(lv_screen_active());
     lv_obj_set_size(arc, disp_w - 20, disp_w - 20);
     lv_arc_set_range(arc, 0, 270);

--- a/examples/widgets/menu/lv_example_menu_custom_back_button.c
+++ b/examples/widgets/menu/lv_example_menu_custom_back_button.c
@@ -20,7 +20,8 @@ void lv_example_menu_custom_back_button(void)
 {
     /*Create a menu object*/
     lv_obj_t * menu = lv_menu_create(lv_screen_active());
-    lv_obj_set_size(menu, lv_display_get_horizontal_resolution(NULL), lv_display_get_vertical_resolution(NULL));
+    lv_display_t * display = lv_display_get_default();
+    lv_obj_set_size(menu, lv_display_get_horizontal_resolution(display), lv_display_get_vertical_resolution(display));
     lv_obj_center(menu);
 
     /*Modify the header*/

--- a/examples/widgets/menu/lv_example_menu_floating_button.c
+++ b/examples/widgets/menu/lv_example_menu_floating_button.c
@@ -50,7 +50,8 @@ void lv_example_menu_floating_button(void)
 {
     /*Create a menu object*/
     menu = lv_menu_create(lv_screen_active());
-    lv_obj_set_size(menu, lv_display_get_horizontal_resolution(NULL), lv_display_get_vertical_resolution(NULL));
+    lv_display_t * display = lv_display_get_default();
+    lv_obj_set_size(menu, lv_display_get_horizontal_resolution(display), lv_display_get_vertical_resolution(display));
     lv_obj_center(menu);
 
     lv_obj_t * cont;

--- a/examples/widgets/menu/lv_example_menu_navigation.c
+++ b/examples/widgets/menu/lv_example_menu_navigation.c
@@ -195,7 +195,8 @@ void lv_example_menu_navigation(void)
     styles_init();
 
     lv_obj_t * menu = menu_create(lv_screen_active());
-    lv_obj_set_size(menu, lv_display_get_horizontal_resolution(NULL), lv_display_get_vertical_resolution(NULL));
+    lv_display_t * display = lv_display_get_default();
+    lv_obj_set_size(menu, lv_display_get_horizontal_resolution(display), lv_display_get_vertical_resolution(display));
     lv_obj_center(menu);
 
     /*Create a sub page*/

--- a/examples/widgets/menu/lv_example_menu_root_back_button.c
+++ b/examples/widgets/menu/lv_example_menu_root_back_button.c
@@ -37,7 +37,8 @@ void lv_example_menu_root_back_button(void)
     lv_obj_t * menu = lv_menu_create(lv_screen_active());
     lv_menu_set_mode_root_back_button(menu, LV_MENU_ROOT_BACK_BUTTON_ENABLED);
     lv_obj_add_event_cb(menu, back_event_handler, LV_EVENT_CLICKED, menu);
-    lv_obj_set_size(menu, lv_display_get_horizontal_resolution(NULL), lv_display_get_vertical_resolution(NULL));
+    lv_display_t * display = lv_display_get_default();
+    lv_obj_set_size(menu, lv_display_get_horizontal_resolution(display), lv_display_get_vertical_resolution(display));
     lv_obj_center(menu);
 
     lv_obj_t * cont;

--- a/examples/widgets/menu/lv_example_menu_sidebar.c
+++ b/examples/widgets/menu/lv_example_menu_sidebar.c
@@ -49,7 +49,8 @@ void lv_example_menu_sidebar(void)
     }
     lv_menu_set_mode_root_back_button(menu, LV_MENU_ROOT_BACK_BUTTON_ENABLED);
     lv_obj_add_event_cb(menu, back_event_handler, LV_EVENT_CLICKED, menu);
-    lv_obj_set_size(menu, lv_display_get_horizontal_resolution(NULL), lv_display_get_vertical_resolution(NULL));
+    lv_display_t * display = lv_display_get_default();
+    lv_obj_set_size(menu, lv_display_get_horizontal_resolution(display), lv_display_get_vertical_resolution(display));
     lv_obj_center(menu);
 
     lv_obj_t * cont;

--- a/examples/widgets/menu/lv_example_menu_sub_page.c
+++ b/examples/widgets/menu/lv_example_menu_sub_page.c
@@ -21,7 +21,8 @@ void lv_example_menu_sub_page(void)
 {
     /*Create a menu object*/
     lv_obj_t * menu = lv_menu_create(lv_screen_active());
-    lv_obj_set_size(menu, lv_display_get_horizontal_resolution(NULL), lv_display_get_vertical_resolution(NULL));
+    lv_display_t * display = lv_display_get_default();
+    lv_obj_set_size(menu, lv_display_get_horizontal_resolution(display), lv_display_get_vertical_resolution(display));
     lv_obj_center(menu);
 
     lv_obj_t * cont;

--- a/examples/widgets/table/lv_example_table_file_browser.c
+++ b/examples/widgets/table/lv_example_table_file_browser.c
@@ -331,7 +331,7 @@ void lv_example_table_file_browser(void)
 
     /*Icon column fits a symbol; name column fills the rest of the browser area*/
     int32_t icon_col = 30;
-    int32_t name_col = lv_display_get_horizontal_resolution(NULL) - 100 - icon_col - 16;
+    int32_t name_col = lv_display_get_horizontal_resolution(lv_display_get_default()) - 100 - icon_col - 16;
     lv_table_set_column_count(browser_table, 2);
     lv_table_set_column_width(browser_table, 0, icon_col);
     lv_table_set_column_width(browser_table, 1, name_col);

--- a/include/lvgl/display/lv_display.h
+++ b/include/lvgl/display/lv_display.h
@@ -103,7 +103,7 @@ void lv_display_delete(lv_display_t * disp);
 
 /**
  * Set a default display. The new screens will be created on it by default.
- * @param disp      pointer to a display
+ * @param disp      pointer to a display @nullable
  */
 void lv_display_set_default(lv_display_t * disp);
 
@@ -115,7 +115,7 @@ lv_display_t * lv_display_get_default(void);
 
 /**
  * Get the next display.
- * @param disp      pointer to the current display. NULL to initialize.
+ * @param disp      pointer to the current display. @nullable. When NULL it returns the first display.
  * @return          the next display or NULL if no more. Gives the first display when the parameter is NULL.
  */
 lv_display_t * lv_display_get_next(lv_display_t * disp);
@@ -262,7 +262,7 @@ int32_t lv_display_get_dpi(const lv_display_t * disp);
  * `hor_res * ver_res * lv_color_format_get_size(lv_display_get_color_format(disp))`
  * @param disp              pointer to a display
  * @param buf1              first buffer
- * @param buf2              second buffer (can be `NULL`)
+ * @param buf2              second buffer @nullable
  * @param buf_size          buffer size in byte
  * @param render_mode       LV_DISPLAY_RENDER_MODE_PARTIAL/DIRECT/FULL
  */
@@ -290,14 +290,14 @@ void lv_display_set_buffers_with_stride(lv_display_t * disp, void * buf1, void *
  * Use this function when an existing lv_draw_buf_t is available.
  * @param disp              pointer to a display
  * @param buf1              first buffer
- * @param buf2              second buffer (can be `NULL`)
+ * @param buf2              second buffer @nullable
  */
 void lv_display_set_draw_buffers(lv_display_t * disp, lv_draw_buf_t * buf1, lv_draw_buf_t * buf2);
 
 /**
  * Set the third draw buffer for a display.
  * @param disp              pointer to a display
- * @param buf3              third buffer
+ * @param buf3              third buffer @nullable. Use NULL to stop using triple buffering
  */
 void lv_display_set_3rd_draw_buffer(lv_display_t * disp, lv_draw_buf_t * buf3);
 
@@ -597,7 +597,7 @@ uint32_t lv_display_remove_event_cb_with_user_data(lv_display_t * disp, lv_event
  * Send an event to a display
  * @param disp          pointer to a display
  * @param code          an event code. LV_EVENT_...
- * @param param         optional param
+ * @param param         optional param @nullable
  * @return              LV_RESULT_OK: disp wasn't deleted in the event.
  */
 lv_result_t lv_display_send_event(lv_display_t * disp, lv_event_code_t code, void * param);
@@ -610,9 +610,21 @@ lv_result_t lv_display_send_event(lv_display_t * disp, lv_event_code_t code, voi
 lv_area_t * lv_event_get_invalidated_area(lv_event_t * e);
 
 /**
- * Set the theme of a display. If there are no user created widgets yet the screens' theme will be updated
+ * Set the theme of a display.
+ *
+ * The theme is applied to each widget when it is created, so this affects the widgets
+ * created afterwards on this display. Widgets that already exist keep their current
+ * styles.
+ *
  * @param disp      pointer to a display
- * @param th        pointer to a theme
+ * @param th        pointer to a theme @nullable. With NULL no theme is applied, so
+ *                  widgets created later get no styles at all and it's up to the
+ *                  application to style them.
+ *
+ * @note If the display is still untouched (no user created screens
+ *       and all screens and layers are empty) the screen created together with the
+ *       display is themed as well. With NULL the layers are cleared of their styles
+ *       too, leaving the whole display unstyled.
  */
 void lv_display_set_theme(lv_display_t * disp, lv_theme_t * th);
 
@@ -625,7 +637,7 @@ lv_theme_t * lv_display_get_theme(lv_display_t * disp);
 
 /**
  * Get elapsed time since last user activity on a display (e.g. click)
- * @param disp      pointer to a display (NULL to get the overall smallest inactivity)
+ * @param disp      pointer to a display @nullable. Use NULL to get the overall smallest inactivity
  * @return          elapsed ticks (milliseconds) since the last activity
  */
 uint32_t lv_display_get_inactive_time(const lv_display_t * disp);
@@ -686,15 +698,48 @@ bool lv_display_unregister_vsync_event(lv_display_t * disp, lv_event_cb_t event_
 /**
  * Send an vsync event to a display
  * @param disp          pointer to a display
- * @param param         optional param
+ * @param param         optional param @nullable
  * @return              LV_RESULT_OK: disp wasn't deleted in the event.
  */
 lv_result_t lv_display_send_vsync_event(lv_display_t * disp, void * param);
 
+/**
+ * Store a custom pointer on the display. LVGL never uses this value, it's free
+ * for the application to use for any purpose.
+ * @param disp          pointer to a display
+ * @param user_data     @nullable custom pointer to store, can be `NULL` to clear it
+ */
 void lv_display_set_user_data(lv_display_t * disp, void * user_data);
+
+/**
+ * Store a pointer to display driver specific data on the display. Intended for
+ * the display driver implementation, the application should use
+ * `lv_display_set_user_data()` instead.
+ * @param disp          pointer to a display
+ * @param driver_data   @nullable custom pointer to store, can be `NULL` to clear it
+ */
 void lv_display_set_driver_data(lv_display_t * disp, void * driver_data);
+
+/**
+ * Get the custom pointer set by `lv_display_set_user_data()`.
+ * @param disp          pointer to a display
+ * @return              the stored user data
+ */
 void * lv_display_get_user_data(lv_display_t * disp);
+
+/**
+ * Get the driver specific pointer set by `lv_display_set_driver_data()`.
+ * @param disp          pointer to a display
+ * @return              the stored driver data
+ */
 void * lv_display_get_driver_data(lv_display_t * disp);
+
+/**
+ * Get the draw buffer LVGL is currently rendering into. With double buffering
+ * this alternates between the two buffers after each flush.
+ * @param disp          pointer to a display
+ * @return              pointer to the active draw buffer
+ */
 lv_draw_buf_t * lv_display_get_buf_active(lv_display_t * disp);
 
 /**
@@ -769,7 +814,7 @@ uint32_t lv_display_get_invalidated_draw_buf_size(lv_display_t * disp, uint32_t 
  * @sa https://stackoverflow.com/questions/2025282/what-is-the-difference-between-px-dip-dp-and-sp
  */
 #define LV_DPX_CALC(dpi, n)   ((n) == 0 ? 0 :LV_MAX((( (dpi) * (n) + 80) / 160), 1)) /*+80 for rounding*/
-#define LV_DPX(n)   LV_DPX_CALC(lv_display_get_dpi(NULL), n)
+#define LV_DPX(n)   LV_DPX_CALC(lv_display_get_dpi(lv_display_get_default()), n)
 
 /**
  * For default display, computes the number of pixels (a distance or size) as if the
@@ -803,9 +848,10 @@ int32_t lv_display_dpx(const lv_display_t * disp, int32_t n);
  * the associated resources.
  *
  * @param disp       Pointer to a display
- * @param data       User-defined data pointer to associate with the display
+ * @param data       User-defined data pointer to associate with the display @nullable
  * @param free_cb    Callback function for cleaning up data when display is deleted.
- *                   Receives data as parameter. NULL means no cleanup required.
+ *                   Receives data as parameter. @nullable.
+ *                   Use NULL to dettach a previously attached callback
  */
 void lv_display_set_external_data(lv_display_t * disp, void * data, void (* free_cb)(void * data));
 #endif

--- a/include/lvgl/display/lv_display.h
+++ b/include/lvgl/display/lv_display.h
@@ -509,7 +509,7 @@ lv_obj_t * lv_display_get_screen_by_name(const lv_display_t * disp, const char *
  * Load a screen on the default display
  * @param scr       pointer to a screen
  */
-void lv_screen_load(struct _lv_obj_t * scr);
+void lv_screen_load(lv_obj_t * scr);
 
 /**
  * Switch screen with animation

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -1166,7 +1166,7 @@ lv_obj_t * lv_obj_find_by_id(const lv_obj_t * obj, const void * id)
 {
     LV_CHECK_ARG(id != NULL, return NULL);
     LV_LOG_DEPRECATED("IDs are used only to print the widget trees. To find a widget use obj_name");
-    if(obj == NULL) obj = lv_display_get_screen_active(NULL);
+    if(obj == NULL) obj = lv_display_get_screen_active(lv_display_get_default());
     if(obj == NULL) return NULL;
     return obj_find_by_id(obj, id);
 }

--- a/src/core/lv_obj_class.c
+++ b/src/core/lv_obj_class.c
@@ -83,8 +83,8 @@ lv_obj_t * lv_obj_class_create_obj(const lv_obj_class_t * class_p, lv_obj_t * pa
         /*Set coordinates to full screen size*/
         obj->coords.x1 = 0;
         obj->coords.y1 = 0;
-        obj->coords.x2 = lv_display_get_horizontal_resolution(NULL) - 1;
-        obj->coords.y2 = lv_display_get_vertical_resolution(NULL) - 1;
+        obj->coords.x2 = lv_display_get_horizontal_resolution(disp) - 1;
+        obj->coords.y2 = lv_display_get_vertical_resolution(disp) - 1;
     }
     /*Create a normal object*/
     else {

--- a/src/core/lv_obj_tree.c
+++ b/src/core/lv_obj_tree.c
@@ -553,7 +553,7 @@ lv_obj_t * lv_obj_find_by_name(const lv_obj_t * parent, const char * name)
 {
     LV_CHECK_ARG(name != NULL, return NULL);
 
-    if(parent == NULL) parent = lv_display_get_screen_active(NULL);
+    if(parent == NULL) parent = lv_display_get_screen_active(lv_display_get_default());
     if(parent == NULL) return NULL;
 
     lv_obj_t * child = find_by_name_direct(parent, name, UINT16_MAX);

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -268,7 +268,10 @@ void lv_obj_redraw(lv_layer_t * layer, lv_obj_t * obj)
 
 lv_result_t lv_inv_area(lv_display_t * disp, const lv_area_t * area_p)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) return LV_RESULT_INVALID;
     if(!lv_display_is_invalidation_enabled(disp)) return LV_RESULT_INVALID;
 

--- a/src/debugging/sysmon/lv_sysmon.c
+++ b/src/debugging/sysmon/lv_sysmon.c
@@ -74,7 +74,6 @@ extern uint32_t LV_SYSMON_GET_IDLE(void);
 
 void lv_sysmon_builtin_init(void)
 {
-
 #if LV_USE_MEM_MONITOR
     static lv_mem_monitor_t mem_info;
     lv_subject_init_pointer(&sysmon_mem.subject, &mem_info);
@@ -96,10 +95,7 @@ lv_obj_t * lv_sysmon_create(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) {
-        LV_LOG_WARN("There is no default display");
-        return NULL;
-    }
+    LV_CHECK_ARG(disp != NULL, return NULL);
 
     lv_obj_t * label = lv_label_create(lv_display_get_layer_sys(disp));
     lv_obj_set_style_bg_opa(label, LV_OPA_50, 0);
@@ -118,10 +114,7 @@ void lv_sysmon_show_performance(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) {
-        LV_LOG_WARN("There is no default display");
-        return;
-    }
+    LV_CHECK_ARG(disp != NULL, return);
 
     if(disp->perf_label == NULL) {
         disp->perf_label = lv_sysmon_create(disp);
@@ -146,10 +139,7 @@ void lv_sysmon_hide_performance(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) {
-        LV_LOG_WARN("There is no default display");
-        return;
-    }
+    LV_CHECK_ARG(disp != NULL, return);
 
     lv_obj_set_hidden(disp->perf_label, true);
 }
@@ -160,20 +150,27 @@ void lv_sysmon_performance_dump(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) {
-        LV_LOG_WARN("There is no default display");
-        return;
-    }
+    LV_CHECK_ARG(disp != NULL, return);
     perf_dump_info(disp);
 }
 
 void lv_sysmon_performance_resume(lv_display_t * disp)
 {
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
+    LV_CHECK_ARG(disp != NULL, return);
     perf_control(disp, true);
 }
 
 void lv_sysmon_performance_pause(lv_display_t * disp)
 {
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
+    LV_CHECK_ARG(disp != NULL, return);
     perf_control(disp, false);
 }
 
@@ -187,11 +184,7 @@ void lv_sysmon_show_memory(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) {
-        LV_LOG_WARN("There is no default display");
-        return;
-    }
-
+    LV_CHECK_ARG(disp != NULL, return);
     if(disp->mem_label == NULL) {
         disp->mem_label = lv_sysmon_create(disp);
         if(disp->mem_label == NULL) {
@@ -212,10 +205,7 @@ void lv_sysmon_hide_memory(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) {
-        LV_LOG_WARN("There is no default display");
-        return;
-    }
+    LV_CHECK_ARG(disp != NULL, return);
 
     lv_obj_set_hidden(disp->mem_label, true);
 }
@@ -230,9 +220,13 @@ void lv_sysmon_hide_memory(lv_display_t * disp)
 
 static void perf_monitor_disp_event_cb(lv_event_t * e)
 {
+    LV_ASSERT(e != NULL);
     lv_display_t * disp = lv_event_get_target(e);
-    lv_event_code_t code = lv_event_get_code(e);
+    LV_ASSERT(disp != NULL);
     lv_sysmon_perf_info_t * info = &disp->perf_sysmon_info;
+    LV_ASSERT(info != NULL);
+
+    lv_event_code_t code = lv_event_get_code(e);
 
     switch(code) {
         case LV_EVENT_REFR_START:
@@ -281,12 +275,13 @@ static void perf_monitor_disp_event_cb(lv_event_t * e)
 
 static void perf_dump_info(lv_display_t * disp)
 {
-
+    LV_ASSERT(disp != NULL);
     lv_sysmon_perf_info_t * info = &disp->perf_sysmon_info;
+    LV_ASSERT(info != NULL);
     info->calculated.run_cnt++;
 
     uint32_t time_since_last_report = lv_tick_elaps(info->measured.last_report_timestamp);
-    lv_timer_t * disp_refr_timer = lv_display_get_refr_timer(NULL);
+    lv_timer_t * disp_refr_timer = lv_display_get_refr_timer(lv_display_get_default());
     uint32_t disp_refr_period = disp_refr_timer ? disp_refr_timer->period : LV_DEF_REFR_PERIOD;
 
     info->calculated.fps = time_since_last_report ? (1000 * info->measured.refr_cnt / time_since_last_report) : 0;
@@ -330,14 +325,19 @@ static void perf_dump_info(lv_display_t * disp)
 
 static void perf_update_timer_cb(lv_timer_t * t)
 {
+    LV_ASSERT(t != NULL);
     lv_display_t * disp = lv_timer_get_user_data(t);
+    LV_ASSERT(disp != NULL);
 
     perf_dump_info(disp);
 }
 
 static void perf_observer_cb(lv_observer_t * observer, lv_subject_t * subject)
 {
+    LV_ASSERT(observer != NULL);
+    LV_ASSERT(subject != NULL);
     const lv_sysmon_perf_info_t * perf = lv_subject_get_pointer(subject);
+    LV_ASSERT(perf != NULL);
 
 #if LV_USE_PERF_MONITOR_LOG_MODE
     LV_UNUSED(observer);
@@ -360,6 +360,7 @@ static void perf_observer_cb(lv_observer_t * observer, lv_subject_t * subject)
 #endif
 #else
     lv_obj_t * label = lv_observer_get_target(observer);
+    LV_ASSERT(label != NULL);
 #if LV_SYSMON_PROC_IDLE_AVAILABLE
     lv_label_set_text_fmt(
         label,
@@ -384,15 +385,7 @@ static void perf_observer_cb(lv_observer_t * observer, lv_subject_t * subject)
 
 static void perf_control(lv_display_t * disp, bool start)
 {
-    if(disp == NULL) {
-        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
-        disp = lv_display_get_default();
-    }
-    if(disp == NULL) {
-        LV_LOG_WARN("There is no default display");
-        return;
-    }
-
+    LV_ASSERT(disp != NULL);
     if(disp->perf_sysmon_backend.timer == NULL) return;
 
     if(start) {
@@ -409,15 +402,21 @@ static void perf_control(lv_display_t * disp, bool start)
 
 static void mem_update_timer_cb(lv_timer_t * t)
 {
+    LV_ASSERT(t != NULL);
     lv_mem_monitor_t * mem_mon = lv_timer_get_user_data(t);
+    LV_ASSERT(mem_mon != NULL);
     lv_mem_monitor(mem_mon);
     lv_subject_set_pointer(&sysmon_mem.subject, mem_mon);
 }
 
 static void mem_observer_cb(lv_observer_t * observer, lv_subject_t * subject)
 {
+    LV_ASSERT(observer != NULL);
+    LV_ASSERT(subject != NULL);
     lv_obj_t * label = lv_observer_get_target(observer);
     const lv_mem_monitor_t * mon = lv_subject_get_pointer(subject);
+    LV_ASSERT(label != NULL);
+    LV_ASSERT(mon != NULL);
 
     size_t used_size = mon->total_size - mon->free_size;
     size_t used_kb = used_size / 1024;

--- a/src/debugging/sysmon/lv_sysmon.c
+++ b/src/debugging/sysmon/lv_sysmon.c
@@ -92,7 +92,10 @@ void lv_sysmon_builtin_deinit(void)
 lv_obj_t * lv_sysmon_create(lv_display_t * disp)
 {
     LV_LOG_INFO("begin");
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) {
         LV_LOG_WARN("There is no default display");
         return NULL;
@@ -111,7 +114,10 @@ lv_obj_t * lv_sysmon_create(lv_display_t * disp)
 
 void lv_sysmon_show_performance(lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) {
         LV_LOG_WARN("There is no default display");
         return;
@@ -136,7 +142,10 @@ void lv_sysmon_show_performance(lv_display_t * disp)
 
 void lv_sysmon_hide_performance(lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) {
         LV_LOG_WARN("There is no default display");
         return;
@@ -147,7 +156,10 @@ void lv_sysmon_hide_performance(lv_display_t * disp)
 
 void lv_sysmon_performance_dump(lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) {
         LV_LOG_WARN("There is no default display");
         return;
@@ -171,7 +183,10 @@ void lv_sysmon_performance_pause(lv_display_t * disp)
 
 void lv_sysmon_show_memory(lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) {
         LV_LOG_WARN("There is no default display");
         return;
@@ -193,7 +208,10 @@ void lv_sysmon_show_memory(lv_display_t * disp)
 
 void lv_sysmon_hide_memory(lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) {
         LV_LOG_WARN("There is no default display");
         return;
@@ -366,7 +384,10 @@ static void perf_observer_cb(lv_observer_t * observer, lv_subject_t * subject)
 
 static void perf_control(lv_display_t * disp, bool start)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) {
         LV_LOG_WARN("There is no default display");
         return;

--- a/src/debugging/test/lv_test_screenshot_compare.c
+++ b/src/debugging/test/lv_test_screenshot_compare.c
@@ -95,7 +95,7 @@ lv_test_screenshot_result_t lv_test_screenshot_compare_core(const char * fn_ref)
     create_folders_if_needed(fn_ref_full);
 #endif
 
-    lv_draw_buf_t * draw_buf = lv_display_get_buf_active(NULL);
+    lv_draw_buf_t * draw_buf = lv_display_get_buf_active(lv_display_get_default());
 
     uint8_t * screen_buf_xrgb8888 = lv_malloc(draw_buf->header.w * draw_buf->header.h * 4);
     if(!screen_buf_xrgb8888) {

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -532,6 +532,12 @@ void lv_display_set_3rd_draw_buffer(lv_display_t * disp, lv_draw_buf_t * buf3)
 void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint32_t buf_size,
                             lv_display_render_mode_t render_mode)
 {
+    lv_display_set_buffers_with_stride(disp, buf1, buf2, buf_size, LV_STRIDE_AUTO, render_mode);
+}
+
+void lv_display_set_buffers_with_stride(lv_display_t * disp, void * buf1, void * buf2, uint32_t buf_size,
+                                        uint32_t stride, lv_display_render_mode_t render_mode)
+{
     LV_ASSERT_MSG(buf1 != NULL, "Null buffer");
     lv_color_format_t cf = lv_display_get_color_format(disp);
     uint32_t w = lv_display_get_original_horizontal_resolution(disp);
@@ -539,10 +545,14 @@ void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint3
     LV_ASSERT_MSG(w != 0 && h != 0, "display resolution is 0");
 
     /* buf1 or buf2 is not aligned according to LV_DRAW_BUF_ALIGN */
-    LV_ASSERT_FORMAT_MSG(buf1 == lv_draw_buf_align(buf1, cf), "buf1 is not aligned: %p", buf1);
-    LV_ASSERT_FORMAT_MSG(buf2 == NULL || buf2 == lv_draw_buf_align(buf2, cf), "buf2 is not aligned: %p", buf2);
+    LV_ASSERT_FORMAT_MSG(buf1 == lv_draw_buf_align(buf1, cf), "buf1 is not properly aligned: %p", buf1);
+    LV_ASSERT_FORMAT_MSG(buf2 == NULL || buf2 == lv_draw_buf_align(buf2, cf), "buf2 is not properly aligned: %p", buf2);
 
-    uint32_t stride = lv_draw_buf_width_to_stride(w, cf);
+    bool is_auto_stride = stride == LV_STRIDE_AUTO;
+    if(is_auto_stride) {
+        stride = lv_draw_buf_width_to_stride(w, cf);
+    }
+
     if(render_mode == LV_DISPLAY_RENDER_MODE_PARTIAL) {
         LV_ASSERT_FORMAT_MSG(stride != 0, "stride is 0, check your color format %d and width: %" LV_PRIu32, cf, w);
         /* for partial mode, we calculate the height based on the buf_size and stride */
@@ -558,41 +568,7 @@ void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint3
     lv_draw_buf_init(&disp->_static_buf2, w, h, cf, stride, buf2, buf_size);
     lv_display_set_draw_buffers(disp, &disp->_static_buf1, buf2 ? &disp->_static_buf2 : NULL);
     lv_display_set_render_mode(disp, render_mode);
-
-    /* the stride was not set explicitly */
-    disp->stride_is_auto = 1;
-}
-
-void lv_display_set_buffers_with_stride(lv_display_t * disp, void * buf1, void * buf2, uint32_t buf_size,
-                                        uint32_t stride, lv_display_render_mode_t render_mode)
-{
-    if(stride == LV_STRIDE_AUTO) {
-        lv_display_set_buffers(disp, buf1, buf2, buf_size, render_mode);
-        return;
-    }
-
-    LV_ASSERT_MSG(buf1 != NULL, "Null buffer");
-    lv_color_format_t cf = lv_display_get_color_format(disp);
-    uint32_t w = lv_display_get_original_horizontal_resolution(disp);
-    uint32_t h = lv_display_get_original_vertical_resolution(disp);
-    LV_ASSERT_MSG(w != 0 && h != 0, "display resolution is 0");
-
-    if(render_mode == LV_DISPLAY_RENDER_MODE_PARTIAL) {
-        /* for partial mode, we calculate the height based on the buf_size and stride */
-        h = buf_size / stride;
-        LV_ASSERT_MSG(h != 0, "the buffer is too small");
-    }
-    else {
-        LV_ASSERT_FORMAT_MSG(stride * h <= buf_size, "%s mode requires screen sized buffer(s)",
-                             render_mode == LV_DISPLAY_RENDER_MODE_FULL ? "FULL" : "DIRECT");
-    }
-
-    lv_draw_buf_init(&disp->_static_buf1, w, h, cf, stride, buf1, buf_size);
-    lv_draw_buf_init(&disp->_static_buf2, w, h, cf, stride, buf2, buf_size);
-    lv_display_set_draw_buffers(disp, &disp->_static_buf1, buf2 ? &disp->_static_buf2 : NULL);
-    lv_display_set_render_mode(disp, render_mode);
-
-    disp->stride_is_auto = 0;
+    disp->stride_is_auto = is_auto_stride;
 }
 
 void lv_display_set_render_mode(lv_display_t * disp, lv_display_render_mode_t render_mode)

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -65,6 +65,8 @@ static void disp_event_cb(lv_event_t * e);
 
 lv_display_t * lv_display_create(int32_t hor_res, int32_t ver_res)
 {
+    LV_CHECK_ARG(hor_res > 0, return NULL);
+    LV_CHECK_ARG(ver_res > 0, return NULL);
     lv_display_t * disp = lv_ll_ins_head(disp_ll_p);
     LV_ASSERT_MALLOC(disp);
     if(!disp) return NULL;
@@ -186,10 +188,11 @@ lv_display_t * lv_display_create(int32_t hor_res, int32_t ver_res)
 
 void lv_display_delete(lv_display_t * disp)
 {
-    bool was_default = false;
-    bool was_refr = false;
-    if(disp == lv_display_get_default()) was_default = true;
-    if(disp == lv_refr_get_disp_refreshing()) was_refr = true;
+    if(!disp) {
+        return;
+    }
+    const bool was_default = disp == lv_display_get_default();
+    const bool was_refr = disp == lv_refr_get_disp_refreshing();
 
     lv_display_send_event(disp, LV_EVENT_DELETE, NULL);
     lv_event_mark_deleted(disp);
@@ -276,7 +279,9 @@ void lv_display_set_resolution(lv_display_t * disp, int32_t hor_res, int32_t ver
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return;
+    LV_CHECK_ARG(disp != NULL, return);
+    LV_CHECK_ARG(hor_res > 0, return);
+    LV_CHECK_ARG(ver_res > 0, return);
 
     if(disp->hor_res == hor_res && disp->ver_res == ver_res) return;
 
@@ -292,13 +297,14 @@ void lv_display_set_physical_resolution(lv_display_t * disp, int32_t hor_res, in
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return;
+    LV_CHECK_ARG(disp != NULL, return);
+    LV_CHECK_ARG(hor_res > 0, return);
+    LV_CHECK_ARG(ver_res > 0, return);
 
     disp->physical_hor_res = hor_res;
     disp->physical_ver_res = ver_res;
 
     lv_obj_invalidate(disp->sys_layer);
-
 }
 
 void lv_display_set_offset(lv_display_t * disp, int32_t x, int32_t y)
@@ -307,7 +313,7 @@ void lv_display_set_offset(lv_display_t * disp, int32_t x, int32_t y)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return;
+    LV_CHECK_ARG(disp != NULL, return);
 
     disp->offset_x = x;
     disp->offset_y = y;
@@ -323,7 +329,7 @@ void lv_display_set_dpi(lv_display_t * disp, int32_t dpi)
         disp = lv_display_get_default();
     }
 
-    if(disp == NULL) return;
+    LV_CHECK_ARG(disp != NULL, return);
 
     disp->dpi = dpi;
 }
@@ -335,17 +341,14 @@ int32_t lv_display_get_horizontal_resolution(const lv_display_t * disp)
         disp = lv_display_get_default();
     }
 
-    if(disp == NULL) {
-        return 0;
-    }
-    else {
-        switch(disp->rotation) {
-            case LV_DISPLAY_ROTATION_90:
-            case LV_DISPLAY_ROTATION_270:
-                return disp->ver_res;
-            default:
-                return disp->hor_res;
-        }
+    LV_CHECK_ARG(disp != NULL, return 0);
+
+    switch(disp->rotation) {
+        case LV_DISPLAY_ROTATION_90:
+        case LV_DISPLAY_ROTATION_270:
+            return disp->ver_res;
+        default:
+            return disp->hor_res;
     }
 }
 
@@ -356,17 +359,13 @@ int32_t lv_display_get_vertical_resolution(const lv_display_t * disp)
         disp = lv_display_get_default();
     }
 
-    if(disp == NULL) {
-        return 0;
-    }
-    else {
-        switch(disp->rotation) {
-            case LV_DISPLAY_ROTATION_90:
-            case LV_DISPLAY_ROTATION_270:
-                return disp->hor_res;
-            default:
-                return disp->ver_res;
-        }
+    LV_CHECK_ARG(disp != NULL, return 0);
+    switch(disp->rotation) {
+        case LV_DISPLAY_ROTATION_90:
+        case LV_DISPLAY_ROTATION_270:
+            return disp->hor_res;
+        default:
+            return disp->ver_res;
     }
 }
 
@@ -376,9 +375,8 @@ int32_t lv_display_get_original_horizontal_resolution(const lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) {
-        return 0;
-    }
+
+    LV_CHECK_ARG(disp != NULL, return 0);
 
     return disp->hor_res;
 }
@@ -389,9 +387,7 @@ int32_t lv_display_get_original_vertical_resolution(const lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) {
-        return 0;
-    }
+    LV_CHECK_ARG(disp != NULL, return 0);
 
     return disp->ver_res;
 }
@@ -402,18 +398,14 @@ int32_t lv_display_get_physical_horizontal_resolution(const lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
+    LV_CHECK_ARG(disp != NULL, return 0);
 
-    if(disp == NULL) {
-        return 0;
-    }
-    else {
-        switch(disp->rotation) {
-            case LV_DISPLAY_ROTATION_90:
-            case LV_DISPLAY_ROTATION_270:
-                return disp->physical_ver_res > 0 ? disp->physical_ver_res : disp->ver_res;
-            default:
-                return disp->physical_hor_res > 0 ? disp->physical_hor_res : disp->hor_res;
-        }
+    switch(disp->rotation) {
+        case LV_DISPLAY_ROTATION_90:
+        case LV_DISPLAY_ROTATION_270:
+            return disp->physical_ver_res > 0 ? disp->physical_ver_res : disp->ver_res;
+        default:
+            return disp->physical_hor_res > 0 ? disp->physical_hor_res : disp->hor_res;
     }
 }
 
@@ -424,17 +416,13 @@ int32_t lv_display_get_physical_vertical_resolution(const lv_display_t * disp)
         disp = lv_display_get_default();
     }
 
-    if(disp == NULL) {
-        return 0;
-    }
-    else {
-        switch(disp->rotation) {
-            case LV_DISPLAY_ROTATION_90:
-            case LV_DISPLAY_ROTATION_270:
-                return disp->physical_hor_res > 0 ? disp->physical_hor_res : disp->hor_res;
-            default:
-                return disp->physical_ver_res > 0 ? disp->physical_ver_res : disp->ver_res;
-        }
+    LV_CHECK_ARG(disp != NULL, return 0);
+    switch(disp->rotation) {
+        case LV_DISPLAY_ROTATION_90:
+        case LV_DISPLAY_ROTATION_270:
+            return disp->physical_hor_res > 0 ? disp->physical_hor_res : disp->hor_res;
+        default:
+            return disp->physical_ver_res > 0 ? disp->physical_ver_res : disp->ver_res;
     }
 }
 
@@ -445,20 +433,16 @@ int32_t lv_display_get_offset_x(const lv_display_t * disp)
         disp = lv_display_get_default();
     }
 
-    if(disp == NULL) {
-        return 0;
-    }
-    else {
-        switch(disp->rotation) {
-            case LV_DISPLAY_ROTATION_90:
-                return disp->offset_y;
-            case LV_DISPLAY_ROTATION_180:
-                return lv_display_get_physical_horizontal_resolution(disp) - disp->offset_x;
-            case LV_DISPLAY_ROTATION_270:
-                return lv_display_get_physical_horizontal_resolution(disp) - disp->offset_y;
-            default:
-                return disp->offset_x;
-        }
+    LV_CHECK_ARG(disp != NULL, return 0);
+    switch(disp->rotation) {
+        case LV_DISPLAY_ROTATION_90:
+            return disp->offset_y;
+        case LV_DISPLAY_ROTATION_180:
+            return lv_display_get_physical_horizontal_resolution(disp) - disp->offset_x;
+        case LV_DISPLAY_ROTATION_270:
+            return lv_display_get_physical_horizontal_resolution(disp) - disp->offset_y;
+        default:
+            return disp->offset_x;
     }
 }
 
@@ -469,20 +453,16 @@ int32_t lv_display_get_offset_y(const lv_display_t * disp)
         disp = lv_display_get_default();
     }
 
-    if(disp == NULL) {
-        return 0;
-    }
-    else {
-        switch(disp->rotation) {
-            case LV_DISPLAY_ROTATION_90:
-                return disp->offset_x;
-            case LV_DISPLAY_ROTATION_180:
-                return lv_display_get_physical_vertical_resolution(disp) - disp->offset_y;
-            case LV_DISPLAY_ROTATION_270:
-                return lv_display_get_physical_vertical_resolution(disp) - disp->offset_x;
-            default:
-                return disp->offset_y;
-        }
+    LV_CHECK_ARG(disp != NULL, return 0);
+    switch(disp->rotation) {
+        case LV_DISPLAY_ROTATION_90:
+            return disp->offset_x;
+        case LV_DISPLAY_ROTATION_180:
+            return lv_display_get_physical_vertical_resolution(disp) - disp->offset_y;
+        case LV_DISPLAY_ROTATION_270:
+            return lv_display_get_physical_vertical_resolution(disp) - disp->offset_x;
+        default:
+            return disp->offset_y;
     }
 }
 
@@ -492,7 +472,8 @@ int32_t lv_display_get_dpi(const lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return LV_DPI_DEF;  /*Do not return 0 because it might be a divider*/
+    LV_CHECK_ARG(disp != NULL, return LV_DPI_DEF);
+
     return disp->dpi;
 }
 
@@ -506,7 +487,9 @@ void lv_display_set_draw_buffers(lv_display_t * disp, lv_draw_buf_t * buf1, lv_d
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return;
+
+    LV_CHECK_ARG(disp != NULL, return);
+    LV_CHECK_ARG(buf1 != NULL, return);
 
     disp->buf_1 = buf1;
     disp->buf_2 = buf2;
@@ -522,9 +505,9 @@ void lv_display_set_3rd_draw_buffer(lv_display_t * disp, lv_draw_buf_t * buf3)
         disp = lv_display_get_default();
     }
     if(disp == NULL) return;
-
-    LV_ASSERT_MSG(disp->buf_1 != NULL, "buf1 is null");
-    LV_ASSERT_MSG(disp->buf_2 != NULL, "buf2 is null");
+    LV_CHECK_ARG(disp != NULL, return);
+    LV_CHECK_ARG(disp->buf_1 != NULL, return, "buf1 should already exist in order to provide a third buffer");
+    LV_CHECK_ARG(disp->buf_2 != NULL, return, "buf2 should already exist in order to provide a third buffer");
 
     disp->buf_3 = buf3;
 }
@@ -532,21 +515,26 @@ void lv_display_set_3rd_draw_buffer(lv_display_t * disp, lv_draw_buf_t * buf3)
 void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint32_t buf_size,
                             lv_display_render_mode_t render_mode)
 {
+    LV_CHECK_ARG(disp != NULL, return);
+    LV_CHECK_ARG(buf1 != NULL, return);
     lv_display_set_buffers_with_stride(disp, buf1, buf2, buf_size, LV_STRIDE_AUTO, render_mode);
 }
 
 void lv_display_set_buffers_with_stride(lv_display_t * disp, void * buf1, void * buf2, uint32_t buf_size,
                                         uint32_t stride, lv_display_render_mode_t render_mode)
 {
-    LV_ASSERT_MSG(buf1 != NULL, "Null buffer");
+    LV_CHECK_ARG(disp != NULL, return);
+    LV_CHECK_ARG(buf1 != NULL, return);
+
     lv_color_format_t cf = lv_display_get_color_format(disp);
     uint32_t w = lv_display_get_original_horizontal_resolution(disp);
     uint32_t h = lv_display_get_original_vertical_resolution(disp);
-    LV_ASSERT_MSG(w != 0 && h != 0, "display resolution is 0");
+
+    LV_CHECK_ARG(w != 0 && h != 0, return, "display resolution is 0");
 
     /* buf1 or buf2 is not aligned according to LV_DRAW_BUF_ALIGN */
-    LV_ASSERT_FORMAT_MSG(buf1 == lv_draw_buf_align(buf1, cf), "buf1 is not properly aligned: %p", buf1);
-    LV_ASSERT_FORMAT_MSG(buf2 == NULL || buf2 == lv_draw_buf_align(buf2, cf), "buf2 is not properly aligned: %p", buf2);
+    LV_CHECK_ARG(buf1 == lv_draw_buf_align(buf1, cf), return, "buf1 is not properly aligned: %p", buf1);
+    LV_CHECK_ARG(buf2 == NULL || buf2 == lv_draw_buf_align(buf2, cf), return, "buf2 is not properly aligned: %p", buf2);
 
     bool is_auto_stride = stride == LV_STRIDE_AUTO;
     if(is_auto_stride) {
@@ -554,14 +542,14 @@ void lv_display_set_buffers_with_stride(lv_display_t * disp, void * buf1, void *
     }
 
     if(render_mode == LV_DISPLAY_RENDER_MODE_PARTIAL) {
-        LV_ASSERT_FORMAT_MSG(stride != 0, "stride is 0, check your color format %d and width: %" LV_PRIu32, cf, w);
+        LV_CHECK_ARG(stride != 0, return, "stride is 0, check your color format %d and width: %" LV_PRIu32, cf, w);
         /* for partial mode, we calculate the height based on the buf_size and stride */
         h = buf_size / stride;
-        LV_ASSERT_MSG(h != 0, "the buffer is too small");
+        LV_CHECK_ARG(h, return, "the buffer is too small");
     }
     else {
-        LV_ASSERT_FORMAT_MSG(stride * h <= buf_size, "%s mode requires screen sized buffer(s)",
-                             render_mode == LV_DISPLAY_RENDER_MODE_FULL ? "FULL" : "DIRECT");
+        LV_CHECK_ARG(stride * h <= buf_size, return, "%s mode requires screen sized buffer(s)",
+                     render_mode == LV_DISPLAY_RENDER_MODE_FULL ? "FULL" : "DIRECT");
     }
 
     lv_draw_buf_init(&disp->_static_buf1, w, h, cf, stride, buf1, buf_size);
@@ -577,7 +565,7 @@ void lv_display_set_render_mode(lv_display_t * disp, lv_display_render_mode_t re
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return;
+    LV_CHECK_ARG(disp != NULL, return);
     disp->render_mode = render_mode;
 }
 
@@ -588,7 +576,7 @@ lv_display_flush_cb_t lv_display_get_flush_cb(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return NULL;
+    LV_CHECK_ARG(disp != NULL, return NULL);
     return disp->flush_cb;
 }
 
@@ -598,7 +586,7 @@ void lv_display_set_flush_cb(lv_display_t * disp, lv_display_flush_cb_t flush_cb
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return;
+    LV_CHECK_ARG(disp != NULL, return);
 
     disp->flush_cb = flush_cb;
 }
@@ -609,7 +597,7 @@ void lv_display_set_flush_wait_cb(lv_display_t * disp, lv_display_flush_wait_cb_
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return;
+    LV_CHECK_ARG(disp != NULL, return);
 
     disp->flush_wait_cb = wait_cb;
 }
@@ -620,7 +608,7 @@ void lv_display_set_sync_cb(lv_display_t * disp, lv_display_sync_cb_t sync_cb)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return;
+    LV_CHECK_ARG(disp != NULL, return);
 
     disp->sync_cb = sync_cb;
 }
@@ -631,7 +619,7 @@ void lv_display_set_sync_wait_cb(lv_display_t * disp, lv_display_sync_wait_cb_t 
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return;
+    LV_CHECK_ARG(disp != NULL, return);
 
     disp->sync_wait_cb = wait_cb;
 }
@@ -642,10 +630,11 @@ void lv_display_set_color_format(lv_display_t * disp, lv_color_format_t color_fo
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return;
+    LV_CHECK_ARG(disp != NULL, return);
 
     disp->color_format = color_format;
     disp->layer_head->color_format = color_format;
+
     if(disp->buf_1) disp->buf_1->header.cf = color_format;
     if(disp->buf_2) disp->buf_2->header.cf = color_format;
     if(disp->buf_3) disp->buf_3->header.cf = color_format;
@@ -666,20 +655,20 @@ lv_color_format_t lv_display_get_color_format(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return LV_COLOR_FORMAT_UNKNOWN;
+    LV_CHECK_ARG(disp != NULL, return LV_COLOR_FORMAT_UNKNOWN);
 
     return disp->color_format;
 }
 
 void lv_display_set_tile_cnt(lv_display_t * disp, uint32_t tile_cnt)
 {
-    LV_ASSERT_FORMAT_MSG(tile_cnt < 256, "tile_cnt must be smaller than 256 (%" LV_PRId32 " was used)", tile_cnt);
 
     if(disp == NULL) {
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return;
+    LV_CHECK_ARG(disp != NULL, return);
+    LV_CHECK_ARG(tile_cnt < 256, return, "tile_cnt must be smaller than 256 (%" LV_PRId32 " was used)", tile_cnt);
 
     disp->tile_cnt = tile_cnt;
 }
@@ -690,7 +679,7 @@ uint32_t lv_display_get_tile_cnt(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return 0;
+    LV_CHECK_ARG(disp != NULL, return 0);
 
     return disp->tile_cnt;
 }
@@ -703,7 +692,7 @@ void lv_display_set_antialiasing(lv_display_t * disp, bool en)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return;
+    LV_CHECK_ARG(disp != NULL, return);
 
     disp->antialiasing = en;
 }
@@ -714,7 +703,7 @@ bool lv_display_get_antialiasing(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return false;
+    LV_CHECK_ARG(disp != NULL, return false);
 
     return disp->antialiasing;
 }
@@ -725,33 +714,38 @@ lv_display_render_mode_t lv_display_get_render_mode(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return LV_DISPLAY_RENDER_MODE_PARTIAL;
+    LV_CHECK_ARG(disp != NULL, return LV_DISPLAY_RENDER_MODE_PARTIAL);
 
     return disp->render_mode;
 }
 
 LV_ATTRIBUTE_FLUSH_READY void lv_display_flush_ready(lv_display_t * disp)
 {
+    LV_CHECK_ARG(disp != NULL, return);
     disp->flushing = 0;
 }
 
 LV_ATTRIBUTE_FLUSH_READY bool lv_display_flush_is_last(lv_display_t * disp)
 {
+    LV_CHECK_ARG(disp != NULL, return false);
     return disp->flushing_last;
 }
 
 LV_ATTRIBUTE_SYNC_READY void lv_display_sync_ready(lv_display_t * disp)
 {
+    LV_CHECK_ARG(disp != NULL, return);
     disp->syncing = 0;
 }
 
 LV_ATTRIBUTE_SYNC_READY bool lv_display_sync_is_last(lv_display_t * disp)
 {
+    LV_CHECK_ARG(disp != NULL, return false);
     return disp->syncing_last;
 }
 
 bool lv_display_is_double_buffered(lv_display_t * disp)
 {
+    LV_CHECK_ARG(disp != NULL, return false);
     return disp->buf_2 != NULL;
 }
 
@@ -765,10 +759,7 @@ lv_obj_t * lv_display_get_screen_active(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp) {
-        LV_LOG_WARN("no display registered to get its active screen");
-        return NULL;
-    }
+    LV_CHECK_ARG(disp != NULL, return NULL);
 
     return disp->act_scr;
 }
@@ -779,10 +770,7 @@ lv_obj_t * lv_display_get_screen_loading(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp) {
-        LV_LOG_WARN("no display registered to get the current screen being loaded");
-        return NULL;
-    }
+    LV_CHECK_ARG(disp != NULL, return NULL);
 
     return disp->scr_to_load;
 }
@@ -793,10 +781,7 @@ lv_obj_t * lv_display_get_screen_prev(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp) {
-        LV_LOG_WARN("no display registered to get its previous screen");
-        return NULL;
-    }
+    LV_CHECK_ARG(disp != NULL, return NULL);
 
     return disp->prev_scr;
 }
@@ -807,10 +792,7 @@ lv_obj_t * lv_display_get_layer_top(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp) {
-        LV_LOG_WARN("lv_layer_top: no display registered to get its top layer");
-        return NULL;
-    }
+    LV_CHECK_ARG(disp != NULL, return NULL);
 
     return disp->top_layer;
 }
@@ -821,10 +803,7 @@ lv_obj_t * lv_display_get_layer_sys(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp) {
-        LV_LOG_WARN("lv_layer_sys: no display registered to get its sys. layer");
-        return NULL;
-    }
+    LV_CHECK_ARG(disp != NULL, return NULL);
 
     return disp->sys_layer;
 }
@@ -835,10 +814,7 @@ lv_obj_t * lv_display_get_layer_bottom(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp) {
-        LV_LOG_WARN("lv_layer_bottom: no display registered to get its bottom layer");
-        return NULL;
-    }
+    LV_CHECK_ARG(disp != NULL, return NULL);
 
     return disp->bottom_layer;
 }
@@ -851,10 +827,8 @@ lv_obj_t * lv_display_get_screen_by_name(const lv_display_t * disp, const char *
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp) {
-        LV_LOG_WARN("no display registered to get a screen by name");
-        return NULL;
-    }
+    LV_CHECK_ARG(disp != NULL, return NULL);
+    LV_CHECK_ARG(screen_name != NULL, return NULL);
 
     uint32_t i;
     for(i = 0; i < disp->screen_cnt; i++) {
@@ -868,14 +842,16 @@ lv_obj_t * lv_display_get_screen_by_name(const lv_display_t * disp, const char *
 
 #endif /*LV_USE_OBJ_NAME*/
 
-void lv_screen_load(struct _lv_obj_t * scr)
+void lv_screen_load(lv_obj_t * scr)
 {
+    LV_CHECK_ARG(scr != NULL, return);
     lv_screen_load_anim(scr, LV_SCREEN_LOAD_ANIM_NONE, 0, 0, false);
 }
 
 void lv_screen_load_anim(lv_obj_t * scr, lv_screen_load_anim_t anim_type, uint32_t time, uint32_t delay,
                          bool auto_del)
 {
+    LV_CHECK_ARG(scr != NULL, return);
     lv_display_t * d = lv_obj_get_display(scr);
     lv_obj_t * act_scr = d->act_scr;
 
@@ -1042,34 +1018,34 @@ void lv_screen_load_anim(lv_obj_t * scr, lv_screen_load_anim_t anim_type, uint32
 lv_event_dsc_t * lv_display_add_event_cb(lv_display_t * disp, lv_event_cb_t event_cb, lv_event_code_t filter,
                                          void * user_data)
 {
-    LV_ASSERT_NULL(disp);
+    LV_CHECK_ARG(disp != NULL, return NULL);
 
     return lv_event_add(&disp->event_list, event_cb, filter, user_data);
 }
 
 uint32_t lv_display_get_event_count(lv_display_t * disp)
 {
-    LV_ASSERT_NULL(disp);
+    LV_CHECK_ARG(disp != NULL, return 0);
     return lv_event_get_count(&disp->event_list);
 }
 
 lv_event_dsc_t * lv_display_get_event_dsc(lv_display_t * disp, uint32_t index)
 {
-    LV_ASSERT_NULL(disp);
+    LV_CHECK_ARG(disp != NULL, return NULL);
     return lv_event_get_dsc(&disp->event_list, index);
 
 }
 
 bool lv_display_remove_event(lv_display_t * disp, uint32_t index)
 {
-    LV_ASSERT_NULL(disp);
+    LV_CHECK_ARG(disp != NULL, return false);
 
     return lv_event_remove(&disp->event_list, index);
 }
 
 uint32_t lv_display_remove_event_cb_with_user_data(lv_display_t * disp, lv_event_cb_t event_cb, void * user_data)
 {
-    LV_ASSERT_NULL(disp);
+    LV_CHECK_ARG(disp != NULL, return 0);
 
     uint32_t event_cnt = lv_display_get_event_count(disp);
     uint32_t removed_count = 0;
@@ -1088,18 +1064,15 @@ uint32_t lv_display_remove_event_cb_with_user_data(lv_display_t * disp, lv_event
 
 lv_result_t lv_display_send_event(lv_display_t * disp, lv_event_code_t code, void * param)
 {
+    LV_CHECK_ARG(disp != NULL, return LV_RESULT_INVALID);
     return lv_event_push_and_send(&disp->event_list, code, disp, param);
 }
 
 lv_area_t * lv_event_get_invalidated_area(lv_event_t * e)
 {
-    if(e->code == LV_EVENT_INVALIDATE_AREA) {
-        return lv_event_get_param(e);
-    }
-    else {
-        LV_LOG_WARN("Not interpreted with this event code");
-        return NULL;
-    }
+    LV_CHECK_ARG(e != NULL, return NULL);
+    LV_CHECK_ARG(e->code == LV_EVENT_INVALIDATE_AREA, return NULL);
+    return lv_event_get_param(e);
 }
 
 void lv_display_set_rotation(lv_display_t * disp, lv_display_rotation_t rotation)
@@ -1108,7 +1081,7 @@ void lv_display_set_rotation(lv_display_t * disp, lv_display_rotation_t rotation
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return;
+    LV_CHECK_ARG(disp != NULL, return);
 
     disp->rotation = rotation;
     update_resolution(disp);
@@ -1120,30 +1093,23 @@ lv_display_rotation_t lv_display_get_rotation(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return LV_DISPLAY_ROTATION_0;
+    LV_CHECK_ARG(disp != NULL, return LV_DISPLAY_ROTATION_0);
     return disp->rotation;
 }
 
 void lv_display_set_matrix_rotation(lv_display_t * disp, bool enable)
 {
-#if LV_DRAW_TRANSFORM_USE_MATRIX
+    LV_CHECK_ARG(LV_DRAW_TRANSFORM_USE_MATRIX == 1, return, "LV_DRAW_TRANSFORM_USE_MATRIX is not enabled");
+
     if(disp == NULL) {
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return;
-
-    if(!(disp->render_mode == LV_DISPLAY_RENDER_MODE_DIRECT || disp->render_mode == LV_DISPLAY_RENDER_MODE_FULL)) {
-        LV_LOG_WARN("Unsupported rendering mode: %d", disp->render_mode);
-        return;
-    }
+    LV_CHECK_ARG(disp != NULL, return);
+    LV_CHECK_ARG(disp->render_mode == LV_DISPLAY_RENDER_MODE_DIRECT ||
+                 disp->render_mode == LV_DISPLAY_RENDER_MODE_FULL, return, "Unsupported rendering mode: %d", disp->render_mode);
 
     disp->matrix_rotation = enable;
-#else
-    (void)disp;
-    (void)enable;
-    LV_LOG_WARN("LV_DRAW_TRANSFORM_USE_MATRIX was not enabled");
-#endif
 }
 
 bool lv_display_get_matrix_rotation(lv_display_t * disp)
@@ -1152,7 +1118,8 @@ bool lv_display_get_matrix_rotation(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) return false;
+    LV_CHECK_ARG(disp != NULL, return false);
+    LV_CHECK_ARG(LV_DRAW_TRANSFORM_USE_MATRIX == 1, return false, "LV_DRAW_TRANSFORM_USE_MATRIX is not enabled");
     return disp->matrix_rotation;
 }
 
@@ -1162,10 +1129,7 @@ void lv_display_set_theme(lv_display_t * disp, lv_theme_t * th)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp) {
-        LV_LOG_WARN("no display registered");
-        return;
-    }
+    LV_CHECK_ARG(disp != NULL, return);
 
     disp->theme = th;
 
@@ -1190,15 +1154,15 @@ lv_theme_t * lv_display_get_theme(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(disp == NULL) {
-        return NULL;
-    }
+    LV_CHECK_ARG(disp != NULL, return NULL);
     return disp->theme;
 }
 
 uint32_t lv_display_get_inactive_time(const lv_display_t * disp)
 {
-    if(disp) return lv_tick_elaps(disp->last_activity_time);
+    if(disp) {
+        return lv_tick_elaps(disp->last_activity_time);
+    }
 
     lv_display_t * d;
     uint32_t t = UINT32_MAX;
@@ -1218,10 +1182,7 @@ void lv_display_trigger_activity(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp) {
-        LV_LOG_WARN("lv_display_trigger_activity: no display registered");
-        return;
-    }
+    LV_CHECK_ARG(disp != NULL, return);
 
     disp->last_activity_time = lv_tick_get();
 }
@@ -1232,11 +1193,7 @@ void lv_display_enable_invalidation(lv_display_t * disp, bool en)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp) {
-        LV_LOG_WARN("no display registered");
-        return;
-    }
-
+    LV_CHECK_ARG(disp != NULL, return);
     disp->inv_en_cnt += en ? 1 : -1;
 }
 
@@ -1246,12 +1203,9 @@ bool lv_display_is_invalidation_enabled(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp) {
-        LV_LOG_WARN("no display registered");
-        return false;
-    }
 
-    return (disp->inv_en_cnt > 0);
+    LV_CHECK_ARG(disp != NULL, return false);
+    return disp->inv_en_cnt > 0;
 }
 
 lv_timer_t * lv_display_get_refr_timer(lv_display_t * disp)
@@ -1260,8 +1214,7 @@ lv_timer_t * lv_display_get_refr_timer(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp) return NULL;
-
+    LV_CHECK_ARG(disp != NULL, return NULL);
     return disp->refr_timer;
 }
 
@@ -1271,7 +1224,7 @@ void lv_display_delete_refr_timer(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp || !disp->refr_timer) return;
+    LV_CHECK_ARG(disp != NULL, return);
 
     lv_timer_delete(disp->refr_timer);
     disp->refr_timer = NULL;
@@ -1283,7 +1236,7 @@ lv_result_t lv_display_send_vsync_event(lv_display_t * disp, void * param)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp) return LV_RESULT_INVALID;
+    LV_CHECK_ARG(disp != NULL, return LV_RESULT_INVALID);
 
     if(disp->vsync_count > 0)
         return lv_display_send_event(disp, LV_EVENT_VSYNC, param);
@@ -1297,7 +1250,7 @@ bool lv_display_register_vsync_event(lv_display_t * disp, lv_event_cb_t event_cb
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp) return false;
+    LV_CHECK_ARG(disp != NULL, return false);
 
     lv_display_add_event_cb(disp, event_cb, LV_EVENT_VSYNC, user_data);
 
@@ -1315,7 +1268,7 @@ bool lv_display_unregister_vsync_event(lv_display_t * disp, lv_event_cb_t event_
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp) return false;
+    LV_CHECK_ARG(disp != NULL, return false);
 
     uint32_t removed_count = lv_display_remove_event_cb_with_user_data(disp, event_cb, user_data);
     if(removed_count == 0)
@@ -1335,7 +1288,7 @@ void lv_display_set_user_data(lv_display_t * disp, void * user_data)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp) return;
+    LV_CHECK_ARG(disp != NULL, return);
     disp->user_data = user_data;
 }
 
@@ -1345,7 +1298,7 @@ void lv_display_set_driver_data(lv_display_t * disp, void * driver_data)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp) return;
+    LV_CHECK_ARG(disp != NULL, return);
 
     disp->driver_data = driver_data;
 }
@@ -1356,7 +1309,8 @@ void * lv_display_get_user_data(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp) return NULL;
+    LV_CHECK_ARG(disp != NULL, return NULL);
+
     return disp->user_data;
 }
 
@@ -1366,7 +1320,7 @@ void * lv_display_get_driver_data(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp) return NULL;
+    LV_CHECK_ARG(disp != NULL, return NULL);
 
     return disp->driver_data;
 }
@@ -1377,12 +1331,14 @@ lv_draw_buf_t * lv_display_get_buf_active(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp) return NULL;
+    LV_CHECK_ARG(disp != NULL, return NULL);
     return disp->buf_act;
 }
 
 void lv_display_rotate_area(lv_display_t * disp, lv_area_t * area)
 {
+    LV_CHECK_ARG(disp != NULL, return);
+    LV_CHECK_ARG(area != NULL, return);
     lv_display_rotation_t rotation = lv_display_get_rotation(disp);
 
     if(rotation == LV_DISPLAY_ROTATION_0) return;
@@ -1416,6 +1372,8 @@ void lv_display_rotate_area(lv_display_t * disp, lv_area_t * area)
 
 void lv_display_rotate_point(lv_display_t * disp, lv_point_t * point)
 {
+    LV_CHECK_ARG(disp != NULL, return);
+    LV_CHECK_ARG(point != NULL, return);
     lv_display_rotation_t rotation = lv_display_get_rotation(disp);
 
     if(rotation == LV_DISPLAY_ROTATION_0) return;
@@ -1477,12 +1435,9 @@ uint32_t lv_display_get_draw_buf_size(lv_display_t * disp)
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
-    if(!disp) return 0;
-
-    if(disp->buf_1) {
-        return disp->buf_1->data_size;
-    }
-    return 0;
+    LV_CHECK_ARG(disp != NULL, return 0);
+    LV_CHECK_ARG(disp->buf_1 != NULL, return 0);
+    return disp->buf_1->data_size;
 }
 
 uint32_t lv_display_get_invalidated_draw_buf_size(lv_display_t * disp, uint32_t width, uint32_t height)
@@ -1491,6 +1446,7 @@ uint32_t lv_display_get_invalidated_draw_buf_size(lv_display_t * disp, uint32_t 
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
+    LV_CHECK_ARG(disp != NULL, return 0);
     if(!disp) return 0;
 
     if(disp->render_mode == LV_DISPLAY_RENDER_MODE_FULL) {
@@ -1501,8 +1457,7 @@ uint32_t lv_display_get_invalidated_draw_buf_size(lv_display_t * disp, uint32_t 
     lv_color_format_t cf = lv_display_get_color_format(disp);
     uint32_t stride = lv_draw_buf_width_to_stride(width, cf);
     uint32_t buf_size = stride * height;
-
-    LV_ASSERT(disp->buf_1 && disp->buf_1->data_size >= buf_size);
+    if(disp->buf_1) LV_ASSERT(disp->buf_1->data_size >= buf_size);
     if(disp->buf_2) LV_ASSERT(disp->buf_2->data_size >= buf_size);
     if(disp->buf_3) LV_ASSERT(disp->buf_3->data_size >= buf_size);
 
@@ -1536,16 +1491,18 @@ int32_t lv_dpx(int32_t n)
 
 int32_t lv_display_dpx(const lv_display_t * disp, int32_t n)
 {
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
+    LV_CHECK_ARG(disp != NULL, return LV_DPI_DEF);
     return LV_DPX_CALC(lv_display_get_dpi(disp), n);
 }
 
 #if LV_USE_EXT_DATA
 void lv_display_set_external_data(lv_display_t * disp, void * data, void (* free_cb)(void * data))
 {
-    if(!disp) {
-        LV_LOG_WARN("Can't attach external user data and destructor callback to a NULL display");
-        return;
-    }
+    LV_CHECK_ARG(disp != NULL, return);
 
     disp->ext_data.data = data;
     disp->ext_data.free_cb = free_cb;
@@ -1567,8 +1524,11 @@ static bool new_screen_deleted(lv_load_screen_result_t res)
 
 static void update_resolution(lv_display_t * disp)
 {
+    LV_ASSERT(disp != NULL);
     int32_t hor_res = lv_display_get_horizontal_resolution(disp);
     int32_t ver_res = lv_display_get_vertical_resolution(disp);
+    LV_ASSERT(hor_res > 0);
+    LV_ASSERT(ver_res > 0);
 
     lv_area_t prev_coords;
     lv_obj_get_coords(disp->sys_layer, &prev_coords);
@@ -1603,13 +1563,16 @@ static void update_resolution(lv_display_t * disp)
 
 static lv_obj_tree_walk_res_t invalidate_layout_cb(lv_obj_t * obj, void * user_data)
 {
+    LV_ASSERT(obj != NULL);
     LV_UNUSED(user_data);
+    LV_ASSERT(obj != NULL);
     lv_obj_mark_layout_as_dirty(obj);
     return LV_OBJ_TREE_WALK_NEXT;
 }
 
 static void screen_event_delete_cb(lv_event_t * e)
 {
+    LV_ASSERT(e != NULL);
     lv_obj_t ** screen_var = lv_event_get_user_data(e);
     *screen_var = NULL;
 }
@@ -1634,10 +1597,9 @@ static lv_load_screen_result_t load_new_screen(lv_obj_t * scr)
 {
     /*scr must not be NULL, but d->act_scr might be*/
     LV_ASSERT_NULL(scr);
-    if(scr == NULL) return false;
 
     lv_display_t * d = lv_obj_get_display(scr);
-    LV_ASSERT_NULL(d);
+    LV_ASSERT(d != NULL);
 
     lv_obj_t * old_scr = d->act_scr;
     /* Attach an event delete cb to the screen so we know if the screen is deleted during an event*/
@@ -1698,7 +1660,9 @@ static lv_load_screen_result_t load_new_screen(lv_obj_t * scr)
 
 static void scr_load_anim_start(lv_anim_t * a)
 {
+    LV_ASSERT(a != NULL);
     lv_display_t * d = lv_obj_get_display(a->var);
+    LV_ASSERT(d != NULL);
 
     d->prev_scr = d->act_scr;
     d->act_scr = a->var;
@@ -1708,22 +1672,27 @@ static void scr_load_anim_start(lv_anim_t * a)
 
 static void opa_scale_anim(void * obj, int32_t v)
 {
+    LV_ASSERT(obj != NULL);
     lv_obj_set_style_opa(obj, v, 0);
 }
 
 static void set_x_anim(void * obj, int32_t v)
 {
+    LV_ASSERT(obj != NULL);
     lv_obj_set_x(obj, v);
 }
 
 static void set_y_anim(void * obj, int32_t v)
 {
+    LV_ASSERT(obj != NULL);
     lv_obj_set_y(obj, v);
 }
 
 static void scr_anim_completed(lv_anim_t * a)
 {
+    LV_ASSERT(a != NULL);
     lv_display_t * d = lv_obj_get_display(a->var);
+    LV_ASSERT(d != NULL);
 
     if(lv_obj_send_event(d->act_scr, LV_EVENT_SCREEN_LOADED, NULL) == LV_RESULT_INVALID) {
         d->act_scr = NULL;
@@ -1754,14 +1723,13 @@ static bool is_out_anim(lv_screen_load_anim_t anim_type)
 
 static void disp_event_cb(lv_event_t * e)
 {
+    LV_ASSERT(e != NULL);
     lv_event_code_t code = lv_event_get_code(e);
     lv_display_t * disp = lv_event_get_target(e);
-    switch(code) {
-        case LV_EVENT_REFR_REQUEST:
-            if(disp->refr_timer) lv_timer_resume(disp->refr_timer);
-            break;
+    LV_ASSERT(disp != NULL);
+    LV_ASSERT(code == LV_EVENT_REFR_REQUEST);
 
-        default:
-            break;
+    if(disp->refr_timer) {
+        lv_timer_resume(disp->refr_timer);
     }
 }

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -272,7 +272,10 @@ lv_display_t * lv_display_get_next(lv_display_t * disp)
 
 void lv_display_set_resolution(lv_display_t * disp, int32_t hor_res, int32_t ver_res)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return;
 
     if(disp->hor_res == hor_res && disp->ver_res == ver_res) return;
@@ -285,7 +288,10 @@ void lv_display_set_resolution(lv_display_t * disp, int32_t hor_res, int32_t ver
 
 void lv_display_set_physical_resolution(lv_display_t * disp, int32_t hor_res, int32_t ver_res)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return;
 
     disp->physical_hor_res = hor_res;
@@ -297,7 +303,10 @@ void lv_display_set_physical_resolution(lv_display_t * disp, int32_t hor_res, in
 
 void lv_display_set_offset(lv_display_t * disp, int32_t x, int32_t y)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return;
 
     disp->offset_x = x;
@@ -309,7 +318,11 @@ void lv_display_set_offset(lv_display_t * disp, int32_t x, int32_t y)
 
 void lv_display_set_dpi(lv_display_t * disp, int32_t dpi)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
+
     if(disp == NULL) return;
 
     disp->dpi = dpi;
@@ -317,7 +330,10 @@ void lv_display_set_dpi(lv_display_t * disp, int32_t dpi)
 
 int32_t lv_display_get_horizontal_resolution(const lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
 
     if(disp == NULL) {
         return 0;
@@ -335,7 +351,10 @@ int32_t lv_display_get_horizontal_resolution(const lv_display_t * disp)
 
 int32_t lv_display_get_vertical_resolution(const lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
 
     if(disp == NULL) {
         return 0;
@@ -353,7 +372,10 @@ int32_t lv_display_get_vertical_resolution(const lv_display_t * disp)
 
 int32_t lv_display_get_original_horizontal_resolution(const lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) {
         return 0;
     }
@@ -363,7 +385,10 @@ int32_t lv_display_get_original_horizontal_resolution(const lv_display_t * disp)
 
 int32_t lv_display_get_original_vertical_resolution(const lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) {
         return 0;
     }
@@ -373,7 +398,10 @@ int32_t lv_display_get_original_vertical_resolution(const lv_display_t * disp)
 
 int32_t lv_display_get_physical_horizontal_resolution(const lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
 
     if(disp == NULL) {
         return 0;
@@ -391,7 +419,10 @@ int32_t lv_display_get_physical_horizontal_resolution(const lv_display_t * disp)
 
 int32_t lv_display_get_physical_vertical_resolution(const lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
 
     if(disp == NULL) {
         return 0;
@@ -409,7 +440,10 @@ int32_t lv_display_get_physical_vertical_resolution(const lv_display_t * disp)
 
 int32_t lv_display_get_offset_x(const lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
 
     if(disp == NULL) {
         return 0;
@@ -430,7 +464,10 @@ int32_t lv_display_get_offset_x(const lv_display_t * disp)
 
 int32_t lv_display_get_offset_y(const lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
 
     if(disp == NULL) {
         return 0;
@@ -451,7 +488,10 @@ int32_t lv_display_get_offset_y(const lv_display_t * disp)
 
 int32_t lv_display_get_dpi(const lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return LV_DPI_DEF;  /*Do not return 0 because it might be a divider*/
     return disp->dpi;
 }
@@ -462,7 +502,10 @@ int32_t lv_display_get_dpi(const lv_display_t * disp)
 
 void lv_display_set_draw_buffers(lv_display_t * disp, lv_draw_buf_t * buf1, lv_draw_buf_t * buf2)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return;
 
     disp->buf_1 = buf1;
@@ -474,7 +517,10 @@ void lv_display_set_draw_buffers(lv_display_t * disp, lv_draw_buf_t * buf1, lv_d
 
 void lv_display_set_3rd_draw_buffer(lv_display_t * disp, lv_draw_buf_t * buf3)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return;
 
     LV_ASSERT_MSG(disp->buf_1 != NULL, "buf1 is null");
@@ -551,7 +597,10 @@ void lv_display_set_buffers_with_stride(lv_display_t * disp, void * buf1, void *
 
 void lv_display_set_render_mode(lv_display_t * disp, lv_display_render_mode_t render_mode)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return;
     disp->render_mode = render_mode;
 }
@@ -559,14 +608,20 @@ void lv_display_set_render_mode(lv_display_t * disp, lv_display_render_mode_t re
 
 lv_display_flush_cb_t lv_display_get_flush_cb(lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return NULL;
     return disp->flush_cb;
 }
 
 void lv_display_set_flush_cb(lv_display_t * disp, lv_display_flush_cb_t flush_cb)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return;
 
     disp->flush_cb = flush_cb;
@@ -574,7 +629,10 @@ void lv_display_set_flush_cb(lv_display_t * disp, lv_display_flush_cb_t flush_cb
 
 void lv_display_set_flush_wait_cb(lv_display_t * disp, lv_display_flush_wait_cb_t wait_cb)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return;
 
     disp->flush_wait_cb = wait_cb;
@@ -582,7 +640,10 @@ void lv_display_set_flush_wait_cb(lv_display_t * disp, lv_display_flush_wait_cb_
 
 void lv_display_set_sync_cb(lv_display_t * disp, lv_display_sync_cb_t sync_cb)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return;
 
     disp->sync_cb = sync_cb;
@@ -590,7 +651,10 @@ void lv_display_set_sync_cb(lv_display_t * disp, lv_display_sync_cb_t sync_cb)
 
 void lv_display_set_sync_wait_cb(lv_display_t * disp, lv_display_sync_wait_cb_t wait_cb)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return;
 
     disp->sync_wait_cb = wait_cb;
@@ -598,7 +662,10 @@ void lv_display_set_sync_wait_cb(lv_display_t * disp, lv_display_sync_wait_cb_t 
 
 void lv_display_set_color_format(lv_display_t * disp, lv_color_format_t color_format)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return;
 
     disp->color_format = color_format;
@@ -619,7 +686,10 @@ void lv_display_set_color_format(lv_display_t * disp, lv_color_format_t color_fo
 
 lv_color_format_t lv_display_get_color_format(lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return LV_COLOR_FORMAT_UNKNOWN;
 
     return disp->color_format;
@@ -629,7 +699,10 @@ void lv_display_set_tile_cnt(lv_display_t * disp, uint32_t tile_cnt)
 {
     LV_ASSERT_FORMAT_MSG(tile_cnt < 256, "tile_cnt must be smaller than 256 (%" LV_PRId32 " was used)", tile_cnt);
 
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return;
 
     disp->tile_cnt = tile_cnt;
@@ -637,7 +710,10 @@ void lv_display_set_tile_cnt(lv_display_t * disp, uint32_t tile_cnt)
 
 uint32_t lv_display_get_tile_cnt(lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return 0;
 
     return disp->tile_cnt;
@@ -647,7 +723,10 @@ void lv_display_set_antialiasing(lv_display_t * disp, bool en)
 {
     LV_LOG_WARN("Disabling anti-aliasing is not supported since v9. This function will be removed.");
 
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return;
 
     disp->antialiasing = en;
@@ -655,7 +734,10 @@ void lv_display_set_antialiasing(lv_display_t * disp, bool en)
 
 bool lv_display_get_antialiasing(lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return false;
 
     return disp->antialiasing;
@@ -663,8 +745,11 @@ bool lv_display_get_antialiasing(lv_display_t * disp)
 
 lv_display_render_mode_t lv_display_get_render_mode(lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
-    LV_ASSERT_MSG(disp != NULL, "No display to get render mode");
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
+    if(disp == NULL) return LV_DISPLAY_RENDER_MODE_PARTIAL;
 
     return disp->render_mode;
 }
@@ -700,7 +785,10 @@ bool lv_display_is_double_buffered(lv_display_t * disp)
 
 lv_obj_t * lv_display_get_screen_active(lv_display_t * disp)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) {
         LV_LOG_WARN("no display registered to get its active screen");
         return NULL;
@@ -711,7 +799,10 @@ lv_obj_t * lv_display_get_screen_active(lv_display_t * disp)
 
 lv_obj_t * lv_display_get_screen_loading(lv_display_t * disp)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) {
         LV_LOG_WARN("no display registered to get the current screen being loaded");
         return NULL;
@@ -722,7 +813,10 @@ lv_obj_t * lv_display_get_screen_loading(lv_display_t * disp)
 
 lv_obj_t * lv_display_get_screen_prev(lv_display_t * disp)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) {
         LV_LOG_WARN("no display registered to get its previous screen");
         return NULL;
@@ -733,7 +827,10 @@ lv_obj_t * lv_display_get_screen_prev(lv_display_t * disp)
 
 lv_obj_t * lv_display_get_layer_top(lv_display_t * disp)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) {
         LV_LOG_WARN("lv_layer_top: no display registered to get its top layer");
         return NULL;
@@ -744,7 +841,10 @@ lv_obj_t * lv_display_get_layer_top(lv_display_t * disp)
 
 lv_obj_t * lv_display_get_layer_sys(lv_display_t * disp)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) {
         LV_LOG_WARN("lv_layer_sys: no display registered to get its sys. layer");
         return NULL;
@@ -755,7 +855,10 @@ lv_obj_t * lv_display_get_layer_sys(lv_display_t * disp)
 
 lv_obj_t * lv_display_get_layer_bottom(lv_display_t * disp)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) {
         LV_LOG_WARN("lv_layer_bottom: no display registered to get its bottom layer");
         return NULL;
@@ -768,7 +871,10 @@ lv_obj_t * lv_display_get_layer_bottom(lv_display_t * disp)
 
 lv_obj_t * lv_display_get_screen_by_name(const lv_display_t * disp, const char * screen_name)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) {
         LV_LOG_WARN("no display registered to get a screen by name");
         return NULL;
@@ -1022,7 +1128,10 @@ lv_area_t * lv_event_get_invalidated_area(lv_event_t * e)
 
 void lv_display_set_rotation(lv_display_t * disp, lv_display_rotation_t rotation)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return;
 
     disp->rotation = rotation;
@@ -1031,7 +1140,10 @@ void lv_display_set_rotation(lv_display_t * disp, lv_display_rotation_t rotation
 
 lv_display_rotation_t lv_display_get_rotation(lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return LV_DISPLAY_ROTATION_0;
     return disp->rotation;
 }
@@ -1039,7 +1151,10 @@ lv_display_rotation_t lv_display_get_rotation(lv_display_t * disp)
 void lv_display_set_matrix_rotation(lv_display_t * disp, bool enable)
 {
 #if LV_DRAW_TRANSFORM_USE_MATRIX
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return;
 
     if(!(disp->render_mode == LV_DISPLAY_RENDER_MODE_DIRECT || disp->render_mode == LV_DISPLAY_RENDER_MODE_FULL)) {
@@ -1057,14 +1172,20 @@ void lv_display_set_matrix_rotation(lv_display_t * disp, bool enable)
 
 bool lv_display_get_matrix_rotation(lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(disp == NULL) return false;
     return disp->matrix_rotation;
 }
 
 void lv_display_set_theme(lv_display_t * disp, lv_theme_t * th)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) {
         LV_LOG_WARN("no display registered");
         return;
@@ -1089,7 +1210,13 @@ void lv_display_set_theme(lv_display_t * disp, lv_theme_t * th)
 
 lv_theme_t * lv_display_get_theme(lv_display_t * disp)
 {
-    if(disp == NULL) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
+    if(disp == NULL) {
+        return NULL;
+    }
     return disp->theme;
 }
 
@@ -1111,7 +1238,10 @@ uint32_t lv_display_get_inactive_time(const lv_display_t * disp)
 
 void lv_display_trigger_activity(lv_display_t * disp)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) {
         LV_LOG_WARN("lv_display_trigger_activity: no display registered");
         return;
@@ -1122,7 +1252,10 @@ void lv_display_trigger_activity(lv_display_t * disp)
 
 void lv_display_enable_invalidation(lv_display_t * disp, bool en)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) {
         LV_LOG_WARN("no display registered");
         return;
@@ -1133,7 +1266,10 @@ void lv_display_enable_invalidation(lv_display_t * disp, bool en)
 
 bool lv_display_is_invalidation_enabled(lv_display_t * disp)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) {
         LV_LOG_WARN("no display registered");
         return false;
@@ -1144,7 +1280,10 @@ bool lv_display_is_invalidation_enabled(lv_display_t * disp)
 
 lv_timer_t * lv_display_get_refr_timer(lv_display_t * disp)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) return NULL;
 
     return disp->refr_timer;
@@ -1152,7 +1291,10 @@ lv_timer_t * lv_display_get_refr_timer(lv_display_t * disp)
 
 void lv_display_delete_refr_timer(lv_display_t * disp)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp || !disp->refr_timer) return;
 
     lv_timer_delete(disp->refr_timer);
@@ -1161,7 +1303,10 @@ void lv_display_delete_refr_timer(lv_display_t * disp)
 
 lv_result_t lv_display_send_vsync_event(lv_display_t * disp, void * param)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) return LV_RESULT_INVALID;
 
     if(disp->vsync_count > 0)
@@ -1172,7 +1317,10 @@ lv_result_t lv_display_send_vsync_event(lv_display_t * disp, void * param)
 
 bool lv_display_register_vsync_event(lv_display_t * disp, lv_event_cb_t event_cb, void * user_data)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) return false;
 
     lv_display_add_event_cb(disp, event_cb, LV_EVENT_VSYNC, user_data);
@@ -1187,7 +1335,10 @@ bool lv_display_register_vsync_event(lv_display_t * disp, lv_event_cb_t event_cb
 
 bool lv_display_unregister_vsync_event(lv_display_t * disp, lv_event_cb_t event_cb, void * user_data)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) return false;
 
     uint32_t removed_count = lv_display_remove_event_cb_with_user_data(disp, event_cb, user_data);
@@ -1204,14 +1355,20 @@ bool lv_display_unregister_vsync_event(lv_display_t * disp, lv_event_cb_t event_
 
 void lv_display_set_user_data(lv_display_t * disp, void * user_data)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) return;
     disp->user_data = user_data;
 }
 
 void lv_display_set_driver_data(lv_display_t * disp, void * driver_data)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) return;
 
     disp->driver_data = driver_data;
@@ -1219,14 +1376,20 @@ void lv_display_set_driver_data(lv_display_t * disp, void * driver_data)
 
 void * lv_display_get_user_data(lv_display_t * disp)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) return NULL;
     return disp->user_data;
 }
 
 void * lv_display_get_driver_data(lv_display_t * disp)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) return NULL;
 
     return disp->driver_data;
@@ -1234,7 +1397,10 @@ void * lv_display_get_driver_data(lv_display_t * disp)
 
 lv_draw_buf_t * lv_display_get_buf_active(lv_display_t * disp)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) return NULL;
     return disp->buf_act;
 }
@@ -1331,7 +1497,10 @@ void lv_display_rotate_point_ccw(lv_display_t * disp, lv_point_t * point)
 
 uint32_t lv_display_get_draw_buf_size(lv_display_t * disp)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) return 0;
 
     if(disp->buf_1) {
@@ -1342,7 +1511,10 @@ uint32_t lv_display_get_draw_buf_size(lv_display_t * disp)
 
 uint32_t lv_display_get_invalidated_draw_buf_size(lv_display_t * disp, uint32_t width, uint32_t height)
 {
-    if(!disp) disp = lv_display_get_default();
+    if(disp == NULL) {
+        LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
+        disp = lv_display_get_default();
+    }
     if(!disp) return 0;
 
     if(disp->render_mode == LV_DISPLAY_RENDER_MODE_FULL) {

--- a/src/display/lv_display_private.h
+++ b/src/display/lv_display_private.h
@@ -20,6 +20,9 @@ extern "C" {
 #include "../debugging/sysmon/lv_sysmon_private.h"
 #endif
 
+#define LOG_NULL_DISPLAY_DEPRECATED_MESSAGE() \
+    LV_LOG_DEPRECATED("Calling this function with a NULL display is deprecated. You can retrieve the default display with `lv_display_get_default()`")
+
 /*********************
  *      DEFINES
  *********************/

--- a/src/misc/lv_anim.c
+++ b/src/misc/lv_anim.c
@@ -90,7 +90,7 @@ void lv_anim_enable_vsync_mode(bool enable)
             LV_ASSERT_NULL(state.timer);
 
             if(state.anim_vsync_registered) {
-                lv_display_unregister_vsync_event(NULL, anim_vsync_event, NULL);
+                lv_display_unregister_vsync_event(lv_display_get_default(), anim_vsync_event, NULL);
                 state.anim_vsync_registered = false;
             }
         }
@@ -777,7 +777,7 @@ static void anim_mark_list_change(void)
         }
 
         if(state.anim_vsync_registered) {
-            lv_display_unregister_vsync_event(NULL, anim_vsync_event, NULL);
+            lv_display_unregister_vsync_event(lv_display_get_default(), anim_vsync_event, NULL);
             state.anim_vsync_registered = false;
         }
 
@@ -790,7 +790,7 @@ static void anim_mark_list_change(void)
     }
 
     if(!state.anim_vsync_registered) {
-        lv_display_register_vsync_event(NULL, anim_vsync_event, NULL);
+        lv_display_register_vsync_event(lv_display_get_default(), anim_vsync_event, NULL);
         state.anim_vsync_registered = true;
     }
 }

--- a/tests/src/lv_test_init.c
+++ b/tests/src/lv_test_init.c
@@ -35,10 +35,10 @@ void lv_test_init(void)
 
 #if LV_USE_SYSMON
 #if LV_USE_MEM_MONITOR
-    lv_sysmon_hide_memory(NULL);
+    lv_sysmon_hide_memory(lv_display_get_default());
 #endif
 #if LV_USE_PERF_MONITOR
-    lv_sysmon_hide_performance(NULL);
+    lv_sysmon_hide_performance(lv_display_get_default());
 #endif
 #endif
 }

--- a/tests/src/test_cases/draw/test_render_to_al88.c
+++ b/tests/src/test_cases/draw/test_render_to_al88.c
@@ -13,7 +13,7 @@ void setUp(void)
 void tearDown(void)
 {
     /* Function run after every test */
-    lv_display_set_color_format(NULL, LV_COLOR_FORMAT_XRGB8888);
+    lv_display_set_color_format(lv_display_get_default(), LV_COLOR_FORMAT_XRGB8888);
 }
 
 void test_render_to_al88(void)
@@ -22,7 +22,7 @@ void test_render_to_al88(void)
 #if LV_USE_DRAW_VG_LITE || LV_USE_DRAW_NANOVG
     TEST_PASS();
 #else
-    lv_display_set_color_format(NULL, LV_COLOR_FORMAT_AL88);
+    lv_display_set_color_format(lv_display_get_default(), LV_COLOR_FORMAT_AL88);
 
     lv_opa_t opa_values[2] = {0xff, 0x80};
     uint32_t opa;

--- a/tests/src/test_cases/draw/test_render_to_argb8888.c
+++ b/tests/src/test_cases/draw/test_render_to_argb8888.c
@@ -13,12 +13,12 @@ void setUp(void)
 void tearDown(void)
 {
     /* Function run after every test */
-    lv_display_set_color_format(NULL, LV_COLOR_FORMAT_XRGB8888);
+    lv_display_set_color_format(lv_display_get_default(), LV_COLOR_FORMAT_XRGB8888);
 }
 
 void test_render_to_argb8888(void)
 {
-    lv_display_set_color_format(NULL, LV_COLOR_FORMAT_ARGB8888);
+    lv_display_set_color_format(lv_display_get_default(), LV_COLOR_FORMAT_ARGB8888);
 
     lv_opa_t opa_values[2] = {0xff, 0x80};
     uint32_t opa;

--- a/tests/src/test_cases/draw/test_render_to_argb8888_premultiplied.c
+++ b/tests/src/test_cases/draw/test_render_to_argb8888_premultiplied.c
@@ -13,7 +13,7 @@ void setUp(void)
 void tearDown(void)
 {
     /* Function run after every test */
-    lv_display_set_color_format(NULL, LV_COLOR_FORMAT_XRGB8888);
+    lv_display_set_color_format(lv_display_get_default(), LV_COLOR_FORMAT_XRGB8888);
 }
 
 void test_render_to_argb8888_premultiplied(void)
@@ -23,7 +23,7 @@ void test_render_to_argb8888_premultiplied(void)
 #if LV_USE_DRAW_NANOVG
     TEST_PASS();
 #else
-    lv_display_set_color_format(NULL, LV_COLOR_FORMAT_ARGB8888_PREMULTIPLIED);
+    lv_display_set_color_format(lv_display_get_default(), LV_COLOR_FORMAT_ARGB8888_PREMULTIPLIED);
 
     lv_opa_t opa_values[2] = {0xff, 0x80};
     uint32_t opa;

--- a/tests/src/test_cases/draw/test_render_to_i1.c
+++ b/tests/src/test_cases/draw/test_render_to_i1.c
@@ -12,14 +12,14 @@ void setUp(void)
 void tearDown(void)
 {
     /* Function run after every test */
-    lv_display_set_color_format(NULL, LV_COLOR_FORMAT_XRGB8888);
+    lv_display_set_color_format(lv_display_get_default(), LV_COLOR_FORMAT_XRGB8888);
 }
 
 void test_render_to_i1(void)
 {
     /*NanoVG reads back the FBO as 32bpp BGRA, so non-XRGB8888 targets don't apply*/
 #if LV_BIN_DECODER_RAM_LOAD && LV_USE_DRAW_VG_LITE == 0 && LV_USE_DRAW_NANOVG == 0
-    lv_display_set_color_format(NULL, LV_COLOR_FORMAT_I1);
+    lv_display_set_color_format(lv_display_get_default(), LV_COLOR_FORMAT_I1);
 
     lv_opa_t opa_values[2] = {0xff, 0xc0};
     uint32_t opa;

--- a/tests/src/test_cases/draw/test_render_to_l8.c
+++ b/tests/src/test_cases/draw/test_render_to_l8.c
@@ -13,7 +13,7 @@ void setUp(void)
 void tearDown(void)
 {
     /* Function run after every test */
-    lv_display_set_color_format(NULL, LV_COLOR_FORMAT_XRGB8888);
+    lv_display_set_color_format(lv_display_get_default(), LV_COLOR_FORMAT_XRGB8888);
 }
 
 void test_render_to_l8(void)
@@ -22,7 +22,7 @@ void test_render_to_l8(void)
 #if LV_USE_DRAW_NANOVG
     TEST_PASS();
 #else
-    lv_display_set_color_format(NULL, LV_COLOR_FORMAT_L8);
+    lv_display_set_color_format(lv_display_get_default(), LV_COLOR_FORMAT_L8);
 
     lv_opa_t opa_values[2] = {0xff, 0x80};
     uint32_t opa;

--- a/tests/src/test_cases/draw/test_render_to_rgb565.c
+++ b/tests/src/test_cases/draw/test_render_to_rgb565.c
@@ -13,7 +13,7 @@ void setUp(void)
 void tearDown(void)
 {
     /* Function run after every test */
-    lv_display_set_color_format(NULL, LV_COLOR_FORMAT_XRGB8888);
+    lv_display_set_color_format(lv_display_get_default(), LV_COLOR_FORMAT_XRGB8888);
 }
 
 void test_render_to_rgb565(void)
@@ -22,7 +22,7 @@ void test_render_to_rgb565(void)
 #if LV_USE_DRAW_NANOVG
     TEST_PASS();
 #else
-    lv_display_set_color_format(NULL, LV_COLOR_FORMAT_RGB565);
+    lv_display_set_color_format(lv_display_get_default(), LV_COLOR_FORMAT_RGB565);
 
     lv_opa_t opa_values[2] = {0xff, 0x80};
     uint32_t opa;

--- a/tests/src/test_cases/draw/test_render_to_rgb565_swapped.c
+++ b/tests/src/test_cases/draw/test_render_to_rgb565_swapped.c
@@ -13,7 +13,7 @@ void setUp(void)
 void tearDown(void)
 {
     /* Function run after every test */
-    lv_display_set_color_format(NULL, LV_COLOR_FORMAT_XRGB8888);
+    lv_display_set_color_format(lv_display_get_default(), LV_COLOR_FORMAT_XRGB8888);
 }
 
 void test_render_to_rgb565_swapped(void)
@@ -25,7 +25,7 @@ void test_render_to_rgb565_swapped(void)
     /*NanoVG reads back the FBO as 32bpp BGRA, so non-XRGB8888 targets don't apply*/
     TEST_PASS();
 #else
-    lv_display_set_color_format(NULL, LV_COLOR_FORMAT_RGB565_SWAPPED);
+    lv_display_set_color_format(lv_display_get_default(), LV_COLOR_FORMAT_RGB565_SWAPPED);
 
     lv_opa_t opa_values[2] = {0xff, 0x80};
     uint32_t opa;

--- a/tests/src/test_cases/draw/test_render_to_rgb888.c
+++ b/tests/src/test_cases/draw/test_render_to_rgb888.c
@@ -13,7 +13,7 @@ void setUp(void)
 void tearDown(void)
 {
     /* Function run after every test */
-    lv_display_set_color_format(NULL, LV_COLOR_FORMAT_XRGB8888);
+    lv_display_set_color_format(lv_display_get_default(), LV_COLOR_FORMAT_XRGB8888);
 }
 
 void test_render_to_rgb888(void)
@@ -22,7 +22,7 @@ void test_render_to_rgb888(void)
 #if LV_USE_DRAW_NANOVG
     TEST_PASS();
 #else
-    lv_display_set_color_format(NULL, LV_COLOR_FORMAT_RGB888);
+    lv_display_set_color_format(lv_display_get_default(), LV_COLOR_FORMAT_RGB888);
 
     lv_opa_t opa_values[2] = {0xff, 0x80};
     uint32_t opa;

--- a/tests/src/test_cases/draw/test_render_to_xrgb8888.c
+++ b/tests/src/test_cases/draw/test_render_to_xrgb8888.c
@@ -13,12 +13,12 @@ void setUp(void)
 void tearDown(void)
 {
     /* Function run after every test */
-    lv_display_set_color_format(NULL, LV_COLOR_FORMAT_XRGB8888);
+    lv_display_set_color_format(lv_display_get_default(), LV_COLOR_FORMAT_XRGB8888);
 }
 
 void test_render_to_xrgb8888(void)
 {
-    lv_display_set_color_format(NULL, LV_COLOR_FORMAT_XRGB8888);
+    lv_display_set_color_format(lv_display_get_default(), LV_COLOR_FORMAT_XRGB8888);
 
     lv_opa_t opa_values[2] = {0xff, 0x80};
     uint32_t opa;

--- a/tests/src/test_cases/test_anim.c
+++ b/tests/src/test_cases/test_anim.c
@@ -241,11 +241,11 @@ void test_anim_vsync_mode(void)
 
     /*Use vsync events to notify anim updates*/
     lv_tick_inc(10);
-    lv_display_send_vsync_event(NULL, NULL);
+    lv_display_send_vsync_event(lv_display_get_default(), NULL);
     TEST_ASSERT_EQUAL(9, var);
 
     lv_tick_inc(10);
-    lv_display_send_vsync_event(NULL, NULL);
+    lv_display_send_vsync_event(lv_display_get_default(), NULL);
     TEST_ASSERT_EQUAL(19, var);
 
     lv_anim_enable_vsync_mode(false);
@@ -253,7 +253,7 @@ void test_anim_vsync_mode(void)
 
     /* Should not update the animation with vsync events when vsync mode is disabled */
     lv_tick_inc(20);
-    lv_display_send_vsync_event(NULL, NULL);
+    lv_display_send_vsync_event(lv_display_get_default(), NULL);
     TEST_ASSERT_EQUAL(19, var);
 
     /* Test normal timer mode */

--- a/tests/src/test_cases/test_config.c
+++ b/tests/src/test_cases/test_config.c
@@ -9,11 +9,11 @@ void test_config(void);
 void test_config(void)
 {
     TEST_ASSERT_EQUAL(130, LV_DPI_DEF);
-    TEST_ASSERT_EQUAL(130, lv_display_get_dpi(NULL));
+    TEST_ASSERT_EQUAL(130, lv_display_get_dpi(lv_display_get_default()));
     TEST_ASSERT_EQUAL(800, LV_HOR_RES);
-    TEST_ASSERT_EQUAL(800, lv_display_get_horizontal_resolution(NULL));
+    TEST_ASSERT_EQUAL(800, lv_display_get_horizontal_resolution(lv_display_get_default()));
     TEST_ASSERT_EQUAL(480, LV_VER_RES);
-    TEST_ASSERT_EQUAL(480, lv_display_get_vertical_resolution(NULL));
+    TEST_ASSERT_EQUAL(480, lv_display_get_vertical_resolution(lv_display_get_default()));
     TEST_ASSERT_EQUAL(32, LV_COLOR_DEPTH);
 }
 

--- a/tests/src/test_cases/test_display.c
+++ b/tests/src/test_cases/test_display.c
@@ -15,7 +15,7 @@ void setUp(void)
 
 void tearDown(void)
 {
-    lv_display_set_matrix_rotation(NULL, false);
+    lv_display_set_matrix_rotation(lv_display_get_default(), false);
     lv_obj_clean(lv_screen_active());
     lv_obj_clean(lv_layer_top());
     lv_obj_clean(lv_layer_sys());
@@ -390,18 +390,18 @@ void test_display_resolution(void)
     test_display_resolution_full_rotation(disp, 320, 480, 240, 320, 10, 20);
 
     /* Test default display */
-    lv_display_set_resolution(NULL, 32, 48);
-    lv_display_set_physical_resolution(NULL, 24, 32);
-    lv_display_set_offset(NULL, 1, 2);
+    lv_display_set_resolution(lv_display_get_default(), 32, 48);
+    lv_display_set_physical_resolution(lv_display_get_default(), 24, 32);
+    lv_display_set_offset(lv_display_get_default(), 1, 2);
     test_display_resolution_full_rotation(disp, 32, 48, 24, 32, 1, 2);
 
     /* Test NULL default display, should not affect the display */
     lv_display_set_default(NULL);
-    lv_display_set_resolution(NULL, 2, 3);
-    lv_display_set_physical_resolution(NULL, 4, 5);
-    lv_display_set_offset(NULL, 6, 7);
+    lv_display_set_resolution(lv_display_get_default(), 2, 3);
+    lv_display_set_physical_resolution(lv_display_get_default(), 4, 5);
+    lv_display_set_offset(lv_display_get_default(), 6, 7);
     test_display_resolution_full_rotation(disp, 32, 48, 24, 32, 1, 2);
-    test_display_resolution_full_rotation(NULL, 0, 0, 0, 0, 0, 0);
+    test_display_resolution_full_rotation(lv_display_get_default(), 0, 0, 0, 0, 0, 0);
 
     /* Restore default display */
     lv_display_set_default(disp_def);
@@ -441,25 +441,25 @@ void test_display_dpi_tile_cnt_antialiasing(void)
     TEST_ASSERT_EQUAL_INT32(10, lv_display_get_tile_cnt(disp));
 
     /* Test default display, should same affect the display */
-    lv_display_set_dpi(NULL, 160);
-    TEST_ASSERT_EQUAL_INT32(160, lv_display_get_dpi(NULL));
-    lv_display_set_antialiasing(NULL, false);
-    TEST_ASSERT_FALSE(lv_display_get_antialiasing(NULL));
-    lv_display_set_antialiasing(NULL, true);
-    TEST_ASSERT_TRUE(lv_display_get_antialiasing(NULL));
-    lv_display_set_tile_cnt(NULL, 20);
-    TEST_ASSERT_EQUAL_INT32(20, lv_display_get_tile_cnt(NULL));
+    lv_display_set_dpi(lv_display_get_default(), 160);
+    TEST_ASSERT_EQUAL_INT32(160, lv_display_get_dpi(lv_display_get_default()));
+    lv_display_set_antialiasing(lv_display_get_default(), false);
+    TEST_ASSERT_FALSE(lv_display_get_antialiasing(lv_display_get_default()));
+    lv_display_set_antialiasing(lv_display_get_default(), true);
+    TEST_ASSERT_TRUE(lv_display_get_antialiasing(lv_display_get_default()));
+    lv_display_set_tile_cnt(lv_display_get_default(), 20);
+    TEST_ASSERT_EQUAL_INT32(20, lv_display_get_tile_cnt(lv_display_get_default()));
 
     /* Test NULL default display, should not affect the display */
     lv_display_set_default(NULL);
-    lv_display_set_dpi(NULL, 200);
-    TEST_ASSERT_EQUAL_INT32(LV_DPI_DEF, lv_display_get_dpi(NULL));
-    lv_display_set_antialiasing(NULL, false);
-    TEST_ASSERT_FALSE(lv_display_get_antialiasing(NULL));
-    lv_display_set_antialiasing(NULL, true);
-    TEST_ASSERT_FALSE(lv_display_get_antialiasing(NULL));
-    lv_display_set_tile_cnt(NULL, 20);
-    TEST_ASSERT_EQUAL_INT32(0, lv_display_get_tile_cnt(NULL));
+    lv_display_set_dpi(lv_display_get_default(), 200);
+    TEST_ASSERT_EQUAL_INT32(LV_DPI_DEF, lv_display_get_dpi(lv_display_get_default()));
+    lv_display_set_antialiasing(lv_display_get_default(), false);
+    TEST_ASSERT_FALSE(lv_display_get_antialiasing(lv_display_get_default()));
+    lv_display_set_antialiasing(lv_display_get_default(), true);
+    TEST_ASSERT_FALSE(lv_display_get_antialiasing(lv_display_get_default()));
+    lv_display_set_tile_cnt(lv_display_get_default(), 20);
+    TEST_ASSERT_EQUAL_INT32(0, lv_display_get_tile_cnt(lv_display_get_default()));
 
     /* Restore default display */
     lv_display_set_default(disp_def);
@@ -548,18 +548,18 @@ void test_display_layers(void)
     lv_display_t * disp_def = lv_display_get_default();
     TEST_ASSERT_NOT_NULL(disp_def);
 
-    TEST_ASSERT_NOT_NULL(lv_display_get_screen_active(NULL));
-    TEST_ASSERT_NULL(lv_display_get_screen_prev(NULL));
-    TEST_ASSERT_NOT_NULL(lv_display_get_layer_top(NULL));
-    TEST_ASSERT_NOT_NULL(lv_display_get_layer_sys(NULL));
-    TEST_ASSERT_NOT_NULL(lv_display_get_layer_bottom(NULL));
+    TEST_ASSERT_NOT_NULL(lv_display_get_screen_active(lv_display_get_default()));
+    TEST_ASSERT_NULL(lv_display_get_screen_prev(lv_display_get_default()));
+    TEST_ASSERT_NOT_NULL(lv_display_get_layer_top(lv_display_get_default()));
+    TEST_ASSERT_NOT_NULL(lv_display_get_layer_sys(lv_display_get_default()));
+    TEST_ASSERT_NOT_NULL(lv_display_get_layer_bottom(lv_display_get_default()));
 
     lv_display_set_default(NULL);
-    TEST_ASSERT_NULL(lv_display_get_screen_active(NULL));
-    TEST_ASSERT_NULL(lv_display_get_screen_prev(NULL));
-    TEST_ASSERT_NULL(lv_display_get_layer_top(NULL));
-    TEST_ASSERT_NULL(lv_display_get_layer_sys(NULL));
-    TEST_ASSERT_NULL(lv_display_get_layer_bottom(NULL));
+    TEST_ASSERT_NULL(lv_display_get_screen_active(lv_display_get_default()));
+    TEST_ASSERT_NULL(lv_display_get_screen_prev(lv_display_get_default()));
+    TEST_ASSERT_NULL(lv_display_get_layer_top(lv_display_get_default()));
+    TEST_ASSERT_NULL(lv_display_get_layer_sys(lv_display_get_default()));
+    TEST_ASSERT_NULL(lv_display_get_layer_bottom(lv_display_get_default()));
 
     lv_display_set_default(disp_def);
 }
@@ -572,15 +572,15 @@ void test_display_active_time(void)
     lv_tick_inc(1000);
     TEST_ASSERT_EQUAL_UINT32(1000, lv_display_get_inactive_time(disp_def));
 
-    lv_display_trigger_activity(NULL);
+    lv_display_trigger_activity(disp_def);
     lv_tick_inc(1000);
-    TEST_ASSERT_EQUAL_UINT32(1000, lv_display_get_inactive_time(NULL));
+    TEST_ASSERT_EQUAL_UINT32(1000, lv_display_get_inactive_time(lv_display_get_default()));
 
     /* Test NULL default display, should not affect the display */
     lv_display_set_default(NULL);
-    lv_display_trigger_activity(NULL);
+    lv_display_trigger_activity(lv_display_get_default());
     lv_tick_inc(1000);
-    TEST_ASSERT_EQUAL_UINT32(2000, lv_display_get_inactive_time(NULL));
+    TEST_ASSERT_EQUAL_UINT32(2000, lv_display_get_inactive_time(lv_display_get_default()));
 
     lv_display_set_default(disp_def);
 }

--- a/tests/src/test_cases/test_snapshot.c
+++ b/tests/src/test_cases/test_snapshot.c
@@ -466,8 +466,9 @@ void test_snapshot_refresh_logic_edge_cases(void)
     TEST_ASSERT_NOT_NULL(draw_buf1);
 
     /* Verify screen snapshot size */
-    int32_t screen_w = lv_display_get_horizontal_resolution(NULL);
-    int32_t screen_h = lv_display_get_vertical_resolution(NULL);
+    lv_display_t * display = lv_display_get_default();
+    int32_t screen_w = lv_display_get_horizontal_resolution(display);
+    int32_t screen_h = lv_display_get_vertical_resolution(display);
     int32_t ext_size = lv_obj_get_ext_draw_size(lv_screen_active());
     TEST_ASSERT_EQUAL_UINT32(screen_w + ext_size * 2, draw_buf1->header.w);
     TEST_ASSERT_EQUAL_UINT32(screen_h + ext_size * 2, draw_buf1->header.h);

--- a/tests/src/test_cases/test_theme.c
+++ b/tests/src/test_cases/test_theme.c
@@ -25,7 +25,8 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj)
 
 void test_theme(void)
 {
-    lv_theme_t * theme = lv_display_get_theme(NULL);
+    lv_display_t * display = lv_display_get_default();
+    lv_theme_t * theme = lv_display_get_theme(display);
     TEST_ASSERT_NOT_NULL(theme);
 
     lv_theme_t new_theme;
@@ -44,8 +45,7 @@ void test_theme(void)
 
     lv_theme_set_apply_cb(&new_theme, NULL);
     TEST_ASSERT_NULL(new_theme.apply_cb);
-
-    lv_display_set_theme(NULL, &new_theme);
+    lv_display_set_theme(display, &new_theme);
 
     lv_obj_t * obj = lv_obj_create(lv_screen_active());
     TEST_ASSERT_EQUAL_PTR(&lv_font_montserrat_16, lv_theme_get_font_small(obj));
@@ -55,7 +55,7 @@ void test_theme(void)
     TEST_ASSERT_EQUAL_COLOR(lv_color_hex(0x00FF00), lv_theme_get_color_secondary(NULL));
 
     /* Verify default values */
-    lv_display_set_theme(NULL, NULL);
+    lv_display_set_theme(display, NULL);
     TEST_ASSERT_EQUAL_PTR(LV_FONT_DEFAULT, lv_theme_get_font_small(obj));
     TEST_ASSERT_EQUAL_PTR(LV_FONT_DEFAULT, lv_theme_get_font_normal(obj));
     TEST_ASSERT_EQUAL_PTR(LV_FONT_DEFAULT, lv_theme_get_font_large(obj));
@@ -162,18 +162,18 @@ void test_theme_default_resolution_change_no_recursion(void)
                                                lv_palette_main(LV_PALETTE_BLUE),
                                                lv_palette_main(LV_PALETTE_RED),
                                                true, LV_FONT_DEFAULT);
-    lv_display_set_theme(NULL, theme);
+    lv_display_set_theme(lv_display_get_default(), theme);
 
     lv_obj_t * label = lv_label_create(lv_screen_active());
     lv_label_set_text(label, "Resolution change test");
     lv_button_create(lv_screen_active());
 
-    lv_display_set_resolution(NULL, 320, 240);
+    lv_display_set_resolution(lv_display_get_default(), 320, 240);
 
     TEST_ASSERT_NOT_NULL(lv_screen_active());
     TEST_ASSERT_TRUE(lv_theme_default_is_inited());
 
-    lv_display_set_resolution(NULL, 800, 480);
+    lv_display_set_resolution(lv_display_get_default(), 800, 480);
 
     TEST_ASSERT_NOT_NULL(lv_screen_active());
     TEST_ASSERT_TRUE(lv_theme_default_is_inited());
@@ -192,7 +192,8 @@ void test_theme_default(void)
                                                lv_palette_main(LV_PALETTE_RED),
                                                false, LV_FONT_DEFAULT);
     TEST_ASSERT_EQUAL_PTR(theme, lv_theme_default_get());
-    lv_display_set_theme(NULL, theme);
+    lv_display_t * display = lv_display_get_default();
+    lv_display_set_theme(display, theme);
     test_widgets("theme_default_light.png");
 
     theme = lv_theme_default_init(NULL,
@@ -200,10 +201,10 @@ void test_theme_default(void)
                                   lv_palette_main(LV_PALETTE_RED),
                                   true, LV_FONT_DEFAULT);
     TEST_ASSERT_EQUAL_PTR(theme, lv_theme_default_get());
-    lv_display_set_theme(NULL, theme);
+    lv_display_set_theme(display, theme);
     test_widgets("theme_default_dark.png");
 
-    lv_display_set_theme(NULL, NULL);
+    lv_display_set_theme(display, NULL);
 
     lv_theme_default_deinit();
     TEST_ASSERT_FALSE(lv_theme_default_is_inited());
@@ -214,15 +215,16 @@ void test_theme_mono(void)
 {
     lv_theme_t * theme = lv_theme_mono_init(NULL, false, LV_FONT_DEFAULT);
     TEST_ASSERT_EQUAL_PTR(theme, lv_theme_mono_get());
-    lv_display_set_theme(NULL, theme);
+    lv_display_t * display = lv_display_get_default();
+    lv_display_set_theme(display, theme);
     test_widgets("theme_mono_light.png");
 
     theme = lv_theme_mono_init(NULL, true, LV_FONT_DEFAULT);
     TEST_ASSERT_EQUAL_PTR(theme, lv_theme_mono_get());
-    lv_display_set_theme(NULL, theme);
+    lv_display_set_theme(display, theme);
     test_widgets("theme_mono_dark.png");
 
-    lv_display_set_theme(NULL, NULL);
+    lv_display_set_theme(display, NULL);
 
     lv_theme_mono_deinit();
     TEST_ASSERT_FALSE(lv_theme_mono_is_inited());
@@ -233,10 +235,11 @@ void test_theme_simple(void)
 {
     lv_theme_t * theme = lv_theme_simple_init(NULL);
     TEST_ASSERT_EQUAL_PTR(theme, lv_theme_simple_get());
-    lv_display_set_theme(NULL, theme);
+    lv_display_t * display = lv_display_get_default();
+    lv_display_set_theme(display, theme);
     test_widgets("theme_simple.png");
 
-    lv_display_set_theme(NULL, NULL);
+    lv_display_set_theme(display, NULL);
 
     lv_theme_simple_deinit();
     TEST_ASSERT_FALSE(lv_theme_simple_is_inited());


### PR DESCRIPTION
- **feat(display): deprecate calling public api with NULL display**
- **feat(sysmon): deprecate calling public api with NULL display**
- **feat(refr): deprecate calling public api with NULL display**
- **refactor(display): explicitly pass default display to lv_display functions**
- **refactor(sysmon): explicitly pass default display to lv_sysmon functions**
- **refactor(display): refactor duplicated code in set_buffers**
- **feat(display): standardize api argument checks**
- **feat(sysmon): standardize api argument checks**


This PR deprecates passing `NULL` to functions who take a `lv_display_t* ` parameter
In some cases these functions mean the default parameter whereas other functions it's invalid, this 
PR standardizes it by simply deprecating that specific usage.

Also adds arg checks to display and sysmon functions as it was a backlog task and this avoids conflicts

Recommend reviewing commit by commit

