### PR TITLE
test(build): add build test with checks and logs disabled

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -22,6 +22,7 @@ jobs:
         # A valid option parameter to the cmake file.
         # See build_only_options and test_options in tests/main.py.
         build_option: ['OPTIONS_MINIMAL',
+                       'OPTIONS_NO_CHECKS',
                        'OPTIONS_LINUX_SW',
                        'OPTIONS_LINUX_OPENGLES',
                        'OPTIONS_NUTTX']

--- a/examples/layouts/flex/lv_example_flex_list.c
+++ b/examples/layouts/flex/lv_example_flex_list.c
@@ -115,6 +115,7 @@ static lv_obj_t * flex_list_add_button(lv_obj_t * list, const void * icon, const
     return btn;
 }
 
+#if LV_USE_LOG
 /**
  * Find the text of a list button by looking for its child label.
  */
@@ -129,14 +130,20 @@ static const char * flex_list_get_button_text(lv_obj_t * btn)
     }
     return "";
 }
+#endif /*LV_USE_LOG*/
 
 static void event_handler(lv_event_t * e)
 {
+#if LV_USE_LOG
     lv_event_code_t code = lv_event_get_code(e);
     lv_obj_t * obj = lv_event_get_target_obj(e);
+
     if(code == LV_EVENT_CLICKED) {
         LV_LOG_USER("Clicked: %s", flex_list_get_button_text(obj));
     }
+#else
+    LV_UNUSED(e);
+#endif
 }
 
 /**

--- a/examples/layouts/flex/lv_example_flex_win.c
+++ b/examples/layouts/flex/lv_example_flex_win.c
@@ -121,8 +121,12 @@ static lv_obj_t * win_add_button(lv_obj_t * win, const void * icon, int32_t btn_
 
 static void event_handler(lv_event_t * e)
 {
+#if LV_USE_LOG
     lv_obj_t * obj = lv_event_get_target_obj(e);
     LV_LOG_USER("Button %d clicked", (int)lv_obj_get_index(obj));
+#else
+    LV_UNUSED(e);
+#endif
 }
 
 /**

--- a/examples/others/file_explorer/lv_example_file_explorer_1.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_1.c
@@ -11,14 +11,19 @@ LV_DEPRECATIONS_IGNORE_BEGIN
 
 static void file_explorer_event_handler(lv_event_t * e)
 {
+#if LV_USE_LOG
     lv_event_code_t code = lv_event_get_code(e);
     lv_obj_t * obj = lv_event_get_target_obj(e);
 
     if(code == LV_EVENT_VALUE_CHANGED) {
         const char * cur_path =  lv_file_explorer_get_current_path(obj);
         const char * sel_fn = lv_file_explorer_get_selected_file_name(obj);
+
         LV_LOG_USER("%s%s", cur_path, sel_fn);
     }
+#else
+    LV_UNUSED(e);
+#endif
 }
 
 /**

--- a/examples/others/file_explorer/lv_example_file_explorer_2.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_2.c
@@ -11,6 +11,7 @@ LV_DEPRECATIONS_IGNORE_BEGIN
 
 static void file_explorer_event_handler(lv_event_t * e)
 {
+#if LV_USE_LOG
     lv_event_code_t code = lv_event_get_code(e);
     lv_obj_t * obj = lv_event_get_target_obj(e);
 
@@ -20,6 +21,9 @@ static void file_explorer_event_handler(lv_event_t * e)
 
         LV_LOG_USER("%s%s", cur_path, sel_fn);
     }
+#else
+    LV_UNUSED(e);
+#endif
 }
 
 #if LV_FILE_EXPLORER_QUICK_ACCESS

--- a/examples/others/file_explorer/lv_example_file_explorer_3.c
+++ b/examples/others/file_explorer/lv_example_file_explorer_3.c
@@ -51,10 +51,12 @@ static void file_explorer_event_handler(lv_event_t * e)
     lv_obj_t * obj = lv_event_get_target_obj(e);
 
     if(code == LV_EVENT_VALUE_CHANGED) {
+#if LV_USE_LOG
         const char * cur_path =  lv_file_explorer_get_current_path(obj);
         const char * sel_fn = lv_file_explorer_get_selected_file_name(obj);
 
         LV_LOG_USER("%s%s", cur_path, sel_fn);
+#endif
     }
     else if(code == LV_EVENT_READY) {
         lv_obj_t * tb = lv_file_explorer_get_file_table(obj);

--- a/src/debugging/profiler/lv_profiler_builtin.c
+++ b/src/debugging/profiler/lv_profiler_builtin.c
@@ -218,8 +218,12 @@ static uint64_t default_tick_get_cb(void)
 
 static void default_flush_cb(const char * buf)
 {
+#if LV_USE_LOG
     LV_ASSERT(buf != NULL);
     LV_LOG("%s", buf);
+#else
+    LV_UNUSED(buf);
+#endif
 }
 
 static int default_tid_get_cb(void)

--- a/src/debugging/test/lv_test_screenshot_compare.c
+++ b/src/debugging/test/lv_test_screenshot_compare.c
@@ -146,6 +146,8 @@ lv_test_screenshot_result_t lv_test_screenshot_compare_core(const char * fn_ref)
             if(LV_ABS((int32_t) ptr_act[0] - (int32_t) ptr_ref[0]) > REF_IMG_TOLERANCE ||
                LV_ABS((int32_t) ptr_act[1] - (int32_t) ptr_ref[1]) > REF_IMG_TOLERANCE ||
                LV_ABS((int32_t) ptr_act[2] - (int32_t) ptr_ref[2]) > REF_IMG_TOLERANCE) {
+                err = true;
+#if LV_USE_LOG
                 uint32_t act_px = (ptr_act[2] << 16) + (ptr_act[1] << 8) + (ptr_act[0] << 0);
                 uint32_t ref_px = 0;
                 memcpy(&ref_px, ptr_ref, 3);
@@ -156,7 +158,7 @@ lv_test_screenshot_result_t lv_test_screenshot_compare_core(const char * fn_ref)
                        "  - Actual:   %X\n"
                        "  - Tolerance: %d\n",
                        fn_ref_full,  x, y, ref_px, act_px, REF_IMG_TOLERANCE);
-                err = true;
+#endif
                 break;
             }
         }

--- a/src/image/lv_bin_decoder.c
+++ b/src/image/lv_bin_decoder.c
@@ -411,7 +411,7 @@ lv_result_t lv_bin_decoder_get_area(lv_image_decoder_t * decoder, lv_image_decod
         return LV_RESULT_INVALID, "Unsupported color format 0x%02x", cf);
     LV_CHECK_ARG(full_area->x1 >= 0 && full_area->x2 < (int32_t)dsc->header.w && full_area->y1 >= 0 &&
                  full_area->y2 < (int32_t)dsc->header.h, return LV_RESULT_INVALID, "Area outside image bounds");
-    LV_CHECK_ARG(dsc->user_data, return LV_RESULT_INVALID, "decoder data unavailable")
+    LV_CHECK_ARG(dsc->user_data, return LV_RESULT_INVALID, "decoder data unavailable");
 
     lv_fs_res_t res = LV_FS_RES_UNKNOWN;
     decoder_data_t * decoder_data = dsc->user_data;

--- a/src/stdlib/builtin/lv_tlsf.c
+++ b/src/stdlib/builtin/lv_tlsf.c
@@ -892,7 +892,13 @@ int lv_tlsf_check(lv_tlsf_t tlsf)
 static void default_walker(void * ptr, size_t size, int used, void * user)
 {
     LV_UNUSED(user);
+#if LV_USE_LOG
     printf("\t%p %s size: %x (%p)\n", ptr, used ? "used" : "free", (unsigned int)size, (void *)block_from_ptr(ptr));
+#else
+    LV_UNUSED(ptr);
+    LV_UNUSED(size);
+    LV_UNUSED(used);
+#endif
 }
 
 void lv_tlsf_walk_pool(lv_pool_t pool, lv_tlsf_walker walker, void * user)

--- a/src/widgets/ffmpeg/lv_ffmpeg.c
+++ b/src/widgets/ffmpeg/lv_ffmpeg.c
@@ -549,6 +549,7 @@ static int ffmpeg_decode_packet(AVCodecContext * dec, const AVPacket * pkt,
 static int ffmpeg_init_codec_context(AVCodecContext ** dec_ctx, const AVCodec * dec,
                                      enum AVMediaType type, AVStream * st)
 {
+    LV_UNUSED(type);
     int ret = 0;
 
     /* Allocate a codec context for the decoder */

