### PR TITLE
feat(qrcode): split the payload API into text and binary setters

### DIFF
--- a/docs/src/changelog/migration-v10.mdx
+++ b/docs/src/changelog/migration-v10.mdx
@@ -617,6 +617,23 @@ Calling the following functions with `NULL` as the display parameter is deprecat
   several property changes into a single re-encode on the next redraw. The default,
   `LV_QRCODE_UPDATE_MODE_IMMEDIATE`, re-encodes inside the setter.
 
+- The payload API is split by kind. `lv_qrcode_update()` is gone: use
+  `lv_qrcode_set_data()` for binary payloads (same arguments as the old
+  `lv_qrcode_update()`) and `lv_qrcode_set_text()` for strings. Both return the encode
+  result. `lv_qrcode_set_data()` previously took a `const char *` and returned `void`.
+
+  ```c
+  /* Before */
+  lv_qrcode_update(qr, data, data_len);
+  lv_qrcode_set_data(qr, "https://lvgl.io");
+
+  /* After */
+  lv_qrcode_set_data(qr, data, data_len);
+  lv_qrcode_set_text(qr, "https://lvgl.io");
+  ```
+
+- New: `lv_qrcode_get_text()` and `lv_qrcode_get_data()` read the stored payload back.
+
 - New: `lv_qrcode_render()` re-encodes the stored payload without taking it as an
   argument, which is how property changes made in the deferred update mode are applied.
 

--- a/docs/src/libs/qrcode.mdx
+++ b/docs/src/libs/qrcode.mdx
@@ -17,8 +17,8 @@ Widget that generates and displays QR Codes using the library.
 Enable <ApiLink name="LV_USE_QRCODE" /> in `lv_conf.h` by setting its value to `1`.
 
 Use <ApiLink name="lv_qrcode_create" /> to create the QR-Code Widget. Then set the
-data to encode with <ApiLink name="lv_qrcode_update" /> for arbitrary binary data, or
-with <ApiLink name="lv_qrcode_set_data" /> for a NUL terminated string.
+payload with <ApiLink name="lv_qrcode_set_text" /> for a NUL terminated string, or
+<ApiLink name="lv_qrcode_set_data" /> for arbitrary binary data.
 
 The appearance can be configured with <ApiLink name="lv_qrcode_set_size" />,
 <ApiLink name="lv_qrcode_set_dark_color" />, <ApiLink name="lv_qrcode_set_light_color" />
@@ -46,7 +46,7 @@ lv_qrcode_render(qr);   /* encode once, here, and get the result */
 ```
 
 <ApiLink name="lv_qrcode_render" /> re-encodes the payload the Widget already stores, so
-unlike <ApiLink name="lv_qrcode_update" /> it does not need the data passed in again.
+unlike the payload setters it does not need the payload passed in again.
 
 If that call is forgotten the bitmap is still correct - the redraw notices it is out of
 date and encodes it - but that is a fallback, not the intended flow, and it logs a
@@ -64,14 +64,14 @@ lv_qrcode_render(qr);                                            /* result avail
 lv_qrcode_set_update_mode(qr, LV_QRCODE_UPDATE_MODE_IMMEDIATE);  /* nothing left to encode */
 ```
 
-The mode does not affect setting the data: <ApiLink name="lv_qrcode_update" /> and
+The mode does not affect setting the payload: <ApiLink name="lv_qrcode_set_text" /> and
 <ApiLink name="lv_qrcode_set_data" /> always encode right away and return the result,
 so an unencodable payload is reported to the caller. The colors are never affected
 either - they are a palette write in both modes.
 
 ### Detecting a failed re-encode
 
-`lv_qrcode_update()` and `lv_qrcode_render()` return the encode result, but the
+The payload setters and `lv_qrcode_render()` return the encode result, but the
 re-encodes triggered by a property change cannot: `lv_qrcode_set_size()` and `lv_qrcode_set_quiet_zone()` return
 `void`, and in deferred mode the work happens in the draw pass. A payload that no longer
 fits - typically after shrinking the object - therefore fails without anything returning
@@ -91,19 +91,42 @@ A failed encode leaves the bitmap marked as out of date, so it is never mistaken
 current one, and it is not retried on every redraw - only a property change makes the
 Widget try again.
 
-Encode failures are not logged when the caller can see the result: `lv_qrcode_update()`
+Encode failures are not logged when the caller can see the result: the payload setters
 and `lv_qrcode_render()` return it, and the property setters are silent because the state
 is available from `lv_qrcode_get_render_failed()`. Animating a size through values that
 are all too small therefore produces no log output at all. The one exception is the
 re-encode done by the redraw - there is no caller to return anything to, so that failure
 is logged, along with the warning that the explicit render call was missed.
 
