### PR TITLE
DON'T SQUASH: add display and indev specific event tests and fixes

### DIFF
--- a/src/misc/lv_event.c
+++ b/src/misc/lv_event.c
@@ -89,7 +89,7 @@ lv_result_t lv_event_push_and_send(lv_event_list_t * event_list, lv_event_code_t
 
     lv_event_push(&e);
     lv_result_t res = lv_event_send(event_list, &e, true);
-    if(res != LV_RESULT_OK) goto ret;
+    if(res != LV_RESULT_OK || e.stop_processing) goto ret;
 
     res = lv_event_send(event_list, &e, false);
     if(res != LV_RESULT_OK) goto ret;

--- a/tests/src/test_cases/test_display_event.c
+++ b/tests/src/test_cases/test_display_event.c
@@ -1,0 +1,611 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+#include "../../lvgl_private.h"
+
+#include "unity/unity.h"
+
+#define TEST_DISP_HOR_RES   200
+#define TEST_DISP_VER_RES   100
+
+/** Every callback appends a character to this log so the call order can be asserted */
+static char call_log[64];
+static uint32_t call_cnt;
+static lv_display_t * last_target;
+static lv_display_t * last_current_target;
+static void * last_param;
+static void * last_user_data;
+static lv_event_code_t last_code;
+static bool stop_in_preprocess;
+static bool stop_in_normal;
+static lv_display_t * test_disp;
+static lv_draw_buf_t * test_draw_buf;
+
+static void log_append(char c);
+static void cb_a(lv_event_t * e);
+static void cb_b(lv_event_t * e);
+static void cb_pre_a(lv_event_t * e);
+static void cb_pre_b(lv_event_t * e);
+static void cb_record(lv_event_t * e);
+static void cb_count(lv_event_t * e);
+static void dummy_flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_map);
+
+void setUp(void)
+{
+    call_log[0] = '\0';
+    call_cnt = 0;
+    last_target = NULL;
+    last_current_target = NULL;
+    last_param = NULL;
+    last_user_data = NULL;
+    last_code = LV_EVENT_ALL;
+    stop_in_preprocess = false;
+    stop_in_normal = false;
+
+    test_draw_buf = lv_draw_buf_create(TEST_DISP_HOR_RES, TEST_DISP_VER_RES, LV_COLOR_FORMAT_NATIVE, 0);
+    test_disp = lv_display_create(TEST_DISP_HOR_RES, TEST_DISP_VER_RES);
+    lv_display_set_flush_cb(test_disp, dummy_flush_cb);
+    lv_display_set_draw_buffers(test_disp, test_draw_buf, NULL);
+    lv_display_set_render_mode(test_disp, LV_DISPLAY_RENDER_MODE_DIRECT);
+}
+
+void tearDown(void)
+{
+    if(test_disp) lv_display_delete(test_disp);
+    test_disp = NULL;
+    if(test_draw_buf) lv_draw_buf_destroy(test_draw_buf);
+    test_draw_buf = NULL;
+}
+
+static void log_append(char c)
+{
+    uint32_t len = lv_strlen(call_log);
+    if(len + 1 >= sizeof(call_log)) return;
+    call_log[len] = c;
+    call_log[len + 1] = '\0';
+}
+
+static void cb_a(lv_event_t * e)
+{
+    LV_UNUSED(e);
+    log_append('a');
+}
+
+static void cb_b(lv_event_t * e)
+{
+    LV_UNUSED(e);
+    log_append('b');
+}
+
+static void cb_pre_a(lv_event_t * e)
+{
+    log_append('A');
+    if(stop_in_preprocess) lv_event_stop_processing(e);
+}
+
+static void cb_pre_b(lv_event_t * e)
+{
+    LV_UNUSED(e);
+    log_append('B');
+}
+
+static void cb_record(lv_event_t * e)
+{
+    call_cnt++;
+    last_code = lv_event_get_code(e);
+    last_target = lv_event_get_target(e);
+    last_current_target = lv_event_get_current_target(e);
+    last_param = lv_event_get_param(e);
+    last_user_data = lv_event_get_user_data(e);
+    if(stop_in_normal) lv_event_stop_processing(e);
+}
+
+static void cb_count(lv_event_t * e)
+{
+    LV_UNUSED(e);
+    call_cnt++;
+}
+
+static void dummy_flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_map)
+{
+    LV_UNUSED(area);
+    LV_UNUSED(px_map);
+    lv_display_flush_ready(disp);
+}
+
+/* A freshly created display already has LVGL's own internal callback registered.
+ * The API must report it and hand out its descriptor. */
+void test_display_event_fresh_display_has_internal_cb(void)
+{
+    TEST_ASSERT_GREATER_THAN_UINT32(0, lv_display_get_event_count(test_disp));
+    TEST_ASSERT_NOT_NULL(lv_display_get_event_dsc(test_disp, 0));
+    TEST_ASSERT_NOT_NULL(lv_event_dsc_get_cb(lv_display_get_event_dsc(test_disp, 0)));
+}
+
+void test_display_event_add_and_query_dsc(void)
+{
+    const uint32_t base_cnt = lv_display_get_event_count(test_disp);
+    int user_data_a = 0;
+    int user_data_b = 0;
+
+    lv_event_dsc_t * dsc_a = lv_display_add_event_cb(test_disp, cb_a, LV_EVENT_REFR_START, &user_data_a);
+    lv_event_dsc_t * dsc_b = lv_display_add_event_cb(test_disp, cb_b, LV_EVENT_ALL, &user_data_b);
+
+    TEST_ASSERT_NOT_NULL(dsc_a);
+    TEST_ASSERT_NOT_NULL(dsc_b);
+    TEST_ASSERT_TRUE(dsc_a != dsc_b);
+    TEST_ASSERT_EQUAL_UINT32(base_cnt + 2, lv_display_get_event_count(test_disp));
+
+    /* The descriptors are handed back in registration order, after the internal ones */
+    TEST_ASSERT_EQUAL_PTR(dsc_a, lv_display_get_event_dsc(test_disp, base_cnt));
+    TEST_ASSERT_EQUAL_PTR(dsc_b, lv_display_get_event_dsc(test_disp, base_cnt + 1));
+
+    TEST_ASSERT_EQUAL_PTR(cb_a, lv_event_dsc_get_cb(dsc_a));
+    TEST_ASSERT_EQUAL_PTR(cb_b, lv_event_dsc_get_cb(dsc_b));
+    TEST_ASSERT_EQUAL_PTR(&user_data_a, lv_event_dsc_get_user_data(dsc_a));
+    TEST_ASSERT_EQUAL_PTR(&user_data_b, lv_event_dsc_get_user_data(dsc_b));
+
+    /* Out of range index */
+    TEST_ASSERT_NULL(lv_display_get_event_dsc(test_disp, base_cnt + 2));
+}
+
+/* An event descriptor is only invoked for its own filter, or for any code when
+ * registered with LV_EVENT_ALL */
+void test_display_event_filter(void)
+{
+    lv_display_add_event_cb(test_disp, cb_a, LV_EVENT_RESOLUTION_CHANGED, NULL);
+    lv_display_add_event_cb(test_disp, cb_b, LV_EVENT_ALL, NULL);
+
+    lv_display_send_event(test_disp, LV_EVENT_RESOLUTION_CHANGED, NULL);
+    TEST_ASSERT_EQUAL_STRING("ab", call_log);
+
+    lv_display_send_event(test_disp, LV_EVENT_COLOR_FORMAT_CHANGED, NULL);
+    TEST_ASSERT_EQUAL_STRING("abb", call_log);
+}
+
+/* For a display event both targets are the display itself, and code/param/user_data
+ * are handed to the callback unchanged */
+void test_display_event_target_param_and_user_data(void)
+{
+    int user_data = 0;
+    int param = 0;
+
+    lv_display_add_event_cb(test_disp, cb_record, LV_EVENT_REFR_REQUEST, &user_data);
+    lv_result_t res = lv_display_send_event(test_disp, LV_EVENT_REFR_REQUEST, &param);
+
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
+    TEST_ASSERT_EQUAL_UINT32(1, call_cnt);
+    TEST_ASSERT_EQUAL(LV_EVENT_REFR_REQUEST, last_code);
+    TEST_ASSERT_EQUAL_PTR(test_disp, last_target);
+    TEST_ASSERT_EQUAL_PTR(test_disp, last_current_target);
+    TEST_ASSERT_EQUAL_PTR(&param, last_param);
+    TEST_ASSERT_EQUAL_PTR(&user_data, last_user_data);
+}
+
+/* Descriptors marked with LV_EVENT_PREPROCESS run before the plain ones,
+ * and lv_event_get_code() reports the code without the flag */
+void test_display_event_preprocess_runs_first(void)
+{
+    lv_display_add_event_cb(test_disp, cb_a, LV_EVENT_REFR_START, NULL);
+    lv_display_add_event_cb(test_disp, cb_pre_a, LV_EVENT_REFR_START | LV_EVENT_PREPROCESS, NULL);
+    lv_display_add_event_cb(test_disp, cb_b, LV_EVENT_REFR_START, NULL);
+    lv_display_add_event_cb(test_disp, cb_pre_b, LV_EVENT_REFR_START | LV_EVENT_PREPROCESS, NULL);
+    lv_display_add_event_cb(test_disp, cb_record, LV_EVENT_REFR_START | LV_EVENT_PREPROCESS, NULL);
+
+    lv_display_send_event(test_disp, LV_EVENT_REFR_START, NULL);
+
+    TEST_ASSERT_EQUAL_STRING("ABab", call_log);
+    TEST_ASSERT_EQUAL(LV_EVENT_REFR_START, last_code);
+}
+
+/* lv_event_stop_processing() in a preprocess callback skips every remaining
+ * callback, including the non-preprocess ones */
+void test_display_event_stop_processing_in_preprocess(void)
+{
+    lv_display_add_event_cb(test_disp, cb_pre_a, LV_EVENT_REFR_START | LV_EVENT_PREPROCESS, NULL);
+    lv_display_add_event_cb(test_disp, cb_pre_b, LV_EVENT_REFR_START | LV_EVENT_PREPROCESS, NULL);
+    lv_display_add_event_cb(test_disp, cb_a, LV_EVENT_REFR_START, NULL);
+
+    stop_in_preprocess = true;
+    lv_display_send_event(test_disp, LV_EVENT_REFR_START, NULL);
+
+    TEST_ASSERT_EQUAL_STRING("A", call_log);
+}
+
+/* lv_event_stop_processing() in a plain callback skips the remaining plain ones */
+void test_display_event_stop_processing_in_normal(void)
+{
+    lv_display_add_event_cb(test_disp, cb_record, LV_EVENT_REFR_START, NULL);
+    lv_display_add_event_cb(test_disp, cb_a, LV_EVENT_REFR_START, NULL);
+
+    stop_in_normal = true;
+    lv_display_send_event(test_disp, LV_EVENT_REFR_START, NULL);
+
+    TEST_ASSERT_EQUAL_UINT32(1, call_cnt);
+    TEST_ASSERT_EQUAL_STRING("", call_log);
+}
+
+void test_display_event_remove_by_index(void)
+{
+    const uint32_t base_cnt = lv_display_get_event_count(test_disp);
+
+    lv_display_add_event_cb(test_disp, cb_a, LV_EVENT_REFR_START, NULL);
+    lv_display_add_event_cb(test_disp, cb_b, LV_EVENT_REFR_START, NULL);
+
+    TEST_ASSERT_TRUE(lv_display_remove_event(test_disp, base_cnt));
+    TEST_ASSERT_EQUAL_UINT32(base_cnt + 1, lv_display_get_event_count(test_disp));
+
+    lv_display_send_event(test_disp, LV_EVENT_REFR_START, NULL);
+    TEST_ASSERT_EQUAL_STRING("b", call_log);
+
+    /* Removing a non-existing index must fail without touching the list */
+    TEST_ASSERT_FALSE(lv_display_remove_event(test_disp, base_cnt + 1));
+    TEST_ASSERT_EQUAL_UINT32(base_cnt + 1, lv_display_get_event_count(test_disp));
+}
+
+/* Only the descriptors matching both the callback and the user_data are removed */
+void test_display_event_remove_cb_with_user_data(void)
+{
+    const uint32_t base_cnt = lv_display_get_event_count(test_disp);
+    int user_data_1 = 0;
+    int user_data_2 = 0;
+
+    lv_display_add_event_cb(test_disp, cb_a, LV_EVENT_REFR_START, &user_data_1);
+    lv_display_add_event_cb(test_disp, cb_a, LV_EVENT_REFR_READY, &user_data_1);
+    lv_display_add_event_cb(test_disp, cb_a, LV_EVENT_REFR_START, &user_data_2);
+    lv_display_add_event_cb(test_disp, cb_b, LV_EVENT_REFR_START, &user_data_1);
+
+    TEST_ASSERT_EQUAL_UINT32(2, lv_display_remove_event_cb_with_user_data(test_disp, cb_a, &user_data_1));
+    TEST_ASSERT_EQUAL_UINT32(base_cnt + 2, lv_display_get_event_count(test_disp));
+
+    lv_display_send_event(test_disp, LV_EVENT_REFR_START, NULL);
+    TEST_ASSERT_EQUAL_STRING("ab", call_log);
+
+    /* Nothing matches anymore */
+    TEST_ASSERT_EQUAL_UINT32(0, lv_display_remove_event_cb_with_user_data(test_disp, cb_a, &user_data_1));
+}
+
+/* A callback may remove itself while the list is being traversed */
+static void cb_remove_self(lv_event_t * e)
+{
+    lv_display_t * disp = lv_event_get_current_target(e);
+    call_cnt++;
+    lv_display_remove_event_cb_with_user_data(disp, cb_remove_self, NULL);
+}
+
+void test_display_event_remove_own_cb_while_sending(void)
+{
+    const uint32_t base_cnt = lv_display_get_event_count(test_disp);
+
+    lv_display_add_event_cb(test_disp, cb_remove_self, LV_EVENT_REFR_START, NULL);
+    lv_display_add_event_cb(test_disp, cb_a, LV_EVENT_REFR_START, NULL);
+
+    lv_display_send_event(test_disp, LV_EVENT_REFR_START, NULL);
+
+    /* The self-removing callback ran once, the one after it still ran */
+    TEST_ASSERT_EQUAL_UINT32(1, call_cnt);
+    TEST_ASSERT_EQUAL_STRING("a", call_log);
+    TEST_ASSERT_EQUAL_UINT32(base_cnt + 1, lv_display_get_event_count(test_disp));
+
+    /* The removal really took effect */
+    lv_display_send_event(test_disp, LV_EVENT_REFR_START, NULL);
+    TEST_ASSERT_EQUAL_UINT32(1, call_cnt);
+    TEST_ASSERT_EQUAL_STRING("aa", call_log);
+}
+
+/* Custom event IDs are unique and can be sent to a display like the built-in ones */
+void test_display_event_custom_registered_id(void)
+{
+    lv_event_code_t custom_1 = (lv_event_code_t)lv_event_register_id();
+    lv_event_code_t custom_2 = (lv_event_code_t)lv_event_register_id();
+
+    TEST_ASSERT_NOT_EQUAL(custom_1, custom_2);
+    TEST_ASSERT_GREATER_OR_EQUAL(LV_EVENT_LAST, custom_1);
+
+    lv_display_add_event_cb(test_disp, cb_record, custom_1, NULL);
+    lv_display_add_event_cb(test_disp, cb_a, custom_2, NULL);
+
+    lv_display_send_event(test_disp, custom_1, NULL);
+
+    TEST_ASSERT_EQUAL_UINT32(1, call_cnt);
+    TEST_ASSERT_EQUAL(custom_1, last_code);
+    TEST_ASSERT_EQUAL_STRING("", call_log);
+}
+
+void test_display_event_resolution_changed(void)
+{
+    lv_display_add_event_cb(test_disp, cb_count, LV_EVENT_RESOLUTION_CHANGED, NULL);
+
+    lv_display_set_resolution(test_disp, TEST_DISP_HOR_RES * 2, TEST_DISP_VER_RES * 2);
+    TEST_ASSERT_EQUAL_UINT32(1, call_cnt);
+
+    lv_display_set_rotation(test_disp, LV_DISPLAY_ROTATION_90);
+    TEST_ASSERT_EQUAL_UINT32(2, call_cnt);
+
+    lv_display_set_rotation(test_disp, LV_DISPLAY_ROTATION_0);
+    TEST_ASSERT_EQUAL_UINT32(3, call_cnt);
+}
+
+void test_display_event_color_format_changed(void)
+{
+    lv_display_add_event_cb(test_disp, cb_count, LV_EVENT_COLOR_FORMAT_CHANGED, NULL);
+
+    lv_display_set_color_format(test_disp, LV_COLOR_FORMAT_RGB888);
+    TEST_ASSERT_EQUAL_UINT32(1, call_cnt);
+
+    lv_display_set_color_format(test_disp, LV_COLOR_FORMAT_ARGB8888);
+    TEST_ASSERT_EQUAL_UINT32(2, call_cnt);
+}
+
+/* lv_event_get_invalidated_area() only returns the area for LV_EVENT_INVALIDATE_AREA */
+static void cb_check_invalidated_area(lv_event_t * e)
+{
+    lv_area_t * area = lv_event_get_invalidated_area(e);
+    call_cnt++;
+    TEST_ASSERT_NOT_NULL(area);
+    last_param = area;
+}
+
+static void cb_invalidated_area_wrong_code(lv_event_t * e)
+{
+    call_cnt++;
+    TEST_ASSERT_NULL(lv_event_get_invalidated_area(e));
+}
+
+void test_display_event_get_invalidated_area(void)
+{
+    lv_area_t area = { 1, 2, 3, 4 };
+
+    lv_display_add_event_cb(test_disp, cb_check_invalidated_area, LV_EVENT_INVALIDATE_AREA, NULL);
+    lv_display_add_event_cb(test_disp, cb_invalidated_area_wrong_code, LV_EVENT_REFR_START, NULL);
+
+    lv_display_send_event(test_disp, LV_EVENT_INVALIDATE_AREA, &area);
+    TEST_ASSERT_EQUAL_UINT32(1, call_cnt);
+    TEST_ASSERT_EQUAL_PTR(&area, last_param);
+
+    lv_display_send_event(test_disp, LV_EVENT_REFR_START, NULL);
+    TEST_ASSERT_EQUAL_UINT32(2, call_cnt);
+}
+
+/* The handler of LV_EVENT_INVALIDATE_AREA may enlarge the area, and the
+ * modification must be the one LVGL stores as invalid */
+static void cb_enlarge_invalidated_area(lv_event_t * e)
+{
+    lv_area_t * area = lv_event_get_invalidated_area(e);
+    call_cnt++;
+    area->x1 = 0;
+    area->y1 = 0;
+    area->x2 = TEST_DISP_HOR_RES - 1;
+    area->y2 = TEST_DISP_VER_RES - 1;
+}
+
+void test_display_event_invalidate_area_can_be_modified(void)
+{
+    lv_obj_t * obj = lv_obj_create(lv_display_get_screen_active(test_disp));
+    lv_obj_set_size(obj, 10, 10);
+    lv_obj_set_pos(obj, 20, 20);
+
+    /* The display was never refreshed, so the coordinates are still unresolved */
+    lv_obj_update_layout(obj);
+
+    /* Drop everything invalidated while building the widget */
+    test_disp->inv_p = 0;
+
+    lv_display_add_event_cb(test_disp, cb_enlarge_invalidated_area, LV_EVENT_INVALIDATE_AREA, NULL);
+    lv_obj_invalidate(obj);
+
+    TEST_ASSERT_EQUAL_UINT32(1, call_cnt);
+    TEST_ASSERT_EQUAL_UINT32(1, test_disp->inv_p);
+    TEST_ASSERT_EQUAL_INT32(0, test_disp->inv_areas[0].x1);
+    TEST_ASSERT_EQUAL_INT32(0, test_disp->inv_areas[0].y1);
+    TEST_ASSERT_EQUAL_INT32(TEST_DISP_HOR_RES - 1, test_disp->inv_areas[0].x2);
+    TEST_ASSERT_EQUAL_INT32(TEST_DISP_VER_RES - 1, test_disp->inv_areas[0].y2);
+}
+
+/* One refresh sends the whole documented sequence of display events, in order */
+static void cb_log_refr_code(lv_event_t * e)
+{
+    switch(lv_event_get_code(e)) {
+        case LV_EVENT_REFR_START:
+            log_append('S');
+            break;
+        case LV_EVENT_RENDER_START:
+            log_append('r');
+            break;
+        case LV_EVENT_RENDER_READY:
+            log_append('R');
+            break;
+        case LV_EVENT_FLUSH_START:
+            log_append('f');
+            break;
+        case LV_EVENT_FLUSH_FINISH:
+            log_append('F');
+            break;
+        case LV_EVENT_REFR_READY:
+            log_append('E');
+            break;
+        default:
+            break;
+    }
+}
+
+void test_display_event_refresh_cycle_events(void)
+{
+    lv_display_add_event_cb(test_disp, cb_log_refr_code, LV_EVENT_REFR_START, NULL);
+    lv_display_add_event_cb(test_disp, cb_log_refr_code, LV_EVENT_RENDER_START, NULL);
+    lv_display_add_event_cb(test_disp, cb_log_refr_code, LV_EVENT_RENDER_READY, NULL);
+    lv_display_add_event_cb(test_disp, cb_log_refr_code, LV_EVENT_FLUSH_START, NULL);
+    lv_display_add_event_cb(test_disp, cb_log_refr_code, LV_EVENT_FLUSH_FINISH, NULL);
+    lv_display_add_event_cb(test_disp, cb_log_refr_code, LV_EVENT_REFR_READY, NULL);
+
+    lv_obj_invalidate(lv_display_get_screen_active(test_disp));
+    lv_refr_now(test_disp);
+
+    /* REFR_START/REFR_READY bracket the cycle, and each phase reports begin before
+     * end. How many times the renderer flushes, and whether it does so inside or
+     * after the render phase, is renderer specific. */
+    const uint32_t len = lv_strlen(call_log);
+    TEST_ASSERT_GREATER_OR_EQUAL_UINT32(6, len);
+    TEST_ASSERT_EQUAL_CHAR('S', call_log[0]);
+    TEST_ASSERT_EQUAL_CHAR('E', call_log[len - 1]);
+    TEST_ASSERT_NOT_NULL(lv_strchr(call_log, 'r'));
+    TEST_ASSERT_NOT_NULL(lv_strchr(call_log, 'f'));
+    TEST_ASSERT_TRUE(lv_strchr(call_log, 'r') < lv_strchr(call_log, 'R'));
+    TEST_ASSERT_TRUE(lv_strchr(call_log, 'f') < lv_strchr(call_log, 'F'));
+
+    /* A refresh with nothing invalidated still brackets the cycle */
+    call_log[0] = '\0';
+    lv_refr_now(test_disp);
+    TEST_ASSERT_EQUAL_STRING("SE", call_log);
+}
+
+/* LV_EVENT_DELETE is sent while the display is still usable, and the whole
+ * event list is dropped afterwards */
+static void cb_on_delete(lv_event_t * e)
+{
+    lv_display_t * disp = lv_event_get_current_target(e);
+    call_cnt++;
+    last_code = lv_event_get_code(e);
+    TEST_ASSERT_EQUAL_INT32(TEST_DISP_HOR_RES, lv_display_get_horizontal_resolution(disp));
+}
+
+void test_display_event_delete(void)
+{
+    lv_display_add_event_cb(test_disp, cb_on_delete, LV_EVENT_DELETE, NULL);
+
+    lv_display_delete(test_disp);
+    test_disp = NULL;
+
+    TEST_ASSERT_EQUAL_UINT32(1, call_cnt);
+    TEST_ASSERT_EQUAL(LV_EVENT_DELETE, last_code);
+}
+
+static void cb_vsync_request(lv_event_t * e)
+{
+    log_append(lv_event_get_param(e) == NULL ? '-' : '+');
+}
+
+void test_display_event_vsync_register_and_send(void)
+{
+    int user_data = 0;
+    int param = 0;
+
+    lv_display_add_event_cb(test_disp, cb_vsync_request, LV_EVENT_VSYNC_REQUEST, NULL);
+
+    /* Without a registered handler there is nothing to notify */
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_display_send_vsync_event(test_disp, &param));
+
+    /* The first registration asks the driver to start generating vsync */
+    TEST_ASSERT_TRUE(lv_display_register_vsync_event(test_disp, cb_record, &user_data));
+    TEST_ASSERT_EQUAL_STRING("+", call_log);
+
+    /* A second registration must not ask again */
+    TEST_ASSERT_TRUE(lv_display_register_vsync_event(test_disp, cb_count, &user_data));
+    TEST_ASSERT_EQUAL_STRING("+", call_log);
+
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_display_send_vsync_event(test_disp, &param));
+    TEST_ASSERT_EQUAL_UINT32(2, call_cnt);
+    TEST_ASSERT_EQUAL(LV_EVENT_VSYNC, last_code);
+    TEST_ASSERT_EQUAL_PTR(&param, last_param);
+    TEST_ASSERT_EQUAL_PTR(&user_data, last_user_data);
+}
+
+void test_display_event_vsync_unregister(void)
+{
+    int user_data = 0;
+    int param = 0;
+
+    lv_display_add_event_cb(test_disp, cb_vsync_request, LV_EVENT_VSYNC_REQUEST, NULL);
+
+    lv_display_register_vsync_event(test_disp, cb_record, &user_data);
+    lv_display_register_vsync_event(test_disp, cb_count, &user_data);
+    TEST_ASSERT_EQUAL_STRING("+", call_log);
+
+    /* Unregistering something that was never registered fails */
+    TEST_ASSERT_FALSE(lv_display_unregister_vsync_event(test_disp, cb_a, &user_data));
+    TEST_ASSERT_FALSE(lv_display_unregister_vsync_event(test_disp, cb_record, &param));
+
+    /* While one handler is left the driver keeps generating vsync */
+    TEST_ASSERT_TRUE(lv_display_unregister_vsync_event(test_disp, cb_count, &user_data));
+    TEST_ASSERT_EQUAL_STRING("+", call_log);
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_display_send_vsync_event(test_disp, &param));
+    TEST_ASSERT_EQUAL_UINT32(1, call_cnt);
+
+    /* Dropping the last one asks the driver to stop */
+    TEST_ASSERT_TRUE(lv_display_unregister_vsync_event(test_disp, cb_record, &user_data));
+    TEST_ASSERT_EQUAL_STRING("+-", call_log);
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_display_send_vsync_event(test_disp, &param));
+    TEST_ASSERT_EQUAL_UINT32(1, call_cnt);
+}
+
+/* The vsync helpers fall back to the default display when disp is NULL */
+void test_display_event_vsync_default_display(void)
+{
+    lv_display_t * def = lv_display_get_default();
+    TEST_ASSERT_NOT_NULL(def);
+    TEST_ASSERT_TRUE(def != test_disp);
+
+    const uint32_t base_cnt = lv_display_get_event_count(def);
+
+    TEST_ASSERT_TRUE(lv_display_register_vsync_event(NULL, cb_count, NULL));
+    TEST_ASSERT_EQUAL_UINT32(base_cnt + 1, lv_display_get_event_count(def));
+
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_display_send_vsync_event(NULL, NULL));
+    TEST_ASSERT_EQUAL_UINT32(1, call_cnt);
+
+    TEST_ASSERT_TRUE(lv_display_unregister_vsync_event(NULL, cb_count, NULL));
+    TEST_ASSERT_EQUAL_UINT32(base_cnt, lv_display_get_event_count(def));
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_display_send_vsync_event(NULL, NULL));
+}
+
+/* A vsync handler must not be notified after being removed with the plain
+ * event API, even though vsync_count was not decremented */
+void test_display_event_vsync_removed_with_plain_api(void)
+{
+    lv_display_register_vsync_event(test_disp, cb_count, NULL);
+    lv_display_remove_event_cb_with_user_data(test_disp, cb_count, NULL);
+
+    lv_display_send_vsync_event(test_disp, NULL);
+    TEST_ASSERT_EQUAL_UINT32(0, call_cnt);
+}
+
+void test_display_event_code_names(void)
+{
+    /* Display related codes */
+    TEST_ASSERT_EQUAL_STRING("EVENT_INVALIDATE_AREA", lv_event_code_get_name(LV_EVENT_INVALIDATE_AREA));
+    TEST_ASSERT_EQUAL_STRING("EVENT_RESOLUTION_CHANGED", lv_event_code_get_name(LV_EVENT_RESOLUTION_CHANGED));
+    TEST_ASSERT_EQUAL_STRING("EVENT_COLOR_FORMAT_CHANGED", lv_event_code_get_name(LV_EVENT_COLOR_FORMAT_CHANGED));
+    TEST_ASSERT_EQUAL_STRING("EVENT_REFR_REQUEST", lv_event_code_get_name(LV_EVENT_REFR_REQUEST));
+    TEST_ASSERT_EQUAL_STRING("EVENT_REFR_START", lv_event_code_get_name(LV_EVENT_REFR_START));
+    TEST_ASSERT_EQUAL_STRING("EVENT_REFR_READY", lv_event_code_get_name(LV_EVENT_REFR_READY));
+    TEST_ASSERT_EQUAL_STRING("EVENT_RENDER_START", lv_event_code_get_name(LV_EVENT_RENDER_START));
+    TEST_ASSERT_EQUAL_STRING("EVENT_RENDER_READY", lv_event_code_get_name(LV_EVENT_RENDER_READY));
+    TEST_ASSERT_EQUAL_STRING("EVENT_FLUSH_START", lv_event_code_get_name(LV_EVENT_FLUSH_START));
+    TEST_ASSERT_EQUAL_STRING("EVENT_FLUSH_FINISH", lv_event_code_get_name(LV_EVENT_FLUSH_FINISH));
+    TEST_ASSERT_EQUAL_STRING("EVENT_FLUSH_WAIT_START", lv_event_code_get_name(LV_EVENT_FLUSH_WAIT_START));
+    TEST_ASSERT_EQUAL_STRING("EVENT_FLUSH_WAIT_FINISH", lv_event_code_get_name(LV_EVENT_FLUSH_WAIT_FINISH));
+    TEST_ASSERT_EQUAL_STRING("EVENT_SYNC_START", lv_event_code_get_name(LV_EVENT_SYNC_START));
+    TEST_ASSERT_EQUAL_STRING("EVENT_SYNC_FINISH", lv_event_code_get_name(LV_EVENT_SYNC_FINISH));
+    TEST_ASSERT_EQUAL_STRING("EVENT_SYNC_WAIT_START", lv_event_code_get_name(LV_EVENT_SYNC_WAIT_START));
+    TEST_ASSERT_EQUAL_STRING("EVENT_SYNC_WAIT_FINISH", lv_event_code_get_name(LV_EVENT_SYNC_WAIT_FINISH));
+    TEST_ASSERT_EQUAL_STRING("EVENT_VSYNC", lv_event_code_get_name(LV_EVENT_VSYNC));
+    TEST_ASSERT_EQUAL_STRING("EVENT_VSYNC_REQUEST", lv_event_code_get_name(LV_EVENT_VSYNC_REQUEST));
+
+    /* A few non-display codes to cover the remaining groups */
+    TEST_ASSERT_EQUAL_STRING("EVENT_ALL", lv_event_code_get_name(LV_EVENT_ALL));
+    TEST_ASSERT_EQUAL_STRING("EVENT_LEAVE", lv_event_code_get_name(LV_EVENT_LEAVE));
+    TEST_ASSERT_EQUAL_STRING("EVENT_INSERT", lv_event_code_get_name(LV_EVENT_INSERT));
+    TEST_ASSERT_EQUAL_STRING("EVENT_CREATE", lv_event_code_get_name(LV_EVENT_CREATE));
+    TEST_ASSERT_EQUAL_STRING("EVENT_REFRESH", lv_event_code_get_name(LV_EVENT_REFRESH));
+    TEST_ASSERT_EQUAL_STRING("EVENT_UPDATE_LAYOUT_COMPLETED",
+                             lv_event_code_get_name(LV_EVENT_UPDATE_LAYOUT_COMPLETED));
+
+    /* The preprocess flag is not part of the name */
+    TEST_ASSERT_EQUAL_STRING("EVENT_REFR_START",
+                             lv_event_code_get_name(LV_EVENT_REFR_START | LV_EVENT_PREPROCESS));
+
+    /* Codes that are flags or out of range have no name */
+    TEST_ASSERT_EQUAL_STRING("EVENT_UNKNOWN", lv_event_code_get_name(LV_EVENT_LAST));
+    TEST_ASSERT_EQUAL_STRING("EVENT_UNKNOWN", lv_event_code_get_name((lv_event_code_t)lv_event_register_id()));
+}
+
+#endif

