### PR TITLE
fix(api_map): restore lv_disp_rotation_t removed from the v9.5 API

### DIFF
--- a/include/lvgl/api_map/lv_api_map_v9_5.h
+++ b/include/lvgl/api_map/lv_api_map_v9_5.h
@@ -22,6 +22,11 @@ extern "C" {
  *      TYPEDEFS
  **********************/
 
+/* Shipped in v9.5.0 through lv_api_map_v8.h, where it was an incorrect spelling of v8's
+ * `lv_disp_rot_t`. Correcting that in #10095 also removed the only definition of this
+ * name, so code written against v9.5.0 no longer compiles. Kept here for compatibility. */
+typedef lv_display_rotation_t lv_disp_rotation_t;
+
 /**********************
  * GLOBAL PROTOTYPES
  **********************/


### PR DESCRIPTION
v9.5.0 shipped `lv_disp_rotation_t` in lv_api_map_v8.h:

    typedef lv_display_rotation_t       lv_disp_rotation_t;

That was an incorrect spelling - v8's actual identifier is `lv_disp_rot_t` - and #10095 rightly corrected it. Correcting it, however, also removed the only definition of `lv_disp_rotation_t` anywhere in the tree, so code that compiled against v9.5.0 no longer builds against master, with no deprecation period and nothing in the api_map headers to cover it.

That is a real break: 18 of the BSPs in espressif/esp-bsp declare `bsp_display_rotate(lv_display_t *, lv_disp_rotation_t)` and currently fail with

    error: unknown type name 'lv_disp_rotation_t';
           did you mean 'lv_display_rotation_t'?

Those BSPs should move to `lv_display_rotation_t`, and a fix is in review upstream, but that does not help anyone whose code already builds against v9.5.0.

lv_api_map_v9_5.h is the right home for it: the name existed in 9.5, so mapping it forward is exactly what that header is for, and unlike the v8 map it is not claiming to describe v8's API. The v8 map keeps the corrected `lv_disp_rot_t` from #10095.

Verified by building an ESP-IDF project against master with an unmodified espressif/esp32_s31_korvo_1 BSP, which fails without this typedef and succeeds with it.