+### Reading the payload back
+
+<ApiLink name="lv_qrcode_get_text" /> returns a payload that was set with
+`lv_qrcode_set_text()` as a NUL terminated string, and `NULL` for a binary one.
+<ApiLink name="lv_qrcode_get_data" /> copies either kind into a caller-provided buffer and
+returns the full length, so truncation is detectable; passing a `NULL` buffer just queries
+the length. A text payload's terminator is stored but is neither encoded nor reported, so
+the length matches the string.
+
+The two kinds share one buffer and are told apart by its last two bytes instead of a
+stored flag, which keeps the Widget one `uint16_t` of flags. Text is stored with its
+terminator, and a binary payload that ends with a `NUL` gets a second one appended, so a
+single trailing `NUL` means text and two mean binary:
+
+```c
+const uint8_t bin[] = {0x8A, 0x42, 0x00};
+lv_qrcode_set_data(qr, bin, sizeof(bin));   /* stored as 8A 42 00 00, all 3 bytes encoded */
+
+lv_qrcode_set_text(qr, "hi");               /* stored as 68 69 00, 2 bytes encoded */
+```
+
+Every payload is therefore encoded verbatim, whatever bytes it holds.
+
 ## Notes
 
 - QR Codes with less data are smaller, but they are scaled by an integer
    value to best fit to the given size. If the size is too small to fit even one
    pixel per QR Code module, the bitmap cannot be generated and
-   <ApiLink name="lv_qrcode_update" /> reports `LV_RESULT_INVALID`. Enabling the
+   <ApiLink name="lv_qrcode_render" /> reports `LV_RESULT_INVALID`. Enabling the
    quiet zone needs more room, so a size that works without it may be too small
    with it.
 - Changing the color (dark or light) only updates the palette, so it is cheap

--- a/examples/libs/qrcode/qrcode_basic/lv_example_qrcode_basic.c
+++ b/examples/libs/qrcode/qrcode_basic/lv_example_qrcode_basic.c
@@ -32,7 +32,7 @@ void lv_example_qrcode_basic(void)
     lv_qrcode_set_size(qrcode, 150);
     lv_qrcode_set_dark_color(qrcode, QR_DARK);
     lv_qrcode_set_light_color(qrcode, QR_LIGHT);
-    lv_qrcode_set_data(qrcode, "https://lvgl.io");
+    lv_qrcode_set_text(qrcode, "https://lvgl.io");
     lv_qrcode_set_quiet_zone(qrcode, true);
     lv_obj_set_style_border_color(qrcode, QR_DARK, 0);
     lv_obj_set_style_border_width(qrcode, 4, 0);

--- a/examples/libs/qrcode/qrcode_basic/lv_example_qrcode_basic.xml
+++ b/examples/libs/qrcode/qrcode_basic/lv_example_qrcode_basic.xml
@@ -16,7 +16,7 @@
 	<view flex_flow="column" style_flex_main_place="center" style_flex_cross_place="center" style_flex_track_place="center" style_pad_row="16">
 		<!-- 💡 Swap dark_color/light_color for brand colors; keep enough contrast or scanners fail. -->
 		<lv_qrcode name="qrcode" size="150" dark_color="#qr_dark" light_color="#qr_light"
-			data="https://lvgl.io" quiet_zone="true"
+			text="https://lvgl.io" quiet_zone="true"
 			style_border_color="#qr_dark" style_border_width="4" />
 	</view>
 </screen>

