### PR TITLE
fix(timeline): fix `start` with repeating anims, and add restart 

### DIFF
--- a/docs/src/main-modules/animation.mdx
+++ b/docs/src/main-modules/animation.mdx
@@ -307,7 +307,7 @@ after adding all Animations and before telling it to start playing.
 
 Call <ApiLink name="lv_anim_timeline_pause" display="lv_anim_timeline_pause(timeline)" /> to pause the Animation Timeline.
 The position it reached is kept, so <ApiLink name="lv_anim_timeline_start" display="lv_anim_timeline_start(timeline)" />
-continues from there <ApiLink name="lv_anim_timeline_restart" display="lv_anim_timeline_restart(timeline)" /> plays it
+continues from there, and <ApiLink name="lv_anim_timeline_restart" display="lv_anim_timeline_restart(timeline)" /> plays it
 again from the beginning (or end if reversed).
 
 Call <ApiLink name="lv_anim_timeline_set_progress" display="lv_anim_timeline_set_progress(timeline, progress)" /> function to set the

--- a/docs/src/main-modules/animation.mdx
+++ b/docs/src/main-modules/animation.mdx
@@ -291,7 +291,7 @@ To create and use an Animation Timeline:
   It plays from wherever the Timeline currently is:  from the beginning, or from the
   point set by <ApiLink name="lv_anim_timeline_set_progress" display="lv_anim_timeline_set_progress(timeline, progress)" />.
   Use <ApiLink name="lv_anim_timeline_restart" display="lv_anim_timeline_restart(timeline)" /> to always play from the
-  beginning, whatever state the Timeline was left in.
+  beginning (or end if reversed), regardless of the previous state of the Timeline.
 
 <Callout type="info">
 own copy of the contents of the Animation template, so if you do not need it
@@ -307,8 +307,8 @@ after adding all Animations and before telling it to start playing.
 
 Call <ApiLink name="lv_anim_timeline_pause" display="lv_anim_timeline_pause(timeline)" /> to pause the Animation Timeline.
 The position it reached is kept, so <ApiLink name="lv_anim_timeline_start" display="lv_anim_timeline_start(timeline)" />
-continues from there, and <ApiLink name="lv_anim_timeline_restart" display="lv_anim_timeline_restart(timeline)" /> plays it
-again from the beginning.
+continues from there <ApiLink name="lv_anim_timeline_restart" display="lv_anim_timeline_restart(timeline)" /> plays it
+again from the beginning (or end if reversed).
 
 Call <ApiLink name="lv_anim_timeline_set_progress" display="lv_anim_timeline_set_progress(timeline, progress)" /> function to set the
 state of the Animation Timeline according to the `progress` value.  `progress` is

--- a/docs/src/main-modules/animation.mdx
+++ b/docs/src/main-modules/animation.mdx
@@ -288,6 +288,9 @@ To create and use an Animation Timeline:
   `start_time` will override any value given to
   <ApiLink name="lv_anim_set_delay" display="lv_anim_set_delay(&anim_template, delay)" />.
 - Call <ApiLink name="lv_anim_timeline_start" display="lv_anim_timeline_start(timeline)" /> to start the Animation Timeline.
+  It always plays from the beginning:  the progress is reset and every Animation on
+  the Timeline is armed again.  Calling it on a Timeline that is already playing
+  therefore restarts it.
 
 <Callout type="info">
 own copy of the contents of the Animation template, so if you do not need it
@@ -295,16 +298,15 @@ later, its contents do not need to be preserved after this call.
 </Callout>
 
 It supports forward and reverse play of the entire Animation group, using
-<ApiLink name="lv_anim_timeline_set_reverse" display="lv_anim_timeline_set_reverse(timeline, reverse)" />. Note that if you want to
-play in reverse from the end of the Timeline, you need to call
-<ApiLink name="lv_anim_timeline_set_progress" display="lv_anim_timeline_set_progress(timeline, LV_ANIM_TIMELINE_PROGRESS_MAX)" />
-after adding all Animations and before telling it to start playing.
+<ApiLink name="lv_anim_timeline_set_reverse" display="lv_anim_timeline_set_reverse(timeline, reverse)" />.  A reversed Timeline
+starts from its end on its own, so no other call is needed to set that up.
 
 Call <ApiLink name="lv_anim_timeline_pause" display="lv_anim_timeline_pause(timeline)" /> to pause the Animation Timeline.