--- a/tests/configs/no_checks.defconfig
+++ b/tests/configs/no_checks.defconfig
@@ -1,0 +1,12 @@
+# Applied on top of "full": build the widest feature set with every runtime
+# diagnostic switched off.
+
+# CONFIG_LV_USE_CHECK_ARG is not set
+
+# CONFIG_LV_USE_ASSERT_NULL is not set
+# CONFIG_LV_USE_ASSERT_MALLOC is not set
+# CONFIG_LV_USE_ASSERT_STYLE is not set
+# CONFIG_LV_USE_ASSERT_MEM_INTEGRITY is not set
+# CONFIG_LV_USE_ASSERT_OBJ is not set
+
+# CONFIG_LV_USE_LOG is not set

--- a/tests/main.py
+++ b/tests/main.py
@@ -38,6 +38,10 @@ build_only_options = {
         "description": "Empty config preset",
         "defconfigs": [PRESET + "empty", "minimal", "depth_16"],
     },
+    "OPTIONS_NO_CHECKS": {
+        "description": "Full config with the argument checks, assertions and logging disabled",
+        "defconfigs": ["full", "depth_32", HOST, "builtin_heap", "no_checks"],
+    },
 }
 
 if platform.system() == "Windows":


### PR DESCRIPTION
Motivated by the missing `;` in lv_bin_decoder.c which fails to compile if `LV_USE_CHECK_ARG` is disabled

See ce413e1eea9132b1ecfaa5f1ff4fb2ef12ed8a5c