--- a/include/lvgl/widgets/lv_qrcode.h
+++ b/include/lvgl/widgets/lv_qrcode.h
@@ -33,7 +33,7 @@ extern "C" {
 /**
  * Controls when a property change is turned into a new QR code bitmap.
  * Only the properties that require re-encoding (size, quiet zone) are affected;
- * `lv_qrcode_update()` always encodes right away and the colors are always a
+ * the payload setters always encode right away and the colors are always a
  * palette-only write.
  */
 typedef enum {
@@ -77,29 +77,54 @@ void lv_qrcode_set_dark_color(lv_obj_t * obj, lv_color_t color);
 void lv_qrcode_set_light_color(lv_obj_t * obj, lv_color_t color);
 
 /**
- * Set the data of a QR code object and generate the bitmap.
- * A copy of the data is stored, so a later `lv_qrcode_set_size()` or
- * `lv_qrcode_set_quiet_zone()` can re-encode it. The properties may therefore be
- * set before or after the data, in any order.
- * Use `lv_qrcode_render()` to re-encode the stored payload without passing it again.
+ * Set the binary payload of a QR code object and generate the bitmap.
+ * The bytes are encoded verbatim. A copy is stored, so a later `lv_qrcode_set_size()` or
+ * `lv_qrcode_set_quiet_zone()` can re-encode it; the properties may therefore be set
+ * before or after the payload, in any order.
+ * Use `lv_qrcode_set_text()` for a NUL terminated string.
  * @param obj      pointer to a QR code object
- * @param data     data to display
+ * @param data     payload to encode
  * @param data_len length of `data` in bytes
  * @return LV_RESULT_OK: if no error; LV_RESULT_INVALID: on error
  */
-lv_result_t lv_qrcode_update(lv_obj_t * obj, const void * data, uint32_t data_len);
+lv_result_t lv_qrcode_set_data(lv_obj_t * obj, const void * data, uint32_t data_len);
 
 /**
- * Helper function to set the data of a QR code object from a string.
- * The NUL terminator is not part of the encoded payload.
+ * Set the text payload of a QR code object and generate the bitmap.
+ * The NUL terminator is stored but not encoded, so the QR code holds exactly the string.
+ * Use `lv_qrcode_set_data()` for arbitrary binary data.
  * @param obj  pointer to a QR code object
- * @param data data to display as a NUL terminated string
+ * @param text payload to encode, as a NUL terminated string
+ * @return LV_RESULT_OK: if no error; LV_RESULT_INVALID: on error
  */
-void lv_qrcode_set_data(lv_obj_t * obj, const char * data);
+lv_result_t lv_qrcode_set_text(lv_obj_t * obj, const char * text);
+
+/**
+ * Get the payload of a QR code object as a string.
+ * Only a payload set with `lv_qrcode_set_text()` is returned; use `lv_qrcode_get_data()`
+ * for binary ones.
+ * @param obj pointer to a QR code object
+ * @return the stored text as a NUL terminated string, or NULL if the payload is binary or
+ *         no payload is set. The buffer is owned by the QR code object.
+ */
+const char * lv_qrcode_get_text(lv_obj_t * obj);
+
+/**
+ * Copy the payload of a QR code object into a caller-provided buffer.
+ * Works for both text and binary payloads; a text payload's NUL terminator is not
+ * included, so the result is always the same length that was encoded.
+ * Pass `buf == NULL` (or `buf_size == 0`) to query the length without copying.
+ * @param obj      pointer to a QR code object
+ * @param buf      buffer to copy the payload into (may be NULL)
+ * @param buf_size size of `buf` in bytes
+ * @return the full length of the payload in bytes. If this is greater than `buf_size`,
+ *         only `buf_size` bytes were copied (the payload was truncated).
+ */
+uint32_t lv_qrcode_get_data(lv_obj_t * obj, void * buf, uint32_t buf_size);
 
 /**
  * (Re)generate the QR code bitmap from the payload that is already stored.
- * Unlike `lv_qrcode_update()` this needs no payload, so it is the way to apply property
+ * Unlike `lv_qrcode_set_data()` / `lv_qrcode_set_text()` this needs no payload, so it is the way to apply property
  * changes made in LV_QRCODE_UPDATE_MODE_DEFERRED: set the size and quiet zone, then call
  * this once to encode them and get the result.
  * The bitmap is regenerated whether or not anything changed.
@@ -147,7 +172,7 @@ lv_qrcode_update_mode_t lv_qrcode_get_update_mode(lv_obj_t * obj);
 
 /**
  * Get whether the QR code bitmap is missing because the last attempt to generate it
- * failed. Most encodes report their result directly: `lv_qrcode_update()` returns it.
+ * failed. Most encodes report their result directly: `lv_qrcode_set_data()` returns it.
  * The ones that cannot are the re-encodes triggered by a property change - they happen
  * in a void setter or, in LV_QRCODE_UPDATE_MODE_DEFERRED, in the draw pass. Use this to
  * detect those, e.g. after shrinking the object below the size its payload needs.

--- a/scripts/gdb/lvglgdb/lvgl/widgets/lv_qrcode.py
+++ b/scripts/gdb/lvglgdb/lvgl/widgets/lv_qrcode.py
@@ -32,7 +32,7 @@ class LVQrcode(LVCanvas):
 
     @property
     def data_len(self):
-        """Stored payload length in bytes"""
+        """Stored payload length in bytes, including the stored NUL if there is one"""
         return int(self._wv_lv_qrcode_t.safe_field("data_len", 0))
 
     @property

--- a/src/widgets/qrcode/lv_qrcode.c
+++ b/src/widgets/qrcode/lv_qrcode.c
@@ -31,7 +31,9 @@ static void lv_qrcode_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj
 static void lv_qrcode_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj);
 static void lv_qrcode_event(const lv_obj_class_t * class_p, lv_event_t * e);
 static int32_t get_satisfied_size(int32_t min_version, int32_t size, int32_t * scale);
-static bool qrcode_store_data(lv_qrcode_t * qrcode, const void * data, uint32_t data_len);
+static bool qrcode_store_data(lv_qrcode_t * qrcode, const void * data, uint32_t data_len, bool append_nul);
+static uint32_t qrcode_payload_len(const lv_qrcode_t * qrcode);
+static lv_result_t qrcode_store_and_encode(lv_obj_t * obj, const void * data, uint32_t data_len, bool append_nul);
 static lv_result_t qrcode_encode(lv_obj_t * obj);
 static void qrcode_mark_dirty(lv_obj_t * obj);
 
@@ -121,7 +123,7 @@ void lv_qrcode_set_light_color(lv_obj_t * obj, lv_color_t color)
     lv_image_cache_drop(draw_buf);
 }
 
-lv_result_t lv_qrcode_update(lv_obj_t * obj, const void * data, uint32_t data_len)
+lv_result_t lv_qrcode_set_data(lv_obj_t * obj, const void * data, uint32_t data_len)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return LV_RESULT_INVALID);
     LV_CHECK_ARG_MSG(data != NULL, return LV_RESULT_INVALID, "data must not be NULL");
@@ -129,25 +131,65 @@ lv_result_t lv_qrcode_update(lv_obj_t * obj, const void * data, uint32_t data_le
                             "data_len %u exceeds the maximum %u",
                             (unsigned)data_len, (unsigned)qrcodegen_BUFFER_LEN_MAX);
 
-    lv_qrcode_t * qrcode = (lv_qrcode_t *)obj;
+    /*LV_CHECK_ARG compiles to nothing when argument checks are disabled, and the payload
+     *is dereferenced while copying it, so this has to be guarded unconditionally*/
+    if(data == NULL) return LV_RESULT_INVALID;
 
-    /*Keep a copy of the payload so a later size or quiet zone change can re-encode it*/
-    if(!qrcode_store_data(qrcode, data, data_len)) return LV_RESULT_INVALID;
+    /*A payload that already ends with a NUL gets a second one appended, so it cannot be
+     *mistaken for the single terminator lv_qrcode_set_text() stores*/
+    const bool ends_with_nul = data_len > 0 && ((const uint8_t *)data)[data_len - 1] == '\0';
 
-    /*A new payload leaves the bitmap out of date, and makes any earlier failure moot*/
-    qrcode->needs_update = true;
-    qrcode->render_failed = false;
-
-    /*Setting the data always encodes right away, in either update mode*/
-    return lv_qrcode_render(obj);
+    return qrcode_store_and_encode(obj, data, data_len, ends_with_nul);
 }
 
-void lv_qrcode_set_data(lv_obj_t * obj, const char * data)
+lv_result_t lv_qrcode_set_text(lv_obj_t * obj, const char * text)
 {
-    LV_CHECK_OBJ(obj, MY_CLASS, return);
-    LV_CHECK_ARG_MSG(data != NULL, return, "data must not be NULL");
+    LV_CHECK_OBJ(obj, MY_CLASS, return LV_RESULT_INVALID);
+    LV_CHECK_ARG_MSG(text != NULL, return LV_RESULT_INVALID, "text must not be NULL");
 
-    lv_qrcode_update(obj, data, lv_strlen(data));
+    /*LV_CHECK_ARG compiles to nothing when argument checks are disabled, and the
+     *lv_strlen() below dereferences `text`, so this has to be guarded unconditionally*/
+    if(text == NULL) return LV_RESULT_INVALID;
+
+    /*One byte of the limit is reserved for the NUL terminator stored with the text*/
+    const size_t len = lv_strlen(text);
+    LV_CHECK_ARG_FORMAT_MSG(len <= qrcodegen_BUFFER_LEN_MAX - 1, return LV_RESULT_INVALID,
+                            "text length %u exceeds the maximum %u",
+                            (unsigned)len, (unsigned)(qrcodegen_BUFFER_LEN_MAX - 1));
+
+    /*The terminator is stored so the copy stays usable as a C string; it is not encoded*/
+    return qrcode_store_and_encode(obj, text, (uint32_t)len, true);
+}
+
+const char * lv_qrcode_get_text(lv_obj_t * obj)
+{
+    LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
+    lv_qrcode_t * qrcode = (lv_qrcode_t *)obj;
+
+    if(qrcode->data == NULL || qrcode->data_len == 0) return NULL;
+
+    /*Text ends with exactly one NUL. Binary either does not end with one, or ended with
+     *one and was stored with a second appended.*/
+    if(qrcode->data[qrcode->data_len - 1] != '\0') return NULL;
+    if(qrcode->data_len > 1 && qrcode->data[qrcode->data_len - 2] == '\0') return NULL;
+
+    return (const char *)qrcode->data;
+}
+
+uint32_t lv_qrcode_get_data(lv_obj_t * obj, void * buf, uint32_t buf_size)
+{
+    LV_CHECK_OBJ(obj, MY_CLASS, return 0);
+    lv_qrcode_t * qrcode = (lv_qrcode_t *)obj;
+
+    const uint32_t payload_len = qrcode_payload_len(qrcode);
+
+    if(buf != NULL && buf_size > 0 && qrcode->data != NULL) {
+        lv_memcpy(buf, qrcode->data, payload_len < buf_size ? payload_len : buf_size);
+    }
+
+    /*Always the full length, so the caller can detect truncation (result > buf_size).
+     *Passing buf == NULL / buf_size == 0 therefore also serves as a size query.*/
+    return payload_len;
 }
 
 lv_result_t lv_qrcode_render(lv_obj_t * obj)
@@ -177,7 +219,7 @@ void lv_qrcode_set_update_mode(lv_obj_t * obj, lv_qrcode_update_mode_t mode)
 
     /*Going back to immediate mode has to apply whatever was deferred, but this setter
      *returns void, so an encode failure would be dropped. Warn and encode anyway: the
-     *order that can report the failure is lv_qrcode_update() first, then switch mode.*/
+     *order that can report the failure is lv_qrcode_render() first, then switch mode.*/
     if(mode == LV_QRCODE_UPDATE_MODE_IMMEDIATE && qrcode->needs_update) {
         qrcode_encode(obj);
         if(qrcode->render_failed) {
@@ -284,7 +326,7 @@ static void lv_qrcode_event(const lv_obj_class_t * class_p, lv_event_t * e)
                 /*Nothing here can return the failure to the application, so report it*/
                 LV_LOG_ERROR("the QR code could not be re-encoded during the redraw "
                              "(%u bytes, quiet zone %s); the bitmap is left blank",
-                             (unsigned)qrcode->data_len, qrcode->quiet_zone ? "on" : "off");
+                             (unsigned)qrcode_payload_len(qrcode), qrcode->quiet_zone ? "on" : "off");
             }
         }
     }