--- a/tests/src/test_cases/test_event.c
+++ b/tests/src/test_cases/test_event.c
@@ -177,4 +177,77 @@ void test_event_remove_event_cb(void)
     lv_obj_delete(obj);
 }
 
+/* A single descriptor can be removed while the others are left in place */
+void test_event_remove_event_dsc(void)
+{
+    lv_obj_t * obj = lv_obj_create(lv_screen_active());
+
+    lv_event_dsc_t * dsc_1 = lv_obj_add_event_cb(obj, test_event_cb_1, LV_EVENT_CLICKED, NULL);
+    lv_event_dsc_t * dsc_2 = lv_obj_add_event_cb(obj, test_event_cb_1, LV_EVENT_PRESSED, NULL);
+    TEST_ASSERT_EQUAL_UINT32(2, lv_obj_get_event_count(obj));
+
+    TEST_ASSERT_TRUE(lv_obj_remove_event_dsc(obj, dsc_1));
+    TEST_ASSERT_EQUAL_UINT32(1, lv_obj_get_event_count(obj));
+    TEST_ASSERT_EQUAL_PTR(dsc_2, lv_obj_get_event_dsc(obj, 0));
+
+    /* Removing the same descriptor twice must fail */
+    TEST_ASSERT_FALSE(lv_obj_remove_event_dsc(obj, dsc_1));
+    TEST_ASSERT_EQUAL_UINT32(1, lv_obj_get_event_count(obj));
+
+    TEST_ASSERT_TRUE(lv_obj_remove_event_dsc(obj, dsc_2));
+    TEST_ASSERT_EQUAL_UINT32(0, lv_obj_get_event_count(obj));
+
+    /* A descriptor of another widget doesn't belong to this list */
+    lv_obj_t * other = lv_obj_create(lv_screen_active());
+    lv_event_dsc_t * dsc_other = lv_obj_add_event_cb(other, test_event_cb_1, LV_EVENT_CLICKED, NULL);
+    TEST_ASSERT_FALSE(lv_obj_remove_event_dsc(obj, dsc_other));
+    TEST_ASSERT_EQUAL_UINT32(1, lv_obj_get_event_count(other));
+
+    lv_obj_delete(other);
+    lv_obj_delete(obj);
+}
+
+static uint32_t bubble_child_cnt;
+static uint32_t bubble_parent_cnt;
+static bool bubble_stop;
+
+static void event_bubble_child_cb(lv_event_t * e)
+{
+    bubble_child_cnt++;
+    if(bubble_stop) lv_event_stop_bubbling(e);
+}
+
+static void event_bubble_parent_cb(lv_event_t * e)
+{
+    LV_UNUSED(e);
+    bubble_parent_cnt++;
+}
+
+/* lv_event_stop_bubbling() keeps the event from reaching the parent */
+void test_event_stop_bubbling(void)
+{
+    lv_obj_t * parent = lv_obj_create(lv_screen_active());
+    lv_obj_t * child = lv_obj_create(parent);
+    lv_obj_set_event_bubble(child, true);
+
+    lv_obj_add_event_cb(child, event_bubble_child_cb, LV_EVENT_CLICKED, NULL);
+    lv_obj_add_event_cb(parent, event_bubble_parent_cb, LV_EVENT_CLICKED, NULL);
+
+    bubble_child_cnt = 0;
+    bubble_parent_cnt = 0;
+    bubble_stop = false;
+    lv_obj_send_event(child, LV_EVENT_CLICKED, NULL);
+    TEST_ASSERT_EQUAL_UINT32(1, bubble_child_cnt);
+    TEST_ASSERT_EQUAL_UINT32(1, bubble_parent_cnt);
+
+    bubble_child_cnt = 0;
+    bubble_parent_cnt = 0;
+    bubble_stop = true;
+    lv_obj_send_event(child, LV_EVENT_CLICKED, NULL);
+    TEST_ASSERT_EQUAL_UINT32(1, bubble_child_cnt);
+    TEST_ASSERT_EQUAL_UINT32(0, bubble_parent_cnt);
+
+    lv_obj_delete(parent);
+}
+
 #endif