-Note:  this does not preserve its state.  The only way to start it again is to call
-<ApiLink name="lv_anim_timeline_start" display="lv_anim_timeline_start(timeline)" />, which starts the Timeline from the
-beginning or at the point set by
-<ApiLink name="lv_anim_timeline_set_progress" display="lv_anim_timeline_set_progress(timeline, progress)" />.
+It keeps its position, and
+<ApiLink name="lv_anim_timeline_resume" display="lv_anim_timeline_resume(timeline)" /> continues from where it was paused.
+Use <ApiLink name="lv_anim_timeline_start" display="lv_anim_timeline_start(timeline)" /> instead to play it again from the
+beginning.  Both pause and resume have no effect on a Timeline that is not
+playing.
 
 Call <ApiLink name="lv_anim_timeline_set_progress" display="lv_anim_timeline_set_progress(timeline, progress)" /> function to set the
 state of the Animation Timeline according to the `progress` value.  `progress` is

--- a/docs/src/main-modules/animation.mdx
+++ b/docs/src/main-modules/animation.mdx
@@ -288,9 +288,10 @@ To create and use an Animation Timeline:
   `start_time` will override any value given to
   <ApiLink name="lv_anim_set_delay" display="lv_anim_set_delay(&anim_template, delay)" />.
 - Call <ApiLink name="lv_anim_timeline_start" display="lv_anim_timeline_start(timeline)" /> to start the Animation Timeline.
-  It always plays from the beginning:  the progress is reset and every Animation on
-  the Timeline is armed again.  Calling it on a Timeline that is already playing
-  therefore restarts it.
+  It plays from wherever the Timeline currently is:  from the beginning, or from the
+  point set by <ApiLink name="lv_anim_timeline_set_progress" display="lv_anim_timeline_set_progress(timeline, progress)" />.
+  Use <ApiLink name="lv_anim_timeline_restart" display="lv_anim_timeline_restart(timeline)" /> to always play from the
+  beginning, whatever state the Timeline was left in.
 
 <Callout type="info">
 own copy of the contents of the Animation template, so if you do not need it
@@ -298,15 +299,16 @@ later, its contents do not need to be preserved after this call.
 </Callout>
 
 It supports forward and reverse play of the entire Animation group, using
-<ApiLink name="lv_anim_timeline_set_reverse" display="lv_anim_timeline_set_reverse(timeline, reverse)" />.  A reversed Timeline
-starts from its end on its own, so no other call is needed to set that up.
+<ApiLink name="lv_anim_timeline_set_reverse" display="lv_anim_timeline_set_reverse(timeline, reverse)" />. Note that if you want to
+play in reverse from the end of the Timeline, you need to call
+<ApiLink name="lv_anim_timeline_set_progress" display="lv_anim_timeline_set_progress(timeline, LV_ANIM_TIMELINE_PROGRESS_MAX)" />
+after adding all Animations and before telling it to start playing.
+<ApiLink name="lv_anim_timeline_restart" display="lv_anim_timeline_restart(timeline)" /> does that for you.
 
 Call <ApiLink name="lv_anim_timeline_pause" display="lv_anim_timeline_pause(timeline)" /> to pause the Animation Timeline.
-It keeps its position, and
-<ApiLink name="lv_anim_timeline_resume" display="lv_anim_timeline_resume(timeline)" /> continues from where it was paused.
-Use <ApiLink name="lv_anim_timeline_start" display="lv_anim_timeline_start(timeline)" /> instead to play it again from the
-beginning.  Both pause and resume have no effect on a Timeline that is not
-playing.
+The position it reached is kept, so <ApiLink name="lv_anim_timeline_start" display="lv_anim_timeline_start(timeline)" />
+continues from there, and <ApiLink name="lv_anim_timeline_restart" display="lv_anim_timeline_restart(timeline)" /> plays it
+again from the beginning.
 
 Call <ApiLink name="lv_anim_timeline_set_progress" display="lv_anim_timeline_set_progress(timeline, progress)" /> function to set the
 state of the Animation Timeline according to the `progress` value.  `progress` is