@@ -313,20 +355,47 @@ static int32_t get_satisfied_size(int32_t min_version, int32_t size, int32_t * s
     return satisfied_version;
 }
 
-static bool qrcode_store_data(lv_qrcode_t * qrcode, const void * data, uint32_t data_len)
+static bool qrcode_store_data(lv_qrcode_t * qrcode, const void * data, uint32_t data_len, bool append_nul)
 {
     LV_ASSERT(qrcode != NULL);
     LV_ASSERT(data != NULL);
 
-    uint8_t * new_data = lv_realloc(qrcode->data, data_len);
+    const uint32_t store_len = data_len + (append_nul ? 1 : 0);
+    uint8_t * new_data = lv_realloc(qrcode->data, store_len);
     LV_ASSERT_MALLOC(new_data);
     if(new_data == NULL) return false;
 
     lv_memcpy(new_data, data, data_len);
+    if(append_nul) new_data[data_len] = '\0';
 
     qrcode->data = new_data;
-    qrcode->data_len = data_len;
+    qrcode->data_len = store_len;
     return true;
+}
+
+static uint32_t qrcode_payload_len(const lv_qrcode_t * qrcode)
+{
+    if(qrcode->data == NULL || qrcode->data_len == 0) return 0;
+
+    /*A trailing NUL is either the text terminator or the byte appended to binary that
+     *ends with one. Neither is encoded.*/
+    return qrcode->data_len - (qrcode->data[qrcode->data_len - 1] == '\0' ? 1 : 0);
+}
+
+static lv_result_t qrcode_store_and_encode(lv_obj_t * obj, const void * data, uint32_t data_len,
+                                           bool append_nul)
+{
+    lv_qrcode_t * qrcode = (lv_qrcode_t *)obj;
+
+    /*Keep a copy of the payload so a later size or quiet zone change can re-encode it*/
+    if(!qrcode_store_data(qrcode, data, data_len, append_nul)) return LV_RESULT_INVALID;
+
+    /*A new payload leaves the bitmap out of date, and makes any earlier failure moot*/
+    qrcode->needs_update = true;
+    qrcode->render_failed = false;
+
+    /*Setting the payload always encodes right away, in either update mode*/
+    return lv_qrcode_render(obj);
 }
 
 static void qrcode_mark_dirty(lv_obj_t * obj)