--- a/tests/src/test_cases/test_indev_event.c
+++ b/tests/src/test_cases/test_indev_event.c
@@ -12,6 +12,27 @@ static uint32_t event_cnt_long_pressed_repeat;
 static uint32_t event_cnt_key;
 static lv_key_t last_key;
 
+/** Every callback of the event API tests appends a character here so the call order
+ * can be asserted */
+static char call_log[64];
+static uint32_t call_cnt;
+static lv_indev_t * last_target;
+static lv_indev_t * last_current_target;
+static void * last_param;
+static void * last_user_data;
+static lv_event_code_t last_code;
+static bool stop_in_preprocess;
+static bool stop_in_normal;
+static lv_indev_t * api_indev;
+
+static void log_append(char c);
+static void cb_a(lv_event_t * e);
+static void cb_b(lv_event_t * e);
+static void cb_pre_a(lv_event_t * e);
+static void cb_pre_b(lv_event_t * e);
+static void cb_record(lv_event_t * e);
+static void cb_count(lv_event_t * e);
+
 void setUp(void)
 {
     /* Function run before every test */
@@ -22,11 +43,27 @@ void setUp(void)
     event_cnt_long_pressed_repeat = 0;
     event_cnt_key = 0;
     last_key = 0;
+
+    call_log[0] = '\0';
+    call_cnt = 0;
+    last_target = NULL;
+    last_current_target = NULL;
+    last_param = NULL;
+    last_user_data = NULL;
+    last_code = LV_EVENT_ALL;
+    stop_in_preprocess = false;
+    stop_in_normal = false;
+
+    api_indev = lv_indev_create();
+    lv_indev_set_mode(api_indev, LV_INDEV_MODE_EVENT);
 }
 
 void tearDown(void)
 {
     /* Function run after every test */
+    if(api_indev) lv_indev_delete(api_indev);
+    api_indev = NULL;
+    lv_obj_clean(lv_screen_active());
 }
 
 static void keypad_event_cb(lv_event_t * e)