--- a/include/lvgl/core/lv_anim_timeline.h
+++ b/include/lvgl/core/lv_anim_timeline.h
@@ -60,9 +60,9 @@ void lv_anim_timeline_delete(lv_anim_timeline_t * at);
 void lv_anim_timeline_add(lv_anim_timeline_t * at, uint32_t start_time, const lv_anim_t * a);
 
 /**
- * Start the animation timeline.
+ * Start the animation timeline from the beginning. Reset it if needed.
  * @param at    pointer to the animation timeline.
- * @return      total time spent in animation timeline.
+ * @return      total playtime of the animation.
  */
 uint32_t lv_anim_timeline_start(lv_anim_timeline_t * at);
 
@@ -71,6 +71,12 @@ uint32_t lv_anim_timeline_start(lv_anim_timeline_t * at);
  * @param at    pointer to the animation timeline.
  */
 void lv_anim_timeline_pause(lv_anim_timeline_t * at);
+
+/**
+ * Resume a paused timeline.
+ * @param at    pointer to the animation timeline.
+ */
+void lv_anim_timeline_resume(lv_anim_timeline_t * at);
 
 /**
  * Set the playback direction of the animation timeline.

--- a/include/lvgl/core/lv_anim_timeline.h
+++ b/include/lvgl/core/lv_anim_timeline.h
@@ -60,23 +60,29 @@ void lv_anim_timeline_delete(lv_anim_timeline_t * at);
 void lv_anim_timeline_add(lv_anim_timeline_t * at, uint32_t start_time, const lv_anim_t * a);
 
 /**
- * Start the animation timeline from the beginning. Reset it if needed.
+ * Start the animation timeline. It plays from where the timeline currently is:
+ * from the beginning, or from the point set by `lv_anim_timeline_set_progress()`.
  * @param at    pointer to the animation timeline.
- * @return      total playtime of the animation.
+ * @return      total time spent in animation timeline.
+ * @note 		`delay` is applied only if the animation is at very beginning or very end (not midway)
+ * @note 		if `reverse` was set it plays backwards.
  */
 uint32_t lv_anim_timeline_start(lv_anim_timeline_t * at);
+
+/**
+ * Play the animation timeline from the beginning, whatever state it was left in.
+ * Same as rewinding with `lv_anim_timeline_set_progress()` and starting it.
+ *
+ * @param at    pointer to the animation timeline.
+ * @return      total time spent in animation timeline.
+ */
+uint32_t lv_anim_timeline_restart(lv_anim_timeline_t * at);
 
 /**
  * Pause the animation timeline.
  * @param at    pointer to the animation timeline.
  */
 void lv_anim_timeline_pause(lv_anim_timeline_t * at);
-
-/**
- * Resume a paused timeline.
- * @param at    pointer to the animation timeline.
- */
-void lv_anim_timeline_resume(lv_anim_timeline_t * at);
 
 /**
  * Set the playback direction of the animation timeline.

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -2011,31 +2011,10 @@ static void play_timeline_on_trigger_event_cb(lv_event_t * e)
     timeline_play_dsc_t * dsc = lv_event_get_user_data(e);
     LV_ASSERT_NULL(dsc);
 
-    /*Reset the progress only if the animation was finished*/
-    uint16_t progress = lv_anim_timeline_get_progress(dsc->at);
-    if(dsc->reverse) {
-        if(progress == 0) {
-            lv_anim_timeline_set_progress(dsc->at, LV_ANIM_TIMELINE_PROGRESS_MAX);
-        }
-
-        if(lv_anim_timeline_get_progress(dsc->at) == LV_ANIM_TIMELINE_PROGRESS_MAX) {
-            lv_anim_timeline_set_delay(dsc->at, dsc->delay);
-        }
-
-        lv_anim_timeline_set_reverse(dsc->at, true);
-    }
-    else {
-        if(progress == LV_ANIM_TIMELINE_PROGRESS_MAX) {
-            lv_anim_timeline_set_progress(dsc->at, 0);
-        }
-
-        if(lv_anim_timeline_get_progress(dsc->at) == 0) {
-            lv_anim_timeline_set_delay(dsc->at, dsc->delay);
-        }
-
-        lv_anim_timeline_set_reverse(dsc->at, false);
-    }
+    lv_anim_timeline_set_delay(dsc->at, dsc->delay);
+    lv_anim_timeline_set_reverse(dsc->at, dsc->reverse);
     lv_anim_timeline_start(dsc->at);