@@ -368,7 +437,7 @@ static lv_result_t qrcode_encode(lv_obj_t * obj)
     if(draw_buf == NULL) return LV_RESULT_INVALID;
 
     const void * data = qrcode->data;
-    const uint32_t data_len = qrcode->data_len;
+    const uint32_t data_len = qrcode_payload_len(qrcode);
 
     lv_draw_buf_clear(draw_buf, NULL);
     /*Set the palette directly on the draw buffer to avoid an extra invalidation here;

--- a/src/widgets/qrcode/lv_qrcode_private.h
+++ b/src/widgets/qrcode/lv_qrcode_private.h
@@ -35,8 +35,9 @@ struct _lv_qrcode_t {
     lv_color_t light_color;
     uint8_t * data;                 /*Copy of the payload, kept so the bitmap can be re-encoded on a property change*/
     /*The setters cap the payload at qrcodegen_BUFFER_LEN_MAX (3918), so 12 bits (up to
-     *4095) cover any length and the four flags fill the rest of the 16-bit word.*/
-    uint16_t data_len : 12;         /*Stored payload length in bytes*/
+     *4095) cover any length with the stored NUL, and the four flags fill the rest of the
+     *16-bit word.*/
+    uint16_t data_len : 12;         /*Stored payload length in bytes, including the stored NUL if there is one*/
     uint16_t quiet_zone : 1;        /*Add the QR spec's blank margin around the code (boolean toggle)*/
     uint16_t update_mode : 1;       /*lv_qrcode_update_mode_t: when a property change is re-encoded*/
     uint16_t needs_update : 1;      /*The bitmap is out of date; re-encoded on the next redraw (deferred mode)*/

--- a/tests/src/test_cases/libs/test_qrcode.c
+++ b/tests/src/test_cases/libs/test_qrcode.c
@@ -49,7 +49,7 @@ void test_qrcode_normal(void)
 
     /*Set data*/
     const char * data = "https://lvgl.io";
-    lv_qrcode_set_data(qr, data);
+    lv_qrcode_set_text(qr, data);
     lv_obj_center(qr);
 
     /*Add a border with bg_color*/
@@ -69,7 +69,7 @@ void test_qrcode_color_after_data(void)
 
     /*Set the data first, then the colors. The colors must still be applied
      *(regression test for the setters being ignored after rendering)*/
-    lv_qrcode_set_data(qr, "https://lvgl.io");
+    lv_qrcode_set_text(qr, "https://lvgl.io");
 
     lv_qrcode_set_dark_color(qr, fg_color);
     lv_qrcode_set_light_color(qr, bg_color);
@@ -92,7 +92,7 @@ void test_qrcode_size_after_data(void)
     /*Set the data before the size, so the bitmap is first encoded into the default
      *sized buffer. Changing the size afterwards must re-encode it, not leave the
      *fresh (empty) buffer as it is.*/
-    lv_qrcode_set_data(qr, "https://lvgl.io");
+    lv_qrcode_set_text(qr, "https://lvgl.io");
     lv_qrcode_set_size(qr, 150);
     lv_qrcode_set_dark_color(qr, fg_color);
     lv_qrcode_set_light_color(qr, bg_color);
@@ -116,7 +116,7 @@ void test_qrcode_quiet_zone(void)
     lv_qrcode_set_quiet_zone(qr, true);
 
     /*Set data*/