@@ -137,6 +174,426 @@ void test_indev_keypad_no_group_long_press(void)
 
     /* Cleanup */
     lv_indev_remove_event_cb_with_user_data(indev, keypad_event_cb, NULL);
+}
+
+static void log_append(char c)
+{
+    uint32_t len = lv_strlen(call_log);
+    if(len + 1 >= sizeof(call_log)) return;
+    call_log[len] = c;
+    call_log[len + 1] = '\0';
+}
+
+static void cb_a(lv_event_t * e)
+{
+    LV_UNUSED(e);
+    log_append('a');
+}
+
+static void cb_b(lv_event_t * e)
+{
+    LV_UNUSED(e);
+    log_append('b');
+}
+
+static void cb_pre_a(lv_event_t * e)
+{
+    log_append('A');
+    if(stop_in_preprocess) lv_event_stop_processing(e);
+}
+
+static void cb_pre_b(lv_event_t * e)
+{
+    LV_UNUSED(e);
+    log_append('B');
+}
+
+static void cb_record(lv_event_t * e)
+{
+    call_cnt++;
+    last_code = lv_event_get_code(e);
+    last_target = lv_event_get_target(e);
+    last_current_target = lv_event_get_current_target(e);
+    last_param = lv_event_get_param(e);
+    last_user_data = lv_event_get_user_data(e);
+    if(stop_in_normal) lv_event_stop_processing(e);
+}
+
+static void cb_count(lv_event_t * e)
+{
+    LV_UNUSED(e);
+    call_cnt++;
+}
+
+void test_indev_event_fresh_indev_event_list(void)
+{
+    const uint32_t expected = LV_USE_GESTURE_RECOGNITION ? 1 : 0;
+    TEST_ASSERT_EQUAL(expected, lv_indev_get_event_count(api_indev));
+}
+
+void test_indev_event_add_and_query_dsc(void)
+{
+    const uint32_t base_cnt = lv_indev_get_event_count(api_indev);
+    int user_data_a = 0;
+    int user_data_b = 0;
+
+    lv_event_dsc_t * dsc_a = lv_indev_add_event_cb(api_indev, cb_a, LV_EVENT_PRESSED, &user_data_a);
+    lv_event_dsc_t * dsc_b = lv_indev_add_event_cb(api_indev, cb_b, LV_EVENT_ALL, &user_data_b);
+
+    TEST_ASSERT_NOT_NULL(dsc_a);
+    TEST_ASSERT_NOT_NULL(dsc_b);
+    TEST_ASSERT_TRUE(dsc_a != dsc_b);
+    TEST_ASSERT_EQUAL_UINT32(base_cnt + 2, lv_indev_get_event_count(api_indev));
+
+    TEST_ASSERT_EQUAL_PTR(dsc_a, lv_indev_get_event_dsc(api_indev, base_cnt));
+    TEST_ASSERT_EQUAL_PTR(dsc_b, lv_indev_get_event_dsc(api_indev, base_cnt + 1));
+
+    TEST_ASSERT_EQUAL_PTR(cb_a, lv_event_dsc_get_cb(dsc_a));
+    TEST_ASSERT_EQUAL_PTR(cb_b, lv_event_dsc_get_cb(dsc_b));
+    TEST_ASSERT_EQUAL_PTR(&user_data_a, lv_event_dsc_get_user_data(dsc_a));
+    TEST_ASSERT_EQUAL_PTR(&user_data_b, lv_event_dsc_get_user_data(dsc_b));
+
+    TEST_ASSERT_NULL(lv_indev_get_event_dsc(api_indev, base_cnt + 2));
+}
+
+void test_indev_event_filter(void)
+{
+    lv_indev_add_event_cb(api_indev, cb_a, LV_EVENT_PRESSED, NULL);
+    lv_indev_add_event_cb(api_indev, cb_b, LV_EVENT_ALL, NULL);
+
+    lv_indev_send_event(api_indev, LV_EVENT_PRESSED, NULL);
+    TEST_ASSERT_EQUAL_STRING("ab", call_log);
+
+    lv_indev_send_event(api_indev, LV_EVENT_RELEASED, NULL);
+    TEST_ASSERT_EQUAL_STRING("abb", call_log);
+}
+
+void test_indev_event_target_param_and_user_data(void)
+{
+    int user_data = 0;
+    int param = 0;
+
+    lv_indev_add_event_cb(api_indev, cb_record, LV_EVENT_PRESSED, &user_data);
+    lv_result_t res = lv_indev_send_event(api_indev, LV_EVENT_PRESSED, &param);
+
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
+    TEST_ASSERT_EQUAL_UINT32(1, call_cnt);
+    TEST_ASSERT_EQUAL(LV_EVENT_PRESSED, last_code);
+    TEST_ASSERT_EQUAL_PTR(api_indev, last_target);
+    TEST_ASSERT_EQUAL_PTR(api_indev, last_current_target);
+    TEST_ASSERT_EQUAL_PTR(&param, last_param);
+    TEST_ASSERT_EQUAL_PTR(&user_data, last_user_data);
+}
+
+void test_indev_event_preprocess_runs_first(void)
+{
+    lv_indev_add_event_cb(api_indev, cb_a, LV_EVENT_PRESSED, NULL);
+    lv_indev_add_event_cb(api_indev, cb_pre_a, LV_EVENT_PRESSED | LV_EVENT_PREPROCESS, NULL);
+    lv_indev_add_event_cb(api_indev, cb_b, LV_EVENT_PRESSED, NULL);
+    lv_indev_add_event_cb(api_indev, cb_pre_b, LV_EVENT_PRESSED | LV_EVENT_PREPROCESS, NULL);
+    lv_indev_add_event_cb(api_indev, cb_record, LV_EVENT_PRESSED | LV_EVENT_PREPROCESS, NULL);
+
+    lv_indev_send_event(api_indev, LV_EVENT_PRESSED, NULL);
+
+    TEST_ASSERT_EQUAL_STRING("ABab", call_log);
+    /* The preprocess flag is not reported to the callback */
+    TEST_ASSERT_EQUAL(LV_EVENT_PRESSED, last_code);
+}
+
+void test_indev_event_stop_processing_in_preprocess(void)
+{
+    lv_indev_add_event_cb(api_indev, cb_pre_a, LV_EVENT_PRESSED | LV_EVENT_PREPROCESS, NULL);
+    lv_indev_add_event_cb(api_indev, cb_pre_b, LV_EVENT_PRESSED | LV_EVENT_PREPROCESS, NULL);
+    lv_indev_add_event_cb(api_indev, cb_a, LV_EVENT_PRESSED, NULL);
+
+    stop_in_preprocess = true;
+    lv_indev_send_event(api_indev, LV_EVENT_PRESSED, NULL);
+
+    TEST_ASSERT_EQUAL_STRING("A", call_log);
+}
+
+void test_indev_event_stop_processing_in_normal(void)
+{
+    lv_indev_add_event_cb(api_indev, cb_record, LV_EVENT_PRESSED, NULL);
+    lv_indev_add_event_cb(api_indev, cb_a, LV_EVENT_PRESSED, NULL);
+
+    stop_in_normal = true;
+    lv_indev_send_event(api_indev, LV_EVENT_PRESSED, NULL);
+
+    TEST_ASSERT_EQUAL_UINT32(1, call_cnt);
+    TEST_ASSERT_EQUAL_STRING("", call_log);
+}
+
+void test_indev_event_remove_by_index(void)
+{
+    const uint32_t base_cnt = lv_indev_get_event_count(api_indev);
+
+    lv_indev_add_event_cb(api_indev, cb_a, LV_EVENT_PRESSED, NULL);
+    lv_indev_add_event_cb(api_indev, cb_b, LV_EVENT_PRESSED, NULL);
+
+    TEST_ASSERT_TRUE(lv_indev_remove_event(api_indev, base_cnt));
+    TEST_ASSERT_EQUAL_UINT32(base_cnt + 1, lv_indev_get_event_count(api_indev));
+
+    lv_indev_send_event(api_indev, LV_EVENT_PRESSED, NULL);
+    TEST_ASSERT_EQUAL_STRING("b", call_log);
+
+    /* Removing a non-existing index must fail without touching the list */
+    TEST_ASSERT_FALSE(lv_indev_remove_event(api_indev, base_cnt + 1));
+    TEST_ASSERT_EQUAL_UINT32(base_cnt + 1, lv_indev_get_event_count(api_indev));
+}
+
+void test_indev_event_remove_cb_with_user_data(void)
+{
+    const uint32_t base_cnt = lv_indev_get_event_count(api_indev);
+    int user_data_1 = 0;
+    int user_data_2 = 0;
+
+    lv_indev_add_event_cb(api_indev, cb_a, LV_EVENT_PRESSED, &user_data_1);
+    lv_indev_add_event_cb(api_indev, cb_a, LV_EVENT_RELEASED, &user_data_1);
+    lv_indev_add_event_cb(api_indev, cb_a, LV_EVENT_PRESSED, &user_data_2);
+    lv_indev_add_event_cb(api_indev, cb_b, LV_EVENT_PRESSED, &user_data_1);
+
+    TEST_ASSERT_EQUAL_UINT32(2, lv_indev_remove_event_cb_with_user_data(api_indev, cb_a, &user_data_1));
+    TEST_ASSERT_EQUAL_UINT32(base_cnt + 2, lv_indev_get_event_count(api_indev));
+
+    lv_indev_send_event(api_indev, LV_EVENT_PRESSED, NULL);
+    TEST_ASSERT_EQUAL_STRING("ab", call_log);
+
+    /* Nothing matches anymore */
+    TEST_ASSERT_EQUAL_UINT32(0, lv_indev_remove_event_cb_with_user_data(api_indev, cb_a, &user_data_1));
+}
+
+void test_indev_event_custom_registered_id(void)
+{
+    lv_event_code_t custom_1 = (lv_event_code_t)lv_event_register_id();
+    lv_event_code_t custom_2 = (lv_event_code_t)lv_event_register_id();
+
+    TEST_ASSERT_NOT_EQUAL(custom_1, custom_2);
+    TEST_ASSERT_GREATER_OR_EQUAL(LV_EVENT_LAST, custom_1);
+
+    lv_indev_add_event_cb(api_indev, cb_record, custom_1, NULL);
+    lv_indev_add_event_cb(api_indev, cb_a, custom_2, NULL);
+
+    lv_indev_send_event(api_indev, custom_1, NULL);
+
+    TEST_ASSERT_EQUAL_UINT32(1, call_cnt);
+    TEST_ASSERT_EQUAL(custom_1, last_code);
+    TEST_ASSERT_EQUAL_STRING("", call_log);
+}
+
+/* A callback may remove itself while the list is being traversed */
+static void cb_remove_self(lv_event_t * e)
+{
+    lv_indev_t * indev = lv_event_get_current_target(e);
+    call_cnt++;
+    lv_indev_remove_event_cb_with_user_data(indev, cb_remove_self, NULL);
+}
+
+void test_indev_event_remove_own_cb_while_sending(void)
+{
+    const uint32_t base_cnt = lv_indev_get_event_count(api_indev);
+
+    lv_indev_add_event_cb(api_indev, cb_remove_self, LV_EVENT_PRESSED, NULL);
+    lv_indev_add_event_cb(api_indev, cb_a, LV_EVENT_PRESSED, NULL);
+
+    lv_indev_send_event(api_indev, LV_EVENT_PRESSED, NULL);
+
+    /* The self-removing callback ran once, the one after it still ran */
+    TEST_ASSERT_EQUAL_UINT32(1, call_cnt);
+    TEST_ASSERT_EQUAL_STRING("a", call_log);
+    TEST_ASSERT_EQUAL_UINT32(base_cnt + 1, lv_indev_get_event_count(api_indev));
+
+    /* The removal really took effect */
+    lv_indev_send_event(api_indev, LV_EVENT_PRESSED, NULL);
+    TEST_ASSERT_EQUAL_UINT32(1, call_cnt);
+    TEST_ASSERT_EQUAL_STRING("aa", call_log);
+}
+
+/* LV_EVENT_DELETE is sent while the indev is still usable */
+static void cb_on_delete(lv_event_t * e)
+{
+    lv_indev_t * indev = lv_event_get_current_target(e);
+    call_cnt++;
+    last_code = lv_event_get_code(e);
+    TEST_ASSERT_EQUAL(LV_INDEV_TYPE_BUTTON, lv_indev_get_type(indev));
+}
+
+void test_indev_event_delete(void)
+{
+    lv_indev_set_type(api_indev, LV_INDEV_TYPE_BUTTON);
+    lv_indev_add_event_cb(api_indev, cb_on_delete, LV_EVENT_DELETE, NULL);
+    lv_indev_add_event_cb(api_indev, cb_a, LV_EVENT_PRESSED, NULL);
+
+    lv_indev_delete(api_indev);
+    api_indev = NULL;
+
+    TEST_ASSERT_EQUAL_UINT32(1, call_cnt);
+    TEST_ASSERT_EQUAL(LV_EVENT_DELETE, last_code);
+    TEST_ASSERT_EQUAL_STRING("", call_log);
+}
+
+/* The indev event list is notified about the click sequence, and the param is the
+ * widget the indev is acting on */
+static void cb_log_pointer_code(lv_event_t * e)
+{
+    lv_obj_t ** target_obj = lv_event_get_user_data(e);
+    *target_obj = lv_event_get_param(e);
+
+    switch(lv_event_get_code(e)) {
+        case LV_EVENT_PRESSED:
+            log_append('P');
+            break;
+        case LV_EVENT_RELEASED:
+            log_append('R');
+            break;
+        case LV_EVENT_SHORT_CLICKED:
+            log_append('S');
+            break;
+        case LV_EVENT_CLICKED:
+            log_append('C');
+            break;
+        default:
+            break;
+    }
+}
+
+void test_indev_event_pointer_click_sequence(void)
+{
+    lv_indev_t * indev = lv_test_indev_get_indev(LV_INDEV_TYPE_POINTER);
+    TEST_ASSERT_NOT_NULL(indev);
+
+    lv_obj_t * btn = lv_button_create(lv_screen_active());
+    lv_obj_set_size(btn, 100, 50);
+    lv_obj_set_pos(btn, 0, 0);
+
+    lv_obj_t * param_obj = NULL;
+    lv_indev_add_event_cb(indev, cb_log_pointer_code, LV_EVENT_PRESSED, &param_obj);
+    lv_indev_add_event_cb(indev, cb_log_pointer_code, LV_EVENT_RELEASED, &param_obj);
+    lv_indev_add_event_cb(indev, cb_log_pointer_code, LV_EVENT_SHORT_CLICKED, &param_obj);
+    lv_indev_add_event_cb(indev, cb_log_pointer_code, LV_EVENT_CLICKED, &param_obj);
+
+    lv_test_mouse_click_at(20, 20);
+
+    TEST_ASSERT_EQUAL_STRING("PRSC", call_log);
+    TEST_ASSERT_EQUAL_PTR(btn, param_obj);
+
+    lv_indev_remove_event_cb_with_user_data(indev, cb_log_pointer_code, &param_obj);
+}
+
+/* An indev event callback runs before the widget's one and can keep the event
+ * from reaching the widget with lv_indev_stop_processing() */
+static void cb_indev_stop_processing(lv_event_t * e)
+{
+    log_append('i');
+    lv_indev_stop_processing(lv_event_get_current_target(e));
+}
+
+static void cb_widget_clicked(lv_event_t * e)
+{
+    LV_UNUSED(e);
+    log_append('w');
+}
+
+void test_indev_event_stop_processing_blocks_widget(void)
+{
+    lv_indev_t * indev = lv_test_indev_get_indev(LV_INDEV_TYPE_POINTER);
+    TEST_ASSERT_NOT_NULL(indev);
+
+    lv_obj_t * btn = lv_button_create(lv_screen_active());
+    lv_obj_set_size(btn, 100, 50);
+    lv_obj_set_pos(btn, 0, 0);
+    lv_obj_add_event_cb(btn, cb_widget_clicked, LV_EVENT_CLICKED, NULL);
+
+    /* Without the indev callback the widget is notified */
+    lv_test_mouse_click_at(20, 20);
+    TEST_ASSERT_EQUAL_STRING("w", call_log);
+
+    call_log[0] = '\0';
+    lv_indev_add_event_cb(indev, cb_indev_stop_processing, LV_EVENT_CLICKED, NULL);
+
+    lv_test_mouse_click_at(20, 20);
+    TEST_ASSERT_EQUAL_STRING("i", call_log);
+
+    lv_indev_remove_event_cb_with_user_data(indev, cb_indev_stop_processing, NULL);
+
+    /* The flag must not leak into the next click */
+    call_log[0] = '\0';
+    lv_test_mouse_click_at(20, 20);
+    TEST_ASSERT_EQUAL_STRING("w", call_log);
+}
+
+/* Resetting a pressed indev notifies its event list with the widget it was acting on */
+void test_indev_event_reset_sends_indev_reset(void)
+{
+    lv_indev_t * indev = lv_test_indev_get_indev(LV_INDEV_TYPE_POINTER);
+    TEST_ASSERT_NOT_NULL(indev);
+
+    lv_obj_t * btn = lv_button_create(lv_screen_active());
+    lv_obj_set_size(btn, 100, 50);
+    lv_obj_set_pos(btn, 0, 0);
+
+    lv_indev_add_event_cb(indev, cb_record, LV_EVENT_INDEV_RESET, NULL);
+
+    /* Press and keep it pressed so the indev has an active widget */
+    lv_test_mouse_move_to(20, 20);
+    lv_test_mouse_press();
+    lv_test_wait(50);
+    TEST_ASSERT_EQUAL_UINT32(0, call_cnt);
+
+    lv_indev_reset(indev, NULL);
+
+    TEST_ASSERT_EQUAL_UINT32(1, call_cnt);
+    TEST_ASSERT_EQUAL(LV_EVENT_INDEV_RESET, last_code);
+    TEST_ASSERT_EQUAL_PTR(indev, last_target);
+    TEST_ASSERT_EQUAL_PTR(btn, last_param);
+
+    lv_indev_remove_event_cb_with_user_data(indev, cb_record, NULL);
+    lv_test_mouse_release();
+    lv_test_wait(50);
+}
+
+/* An indev that is disabled must not emit any event */
+void test_indev_event_disabled_indev_is_silent(void)
+{
+    lv_indev_t * indev = lv_test_indev_get_indev(LV_INDEV_TYPE_POINTER);
+    TEST_ASSERT_NOT_NULL(indev);
+
+    lv_obj_t * btn = lv_button_create(lv_screen_active());
+    lv_obj_set_size(btn, 100, 50);
+    lv_obj_set_pos(btn, 0, 0);
+
+    lv_indev_add_event_cb(indev, cb_count, LV_EVENT_ALL, NULL);
+
+    lv_indev_enable(indev, false);
+    lv_test_mouse_click_at(20, 20);
+    TEST_ASSERT_EQUAL_UINT32(0, call_cnt);
+
+    lv_indev_enable(indev, true);
+    lv_test_mouse_click_at(20, 20);
+    TEST_ASSERT_GREATER_THAN_UINT32(0, call_cnt);
+
+    lv_indev_remove_event_cb_with_user_data(indev, cb_count, NULL);
+}
+
+void test_indev_event_code_names(void)
+{
+    TEST_ASSERT_EQUAL_STRING("EVENT_PRESSED", lv_event_code_get_name(LV_EVENT_PRESSED));
+    TEST_ASSERT_EQUAL_STRING("EVENT_PRESSING", lv_event_code_get_name(LV_EVENT_PRESSING));
+    TEST_ASSERT_EQUAL_STRING("EVENT_PRESS_LOST", lv_event_code_get_name(LV_EVENT_PRESS_LOST));
+    TEST_ASSERT_EQUAL_STRING("EVENT_SHORT_CLICKED", lv_event_code_get_name(LV_EVENT_SHORT_CLICKED));
+    TEST_ASSERT_EQUAL_STRING("EVENT_SINGLE_CLICKED", lv_event_code_get_name(LV_EVENT_SINGLE_CLICKED));
+    TEST_ASSERT_EQUAL_STRING("EVENT_DOUBLE_CLICKED", lv_event_code_get_name(LV_EVENT_DOUBLE_CLICKED));
+    TEST_ASSERT_EQUAL_STRING("EVENT_TRIPLE_CLICKED", lv_event_code_get_name(LV_EVENT_TRIPLE_CLICKED));
+    TEST_ASSERT_EQUAL_STRING("EVENT_LONG_PRESSED", lv_event_code_get_name(LV_EVENT_LONG_PRESSED));
+    TEST_ASSERT_EQUAL_STRING("EVENT_LONG_PRESSED_REPEAT", lv_event_code_get_name(LV_EVENT_LONG_PRESSED_REPEAT));
+    TEST_ASSERT_EQUAL_STRING("EVENT_CLICKED", lv_event_code_get_name(LV_EVENT_CLICKED));
+    TEST_ASSERT_EQUAL_STRING("EVENT_RELEASED", lv_event_code_get_name(LV_EVENT_RELEASED));
+    TEST_ASSERT_EQUAL_STRING("EVENT_GESTURE", lv_event_code_get_name(LV_EVENT_GESTURE));
+    TEST_ASSERT_EQUAL_STRING("EVENT_KEY", lv_event_code_get_name(LV_EVENT_KEY));
+    TEST_ASSERT_EQUAL_STRING("EVENT_ROTARY", lv_event_code_get_name(LV_EVENT_ROTARY));
+    TEST_ASSERT_EQUAL_STRING("EVENT_INDEV_RESET", lv_event_code_get_name(LV_EVENT_INDEV_RESET));
+    TEST_ASSERT_EQUAL_STRING("EVENT_HOVER_OVER", lv_event_code_get_name(LV_EVENT_HOVER_OVER));
+    TEST_ASSERT_EQUAL_STRING("EVENT_HOVER_LEAVE", lv_event_code_get_name(LV_EVENT_HOVER_LEAVE));
 }
 
 #endif


### PR DESCRIPTION
Adds display and indev event tests and fixes an issue where if the preprocess pass would stop processing, the non-preprocess pass would still happen

- **test(event): add display and indev specific event tests**
- **fix(event): return immediately if preprocess stops event processing**
