### PR TITLE
build(cmake): remove unused PUBLIC_HEADER property from lvgl_thorvg

### DIFF
--- a/env_support/cmake/main.cmake
+++ b/env_support/cmake/main.cmake
@@ -159,8 +159,6 @@ if (NOT LV_BUILD_USE_KCONFIG)
 
         set(CONF_INC_DIR ${LV_BUILD_CONF_DIR})
 
-        list(APPEND LVGL_PUBLIC_HEADERS ${CONF_INC_DIR}/lv_conf.h)
-
         # Avoid compilation errors due to the relative path of the include directory
         if (NOT IS_ABSOLUTE ${CONF_INC_DIR})
             file(REAL_PATH ${CONF_INC_DIR} CONF_INC_DIR BASE_DIRECTORY ${CMAKE_SOURCE_DIR})
@@ -174,8 +172,6 @@ if (NOT LV_BUILD_USE_KCONFIG)
     else()
 
         message(STATUS "Using lv_conf.h from the top-level project directory")
-
-        list(APPEND LVGL_PUBLIC_HEADERS ${CMAKE_SOURCE_DIR}/lv_conf.h)
 
         set(CONF_INC_DIR ${CMAKE_SOURCE_DIR})
         set(CONF_PATH ${CONF_INC_DIR}/lv_conf.h)
@@ -475,8 +471,7 @@ if(CONFIG_LV_USE_THORVG_INTERNAL)
         VERSION ${LVGL_VERSION}
         SOVERSION ${LVGL_SOVERSION}
         ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib"
-        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib"
-        PUBLIC_HEADER "${LVGL_PUBLIC_HEADERS}")
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib")
 
     install(TARGETS lvgl_thorvg
         EXPORT lvglTargets


### PR DESCRIPTION
Fixes this warning:

```
CMake Warning (dev) at lvgl/env_support/cmake/main.cmake:481 (install):
  Target lvgl_thorvg has PUBLIC_HEADER files but no PUBLIC_HEADER
  DESTINATION.
Call Stack (most recent call first):
  lvgl/CMakeLists.txt:26 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```