-    lv_qrcode_set_data(qr, "https://lvgl.io");
+    lv_qrcode_set_text(qr, "https://lvgl.io");
     lv_obj_center(qr);
 
     TEST_ASSERT_EQUAL_SCREENSHOT("libs/qrcode_2.png");
@@ -136,13 +136,93 @@ void test_qrcode_quiet_zone_after_data(void)
     /*Set the data first (renders without quiet zone), then enable the quiet zone.
      *This is the case the old code silently dropped: a geometry change after the
      *data must re-encode the bitmap. The result must match the quiet-zone reference.*/
-    lv_qrcode_set_data(qr, "https://lvgl.io");
+    lv_qrcode_set_text(qr, "https://lvgl.io");
 
     lv_qrcode_set_quiet_zone(qr, true);
     lv_obj_center(qr);
 
     TEST_ASSERT_EQUAL_SCREENSHOT("libs/qrcode_2.png");
 }
+
+void test_qrcode_text_and_binary_round_trip(void)
+{
+    lv_obj_t * qr = lv_qrcode_create(active_screen);
+    TEST_ASSERT_NOT_NULL(qr);
+    lv_qrcode_set_size(qr, 150);
+
+    /*Nothing set yet*/
+    TEST_ASSERT_NULL(lv_qrcode_get_text(qr));
+    TEST_ASSERT_EQUAL(0, lv_qrcode_get_data(qr, NULL, 0));
+
+    /*Text: readable back as a string, and its NUL is not part of the payload*/
+    const char * text = "https://lvgl.io";
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_set_text(qr, text));
+    TEST_ASSERT_EQUAL_STRING(text, lv_qrcode_get_text(qr));
+    TEST_ASSERT_EQUAL(strlen(text), lv_qrcode_get_data(qr, NULL, 0));
+
+    uint8_t out[32];
+    lv_memset(out, 0xEE, sizeof(out));
+    TEST_ASSERT_EQUAL(strlen(text), lv_qrcode_get_data(qr, out, sizeof(out)));
+    TEST_ASSERT_EQUAL_MEMORY(text, out, strlen(text));
+
+    /*Binary with an embedded NUL is kept whole and is not a string*/
+    const uint8_t bin[] = {'a', 'b', 0x00, 'c', 'd'};
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_set_data(qr, bin, sizeof(bin)));
+    TEST_ASSERT_NULL(lv_qrcode_get_text(qr));
+    TEST_ASSERT_EQUAL(sizeof(bin), lv_qrcode_get_data(qr, NULL, 0));
+    lv_memset(out, 0xEE, sizeof(out));
+    TEST_ASSERT_EQUAL(sizeof(bin), lv_qrcode_get_data(qr, out, sizeof(out)));
+    TEST_ASSERT_EQUAL_MEMORY(bin, out, sizeof(bin));
+
+    /*A too-small buffer truncates but still reports the full length*/
+    uint8_t small[2];
+    TEST_ASSERT_EQUAL(sizeof(bin), lv_qrcode_get_data(qr, small, sizeof(small)));
+    TEST_ASSERT_EQUAL_MEMORY(bin, small, sizeof(small));
+}
+
+void test_qrcode_binary_ending_in_nul_stays_binary(void)
+{
+    lv_obj_t * qr = lv_qrcode_create(active_screen);
+    TEST_ASSERT_NOT_NULL(qr);
+    lv_qrcode_set_size(qr, 150);
+
+    uint8_t out[8];
+
+    /*A trailing NUL is kept: it is stored with a second one appended, which is what tells
+     *it apart from the single terminator set_text() stores*/
+    const uint8_t trailing[] = {0x01, 0xFF, 0x00};
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_set_data(qr, trailing, sizeof(trailing)));
+    TEST_ASSERT_NULL(lv_qrcode_get_text(qr));
+    TEST_ASSERT_EQUAL(sizeof(trailing), lv_qrcode_get_data(qr, out, sizeof(out)));
+    TEST_ASSERT_EQUAL_MEMORY(trailing, out, sizeof(trailing));
+
+    /*Two trailing NULs, so the appended one makes three*/
+    const uint8_t two_nuls[] = {0x01, 0x00, 0x00};
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_set_data(qr, two_nuls, sizeof(two_nuls)));
+    TEST_ASSERT_NULL(lv_qrcode_get_text(qr));
+    TEST_ASSERT_EQUAL(sizeof(two_nuls), lv_qrcode_get_data(qr, out, sizeof(out)));
+    TEST_ASSERT_EQUAL_MEMORY(two_nuls, out, sizeof(two_nuls));
+
+    /*A lone NUL byte*/
+    const uint8_t only_nul[] = {0x00};
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_set_data(qr, only_nul, sizeof(only_nul)));
+    TEST_ASSERT_NULL(lv_qrcode_get_text(qr));
+    TEST_ASSERT_EQUAL(sizeof(only_nul), lv_qrcode_get_data(qr, out, sizeof(out)));
+    TEST_ASSERT_EQUAL_MEMORY(only_nul, out, sizeof(only_nul));
+
+    /*No NUL at all*/
+    const uint8_t no_nul[] = {0x01, 0xFF};
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_set_data(qr, no_nul, sizeof(no_nul)));
+    TEST_ASSERT_NULL(lv_qrcode_get_text(qr));
+    TEST_ASSERT_EQUAL(sizeof(no_nul), lv_qrcode_get_data(qr, out, sizeof(out)));
+    TEST_ASSERT_EQUAL_MEMORY(no_nul, out, sizeof(no_nul));
+
+    /*An empty string is text, not binary*/
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_set_text(qr, ""));
+    TEST_ASSERT_EQUAL_STRING("", lv_qrcode_get_text(qr));
+    TEST_ASSERT_EQUAL(0, lv_qrcode_get_data(qr, NULL, 0));
+}
+
 
 void test_qrcode_update_mode_default_is_immediate(void)
 {
@@ -170,12 +250,12 @@ void test_qrcode_update_mode_deferred_renders_on_redraw(void)
     lv_qrcode_set_dark_color(qr, fg_color);
     lv_qrcode_set_light_color(qr, bg_color);
 
-    /*Deferred mode expects an explicit lv_qrcode_update(). This test deliberately omits
+    /*Deferred mode expects an explicit lv_qrcode_render(). This test deliberately omits
      *it to cover the fallback: the redraw notices the bitmap is out of date, warns, and
      *encodes it anyway, so the result must still be correct.*/
     lv_log_register_print_cb(count_qrcode_logs_cb);
     lv_qrcode_set_update_mode(qr, LV_QRCODE_UPDATE_MODE_DEFERRED);
-    lv_qrcode_set_data(qr, "https://lvgl.io");
+    lv_qrcode_set_text(qr, "https://lvgl.io");
     lv_qrcode_set_quiet_zone(qr, true);
     lv_obj_center(qr);
 
@@ -198,7 +278,7 @@ void test_qrcode_render_applies_deferred_changes(void)
     lv_qrcode_set_size(qr, 150);
     lv_qrcode_set_dark_color(qr, fg_color);
     lv_qrcode_set_light_color(qr, bg_color);
-    lv_qrcode_set_data(qr, "https://lvgl.io");
+    lv_qrcode_set_text(qr, "https://lvgl.io");
 
     lv_log_register_print_cb(count_qrcode_logs_cb);
 
@@ -230,7 +310,7 @@ void test_qrcode_update_before_switching_mode_reports_result(void)
     lv_qrcode_set_light_color(qr, bg_color);
 
     lv_qrcode_set_update_mode(qr, LV_QRCODE_UPDATE_MODE_DEFERRED);
-    lv_qrcode_set_data(qr, "https://lvgl.io");
+    lv_qrcode_set_text(qr, "https://lvgl.io");
     lv_qrcode_set_quiet_zone(qr, true);
 
     /*The order that can report a failure: render() encodes the deferred change and
@@ -255,7 +335,7 @@ void test_qrcode_update_mode_immediate_applies_pending_change(void)
     lv_qrcode_set_light_color(qr, bg_color);
 
     lv_qrcode_set_update_mode(qr, LV_QRCODE_UPDATE_MODE_DEFERRED);
-    lv_qrcode_set_data(qr, "https://lvgl.io");
+    lv_qrcode_set_text(qr, "https://lvgl.io");
     lv_qrcode_set_quiet_zone(qr, true);
 
     /*Switching back to immediate while out of date must still encode the deferred
@@ -277,7 +357,7 @@ void test_qrcode_deferred_render_failure_is_detectable(void)
     TEST_ASSERT_TRUE(lv_qrcode_get_render_failed(qr));
 
     lv_qrcode_set_size(qr, 150);
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_update(qr, "https://lvgl.io", 15));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_set_data(qr, "https://lvgl.io", 15));
     TEST_ASSERT_FALSE(lv_qrcode_get_render_failed(qr));
 
     /*In deferred mode the re-encode happens in the draw pass, so nothing returns its
@@ -300,7 +380,7 @@ void test_qrcode_failed_render_is_not_retried_every_frame(void)
     lv_obj_t * qr = lv_qrcode_create(active_screen);
     TEST_ASSERT_NOT_NULL(qr);
     lv_qrcode_set_size(qr, 150);
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_update(qr, "https://lvgl.io", 15));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_set_data(qr, "https://lvgl.io", 15));
     lv_obj_center(qr);
     lv_refr_now(NULL);
 
@@ -341,7 +421,7 @@ void test_qrcode_failures_are_silent_when_the_caller_sees_the_result(void)
     lv_obj_t * qr = lv_qrcode_create(active_screen);
     TEST_ASSERT_NOT_NULL(qr);
     lv_qrcode_set_size(qr, 150);
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_update(qr, "https://lvgl.io", 15));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_set_data(qr, "https://lvgl.io", 15));
 
     lv_log_register_print_cb(count_qrcode_logs_cb);
 
@@ -381,12 +461,12 @@ void test_qrcode_update_reports_unencodable_payload(void)
     static char too_long[3000];
     lv_memset(too_long, 'a', sizeof(too_long) - 1);
     too_long[sizeof(too_long) - 1] = '\0';
-    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_qrcode_update(qr, too_long, sizeof(too_long) - 1));
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_qrcode_set_data(qr, too_long, sizeof(too_long) - 1));
 
     TEST_ASSERT_TRUE(lv_qrcode_get_render_failed(qr));
 
     /*A payload that does fit is reported as success*/
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_update(qr, "https://lvgl.io", 15));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_set_data(qr, "https://lvgl.io", 15));
     TEST_ASSERT_FALSE(lv_qrcode_get_render_failed(qr));
 }
 