+
 }
 
 

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -2013,9 +2013,9 @@ static void play_timeline_on_trigger_event_cb(lv_event_t * e)
 
     lv_anim_timeline_set_delay(dsc->at, dsc->delay);
     lv_anim_timeline_set_reverse(dsc->at, dsc->reverse);
-    lv_anim_timeline_start(dsc->at);
-
+    lv_anim_timeline_restart(dsc->at);
 }
+
 
 
 static void delete_on_screen_unloaded_event_cb(lv_event_t * e)

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -2011,11 +2011,24 @@ static void play_timeline_on_trigger_event_cb(lv_event_t * e)
     timeline_play_dsc_t * dsc = lv_event_get_user_data(e);
     LV_ASSERT_NULL(dsc);
 
-    lv_anim_timeline_set_delay(dsc->at, dsc->delay);
-    lv_anim_timeline_set_reverse(dsc->at, dsc->reverse);
-    lv_anim_timeline_restart(dsc->at);
-}
+    /*Reset the progress only if the animation was finished*/
+    uint16_t progress = lv_anim_timeline_get_progress(dsc->at);
+    if(dsc->reverse) {
+        if(progress == 0) {
+            lv_anim_timeline_set_progress(dsc->at, LV_ANIM_TIMELINE_PROGRESS_MAX);
+        }
 
+        lv_anim_timeline_set_reverse(dsc->at, true);
+    }
+    else {
+        if(progress == LV_ANIM_TIMELINE_PROGRESS_MAX) {
+            lv_anim_timeline_set_progress(dsc->at, 0);
+        }
+
+    }
+    lv_anim_timeline_set_reverse(dsc->at, dsc->reverse);
+    lv_anim_timeline_start(dsc->at);
+}
 
 
 static void delete_on_screen_unloaded_event_cb(lv_event_t * e)

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -2015,13 +2015,13 @@ static void play_timeline_on_trigger_event_cb(lv_event_t * e)
     uint16_t progress = lv_anim_timeline_get_progress(dsc->at);
     if(dsc->reverse) {
         if(progress == 0) {
+            lv_anim_timeline_set_delay(dsc->at, dsc->delay);
             lv_anim_timeline_set_progress(dsc->at, LV_ANIM_TIMELINE_PROGRESS_MAX);
         }
-
-        lv_anim_timeline_set_reverse(dsc->at, true);
     }
     else {
         if(progress == LV_ANIM_TIMELINE_PROGRESS_MAX) {
+            lv_anim_timeline_set_delay(dsc->at, dsc->delay);
             lv_anim_timeline_set_progress(dsc->at, 0);
         }
 

--- a/src/misc/lv_anim_timeline.c
+++ b/src/misc/lv_anim_timeline.c
@@ -69,40 +69,41 @@ void lv_anim_timeline_add(lv_anim_timeline_t * at, uint32_t start_time, const lv
     at->anim_dsc[at->anim_dsc_cnt - 1].start_time = start_time;
 }
 
+
 uint32_t lv_anim_timeline_start(lv_anim_timeline_t * at)
 {
     LV_CHECK_ARG(at != NULL, return 0);
 
-    uint32_t playtime = lv_anim_timeline_get_playtime(at);
-    uint32_t repeat = at->repeat_count;
-    uint32_t repeat_delay = at->repeat_delay;
-    uint32_t start = at->act_time;
-    uint32_t end = at->reverse ? 0 : playtime;
-    uint32_t duration = end > start ? end - start : start - end;
-
-    if((!at->reverse && at->act_time == 0) || (at->reverse && at->act_time == playtime)) {
-        for(uint32_t i = 0; i < at->anim_dsc_cnt; i++) {
-            at->anim_dsc[i].is_started   = 0;
-            at->anim_dsc[i].is_completed = 0;
-        }
+    for(uint32_t i = 0; i < at->anim_dsc_cnt; i++) {
+        at->anim_dsc[i].is_started   = 0;
+        at->anim_dsc[i].is_completed = 0;
     }
 
-    /*Apply the delay only if playing from any ends*/
-    uint32_t delay = 0;
-    if(!at->reverse && at->act_time == 0) delay = at->delay;
-    else if(at->reverse && at->act_time == playtime) delay = at->delay;
+    uint32_t playtime = lv_anim_timeline_get_playtime(at);
+    at->act_time = 0;
 
+    /*Start an animation going from 0 to `playtime` in `playtime` ms.
+     *That it just sweep through the playtime*/
     lv_anim_t a;
     lv_anim_init(&a);
     lv_anim_set_var(&a, at);
     lv_anim_set_exec_cb(&a, anim_timeline_exec_cb);
-    lv_anim_set_values(&a, start, end);
-    lv_anim_set_duration(&a, duration);
-    lv_anim_set_delay(&a, delay);
+    if(at->reverse) {
+        lv_anim_set_values(&a, playtime, 0);
+        at->act_time = playtime;
+    }
+    else {
+        lv_anim_set_values(&a, 0, playtime);
+        at->act_time = 0;
+    }
+
+    lv_anim_set_duration(&a, playtime);
+    lv_anim_set_delay(&a, at->delay);
     lv_anim_set_path_cb(&a, anim_timeline_path_cb);
-    lv_anim_set_repeat_count(&a, repeat);
-    lv_anim_set_repeat_delay(&a, repeat_delay);
+    lv_anim_set_repeat_count(&a, at->repeat_count);
+    lv_anim_set_repeat_delay(&a,  at->repeat_delay);
     lv_anim_start(&a);
+
     return playtime;
 }
 
@@ -110,8 +111,27 @@ void lv_anim_timeline_pause(lv_anim_timeline_t * at)
 {
     LV_CHECK_ARG(at != NULL, return);
 
-    lv_anim_delete(at, anim_timeline_exec_cb);
+    lv_anim_t * a = lv_anim_get(at, anim_timeline_exec_cb);
+    if(a == NULL) {
+        LV_LOG_WARN("The timeline is not running so it can't be paused");
+    }
+    else {
+        lv_anim_pause(a);
+    }
 }
+
+void lv_anim_timeline_resume(lv_anim_timeline_t * at)
+{
+    LV_CHECK_ARG(at != NULL, return);
+    lv_anim_t * a = lv_anim_get(at, anim_timeline_exec_cb);
+    if(a == NULL) {
+        LV_LOG_WARN("The timeline is not running so it can't be resumed");
+    }
+    else {
+        lv_anim_resume(a);
+    }
+}
+
 
 void lv_anim_timeline_set_reverse(lv_anim_timeline_t * at, bool reverse)
 {
@@ -317,9 +337,12 @@ static void anim_timeline_set_act_time(lv_anim_timeline_t * at, uint32_t act_tim
     }
 }
 
+
 static int32_t anim_timeline_path_cb(const lv_anim_t * a)
 {
-    /* Directly map original timestamps to avoid loss of accuracy */
+    /*Map the timestamps directly. The default linear path goes through a
+     *1024 step intermediate, which quantises `act_time` and would stop a
+     *descriptor whose `start_time` falls between two steps from starting.*/
     return lv_map(a->act_time, 0, a->duration, a->start_value, a->end_value);
 }
 

--- a/src/misc/lv_anim_timeline.c
+++ b/src/misc/lv_anim_timeline.c
@@ -74,64 +74,61 @@ uint32_t lv_anim_timeline_start(lv_anim_timeline_t * at)
 {
     LV_CHECK_ARG(at != NULL, return 0);
 
-    for(uint32_t i = 0; i < at->anim_dsc_cnt; i++) {
-        at->anim_dsc[i].is_started   = 0;
-        at->anim_dsc[i].is_completed = 0;
+    uint32_t playtime = lv_anim_timeline_get_playtime(at);
+
+    if((!at->reverse && at->act_time == 0) || (at->reverse && at->act_time == playtime)) {
+        for(uint32_t i = 0; i < at->anim_dsc_cnt; i++) {
+            at->anim_dsc[i].is_started   = 0;
+            at->anim_dsc[i].is_completed = 0;
+        }
     }
 
-    uint32_t playtime = lv_anim_timeline_get_playtime(at);
-    at->act_time = 0;
-
-    /*Start an animation going from 0 to `playtime` in `playtime` ms.
-     *That it just sweep through the playtime*/
+    /*Always animate the whole 0..playtime range in `playtime` ms and seek into it if
+     *the timeline is not at its beginning. Starting the animation at `act_time`
+     *instead would shorten it, and as a repeat replays the same values, every later
+     *repeat would keep playing only that remaining part.*/
     lv_anim_t a;
     lv_anim_init(&a);
     lv_anim_set_var(&a, at);
     lv_anim_set_exec_cb(&a, anim_timeline_exec_cb);
-    if(at->reverse) {
-        lv_anim_set_values(&a, playtime, 0);
-        at->act_time = playtime;
-    }
-    else {
-        lv_anim_set_values(&a, 0, playtime);
-        at->act_time = 0;
-    }
+    if(at->reverse) lv_anim_set_values(&a, playtime, 0);
+    else lv_anim_set_values(&a, 0, playtime);
 
     lv_anim_set_duration(&a, playtime);
-    lv_anim_set_delay(&a, at->delay);
     lv_anim_set_path_cb(&a, anim_timeline_path_cb);
     lv_anim_set_repeat_count(&a, at->repeat_count);
-    lv_anim_set_repeat_delay(&a,  at->repeat_delay);
+    lv_anim_set_repeat_delay(&a, at->repeat_delay);
+
+    /*How much of the timeline has already played. A reversed one counts from its end.*/
+    uint32_t elapsed = at->reverse ? playtime - at->act_time : at->act_time;
+    if(elapsed == 0) {
+        /*Apply the delay only if playing from any ends*/
+        lv_anim_set_delay(&a, at->delay);
+    }
+    else {
+        /*`lv_anim_set_delay()` writes act_time as well, so seek after it*/
+        a.act_time = (int32_t)elapsed;
+    }
+
     lv_anim_start(&a);
 
     return playtime;
+}
+
+uint32_t lv_anim_timeline_restart(lv_anim_timeline_t * at)
+{
+    LV_CHECK_ARG(at != NULL, return 0);
+
+    lv_anim_timeline_set_progress(at, at->reverse ? LV_ANIM_TIMELINE_PROGRESS_MAX : 0);
+    return lv_anim_timeline_start(at);
 }
 
 void lv_anim_timeline_pause(lv_anim_timeline_t * at)
 {
     LV_CHECK_ARG(at != NULL, return);
 
-    lv_anim_t * a = lv_anim_get(at, anim_timeline_exec_cb);
-    if(a == NULL) {
-        LV_LOG_WARN("The timeline is not running so it can't be paused");
-    }
-    else {
-        lv_anim_pause(a);
-    }
+    lv_anim_delete(at, anim_timeline_exec_cb);
 }
-
-void lv_anim_timeline_resume(lv_anim_timeline_t * at)
-{
-    LV_CHECK_ARG(at != NULL, return);
-    lv_anim_t * a = lv_anim_get(at, anim_timeline_exec_cb);
-    if(a == NULL) {
-        LV_LOG_WARN("The timeline is not running so it can't be resumed");
-    }
-    else {
-        lv_anim_resume(a);
-    }
-}
-
 
 void lv_anim_timeline_set_reverse(lv_anim_timeline_t * at, bool reverse)
 {

--- a/tests/src/test_cases/test_anim_timeline.c
+++ b/tests/src/test_cases/test_anim_timeline.c
@@ -616,4 +616,101 @@ void test_anim_timeline_without_exec_cb_but_anim_start_cb_and_completed_cb(void)
     TEST_ASSERT_EQUAL(2, anim1_completed_called);
 }
 
+void test_anim_timeline_restart_while_running(void)
+{
+    lv_obj_t * obj = lv_obj_create(lv_screen_active());
+    lv_obj_set_size(obj, 100, 100);
+    lv_obj_set_pos(obj, 30, 40);
+
+    lv_anim_t a1;
+    lv_anim_init(&a1);
+    lv_anim_set_exec_cb(&a1, (lv_anim_exec_xcb_t)lv_obj_set_x);
+    lv_anim_set_var(&a1, obj);
+    lv_anim_set_values(&a1, 0, 1000);
+    lv_anim_set_duration(&a1, 1000);
+
+    anim_timeline = lv_anim_timeline_create();
+    lv_anim_timeline_add(anim_timeline, 0, &a1);
+    lv_anim_timeline_start(anim_timeline);
+    lv_refr_now(NULL);
+
+    lv_test_wait(400);
+    TEST_ASSERT_EQUAL(399, lv_obj_get_x(obj));
+
+    /*Starting again plays from the beginning, not from where it was*/
+    lv_anim_timeline_start(anim_timeline);
+    lv_refr_now(NULL);
+    TEST_ASSERT_EQUAL(0, lv_obj_get_x(obj));
+
+    lv_test_wait(400);
+    TEST_ASSERT_EQUAL(399, lv_obj_get_x(obj));
+
+    lv_test_wait(600);
+    TEST_ASSERT_EQUAL(1000, lv_obj_get_x(obj));
+}
+
+void test_anim_timeline_restart_keeps_the_whole_range_on_repeat(void)
+{
+    lv_obj_t * obj = lv_obj_create(lv_screen_active());
+    lv_obj_set_size(obj, 100, 100);
+    lv_obj_set_pos(obj, 30, 40);
+
+    lv_anim_t a1;
+    lv_anim_init(&a1);
+    lv_anim_set_exec_cb(&a1, (lv_anim_exec_xcb_t)lv_obj_set_x);
+    lv_anim_set_var(&a1, obj);
+    lv_anim_set_values(&a1, 0, 1000);
+    lv_anim_set_duration(&a1, 1000);
+
+    anim_timeline = lv_anim_timeline_create();
+    lv_anim_timeline_add(anim_timeline, 0, &a1);
+    lv_anim_timeline_set_repeat_count(anim_timeline, LV_ANIM_REPEAT_INFINITE);
+    lv_anim_timeline_start(anim_timeline);
+    lv_refr_now(NULL);
+
+    /*Restart in the middle. Every later repeat still has to sweep 0..1000;
+     *capturing the range from the current time truncated it forever.*/
+    lv_test_wait(400);
+    lv_anim_timeline_start(anim_timeline);
+    lv_refr_now(NULL);
+
+    lv_test_wait(1000);   /*end of the first cycle, the second begins*/
+    lv_test_wait(400);
+    TEST_ASSERT_EQUAL(399, lv_obj_get_x(obj));
+
+    lv_test_wait(600);    /*end of the second cycle*/
+    lv_test_wait(400);
+    TEST_ASSERT_EQUAL(399, lv_obj_get_x(obj));
+}
+
+void test_anim_timeline_pause_and_resume(void)
+{
+    lv_obj_t * obj = lv_obj_create(lv_screen_active());
+    lv_obj_set_size(obj, 100, 100);
+    lv_obj_set_pos(obj, 30, 40);
+
+    lv_anim_t a1;
+    lv_anim_init(&a1);
+    lv_anim_set_exec_cb(&a1, (lv_anim_exec_xcb_t)lv_obj_set_x);
+    lv_anim_set_var(&a1, obj);
+    lv_anim_set_values(&a1, 0, 1000);
+    lv_anim_set_duration(&a1, 1000);
+
+    anim_timeline = lv_anim_timeline_create();
+    lv_anim_timeline_add(anim_timeline, 0, &a1);
+    lv_anim_timeline_start(anim_timeline);
+    lv_refr_now(NULL);
+
+    lv_test_wait(300);
+    TEST_ASSERT_EQUAL(299, lv_obj_get_x(obj));
+
+    lv_anim_timeline_pause(anim_timeline);
+    lv_test_wait(500);
+    TEST_ASSERT_EQUAL(299, lv_obj_get_x(obj));
+
+    lv_anim_timeline_resume(anim_timeline);
+    lv_test_wait(300);
+    TEST_ASSERT_EQUAL(599, lv_obj_get_x(obj));
+}
+
 #endif

--- a/tests/src/test_cases/test_anim_timeline.c
+++ b/tests/src/test_cases/test_anim_timeline.c
@@ -637,8 +637,8 @@ void test_anim_timeline_restart_while_running(void)
     lv_test_wait(400);
     TEST_ASSERT_EQUAL(399, lv_obj_get_x(obj));
 
-    /*Starting again plays from the beginning, not from where it was*/
-    lv_anim_timeline_start(anim_timeline);
+    /*Restarting plays from the beginning, not from where it was*/
+    lv_anim_timeline_restart(anim_timeline);
     lv_refr_now(NULL);
     TEST_ASSERT_EQUAL(0, lv_obj_get_x(obj));
 
@@ -671,7 +671,7 @@ void test_anim_timeline_restart_keeps_the_whole_range_on_repeat(void)
     /*Restart in the middle. Every later repeat still has to sweep 0..1000;
      *capturing the range from the current time truncated it forever.*/
     lv_test_wait(400);
-    lv_anim_timeline_start(anim_timeline);
+    lv_anim_timeline_restart(anim_timeline);
     lv_refr_now(NULL);
 
     lv_test_wait(1000);   /*end of the first cycle, the second begins*/
@@ -683,7 +683,7 @@ void test_anim_timeline_restart_keeps_the_whole_range_on_repeat(void)
     TEST_ASSERT_EQUAL(399, lv_obj_get_x(obj));
 }
 
-void test_anim_timeline_pause_and_resume(void)
+void test_anim_timeline_pause_and_continue(void)
 {
     lv_obj_t * obj = lv_obj_create(lv_screen_active());
     lv_obj_set_size(obj, 100, 100);
@@ -708,9 +708,41 @@ void test_anim_timeline_pause_and_resume(void)
     lv_test_wait(500);
     TEST_ASSERT_EQUAL(299, lv_obj_get_x(obj));
 
-    lv_anim_timeline_resume(anim_timeline);
+    /*The position is kept, so starting it continues from there*/
+    lv_anim_timeline_start(anim_timeline);
     lv_test_wait(300);
     TEST_ASSERT_EQUAL(599, lv_obj_get_x(obj));
+}
+
+void test_anim_timeline_start_plays_from_the_set_progress(void)
+{
+    lv_obj_t * obj = lv_obj_create(lv_screen_active());
+    lv_obj_set_size(obj, 100, 100);
+    lv_obj_set_pos(obj, 30, 40);
+
+    lv_anim_t a1;
+    lv_anim_init(&a1);
+    lv_anim_set_exec_cb(&a1, (lv_anim_exec_xcb_t)lv_obj_set_x);
+    lv_anim_set_var(&a1, obj);
+    lv_anim_set_values(&a1, 0, 1000);
+    lv_anim_set_duration(&a1, 1000);
+
+    anim_timeline = lv_anim_timeline_create();
+    lv_anim_timeline_add(anim_timeline, 0, &a1);
+
+    /*Seek, then play on from there. `restart` would rewind to the beginning.*/
+    lv_anim_timeline_set_progress(anim_timeline, 32768);
+    lv_refr_now(NULL);
+    TEST_ASSERT_EQUAL(500, lv_obj_get_x(obj));
+
+    lv_anim_timeline_start(anim_timeline);
+    lv_refr_now(NULL);
+
+    lv_test_wait(300);
+    TEST_ASSERT_EQUAL(799, lv_obj_get_x(obj));
+
+    lv_test_wait(200);
+    TEST_ASSERT_EQUAL(1000, lv_obj_get_x(obj));
 }
 
 #endif


### PR DESCRIPTION
`lv_anim_timeline_start` set the start value to `act_value` meaning if you called it on a repeating animation is animated between `old act_value` and `end_value`.

Also updated the incorrect docs stating `lv_anim_timeline_start` restarts the timeline, and add an `lv_anim_timeline_restart` explicitly. 

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
