### PR TITLE
fix(calendar): parse pressed day correctly when lunar text follows

### DIFF
--- a/src/widgets/calendar/lv_calendar.c
+++ b/src/widgets/calendar/lv_calendar.c
@@ -323,8 +323,13 @@ lv_result_t lv_calendar_get_pressed_date(const lv_obj_t * obj, lv_calendar_date_
 
     const char * txt = lv_buttonmatrix_get_button_text(calendar->btnm, lv_buttonmatrix_get_selected_button(calendar->btnm));
 
-    if(txt[1] == 0) date->day = txt[0] - '0';
-    else date->day = (txt[0] - '0') * 10 + (txt[1] - '0');
+    uint32_t day = 0;
+    uint32_t i = 0;
+    while(txt[i] >= '0' && txt[i] <= '9') {
+        day = day * 10 + (txt[i] - '0');
+        i++;
+    }
+    date->day = day;
 
     date->year = calendar->showed_date.year;
     date->month = calendar->showed_date.month;

--- a/tests/src/test_cases/widgets/test_calendar.c
+++ b/tests/src/test_cases/widgets/test_calendar.c
@@ -271,7 +271,10 @@ void test_calendar_get_pressed_date_parses_single_and_double_digit_days(void)
     int32_t double_digit_id = -1;
 
     for(uint32_t i = 0; map[i] != NULL; i++) {
-        if(map[i][0] == '\n') continue;
+        /* Skip separators (newline entries) */
+        if(map[i][0] == '\0' || map[i][0] == '\n') {
+            continue;
+        }
 
         size_t len = strlen(map[i]);
 

--- a/tests/src/test_cases/widgets/test_calendar.c
+++ b/tests/src/test_cases/widgets/test_calendar.c
@@ -3,6 +3,7 @@
 #include "../../lvgl_private.h"
 
 #include "unity/unity.h"
+#include <string.h>
 
 /* This function runs before each test */
 void setUp(void);
@@ -253,6 +254,48 @@ void test_calendar_chinese_calendar(void)
     lv_calendar_set_chinese_mode(g_calendar, true);
 
     TEST_ASSERT_EQUAL_SCREENSHOT("widgets/calendar_09.png");
+}
+
+void test_calendar_get_pressed_date_parses_single_and_double_digit_days(void)
+{
+    lv_calendar_set_month_shown(g_calendar, 2022, 9);
+
+    lv_obj_t * btnm = lv_calendar_get_btnmatrix(g_calendar);
+    const char * const * map = lv_buttonmatrix_get_map(btnm);
+
+    uint32_t btn_id = 0;
+    int32_t single_digit_id = -1;
+    int32_t double_digit_id = -1;
+
+    for(uint32_t i = 0; map[i] != NULL; i++) {
+        if(map[i][0] == '\n') continue;
+
+        size_t len = strlen(map[i]);
+
+        if(single_digit_id < 0 && len == 1 && map[i][0] == '5') {
+            single_digit_id = (int32_t)btn_id;
+        }
+        if(double_digit_id < 0 && len >= 2 && map[i][0] == '1' && map[i][1] == '5') {
+            double_digit_id = (int32_t)btn_id;
+        }
+
+        btn_id++;
+    }
+
+    TEST_ASSERT_TRUE(single_digit_id >= 0);
+    TEST_ASSERT_TRUE(double_digit_id >= 0);
+
+    lv_calendar_date_t pressed_date;
+
+    lv_buttonmatrix_set_selected_button(btnm, (uint32_t)single_digit_id);
+    lv_result_t res = lv_calendar_get_pressed_date(g_calendar, &pressed_date);
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
+    TEST_ASSERT_EQUAL_UINT8(5, pressed_date.day);
+
+    lv_buttonmatrix_set_selected_button(btnm, (uint32_t)double_digit_id);
+    res = lv_calendar_get_pressed_date(g_calendar, &pressed_date);
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, res);
+    TEST_ASSERT_EQUAL_UINT8(15, pressed_date.day);
 }
 
 #endif  /* LV_BUILD_TEST */

--- a/tests/src/test_cases/widgets/test_calendar.c
+++ b/tests/src/test_cases/widgets/test_calendar.c
@@ -261,7 +261,10 @@ void test_calendar_get_pressed_date_parses_single_and_double_digit_days(void)
     lv_calendar_set_month_shown(g_calendar, 2022, 9);
 
     lv_obj_t * btnm = lv_calendar_get_btnmatrix(g_calendar);
+    TEST_ASSERT_NOT_NULL(btnm);
+
     const char * const * map = lv_buttonmatrix_get_map(btnm);
+    TEST_ASSERT_NOT_NULL(map);
 
     uint32_t btn_id = 0;
     int32_t single_digit_id = -1;

--- a/tests/src/test_cases/widgets/test_calendar.c
+++ b/tests/src/test_cases/widgets/test_calendar.c
@@ -272,9 +272,8 @@ void test_calendar_get_pressed_date_parses_single_and_double_digit_days(void)
 
     for(uint32_t i = 0; map[i] != NULL; i++) {
         /* Skip separators (newline entries) */
-        if(map[i][0] == '\0' || map[i][0] == '\n') {
-            continue;
-        }
+        if(map[i][0] == '\0') break;   /* empty string terminates the map */
+        if(map[i][0] == '\n') continue; /* row separator */
 
         size_t len = strlen(map[i]);
 


### PR DESCRIPTION
Fixes #10479 

## What does this PR do?
When Chinese lunar calendar mode is enabled, the button text for each
day becomes `"<day>\n<lunar_text>"` instead of a plain 1-2 digit number.
The old parsing logic assumed a fixed 1- or 2-byte string, which caused
single-digit days (1-9) to be parsed incorrectly.

This PR replaces the fixed-length parsing with a loop that reads only
the leading numeric characters, so it works correctly regardless of
whether lunar text follows the day number.

## Testing
Tested on SDL2 simulator (lv_port_pc_vscode, Ubuntu 22.04). Verified
that clicking days 1-9 and 10-31 all report the correct day when
Chinese lunar mode is enabled.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