@@ -399,33 +479,33 @@ void test_qrcode_canvas_too_small_is_reported(void)
      *hold even one pixel per module, so the bitmap would stay blank. That must be
      *reported as a failure rather than as a successfully rendered QR code.*/
     lv_qrcode_set_size(qr, 10);
-    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_qrcode_update(qr, "https://lvgl.io", 15));
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_qrcode_set_data(qr, "https://lvgl.io", 15));
 
     /*The same holds with a quiet zone, which needs even more room*/
     lv_qrcode_set_quiet_zone(qr, true);
-    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_qrcode_update(qr, "https://lvgl.io", 15));
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_qrcode_set_data(qr, "https://lvgl.io", 15));
 
     /*A canvas large enough for both renders and reports success*/
     lv_qrcode_set_size(qr, 150);
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_update(qr, "https://lvgl.io", 15));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_set_data(qr, "https://lvgl.io", 15));
     lv_qrcode_set_quiet_zone(qr, false);
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_update(qr, "https://lvgl.io", 15));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_set_data(qr, "https://lvgl.io", 15));
 }
 
-void test_qrcode_set_data_ignores_null(void)
+void test_qrcode_set_text_ignores_null(void)
 {
     lv_obj_t * qr = lv_qrcode_create(active_screen);
     TEST_ASSERT_NOT_NULL(qr);
     lv_qrcode_set_size(qr, 150);
-    lv_qrcode_set_data(qr, "https://lvgl.io");
+    lv_qrcode_set_text(qr, "https://lvgl.io");
     TEST_ASSERT_FALSE(lv_qrcode_get_render_failed(qr));
 
-    /*A NULL string is a no-op, not a crash, and leaves the stored payload alone.
-     *The guard is unconditional because lv_strlen() would dereference it even when
-     *argument checks are compiled out.*/
-    lv_qrcode_set_data(qr, NULL);
+    /*A NULL string is rejected, not a crash, and leaves the stored payload alone. The
+     *guard is unconditional because lv_strlen() would dereference it even when argument
+     *checks are compiled out.*/
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_qrcode_set_text(qr, NULL));
     TEST_ASSERT_FALSE(lv_qrcode_get_render_failed(qr));
-    TEST_ASSERT_EQUAL(15, ((lv_qrcode_t *)qr)->data_len);
+    TEST_ASSERT_EQUAL_STRING("https://lvgl.io", lv_qrcode_get_text(qr));
 }
 
 void test_qrcode_update_rejects_invalid_arguments(void)
@@ -437,16 +517,16 @@ void test_qrcode_update_rejects_invalid_arguments(void)
     lv_obj_t * qr = lv_qrcode_create(active_screen);
     TEST_ASSERT_NOT_NULL(qr);
 
-    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_qrcode_update(qr, NULL, 4));
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_qrcode_set_data(qr, NULL, 4));
 
     /*More bytes than any QR code can hold is rejected before anything is stored*/
     static char over_len[qrcodegen_BUFFER_LEN_MAX + 1];
     lv_memset(over_len, 'a', sizeof(over_len));
-    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_qrcode_update(qr, over_len, qrcodegen_BUFFER_LEN_MAX + 1));
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_qrcode_set_data(qr, over_len, qrcodegen_BUFFER_LEN_MAX + 1));
 
     /*A previously set payload survives a rejected call*/
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_update(qr, "https://lvgl.io", 15));
-    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_qrcode_update(qr, over_len, qrcodegen_BUFFER_LEN_MAX + 1));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_set_data(qr, "https://lvgl.io", 15));
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_qrcode_set_data(qr, over_len, qrcodegen_BUFFER_LEN_MAX + 1));
 #endif /*LV_USE_CHECK_ARG*/
 }
 


### PR DESCRIPTION
`lv_qrcode_update()` both stored and encoded the payload, `lv_qrcode_set_data()`
was a string-only wrapper around it, and the payload could not be read back.

One setter per payload kind, plus getters:

| Before | After |
| --- | --- |
| `lv_result_t lv_qrcode_update(obj, data, data_len)` | `lv_result_t lv_qrcode_set_data(obj, data, data_len)` |
| `void lv_qrcode_set_data(obj, const char *)` | `lv_result_t lv_qrcode_set_text(obj, const char *)` |
| — | `const char * lv_qrcode_get_text(obj)` |
| — | `uint32_t lv_qrcode_get_data(obj, buf, buf_size)` |

Both setters encode immediately and return the result. `lv_qrcode_get_data()`
returns the full length even when the buffer is too small, so truncation is
detectable; `buf == NULL` is a size query.

Both kinds share one buffer, and the kind comes from the last two stored bytes
instead of a flag: text keeps its terminator, and binary that ends with a `NUL`
gets a second one appended. One trailing `NUL` means text, two mean binary. No
traversal, no ambiguity — every payload encodes verbatim.

Tests cover the round trip for both kinds, a truncating copy, and the payload
shapes that pin the `NUL` rule: one trailing `NUL`, two, a lone `NUL`, none, and
an empty string.

`test_qrcode` passes on `OPTIONS_TEST_SYSHEAP`, `OPTIONS_NO_CHECKS` links,
`code-format.py` clean.
