### PR TITLE
refactor(docs): treat doxygen warnings as errors and correctly match docs and fn args

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -762,7 +762,7 @@ WARN_NO_PARAMDOC       = NO
 # a warning is encountered.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = YES
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which
@@ -778,7 +778,7 @@ WARN_FORMAT            = "WARNING: $file:$line: $text"
 # messages should be written. If left blank the output is written to standard
 # error (stderr).
 
-WARN_LOGFILE           = doxygen_warnings.txt
+WARN_LOGFILE           =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the input files

--- a/include/lvgl/3d/lv_gltf_environment.h
+++ b/include/lvgl/3d/lv_gltf_environment.h
@@ -43,8 +43,8 @@ lv_gltf_ibl_sampler_t * lv_gltf_ibl_sampler_create(void);
 
 /**
  * Set the resolution for each cubemap face
- * @param   pointer to a sampler
- * @param   resolution of each cube map face in pixels (recommended: 64-512 for embedded)
+ * @param   sampler    pointer to a sampler
+ * @param   resolution resolution of each cube map face in pixels (recommended: 64-512 for embedded)
  */
 void lv_gltf_ibl_sampler_set_cube_map_pixel_resolution(lv_gltf_ibl_sampler_t * sampler, uint32_t resolution);
 

--- a/include/lvgl/3d/lv_gltf_model_node.h
+++ b/include/lvgl/3d/lv_gltf_model_node.h
@@ -46,29 +46,29 @@ extern "C" {
 /**
  * @brief Get a glTF model node by its index
  *
- * @param data Pointer to the glTF model structure
+ * @param model Pointer to the glTF model structure
  * @param index The index of the node to retrieve
  * @return Pointer to the glTF model node, or NULL if not found
  */
-lv_gltf_model_node_t * lv_gltf_model_node_get_by_index(lv_gltf_model_t * data, size_t index);
+lv_gltf_model_node_t * lv_gltf_model_node_get_by_index(lv_gltf_model_t * model, size_t index);
 
 /**
  * @brief Get a glTF model node by its numeric path
  *
- * @param data Pointer to the glTF model structure
+ * @param model Pointer to the glTF model structure
  * @param num_path The numeric path string of the node to retrieve (eg. ".0")
  * @return Pointer to the glTF model node, or NULL if not found
  */
-lv_gltf_model_node_t * lv_gltf_model_node_get_by_numeric_path(lv_gltf_model_t * data, const char * num_path);
+lv_gltf_model_node_t * lv_gltf_model_node_get_by_numeric_path(lv_gltf_model_t * model, const char * num_path);
 
 /**
  * @brief Get a glTF model node by its path
  *
- * @param data Pointer to the glTF model structure
+ * @param model Pointer to the glTF model structure
  * @param path The path string of the node to retrieve
  * @return Pointer to the glTF model node, or NULL if not found
  */
-lv_gltf_model_node_t * lv_gltf_model_node_get_by_path(lv_gltf_model_t * data, const char * path);
+lv_gltf_model_node_t * lv_gltf_model_node_get_by_path(lv_gltf_model_t * model, const char * path);
 
 /**
  * @brief Get the path of a glTF model node

--- a/include/lvgl/core/lv_anim.h
+++ b/include/lvgl/core/lv_anim.h
@@ -472,12 +472,12 @@ uint32_t lv_anim_speed_clamped(uint32_t speed, uint32_t min_time, uint32_t max_t
 /**
  * Resolve the speed (created with `lv_anim_speed` or `lv_anim_speed_clamped`) to time
  * based on start and end values.
- * @param speed     return values of `lv_anim_speed` or `lv_anim_speed_clamped`
+ * @param speed_or_time return values of `lv_anim_speed` or `lv_anim_speed_clamped`
  * @param start     the start value of the animation
  * @param end       the end value of the animation
  * @return          the time required to get from `start` to `end` with the given `speed` setting
  */
-uint32_t lv_anim_resolve_speed(uint32_t speed, int32_t start, int32_t end);
+uint32_t lv_anim_resolve_speed(uint32_t speed_or_time, int32_t start, int32_t end);
 
 /**
  * Calculate the time of an animation based on its speed, start and end values.

--- a/include/lvgl/core/lv_group.h
+++ b/include/lvgl/core/lv_group.h
@@ -260,7 +260,7 @@ void lv_group_set_user_data(lv_group_t * group, void * user_data);
 
 /**
  * Get a pointer to the user data of the group
- * @param indev pointer to a group
+ * @param group pointer to a group
  * @return pointer to the user data or NULL if group is NULL
  */
 void * lv_group_get_user_data(const lv_group_t * group);

--- a/include/lvgl/core/lv_matrix.h
+++ b/include/lvgl/core/lv_matrix.h
@@ -51,7 +51,7 @@ void lv_matrix_identity(lv_matrix_t * matrix);
  * Translate the matrix to new position
  * @param matrix           pointer to a matrix
  * @param tx               the amount of translate in x direction
- * @param tx               the amount of translate in y direction
+ * @param ty               the amount of translate in y direction
  */
 void lv_matrix_translate(lv_matrix_t * matrix, float tx, float ty);
 
@@ -81,7 +81,7 @@ void lv_matrix_skew(lv_matrix_t * matrix, float skew_x, float skew_y);
 /**
  * Multiply two matrix and store the result to the first one
  * @param matrix           pointer to a matrix
- * @param matrix2          pointer to another matrix
+ * @param mul              pointer to another matrix
  */
 void lv_matrix_multiply(lv_matrix_t * matrix, const lv_matrix_t * mul);
 

--- a/include/lvgl/core/lv_obj_scroll.h
+++ b/include/lvgl/core/lv_obj_scroll.h
@@ -272,10 +272,10 @@ void lv_obj_update_snap(lv_obj_t * obj, lv_anim_enable_t anim_en);
 /**
  * Get the area of the scrollbars
  * @param obj   pointer to Widget
- * @param hor   pointer to store the area of the horizontal scrollbar
- * @param ver   pointer to store the area of the vertical  scrollbar
+ * @param hor_area pointer to store the area of the horizontal scrollbar
+ * @param ver_area pointer to store the area of the vertical  scrollbar
  */
-void lv_obj_get_scrollbar_area(lv_obj_t * obj, lv_area_t * hor, lv_area_t * ver);
+void lv_obj_get_scrollbar_area(lv_obj_t * obj, lv_area_t * hor_area, lv_area_t * ver_area);
 
 /**
  * Invalidate the area of the scrollbars

--- a/include/lvgl/core/lv_obj_tree.h
+++ b/include/lvgl/core/lv_obj_tree.h
@@ -257,6 +257,7 @@ void lv_obj_get_name_resolved(const lv_obj_t * obj, char buf[], size_t buf_size)
  * be created for it using `lv_obj_get_name_resolved`.
  *
  * @param parent        the widget where the search should start
+ * @param name          the name of the widget
  * @return              the found widget or NULL if not found.
  */
 lv_obj_t * lv_obj_find_by_name(const lv_obj_t * parent, const char * name);
@@ -271,6 +272,7 @@ lv_obj_t * lv_obj_find_by_name(const lv_obj_t * parent, const char * name);
  * be created for it using `lv_obj_get_name_resolved`.
  *
  * @param parent        the widget where the search should start
+ * @param name_path     the widget name path
  * @return              the found widget or NULL if not found.
  */
 lv_obj_t * lv_obj_get_child_by_name(const lv_obj_t * parent, const char * name_path);

--- a/include/lvgl/core/lv_timer.h
+++ b/include/lvgl/core/lv_timer.h
@@ -212,7 +212,7 @@ bool lv_timer_get_paused(lv_timer_t * timer);
  *
  * @param timer      Pointer to the timer object
  * @param data       User-defined data pointer to associate with the timer
- * @param destructor Callback function for cleaning up ext_data when timer is deleted.
+ * @param free_cb    Callback function for cleaning up ext_data when timer is deleted.
  *                   Receives ext_data as parameter. NULL means no cleanup required.
  */
 void lv_timer_set_external_data(lv_timer_t * timer, void * data, void (* free_cb)(void * data));

--- a/include/lvgl/debugging/test/lv_test_indev.h
+++ b/include/lvgl/debugging/test/lv_test_indev.h
@@ -104,7 +104,6 @@ void lv_test_key_press(uint32_t k);
 /**
  * Release the previously press key.
  * This function doesn't wait, but just changes the state and returns immediately.
- * @param k     the key to press
  */
 void lv_test_key_release(void);
 

--- a/include/lvgl/display/lv_display.h
+++ b/include/lvgl/display/lv_display.h
@@ -273,7 +273,7 @@ void lv_display_set_buffers(lv_display_t * disp, void * buf1, void * buf2, uint3
  * Set the frame buffers for a display, similarly to `lv_display_set_buffers`, but allow
  * for a custom stride as required by a display controller.
  * This allows the frame buffers to have a stride alignment different from the rest of
- * the buffers`
+ * the buffers.
  * @param disp              pointer to a display
  * @param buf1              first buffer
  * @param buf2              second buffer (can be `NULL`)

--- a/include/lvgl/draw/lv_draw.h
+++ b/include/lvgl/draw/lv_draw.h
@@ -216,6 +216,7 @@ void * lv_draw_create_unit(size_t size);
  * Add an empty draw task to the draw task list of a layer.
  * @param layer     pointer to a layer
  * @param coords    the coordinates of the draw task
+ * @param type      the draw task type
  * @return          the created draw task which needs to be
  *                  further configured e.g. by added a draw descriptor
  */
@@ -331,7 +332,6 @@ lv_layer_t * lv_draw_layer_create(lv_layer_t * parent_layer, lv_color_format_t c
  * @param parent_layer      the parent layer to which the layer will be merged when it's rendered
  * @param color_format      the color format of the layer
  * @param area              the areas of the layer (absolute coordinates)
- * @return                  the new target_layer or NULL on error
  */
 void lv_draw_layer_init(lv_layer_t * layer, lv_layer_t * parent_layer, lv_color_format_t color_format,
                         const lv_area_t * area);

--- a/include/lvgl/draw/lv_draw_3d.h
+++ b/include/lvgl/draw/lv_draw_3d.h
@@ -55,6 +55,7 @@ lv_draw_3d_dsc_t * lv_draw_task_get_3d_dsc(lv_draw_task_t * task);
  * Create a 3D draw task
  * @param layer     pointer to a layer
  * @param dsc       pointer to an initialized `lv_draw_3d_dsc_t` variable
+ * @param coords    the coordinates of where to draw the widget
  */
 void lv_draw_3d(lv_layer_t * layer, const lv_draw_3d_dsc_t * dsc, const lv_area_t * coords);
 

--- a/include/lvgl/drivers/display/lv_draw_eve_display_defines.h
+++ b/include/lvgl/drivers/display/lv_draw_eve_display_defines.h
@@ -596,7 +596,7 @@ static inline uint32_t LV_EVE_BITMAP_LAYOUT_H(uint16_t linestride, uint16_t heig
 //#define LV_EVE_BITMAP_SIZE_H(width,height) ((LV_EVE_DL_BITMAP_SIZE_H) | (((((width) & 0x600U) >> 9U) & 3UL) << 2U) | ((((height) & 0x600U) >> 9U) & 3UL))
 /**
  * @brief Set the 2 most significant bits of bitmaps dimension for the current handle.
- * @param linestride 11-bit value of bitmap width, the 2 most significant bits are used
+ * @param width      11-bit value of bitmap width, the 2 most significant bits are used
  * @param height 11-bit value of bitmap width, the 2 most significant bits are used
  * @note this is different to FTDIs implementation as this takes the original values as parameters and not only the upper bits
  * @return a 32 bit word for use with EVE_cmd_dl()

--- a/include/lvgl/drivers/display/lv_ili9341.h
+++ b/include/lvgl/drivers/display/lv_ili9341.h
@@ -40,8 +40,8 @@ typedef lv_lcd_send_color_cb_t lv_ili9341_send_color_cb_t;
  * @param hor_res       horizontal resolution
  * @param ver_res       vertical resolution
  * @param flags         default configuration settings (mirror, RGB ordering, etc.)
- * @param send_cmd      platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
- * @param send_color    platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
+ * @param send_cmd_cb   platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
+ * @param send_color_cb platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
  * @return              pointer to the created display
  */
 lv_display_t * lv_ili9341_create(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,

--- a/include/lvgl/drivers/display/lv_lcd_generic_mipi.h
+++ b/include/lvgl/drivers/display/lv_lcd_generic_mipi.h
@@ -178,8 +178,8 @@ typedef struct {
  * @param hor_res       horizontal resolution
  * @param ver_res       vertical resolution
  * @param flags         default configuration settings (mirror, RGB ordering, etc.)
- * @param send_cmd      platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
- * @param send_color    platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer).
+ * @param send_cmd_cb   platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
+ * @param send_color_cb platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer).
  *                      `lv_display_flush_ready` must be called after the transfer has finished.
  * @return              pointer to the created display
  */

--- a/include/lvgl/drivers/display/lv_nv3007.h
+++ b/include/lvgl/drivers/display/lv_nv3007.h
@@ -40,8 +40,8 @@ typedef lv_lcd_send_color_cb_t lv_nv3007_send_color_cb_t;
  * @param hor_res       horizontal resolution
  * @param ver_res       vertical resolution
  * @param flags         default configuration settings (mirror, RGB ordering, etc.)
- * @param send_cmd      platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
- * @param send_color    platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
+ * @param send_cmd_cb   platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
+ * @param send_color_cb platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
  * @return              pointer to the created display
  */
 lv_display_t * lv_nv3007_create(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,

--- a/include/lvgl/drivers/display/lv_st7735.h
+++ b/include/lvgl/drivers/display/lv_st7735.h
@@ -40,8 +40,8 @@ typedef lv_lcd_send_color_cb_t lv_st7735_send_color_cb_t;
  * @param hor_res       horizontal resolution
  * @param ver_res       vertical resolution
  * @param flags         default configuration settings (mirror, RGB ordering, etc.)
- * @param send_cmd      platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
- * @param send_color    platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
+ * @param send_cmd_cb   platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
+ * @param send_color_cb platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
  * @return              pointer to the created display
  */
 lv_display_t * lv_st7735_create(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,

--- a/include/lvgl/drivers/display/lv_st7789.h
+++ b/include/lvgl/drivers/display/lv_st7789.h
@@ -40,8 +40,8 @@ typedef lv_lcd_send_color_cb_t lv_st7789_send_color_cb_t;
  * @param hor_res       horizontal resolution
  * @param ver_res       vertical resolution
  * @param flags         default configuration settings (mirror, RGB ordering, etc.)
- * @param send_cmd      platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
- * @param send_color    platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
+ * @param send_cmd_cb   platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
+ * @param send_color_cb platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
  * @return              pointer to the created display
  */
 lv_display_t * lv_st7789_create(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,

--- a/include/lvgl/drivers/display/lv_st7796.h
+++ b/include/lvgl/drivers/display/lv_st7796.h
@@ -40,8 +40,8 @@ typedef lv_lcd_send_color_cb_t lv_st7796_send_color_cb_t;
  * @param hor_res       horizontal resolution
  * @param ver_res       vertical resolution
  * @param flags         default configuration settings (mirror, RGB ordering, etc.)
- * @param send_cmd      platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
- * @param send_color    platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
+ * @param send_cmd_cb   platform-dependent function to send a command to the LCD controller (usually uses polling transfer)
+ * @param send_color_cb platform-dependent function to send pixel data to the LCD controller (usually uses DMA transfer: must implement a 'ready' callback)
  * @return              pointer to the created display
  */
 lv_display_t * lv_st7796_create(uint32_t hor_res, uint32_t ver_res, lv_lcd_flag_t flags,

--- a/include/lvgl/drivers/indev/lv_evdev.h
+++ b/include/lvgl/drivers/indev/lv_evdev.h
@@ -41,7 +41,7 @@ typedef void (*lv_evdev_discovery_cb_t)(lv_indev_t * indev, lv_evdev_type_t type
 
 /**
  * Create evdev input device from a given path.
- * @param type LV_INDEV_TYPE_POINTER or LV_INDEV_TYPE_KEYPAD
+ * @param indev_type LV_INDEV_TYPE_POINTER or LV_INDEV_TYPE_KEYPAD
  * @param dev_path device path, e.g., /dev/input/event0
  * @return pointer to input device or NULL if opening failed
  */
@@ -49,7 +49,7 @@ lv_indev_t * lv_evdev_create(lv_indev_type_t indev_type, const char * dev_path);
 
 /**
  * Create evdev input device, taking ownership of the given file descriptor.
- * @param type LV_INDEV_TYPE_POINTER or LV_INDEV_TYPE_KEYPAD
+ * @param indev_type LV_INDEV_TYPE_POINTER or LV_INDEV_TYPE_KEYPAD
  * @param fd file descriptor of the evdev device
  * @return pointer to input device or NULL if opening failed
  */

--- a/include/lvgl/drivers/indev/lv_libinput.h
+++ b/include/lvgl/drivers/indev/lv_libinput.h
@@ -66,7 +66,7 @@ char * lv_libinput_find_dev(lv_libinput_capability capabilities, bool force_resc
 /**
  * Find connected input devices with specific capabilities
  * @param capabilities required device capabilities
- * @param devices pre-allocated array to store the found device node paths (e.g. /dev/input/event0). The pointers are
+ * @param found   pre-allocated array to store the found device node paths (e.g. /dev/input/event0). The pointers are
  *                safe to use until the next forceful device search.
  * @param count maximum number of devices to find (the devices array should be at least this long)
  * @param force_rescan erase the device cache (if any) and rescan the file system for available devices
@@ -76,7 +76,7 @@ size_t lv_libinput_find_devs(lv_libinput_capability capabilities, char ** found,
 
 /**
  * Create a new libinput input device
- * @param type LV_INDEV_TYPE_POINTER or LV_INDEV_TYPE_KEYPAD
+ * @param indev_type LV_INDEV_TYPE_POINTER or LV_INDEV_TYPE_KEYPAD
  * @param dev_path device path, e.g. /dev/input/event0
  * @return pointer to input device or NULL if opening failed
  */

--- a/include/lvgl/drivers/indev/lv_xkb.h
+++ b/include/lvgl/drivers/indev/lv_xkb.h
@@ -44,7 +44,7 @@ void lv_xkb_deinit(lv_xkb_t * dsc);
 
 /**
  * Process an evdev scancode using a specific XKB descriptor.
- * @param state XKB descriptor to use
+ * @param dsc   XKB descriptor to use
  * @param scancode evdev scancode to process
  * @param down true if the key was pressed, false if it was releases
  * @return the (first) UTF-8 character produced by the event or 0 if no output was produced

--- a/include/lvgl/drivers/opengles/lv_opengles_driver.h
+++ b/include/lvgl/drivers/opengles/lv_opengles_driver.h
@@ -46,13 +46,14 @@ void lv_opengles_deinit(void);
 
 /**
  * Render a texture using alternate blending mode for smoother translucent materials and correct anti-aliasing of glTF elements when using transparent background
- * @param texture        OpenGL texture ID
- * @param texture_area   the area in the window to render the texture in
- * @param opa            opacity to blend the texture with existing contents
- * @param disp_w         width of the window/framebuffer being rendered to
- * @param disp_h         height of the window/framebuffer being rendered to
- * @param h_flip         horizontal flip
- * @param v_flip         vertical flip
+ * @param texture               OpenGL texture ID
+ * @param texture_area          the area in the window to render the texture in
+ * @param opa                   opacity to blend the texture with existing contents
+ * @param disp_w                width of the window/framebuffer being rendered to
+ * @param disp_h                height of the window/framebuffer being rendered to
+ * @param texture_clip_area     the area of the texture to draw
+ * @param h_flip                horizontal flip
+ * @param v_flip                vertical flip
  */
 void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa, int32_t disp_w,
                                 int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip);

--- a/include/lvgl/drivers/wayland/lv_wayland_window.h
+++ b/include/lvgl/drivers/wayland/lv_wayland_window.h
@@ -81,7 +81,7 @@ void lv_wayland_window_set_fullscreen(lv_display_t * disp, bool fullscreen);
 /**
  * Sets the maximized state of the window
  * @param disp Reference to the LVGL display associated to the window
- * @param fullscreen If true the window is maximized
+ * @param maximize   If true the window is maximized
  */
 void lv_wayland_window_set_maximized(lv_display_t * disp, bool maximize);
 

--- a/include/lvgl/font/lv_bidi.h
+++ b/include/lvgl/font/lv_bidi.h
@@ -52,7 +52,7 @@ void lv_bidi_calculate_align(lv_text_align_t * align, lv_base_dir_t * base_dir, 
 
 /**
  * Set custom neutrals string
- * @param neutrals  default " \t\n\r.,:;'\"`!?%/\\-=()[]{}<>@#&$|"
+ * @param neutrals  default " \t\n\r.,:;'\"\`!?%/\\-=()[]{}<>@#&$|"
  */
 void lv_bidi_set_custom_neutrals_static(const char * neutrals);
 

--- a/include/lvgl/font/lv_font_fmt_txt.h
+++ b/include/lvgl/font/lv_font_fmt_txt.h
@@ -161,7 +161,7 @@ typedef struct {
 
     /**
      * Store kerning values.
-     * Can be `lv_font_fmt_txt_kern_pair_t *  or `lv_font_kern_classes_fmt_txt_t *`
+     * Can be @ref lv_font_fmt_txt_kern_pair_t * or @ref lv_font_fmt_txt_kern_classes_t *
      * depending on `kern_classes`
      */
     const void * kern_dsc;
@@ -219,7 +219,7 @@ const void * lv_font_get_bitmap_fmt_txt(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf
  * @param unicode_letter a UNICODE letter code
  * @param unicode_letter_next the unicode letter succeeding the letter under test
  * @return true: descriptor is successfully loaded into `dsc_out`.
- *         false: the letter was not found, no data is loaded to `dsc_out`
+ *         false: the letter was not found, no data is loaded to `dsc_out`.
  */
 bool lv_font_get_glyph_dsc_fmt_txt(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, uint32_t unicode_letter,
                                    uint32_t unicode_letter_next);

--- a/include/lvgl/font/lv_font_manager.h
+++ b/include/lvgl/font/lv_font_manager.h
@@ -98,7 +98,6 @@ lv_font_t * lv_font_manager_create_font(lv_font_manager_t * manager,
  * Delete font.
  * @param manager pointer to main font manager.
  * @param font point to the font.
- * @return return true if the deletion was successful.
  */
 void lv_font_manager_delete_font(lv_font_manager_t * manager, lv_font_t * font);
 

--- a/include/lvgl/font/lv_freetype.h
+++ b/include/lvgl/font/lv_freetype.h
@@ -96,7 +96,7 @@ lv_font_t * lv_freetype_font_create_with_info(const lv_font_info_t * font_info);
 /**
  * Create a freetype font.
  * @param pathname font file path.
- * @param render_mode font render mode(see @lv_freetype_font_render_mode_t for details).
+ * @param render_mode font render mode(see @ref lv_freetype_font_render_mode_t for details).
  * @param size font size.
  * @param style font style(see lv_freetype_font_style_t for details).
  * @return Created font, or NULL on failure.
@@ -115,9 +115,9 @@ void lv_freetype_font_delete(lv_font_t * font);
 /**
  * Register a callback function to generate outlines for FreeType fonts.
  *
- * @param cb The callback function to be registered.
+ * @param event_cb The callback function to be registered.
+ * @param filter The event code to filter for, or LV_EVENT_ALL to receive every event.
  * @param user_data User data to be passed to the callback function.
- * @return The ID of the registered callback function, or a negative value on failure.
  */
 void lv_freetype_outline_add_event(lv_event_cb_t event_cb, lv_event_code_t filter, void * user_data);
 

--- a/include/lvgl/fs/lv_fs.h
+++ b/include/lvgl/fs/lv_fs.h
@@ -261,7 +261,7 @@ lv_fs_res_t lv_fs_load_to_buf(void * buf, uint32_t buf_size, const char * path);
 
 /**
  * Load a file into a memory buffer.
- * @param filename  the path of the file
+ * @param path      the path of the file
  * @param size      pointer to store the size of the loaded file
  * @return          a pointer to the loaded file buffer, or NULL if an error occurred
  */

--- a/include/lvgl/indev/lv_indev_gesture.h
+++ b/include/lvgl/indev/lv_indev_gesture.h
@@ -179,21 +179,23 @@ lv_dir_t lv_event_get_two_fingers_swipe_dir(lv_event_t * gesture_event);
  * it is usually called from the indev read callback
  * @param data the indev data
  * @param recognizer pointer to a gesture recognizer
+ * @param type          the gesture type
  */
 void lv_indev_set_gesture_data(lv_indev_data_t * data, lv_indev_gesture_recognizer_t * recognizer,
                                lv_indev_gesture_type_t type);
 
 /**
  * Obtains the center point of a gesture
- * @param gesture_event     pointer to a gesture recognizer event
+ * @param recognizer        pointer to a gesture recognizer event
  * @param point             pointer to a point
  */
 void lv_indev_get_gesture_center_point(lv_indev_gesture_recognizer_t * recognizer, lv_point_t * point);
 
 /**
  * Obtains the current state of the gesture recognizer attached to an event
- * @param gesture_event     pointer to a gesture recognizer event
- * @return                  current state of the gesture recognizer
+ * @param gesture_event pointer to a gesture recognizer event
+ * @param type          the gesture type
+ * @return              current state of the gesture recognizer
  */
 lv_indev_gesture_state_t lv_event_get_gesture_state(lv_event_t * gesture_event, lv_indev_gesture_type_t type);
 

--- a/include/lvgl/lvgl.h
+++ b/include/lvgl/lvgl.h
@@ -220,28 +220,37 @@
     #include "api_map/lv_api_map_v9_5.h"
 #endif /*LV_DISABLE_API_MAPPING*/
 
-/** Gives 1 if the x.y.z version is supported in the current version
+/**
+ * Gives 1 if the x.y.z version is supported in the current version
+ *
  * Usage:
  *
- * - Require v6
- * #if LV_VERSION_CHECK(6,0,0)
- *   new_func_in_v6();
+ * Require v6:
+ * @code{.c}
+ * #if LV_VERSION_CHECK(6, 0, 0)
+ *     new_func_in_v6();
  * #endif
+ * @endcode
  *
- *
- * - Require at least v5.3
- * #if LV_VERSION_CHECK(5,3,0)
- *   new_feature_from_v5_3();
+ * Require at least v5.3:
+ * @code{.c}
+ * #if LV_VERSION_CHECK(5, 3, 0)
+ *     new_feature_from_v5_3();
  * #endif
+ * @endcode
  *
- *
- * - Require v5.3.2 bugfixes
- * #if LV_VERSION_CHECK(5,3,2)
- *   bugfix_in_v5_3_2();
+ * Require v5.3.2 bugfixes:
+ * @code{.c}
+ * #if LV_VERSION_CHECK(5, 3, 2)
+ *     bugfix_in_v5_3_2();
  * #endif
+ * @endcode
  *
+ * @param x  major version to check against
+ * @param y  minor version to check against
+ * @param z  patch version to check against
  */
-#define LV_VERSION_CHECK(x,y,z) (x == LVGL_VERSION_MAJOR && (y < LVGL_VERSION_MINOR || (y == LVGL_VERSION_MINOR && z <= LVGL_VERSION_PATCH)))
+#define LV_VERSION_CHECK(x, y, z) (x == LVGL_VERSION_MAJOR && (y < LVGL_VERSION_MINOR || (y == LVGL_VERSION_MINOR && z <= LVGL_VERSION_PATCH)))
 
 /**
  * Wrapper functions for VERSION macros

--- a/include/lvgl/widgets/lv_buttonmatrix.h
+++ b/include/lvgl/widgets/lv_buttonmatrix.h
@@ -194,7 +194,7 @@ uint32_t lv_buttonmatrix_get_selected_button(const lv_obj_t * obj);
  * Get the button's text
  * @param obj       pointer to button matrix object
  * @param btn_id    the index a button not counting new line characters.
- * @return          text of btn_index` button
+ * @return          text of `btn_index` button
  */
 const char * lv_buttonmatrix_get_button_text(const lv_obj_t * obj, uint32_t btn_id);
 

--- a/include/lvgl/widgets/lv_calendar.h
+++ b/include/lvgl/widgets/lv_calendar.h
@@ -139,40 +139,40 @@ lv_obj_t * lv_calendar_get_btnmatrix(const lv_obj_t * obj);
 
 /**
  * Get the today's date
- * @param calendar  pointer to a calendar object
+ * @param obj       pointer to a calendar object
  * @return          return pointer to an `lv_calendar_date_t` variable containing the date of today.
  */
-const lv_calendar_date_t * lv_calendar_get_today_date(const lv_obj_t * calendar);
+const lv_calendar_date_t * lv_calendar_get_today_date(const lv_obj_t * obj);
 
 /**
  * Get the currently showed
- * @param calendar  pointer to a calendar object
+ * @param obj       pointer to a calendar object
  * @return          pointer to an `lv_calendar_date_t` variable containing the date is being shown.
  */
-const lv_calendar_date_t * lv_calendar_get_showed_date(const lv_obj_t * calendar);
+const lv_calendar_date_t * lv_calendar_get_showed_date(const lv_obj_t * obj);
 
 /**
  * Get the highlighted dates
- * @param calendar  pointer to a calendar object
+ * @param obj       pointer to a calendar object
  * @return          pointer to an `lv_calendar_date_t` array containing the dates.
  */
-lv_calendar_date_t * lv_calendar_get_highlighted_dates(const lv_obj_t * calendar);
+lv_calendar_date_t * lv_calendar_get_highlighted_dates(const lv_obj_t * obj);
 
 /**
  * Get the number of the highlighted dates
- * @param calendar  pointer to a calendar object
+ * @param obj       pointer to a calendar object
  * @return          number of highlighted days
  */
-size_t lv_calendar_get_highlighted_dates_num(const lv_obj_t * calendar);
+size_t lv_calendar_get_highlighted_dates_num(const lv_obj_t * obj);
 
 /**
  * Get the currently pressed day
- * @param calendar  pointer to a calendar object
+ * @param obj       pointer to a calendar object
  * @param date      store the pressed date here
  * @return          LV_RESULT_OK: there is a valid pressed date
  *                  LV_RESULT_INVALID: there is no pressed data
  */
-lv_result_t lv_calendar_get_pressed_date(const lv_obj_t * calendar, lv_calendar_date_t * date);
+lv_result_t lv_calendar_get_pressed_date(const lv_obj_t * obj, lv_calendar_date_t * date);
 
 /*=====================
  * Other functions

--- a/include/lvgl/widgets/lv_calendar_header_dropdown.h
+++ b/include/lvgl/widgets/lv_calendar_header_dropdown.h
@@ -44,7 +44,7 @@ lv_obj_t * lv_calendar_add_header_dropdown(lv_obj_t * parent);
  * Sets a custom calendar year list
  * @param parent        pointer to a calendar object
  * @param years_list    pointer to an const char array with the years list, see lv_dropdown set_options for more information.
- *                      E.g. `const char * years = "2023\n2022\n2021\n2020\n2019"
+ *                      E.g. `const char * years = "2023\n2022\n2021\n2020\n2019"`
  *                      Only the pointer will be saved so this variable can't be local which will be destroyed later.
  */
 void lv_calendar_header_dropdown_set_year_list(lv_obj_t * parent, const char * years_list);

--- a/include/lvgl/widgets/lv_canvas.h
+++ b/include/lvgl/widgets/lv_canvas.h
@@ -116,19 +116,19 @@ lv_color32_t lv_canvas_get_px(lv_obj_t * obj, int32_t x, int32_t y);
 
 /**
  * Get the image of the canvas as a pointer to an `lv_image_dsc_t` variable.
- * @param canvas    pointer to a canvas object
+ * @param obj       pointer to a canvas object
  * @return          pointer to the image descriptor.
  */
-lv_image_dsc_t * lv_canvas_get_image(lv_obj_t * canvas);
+lv_image_dsc_t * lv_canvas_get_image(lv_obj_t * obj);
 
 /**
  * Return the pointer for the buffer.
  * It's recommended to use this function instead of the buffer form the
  * return value of lv_canvas_get_image() as is can be aligned
- * @param canvas    pointer to a canvas object
+ * @param obj       pointer to a canvas object
  * @return          pointer to the buffer
  */
-const void * lv_canvas_get_buf(lv_obj_t * canvas);
+const void * lv_canvas_get_buf(lv_obj_t * obj);
 
 /*=====================
  * Other functions
@@ -157,10 +157,10 @@ void lv_canvas_fill_bg(lv_obj_t * obj, lv_color_t color, lv_opa_t opa);
 /**
  * Initialize a layer to use LVGL's generic draw functions (lv_draw_rect/label/...) on the canvas.
  * Needs to be usd in pair with `lv_canvas_finish_layer`.
- * @param canvas    pointer to a canvas
+ * @param obj       pointer to a canvas
  * @param layer     pointer to a layer variable to initialize
  */
-void lv_canvas_init_layer(lv_obj_t * canvas, lv_layer_t * layer);
+void lv_canvas_init_layer(lv_obj_t * obj, lv_layer_t * layer);
 
 /**
  * Wait until all the drawings are finished on layer.

--- a/include/lvgl/widgets/lv_chart.h
+++ b/include/lvgl/widgets/lv_chart.h
@@ -266,11 +266,11 @@ void lv_chart_set_x_start_point(lv_obj_t * obj, lv_chart_series_t * ser, uint32_
 
 /**
  * Get the next series.
- * @param chart     pointer to a chart
+ * @param obj       pointer to a chart
  * @param ser      the previous series or NULL to get the first
  * @return          the next series or NULL if there is no more.
  */
-lv_chart_series_t * lv_chart_get_series_next(const lv_obj_t * chart, const lv_chart_series_t * ser);
+lv_chart_series_t * lv_chart_get_series_next(const lv_obj_t * obj, const lv_chart_series_t * ser);
 
 /*=====================
  * Cursor

--- a/include/lvgl/widgets/lv_gltf.h
+++ b/include/lvgl/widgets/lv_gltf.h
@@ -382,7 +382,7 @@ lv_gltf_aa_mode_t lv_gltf_get_antialiasing_mode(const lv_obj_t * obj);
 /**
  * Get the point that a given ray intersects with a specified plane at, if any
  * @param ray the intersection test ray
- * @param screen_y the plane to test ray intersection with
+ * @param plane    the plane to test ray intersection with
  * @param collision_point output lv_3dpoint_t holder, values are only valid if true is the return value
  * @return LV_RESULT_OK if intersection, LV_RESULT_INVALID if no intersection
  */
@@ -410,7 +410,7 @@ lv_3dray_t lv_gltf_get_ray_from_2d_coordinate(lv_obj_t * obj, const lv_point_t *
  * Get the screen position of a 3d point
  * @param obj pointer to a GLTF viewer object
  * @param world_pos world position to convert
- * @param lv_point_t the resulting point, in pixels. only valid if return value is true
+ * @param screen_pos the resulting point, in pixels. only valid if return value is true
  * @return LV_RESULT_OK if conversion valid, LV_RESULT_INVALID if no valid conversion
  */
 lv_result_t lv_gltf_world_to_screen(lv_obj_t * obj, const lv_3dpoint_t world_pos, lv_point_t * screen_pos);

--- a/include/lvgl/widgets/lv_gstreamer.h
+++ b/include/lvgl/widgets/lv_gstreamer.h
@@ -97,7 +97,7 @@ lv_obj_t * lv_gstreamer_create(lv_obj_t * parent);
 
 /**
  * Add a source to this gstreamer object
- * @param gstreamer     pointer to a gstreamer object
+ * @param obj           pointer to a gstreamer object
  * @param factory_name  the factory name for the source of this gstreamer object.
  *                      for common factory names, check `LV_GSTREAMER_FACTORY_XXX` defines
  * @param property      the property name for the gstreamer source object
@@ -107,71 +107,71 @@ lv_obj_t * lv_gstreamer_create(lv_obj_t * parent);
  *                      Passing NULL will create the source object but not set its source
  * @return LV_RESULT_OK if the source was correctly set else LV_RESULT_INVALID
  */
-lv_result_t lv_gstreamer_set_src(lv_obj_t * gstreamer, const char * factory_name, const char * property,
+lv_result_t lv_gstreamer_set_src(lv_obj_t * obj, const char * factory_name, const char * property,
                                  const char * source);
 
 /**
  * Play this gstreamer
- * @param gstreamer     pointer to a gstreamer object
+ * @param obj           pointer to a gstreamer object
  */
-void lv_gstreamer_play(lv_obj_t * gstreamer);
+void lv_gstreamer_play(lv_obj_t * obj);
 
 /**
  * Pause this gstreamer
- * @param gstreamer     pointer to a gstreamer object
+ * @param obj           pointer to a gstreamer object
  */
-void lv_gstreamer_pause(lv_obj_t * gstreamer);
+void lv_gstreamer_pause(lv_obj_t * obj);
 
 /**
  * Stop this gstreamer
- * @param gstreamer     pointer to a gstreamer object
+ * @param obj           pointer to a gstreamer object
  */
-void lv_gstreamer_stop(lv_obj_t * gstreamer);
+void lv_gstreamer_stop(lv_obj_t * obj);
 
 /**
  * Seek a position in this gstreamer
- * @param gstreamer     pointer to a gstreamer object
+ * @param obj           pointer to a gstreamer object
  * @param position      position to seek to
  */
-void lv_gstreamer_set_position(lv_obj_t * gstreamer, uint32_t position);
+void lv_gstreamer_set_position(lv_obj_t * obj, uint32_t position);
 
 /**
  * Get the duration of this gstreamer
- * @param gstreamer     pointer to a gstreamer object
+ * @param obj           pointer to a gstreamer object
  * @return              the duration (in ms) of the gstreamer object
  */
-uint32_t lv_gstreamer_get_duration(lv_obj_t * gstreamer);
+uint32_t lv_gstreamer_get_duration(lv_obj_t * obj);
 
 /**
  * Get the position of this gstreamer
- * @param gstreamer     pointer to a gstreamer object
+ * @param obj           pointer to a gstreamer object
  * @return              the position (in ms) of the gstreamer object
  */
-uint32_t lv_gstreamer_get_position(lv_obj_t * gstreamer);
+uint32_t lv_gstreamer_get_position(lv_obj_t * obj);
 
 /**
  * Get the state of this gstreamer
- * @param gstreamer     pointer to a gstreamer object
+ * @param obj           pointer to a gstreamer object
  */
-lv_gstreamer_state_t lv_gstreamer_get_state(lv_obj_t * gstreamer);
+lv_gstreamer_state_t lv_gstreamer_get_state(lv_obj_t * obj);
 
 /**
  * Set the volume of this gstreamer
- * @param gstreamer     pointer to a gstreamer object
+ * @param obj           pointer to a gstreamer object
  * @param volume         the value to set in the range [0..100]. Higher values are clamped
  */
-void lv_gstreamer_set_volume(lv_obj_t * gstreamer, uint8_t volume);
+void lv_gstreamer_set_volume(lv_obj_t * obj, uint8_t volume);
 
 /**
  * Get the volume of this gstreamer
- * @param gstreamer     pointer to a gstreamer object
+ * @param obj           pointer to a gstreamer object
  * @return      the volume for this gstreamer
  */
-uint8_t lv_gstreamer_get_volume(lv_obj_t * gstreamer);
+uint8_t lv_gstreamer_get_volume(lv_obj_t * obj);
 
 /**
  * Set the speed rate of this gstreamer
- * @param gstreamer     pointer to a gstreamer object
+ * @param obj           pointer to a gstreamer object
  * @param rate      the rate factor.  Example values:
  *                      - 256:   1x
  *                      - <256:  slow down
@@ -179,7 +179,7 @@ uint8_t lv_gstreamer_get_volume(lv_obj_t * gstreamer);
  *                      - 128:   0.5x
  *                      - 512:   2x
  */
-void lv_gstreamer_set_rate(lv_obj_t * gstreamer, uint32_t rate);
+void lv_gstreamer_set_rate(lv_obj_t * obj, uint32_t rate);
 
 /**
  * Retrieve the stream state from a STATE_CHANGED event callback

--- a/include/lvgl/widgets/lv_image.h
+++ b/include/lvgl/widgets/lv_image.h
@@ -223,7 +223,7 @@ void lv_image_set_bitmap_map_src(lv_obj_t * obj, const lv_image_dsc_t * src);
 /**
  * Get the source of the image
  * @param obj       pointer to an image object
- * @return          the image source (symbol, file name or ::lv-img_dsc_t for C arrays)
+ * @return          the image source (symbol, file name or @ref lv_image_dsc_t for C arrays)
  */
 const void * lv_image_get_src(lv_obj_t * obj);
 

--- a/include/lvgl/widgets/lv_imagebutton.h
+++ b/include/lvgl/widgets/lv_imagebutton.h
@@ -110,7 +110,7 @@ void lv_imagebutton_set_state(lv_obj_t * obj, lv_imagebutton_state_t state);
 /**
  * Get the left image in a given state
  * @param obj           pointer to an image button object
- * @param state         the state where to get the image (from `lv_button_state_t`) `
+ * @param state         the state where to get the image (from @ref lv_imagebutton_state_t)
  * @return              pointer to the left image source (a C array or path to a file)
  */
 const void * lv_imagebutton_get_src_left(lv_obj_t * obj, lv_imagebutton_state_t state);
@@ -118,7 +118,7 @@ const void * lv_imagebutton_get_src_left(lv_obj_t * obj, lv_imagebutton_state_t 
 /**
  * Get the middle image in a given state
  * @param obj           pointer to an image button object
- * @param state         the state where to get the image (from `lv_button_state_t`) `
+ * @param state         the state where to get the image (from `lv_button_state_t`)
  * @return              pointer to the middle image source (a C array or path to a file)
  */
 const void * lv_imagebutton_get_src_middle(lv_obj_t * obj, lv_imagebutton_state_t state);
@@ -126,7 +126,7 @@ const void * lv_imagebutton_get_src_middle(lv_obj_t * obj, lv_imagebutton_state_
 /**
  * Get the right image in a given state
  * @param obj           pointer to an image button object
- * @param state         the state where to get the image (from `lv_button_state_t`) `
+ * @param state         the state where to get the image (from `lv_button_state_t`)
  * @return              pointer to the left image source (a C array or path to a file)
  */
 const void * lv_imagebutton_get_src_right(lv_obj_t * obj, lv_imagebutton_state_t state);

--- a/include/lvgl/widgets/lv_keyboard.h
+++ b/include/lvgl/widgets/lv_keyboard.h
@@ -70,35 +70,35 @@ lv_obj_t * lv_keyboard_create(lv_obj_t * parent);
 
 /**
  * Assign a text area to the keyboard. Pressed characters will be inserted there.
- * @param kb        pointer to a keyboard object
+ * @param obj       pointer to a keyboard object
  * @param ta        pointer to a text area object to write into
  */
-void lv_keyboard_set_textarea(lv_obj_t * kb, lv_obj_t * ta);
+void lv_keyboard_set_textarea(lv_obj_t * obj, lv_obj_t * ta);
 
 /**
  * Set a new mode (e.g., text, number, special characters).
- * @param kb        pointer to a keyboard object
+ * @param obj       pointer to a keyboard object
  * @param mode      the desired mode (see 'lv_keyboard_mode_t')
  */
-void lv_keyboard_set_mode(lv_obj_t * kb, lv_keyboard_mode_t mode);
+void lv_keyboard_set_mode(lv_obj_t * obj, lv_keyboard_mode_t mode);
 
 /**
  * Enable or disable popovers showing button titles on press.
- * @param kb        pointer to a keyboard object
+ * @param obj       pointer to a keyboard object
  * @param en        true to enable popovers; false to disable
  */
-void lv_keyboard_set_popovers(lv_obj_t * kb, bool en);
+void lv_keyboard_set_popovers(lv_obj_t * obj, bool en);
 
 /**
  * Set a custom button map for the keyboard.
- * @param kb        pointer to a keyboard object
+ * @param obj       pointer to a keyboard object
  * @param mode      the mode to assign the new map to (see 'lv_keyboard_mode_t')
  * @param map       pointer to a string array describing the button map
  *                  see 'lv_buttonmatrix_set_map()' for more details
  * @param ctrl_map  pointer to the control map. See 'lv_buttonmatrix_set_ctrl_map()'
 
  */
-void lv_keyboard_set_map(lv_obj_t * kb, lv_keyboard_mode_t mode, const char * const map[],
+void lv_keyboard_set_map(lv_obj_t * obj, lv_keyboard_mode_t mode, const char * const map[],
                          const lv_buttonmatrix_ctrl_t ctrl_map[]);
 
 /*=====================
@@ -107,17 +107,17 @@ void lv_keyboard_set_map(lv_obj_t * kb, lv_keyboard_mode_t mode, const char * co
 
 /**
  * Get the text area currently assigned to the keyboard.
- * @param kb        pointer to a keyboard object
+ * @param obj       pointer to a keyboard object
  * @return          pointer to the assigned text area object
  */
-lv_obj_t * lv_keyboard_get_textarea(const lv_obj_t * kb);
+lv_obj_t * lv_keyboard_get_textarea(const lv_obj_t * obj);
 
 /**
  * Get the current mode of the keyboard.
- * @param kb        pointer to a keyboard object
+ * @param obj       pointer to a keyboard object
  * @return          the current mode (see 'lv_keyboard_mode_t')
  */
-lv_keyboard_mode_t lv_keyboard_get_mode(const lv_obj_t * kb);
+lv_keyboard_mode_t lv_keyboard_get_mode(const lv_obj_t * obj);
 
 /**
  * Check whether popovers are enabled on the keyboard.

--- a/include/lvgl/widgets/lv_led.h
+++ b/include/lvgl/widgets/lv_led.h
@@ -57,17 +57,17 @@ lv_obj_t * lv_led_create(lv_obj_t * parent);
 
 /**
  * Set the color of the LED
- * @param led       pointer to a LED object
+ * @param obj       pointer to a LED object
  * @param color     the color of the LED
  */
-void lv_led_set_color(lv_obj_t * led, lv_color_t color);
+void lv_led_set_color(lv_obj_t * obj, lv_color_t color);
 
 /**
  * Set the brightness of a LED object
- * @param led       pointer to a LED object
+ * @param obj       pointer to a LED object
  * @param bright    LV_LED_BRIGHT_MIN (max. dark) ... LV_LED_BRIGHT_MAX (max. light)
  */
-void lv_led_set_brightness(lv_obj_t * led, uint8_t bright);
+void lv_led_set_brightness(lv_obj_t * obj, uint8_t bright);
 
 /**
  * Light on a LED
@@ -83,9 +83,9 @@ void lv_led_off(lv_obj_t * led);
 
 /**
  * Toggle the state of a LED
- * @param led       pointer to a LED object
+ * @param obj       pointer to a LED object
  */
-void lv_led_toggle(lv_obj_t * led);
+void lv_led_toggle(lv_obj_t * obj);
 
 /**
  * Get the brightness of a LED object

--- a/include/lvgl/widgets/lv_msgbox.h
+++ b/include/lvgl/widgets/lv_msgbox.h
@@ -117,15 +117,15 @@ lv_obj_t * lv_msgbox_get_title(lv_obj_t * obj);
 
 /**
  * Close a message box
- * @param mbox           pointer to a message box
+ * @param obj            pointer to a message box
  */
-void lv_msgbox_close(lv_obj_t * mbox);
+void lv_msgbox_close(lv_obj_t * obj);
 
 /**
  * Close a message box in the next call of the message box
- * @param mbox           pointer to a message box
+ * @param obj            pointer to a message box
  */
-void lv_msgbox_close_async(lv_obj_t * mbox);
+void lv_msgbox_close_async(lv_obj_t * obj);
 
 /**********************
  *      MACROS

--- a/include/lvgl/widgets/lv_scale.h
+++ b/include/lvgl/widgets/lv_scale.h
@@ -145,7 +145,7 @@ void lv_scale_set_min_value(lv_obj_t * obj, int32_t min);
 /**
  * Set maximum values on Scale.
  * @param obj       pointer to Scale Widget
- * @param min       minimum value of Scale
+ * @param max       maximum value of Scale
  */
 void lv_scale_set_max_value(lv_obj_t * obj, int32_t max);
 
@@ -153,7 +153,7 @@ void lv_scale_set_max_value(lv_obj_t * obj, int32_t max);
  * Set angle between the low end and the high end of the Scale.
  * (Applies only to round Scales.)
  * @param obj         pointer to Scale Widget
- * @param max_angle   angle in degrees from Scale minimum where top end of Scale will be drawn
+ * @param angle_range angle in degrees from Scale minimum where top end of Scale will be drawn
  */
 void lv_scale_set_angle_range(lv_obj_t * obj, uint32_t angle_range);
 
@@ -236,8 +236,8 @@ lv_scale_section_t * lv_scale_add_section(lv_obj_t * obj);
  * DEPRECATED, use lv_scale_set_section_range instead.
  * Set range for specified Scale Section
  * @param section       pointer to Section
- * @param range_min     Section new minimum value
- * @param range_max     Section new maximum value
+ * @param min           Section new minimum value
+ * @param max           Section new maximum value
  */
 void lv_scale_section_set_range(lv_scale_section_t * section, int32_t min, int32_t max);
 
@@ -245,8 +245,8 @@ void lv_scale_section_set_range(lv_scale_section_t * section, int32_t min, int32
  * Set the range of a scale section
  * @param scale         pointer to scale
  * @param section       pointer to section
- * @param range_min     the section's new minimum value
- * @param range_max     the section's new maximum value
+ * @param min           the section's new minimum value
+ * @param max           the section's new maximum value
  */
 void lv_scale_set_section_range(lv_obj_t * scale, lv_scale_section_t * section, int32_t min, int32_t max);
 

--- a/include/lvgl/widgets/lv_slider.h
+++ b/include/lvgl/widgets/lv_slider.h
@@ -169,7 +169,7 @@ lv_slider_mode_t lv_slider_get_mode(lv_obj_t * slider);
  * @param obj       pointer to a slider object
  * @return          slider orientation from `lv_slider_orientation_t`
  */
-lv_slider_orientation_t lv_slider_get_orientation(lv_obj_t * slider);
+lv_slider_orientation_t lv_slider_get_orientation(lv_obj_t * obj);
 
 /**
  * Give the slider is in symmetrical mode or not

--- a/include/lvgl/widgets/lv_span.h
+++ b/include/lvgl/widgets/lv_span.h
@@ -154,13 +154,6 @@ void lv_spangroup_set_span_text_static(lv_obj_t * obj, lv_span_t * span, const c
  */
 void lv_spangroup_set_span_text_fmt(lv_obj_t * obj, lv_span_t * span, const char * fmt, ...) LV_FORMAT_ATTRIBUTE(3, 4);
 
-/**
- * Set a static text. It will not be saved by the span so the 'text' variable
- * has to be 'alive' while the span exist.
- * @param span  pointer to a span.
- * @param text  pointer to a text.
- */
-void lv_span_set_text_static(lv_span_t * span, const char * text);
 
 /**
  * Copy all style properties of style to the bbuilt-in static style of the span.
@@ -334,10 +327,10 @@ lv_span_coords_t lv_spangroup_get_span_coords(lv_obj_t * obj, const lv_span_t * 
 /**
  * Get the span object by point.
  * @param obj       pointer to a spangroup object.
- * @param point     pointer to point containing absolute coordinates
+ * @param p         pointer to point containing absolute coordinates
  * @return          pointer to the span under the point or `NULL` if not found.
  */
-lv_span_t * lv_spangroup_get_span_by_point(lv_obj_t * obj, const lv_point_t * point);
+lv_span_t * lv_spangroup_get_span_by_point(lv_obj_t * obj, const lv_point_t * p);
 
 /*=====================
  * Other functions

--- a/include/lvgl/widgets/lv_tileview.h
+++ b/include/lvgl/widgets/lv_tileview.h
@@ -47,11 +47,11 @@ lv_obj_t * lv_tileview_add_tile(lv_obj_t * tv, uint8_t col_id, uint8_t row_id, l
 
 /**
  * Set the active tile in the tileview.
- * @param parent      pointer to the tileview object
+ * @param obj         pointer to the tileview object
  * @param tile_obj    pointer to the tile object to be set as active
  * @param anim_en     animation enable flag (LV_ANIM_ON or LV_ANIM_OFF)
  */
-void lv_tileview_set_tile(lv_obj_t * tv, lv_obj_t * tile_obj, lv_anim_enable_t anim_en);
+void lv_tileview_set_tile(lv_obj_t * obj, lv_obj_t * tile_obj, lv_anim_enable_t anim_en);
 
 /**
  * Set the active tile by index in the tileview

--- a/include/lvgl/widgets/lv_win.h
+++ b/include/lvgl/widgets/lv_win.h
@@ -46,7 +46,7 @@ lv_obj_t * lv_win_create(lv_obj_t * parent);
 
 /**
  * Add a title to the window
- * @param obj       pointer to a window widget
+ * @param win       pointer to a window widget
  * @param txt       the text of the title
  * @return          the widget where the content of the title can be created
  * @deprecated The `lv_win` widget is deprecated. See `lv_example_flex_win`.
@@ -56,7 +56,7 @@ lv_obj_t * lv_win_add_title(lv_obj_t * win, const char * txt);
 
 /**
  * Add a button to the window
- * @param obj       pointer to a window widget
+ * @param win       pointer to a window widget
  * @param icon      an icon to be displayed on the button
  * @param btn_w     width of the button
  * @return          the widget where the content of the button can be created

--- a/libs/nema_gfx/include/cortex_m33/nema_vg_context.h
+++ b/libs/nema_gfx/include/cortex_m33/nema_vg_context.h
@@ -43,14 +43,17 @@
 extern "C" {
 #endif
 
-
+/** NemaVG handle object (void pointer)*/
 #ifndef NEMA_VG_HANDLE
-#define NEMA_VG_HANDLE void* /**< NemaVG handle object (void pointer)*/
+#define NEMA_VG_HANDLE void*
 #endif
 
-#define NEMA_VG_PATH_HANDLE NEMA_VG_HANDLE  /**< NemaVG path handle (pointer to path object)*/
-#define NEMA_VG_PAINT_HANDLE NEMA_VG_HANDLE /**< NemaVG paint handle (pointer to paint object)*/
-#define NEMA_VG_GRAD_HANDLE NEMA_VG_HANDLE  /**< NemaVG gradient handle (pointer to gradient object)*/
+/** NemaVG path handle (pointer to path object)*/
+#define NEMA_VG_PATH_HANDLE NEMA_VG_HANDLE
+/** NemaVG paint handle (pointer to paint object)*/
+#define NEMA_VG_PAINT_HANDLE NEMA_VG_HANDLE
+/** NemaVG gradient handle (pointer to gradient object)*/
+#define NEMA_VG_GRAD_HANDLE NEMA_VG_HANDLE
 
 typedef float nema_vg_float_t; /**< Floating point data type (default is 'float') */
 
@@ -134,27 +137,28 @@ void nema_vg_set_fill_rule(uint8_t fill_rule);
  */
 void nema_vg_stroke_set_width(float width);
 
- /** \brief Set stroke cap style
- *
- * \param cap_style Cap style (NEMA_VG_CAP_BUTT | NEMA_VG_CAP_SQUARE | NEMA_VG_CAP_ROUND)
- *
- */
+/** \brief Set stroke cap style
+*
+* \param start_cap_style Cap style for the start of the stroke (NEMA_VG_CAP_BUTT | NEMA_VG_CAP_SQUARE | NEMA_VG_CAP_ROUND)
+* \param end_cap_style Cap style for the end of the stroke (NEMA_VG_CAP_BUTT | NEMA_VG_CAP_SQUARE | NEMA_VG_CAP_ROUND)
+*
+*/
 void nema_vg_stroke_set_cap_style(uint8_t start_cap_style, uint8_t end_cap_style);
 
- /** \brief Set stroke join style
- *
- * \param join_style Join style (NEMA_VG_JOIN_BEVEL | NEMA_VG_JOIN_MITER | NEMA_VG_JOIN_ROUND)
- *
- */
+/** \brief Set stroke join style
+*
+* \param join_style Join style (NEMA_VG_JOIN_BEVEL | NEMA_VG_JOIN_MITER | NEMA_VG_JOIN_ROUND)
+*
+*/
 void nema_vg_stroke_set_join_style(uint8_t join_style);
 
- /** \brief Set stroke miter limit
- * If miter join is chosen and miter length is bigger than the product
- * of miter limit and stroke width a bevel join will be added instead
- *
- * \param miter_limit miter join limit to be set
- *
- */
+/** \brief Set stroke miter limit
+* If miter join is chosen and miter length is bigger than the product
+* of miter limit and stroke width a bevel join will be added instead
+*
+* \param miter_limit miter join limit to be set
+*
+*/
 void nema_vg_stroke_set_miter_limit(float miter_limit);
 
 /** \brief Enable/Disable Masking.
@@ -170,7 +174,7 @@ void nema_vg_masking(uint8_t masking);
  * \return Error code. If no error occurs, NEMA_VG_ERR_NO_ERROR otherwise NEMA_VG_ERR_INVALID_MASKING_FORMAT.
  *
  */
-uint32_t nema_vg_set_mask(nema_img_obj_t *mask_obj);
+uint32_t nema_vg_set_mask(nema_img_obj_t * mask_obj);
 
 /** \brief Translate the mask object (texture) with respect to origin point (0, 0). Sets the position of the mask object.
  *
@@ -218,7 +222,7 @@ void nema_vg_handle_large_coords(uint8_t enable, uint8_t allow_internal_alloc);
  * \param data_size_bytes Data buffer size in bytes
  *
  */
-uint32_t nema_vg_bind_clip_coords_buf(void *segs, uint32_t segs_size_bytes, void *data, uint32_t data_size_bytes);
+uint32_t nema_vg_bind_clip_coords_buf(void * segs, uint32_t segs_size_bytes, void * data, uint32_t data_size_bytes);
 
 /** \brief Unbind segment and data buffers to be used for handling large coordinates
  *

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -1813,7 +1813,7 @@ static void lv_obj_event(const lv_obj_class_t * class_p, lv_event_t * e)
  * Set the state (fully overwrite) of an object.
  * If specified in the styles, transition animations will be started from the previous state to the current.
  * @param obj       pointer to an object
- * @param state     the new state
+ * @param new_state the new state
  */
 static void update_obj_state(lv_obj_t * obj, lv_state_t new_state)
 {

--- a/src/core/lv_obj_style_private.h
+++ b/src/core/lv_obj_style_private.h
@@ -65,10 +65,10 @@ void lv_obj_style_deinit(void);
  * @param part
  * @param prev_state
  * @param new_state
- * @param tr
+ * @param tr_dsc
  */
 void lv_obj_style_create_transition(lv_obj_t * obj, lv_part_t part, lv_state_t prev_state,
-                                    lv_state_t new_state, const lv_obj_style_transition_dsc_t * tr);
+                                    lv_state_t new_state, const lv_obj_style_transition_dsc_t * tr_dsc);
 
 /**
  * Used internally to compare the appearance of an object in 2 states

--- a/src/core/lv_observer.c
+++ b/src/core/lv_observer.c
@@ -414,23 +414,23 @@ void lv_subject_deinit(lv_subject_t * subject)
     lv_ll_clear(&subject->subs_ll);
 }
 
-lv_observer_t * lv_subject_add_observer(lv_subject_t * subject, lv_observer_cb_t cb, void * user_data)
+lv_observer_t * lv_subject_add_observer(lv_subject_t * subject, lv_observer_cb_t observer_cb, void * user_data)
 {
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(cb != NULL, return NULL);
+    LV_CHECK_ARG(observer_cb != NULL, return NULL);
 
-    lv_observer_t * observer = lv_subject_add_observer_obj(subject, cb, NULL, user_data);
+    lv_observer_t * observer = lv_subject_add_observer_obj(subject, observer_cb, NULL, user_data);
     if(observer == NULL) return NULL;
 
     observer->for_obj = 0;
     return observer;
 }
 
-lv_observer_t * lv_subject_add_observer_obj(lv_subject_t * subject, lv_observer_cb_t cb, lv_obj_t * obj,
+lv_observer_t * lv_subject_add_observer_obj(lv_subject_t * subject, lv_observer_cb_t observer_cb, lv_obj_t * obj,
                                             void * user_data)
 {
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(cb != NULL, return NULL);
+    LV_CHECK_ARG(observer_cb != NULL, return NULL);
     LV_CHECK_ARG(subject->type != LV_SUBJECT_TYPE_INVALID, return NULL);
 
     lv_observer_t * observer = lv_ll_ins_tail(&(subject->subs_ll));
@@ -440,7 +440,7 @@ lv_observer_t * lv_subject_add_observer_obj(lv_subject_t * subject, lv_observer_
     lv_memzero(observer, sizeof(*observer));
 
     observer->subject = subject;
-    observer->cb = cb;
+    observer->cb = observer_cb;
     observer->user_data = user_data;
     observer->target = obj;
     observer->for_obj = 1;
@@ -455,11 +455,11 @@ lv_observer_t * lv_subject_add_observer_obj(lv_subject_t * subject, lv_observer_
     return observer;
 }
 
-lv_observer_t * lv_subject_add_observer_with_target(lv_subject_t * subject, lv_observer_cb_t cb, void * target,
+lv_observer_t * lv_subject_add_observer_with_target(lv_subject_t * subject, lv_observer_cb_t observer_cb, void * target,
                                                     void * user_data)
 {
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(cb != NULL, return NULL);
+    LV_CHECK_ARG(observer_cb != NULL, return NULL);
     LV_CHECK_ARG(subject->type != LV_SUBJECT_TYPE_INVALID, return NULL);
 
     lv_observer_t * observer = lv_ll_ins_tail(&(subject->subs_ll));
@@ -469,7 +469,7 @@ lv_observer_t * lv_subject_add_observer_with_target(lv_subject_t * subject, lv_o
     lv_memzero(observer, sizeof(*observer));
 
     observer->subject = subject;
-    observer->cb = cb;
+    observer->cb = observer_cb;
     observer->user_data = user_data;
     observer->target = target;
 

--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -359,18 +359,18 @@ void lv_refr_set_disp_refreshing(lv_display_t * disp)
     disp_refr = disp;
 }
 
-void lv_display_refr_timer(lv_timer_t * tmr)
+void lv_display_refr_timer(lv_timer_t * timer)
 {
     LV_PROFILER_REFR_BEGIN;
     LV_TRACE_REFR("begin");
 
-    if(tmr) {
-        disp_refr = tmr->user_data;
+    if(timer) {
+        disp_refr = timer->user_data;
         /* Ensure the timer does not run again automatically.
          * This is done before refreshing in case refreshing invalidates something else.
          * However if the performance monitor is enabled keep the timer running to count the FPS.*/
 #if !LV_USE_PERF_MONITOR
-        lv_timer_pause(tmr);
+        lv_timer_pause(timer);
 #endif
     }
     else {
@@ -1129,8 +1129,8 @@ static void refr_configured_layer(lv_layer_t * layer)
 
 /**
  * Make the refreshing from an object. Draw all its children and the youngers too.
- * @param top_p pointer to an objects. Start the drawing from it.
- * @param mask_p pointer to an area, the objects will be drawn only here
+ * @param layer pointer to the layer to draw into
+ * @param top_obj pointer to an object. Start the drawing from it.
  */
 static void refr_obj_and_children(lv_layer_t * layer, lv_obj_t * top_obj)
 {

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -791,13 +791,13 @@ void lv_screen_load(struct _lv_obj_t * scr)
     lv_screen_load_anim(scr, LV_SCREEN_LOAD_ANIM_NONE, 0, 0, false);
 }
 
-void lv_screen_load_anim(lv_obj_t * new_scr, lv_screen_load_anim_t anim_type, uint32_t time, uint32_t delay,
+void lv_screen_load_anim(lv_obj_t * scr, lv_screen_load_anim_t anim_type, uint32_t time, uint32_t delay,
                          bool auto_del)
 {
-    lv_display_t * d = lv_obj_get_display(new_scr);
+    lv_display_t * d = lv_obj_get_display(scr);
     lv_obj_t * act_scr = d->act_scr;
 
-    if(act_scr == new_scr || d->scr_to_load == new_scr) {
+    if(act_scr == scr || d->scr_to_load == scr) {
         return;
     }
 
@@ -822,7 +822,7 @@ void lv_screen_load_anim(lv_obj_t * new_scr, lv_screen_load_anim_t anim_type, ui
         }
     }
 
-    d->scr_to_load = new_scr;
+    d->scr_to_load = scr;
 
     if(d->prev_scr && d->del_prev) {
         lv_obj_delete(d->prev_scr);
@@ -833,18 +833,18 @@ void lv_screen_load_anim(lv_obj_t * new_scr, lv_screen_load_anim_t anim_type, ui
     d->del_prev = auto_del;
 
     /*Be sure there is no other animation on the screens*/
-    lv_anim_delete(new_scr, NULL);
+    lv_anim_delete(scr, NULL);
     if(act_scr) lv_anim_delete(act_scr, NULL);
 
     /*Be sure both screens are in a normal position*/
-    lv_obj_set_pos(new_scr, 0, 0);
+    lv_obj_set_pos(scr, 0, 0);
     if(act_scr) lv_obj_set_pos(act_scr, 0, 0);
-    lv_obj_remove_local_style_prop(new_scr, LV_STYLE_OPA, 0);
+    lv_obj_remove_local_style_prop(scr, LV_STYLE_OPA, 0);
     if(act_scr) lv_obj_remove_local_style_prop(act_scr, LV_STYLE_OPA, 0);
 
     /*Shortcut for immediate load*/
     if(time == 0 && delay == 0) {
-        lv_load_screen_result_t res = load_new_screen(new_scr);
+        lv_load_screen_result_t res = load_new_screen(scr);
         if(res == LV_LOAD_SCREEN_RESULT_DISPLAY_DELETED) {
             return;
         }
@@ -859,7 +859,7 @@ void lv_screen_load_anim(lv_obj_t * new_scr, lv_screen_load_anim_t anim_type, ui
 
     lv_anim_t a_new;
     lv_anim_init(&a_new);
-    lv_anim_set_var(&a_new, new_scr);
+    lv_anim_set_var(&a_new, scr);
     lv_anim_set_start_cb(&a_new, scr_load_anim_start);
     lv_anim_set_completed_cb(&a_new, scr_anim_completed);
     lv_anim_set_duration(&a_new, time);

--- a/src/draw/convert/lv_draw_buf_convert.h
+++ b/src/draw/convert/lv_draw_buf_convert.h
@@ -26,9 +26,9 @@ extern "C" {
 
 /**
  * Convert draw_buf  to premultiplied format
- * @param buf     pointer to a draw buf
+ * @param draw_buf pointer to a draw buf
  */
-lv_result_t lv_draw_buf_convert_premultiply(lv_draw_buf_t * buf);
+lv_result_t lv_draw_buf_convert_premultiply(lv_draw_buf_t * draw_buf);
 
 
 #ifdef __cplusplus

--- a/src/draw/lv_draw_buf.c
+++ b/src/draw/lv_draw_buf.c
@@ -107,14 +107,14 @@ uint32_t lv_draw_buf_width_to_stride_ex(const lv_draw_buf_handlers_t * handlers,
     else return 0;
 }
 
-void * lv_draw_buf_align(void * data, lv_color_format_t color_format)
+void * lv_draw_buf_align(void * buf, lv_color_format_t color_format)
 {
-    return lv_draw_buf_align_ex(&default_handlers, data, color_format);
+    return lv_draw_buf_align_ex(&default_handlers, buf, color_format);
 }
 
-void * lv_draw_buf_align_ex(const lv_draw_buf_handlers_t * handlers, void * data, lv_color_format_t color_format)
+void * lv_draw_buf_align_ex(const lv_draw_buf_handlers_t * handlers, void * buf, lv_color_format_t color_format)
 {
-    if(handlers->align_pointer_cb) return handlers->align_pointer_cb(data, color_format);
+    if(handlers->align_pointer_cb) return handlers->align_pointer_cb(buf, color_format);
     else return NULL;
 }
 

--- a/src/draw/lv_draw_image.c
+++ b/src/draw/lv_draw_image.c
@@ -90,7 +90,7 @@ void lv_draw_layer(lv_layer_t * layer, const lv_draw_image_dsc_t * dsc, const lv
     LV_PROFILER_DRAW_END;
 }
 
-void lv_draw_image(lv_layer_t * layer, const lv_draw_image_dsc_t * dsc, const lv_area_t * image_coords)
+void lv_draw_image(lv_layer_t * layer, const lv_draw_image_dsc_t * dsc, const lv_area_t * coords)
 {
     if(dsc->src == NULL) {
         LV_LOG_WARN("Image draw: src is NULL");
@@ -106,11 +106,11 @@ void lv_draw_image(lv_layer_t * layer, const lv_draw_image_dsc_t * dsc, const lv
     LV_PROFILER_DRAW_BEGIN;
 
     if(dsc->base.drop_shadow_opa) {
-        lv_layer_t * ds_layer = lv_draw_layer_create_drop_shadow(layer, &dsc->base, image_coords);
+        lv_layer_t * ds_layer = lv_draw_layer_create_drop_shadow(layer, &dsc->base, coords);
         LV_ASSERT_NULL(ds_layer);
         lv_draw_image_dsc_t ds_dsc = *dsc;
         ds_dsc.base.drop_shadow_opa = 0; /*Disable drop shadow so rendering below will render plain image*/
-        lv_draw_image(ds_layer, &ds_dsc, image_coords);
+        lv_draw_image(ds_layer, &ds_dsc, coords);
         lv_draw_layer_finish_drop_shadow(ds_layer, &dsc->base);
     }
 
@@ -125,17 +125,17 @@ void lv_draw_image(lv_layer_t * layer, const lv_draw_image_dsc_t * dsc, const lv
 
     /*If the image_area is not set assume that it's the same as the rendering area */
     if(new_image_dsc.image_area.x2 == LV_COORD_MIN) {
-        new_image_dsc.image_area = *image_coords;
+        new_image_dsc.image_area = *coords;
     }
 
     /*Typical case, draw the image as bitmap*/
     if(!(new_image_dsc.header.flags & LV_IMAGE_FLAGS_CUSTOM_DRAW)) {
-        lv_draw_task_t * t = lv_draw_add_task(layer, image_coords, LV_DRAW_TASK_TYPE_IMAGE);
+        lv_draw_task_t * t = lv_draw_add_task(layer, coords, LV_DRAW_TASK_TYPE_IMAGE);
         lv_memcpy(t->draw_dsc, &new_image_dsc, sizeof(lv_draw_image_dsc_t));
 
-        lv_image_buf_get_transformed_area(&t->_real_area, lv_area_get_width(image_coords), lv_area_get_height(image_coords),
+        lv_image_buf_get_transformed_area(&t->_real_area, lv_area_get_width(coords), lv_area_get_height(coords),
                                           dsc->rotation, dsc->scale_x, dsc->scale_y, &dsc->pivot);
-        lv_area_move(&t->_real_area, image_coords->x1, image_coords->y1);
+        lv_area_move(&t->_real_area, coords->x1, coords->y1);
 
         lv_draw_finalize_task_creation(layer, t);
     }
@@ -152,15 +152,15 @@ void lv_draw_image(lv_layer_t * layer, const lv_draw_image_dsc_t * dsc, const lv
 
         if(decoder_dsc.decoder && decoder_dsc.decoder->custom_draw_cb) {
             lv_area_t draw_area = layer->buf_area;
-            lv_area_t coords_area = *image_coords;
+            lv_area_t coords_area = *coords;
 
             lv_area_t obj_area = dsc->base.obj->coords;
             if(layer->parent) { /* child layer */
                 if(lv_area_intersect(&coords_area, &coords_area, &obj_area)) {
-                    int32_t xpos = image_coords->x1 - draw_area.x1;
-                    int32_t ypos = image_coords->y1 - draw_area.y1;
+                    int32_t xpos = coords->x1 - draw_area.x1;
+                    int32_t ypos = coords->y1 - draw_area.y1;
 
-                    lv_area_move(&coords_area, -(image_coords->x1 - xpos), -(image_coords->y1 - ypos));
+                    lv_area_move(&coords_area, -(coords->x1 - xpos), -(coords->y1 - ypos));
                     layer->_clip_area = coords_area;
                     decoder_dsc.decoder->custom_draw_cb(layer, &decoder_dsc, &coords_area, &new_image_dsc, &coords_area);
                 }
@@ -169,13 +169,13 @@ void lv_draw_image(lv_layer_t * layer, const lv_draw_image_dsc_t * dsc, const lv
                 lv_area_t clip_area = draw_area;
                 if(lv_area_intersect(&clip_area, &clip_area, &coords_area)) {
 
-                    lv_image_buf_get_transformed_area(&coords_area, lv_area_get_width(image_coords), lv_area_get_height(image_coords),
+                    lv_image_buf_get_transformed_area(&coords_area, lv_area_get_width(coords), lv_area_get_height(coords),
                                                       dsc->rotation, dsc->scale_x, dsc->scale_y, &dsc->pivot);
-                    lv_area_move(&coords_area, image_coords->x1, image_coords->y1);
+                    lv_area_move(&coords_area, coords->x1, coords->y1);
 
-                    lv_image_buf_get_transformed_area(&clip_area, lv_area_get_width(image_coords), lv_area_get_height(image_coords),
+                    lv_image_buf_get_transformed_area(&clip_area, lv_area_get_width(coords), lv_area_get_height(coords),
                                                       dsc->rotation, dsc->scale_x, dsc->scale_y, &dsc->pivot);
-                    lv_area_move(&clip_area, image_coords->x1, image_coords->y1);
+                    lv_area_move(&clip_area, coords->x1, coords->y1);
 
                     if(lv_area_intersect(&clip_area, &clip_area, &obj_area)) {
                         decoder_dsc.decoder->custom_draw_cb(layer, &decoder_dsc, &coords_area, &new_image_dsc, &clip_area);

--- a/src/draw/lv_draw_triangle.c
+++ b/src/draw/lv_draw_triangle.c
@@ -33,17 +33,17 @@
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_triangle_dsc_init(lv_draw_triangle_dsc_t * dsc)
+void lv_draw_triangle_dsc_init(lv_draw_triangle_dsc_t * draw_dsc)
 {
     LV_PROFILER_DRAW_BEGIN;
-    lv_memzero(dsc, sizeof(lv_draw_triangle_dsc_t));
-    dsc->color = lv_color_white();
-    dsc->grad.stops[0].color = lv_color_white();
-    dsc->grad.stops[1].color = lv_color_black();
-    dsc->grad.stops[1].frac = 0xFF;
-    dsc->grad.stops_count = 2;
-    dsc->opa = LV_OPA_COVER;
-    dsc->base.dsc_size = sizeof(lv_draw_triangle_dsc_t);
+    lv_memzero(draw_dsc, sizeof(lv_draw_triangle_dsc_t));
+    draw_dsc->color = lv_color_white();
+    draw_dsc->grad.stops[0].color = lv_color_white();
+    draw_dsc->grad.stops[1].color = lv_color_black();
+    draw_dsc->grad.stops[1].frac = 0xFF;
+    draw_dsc->grad.stops_count = 2;
+    draw_dsc->opa = LV_OPA_COVER;
+    draw_dsc->base.dsc_size = sizeof(lv_draw_triangle_dsc_t);
     LV_PROFILER_DRAW_END;
 }
 
@@ -52,31 +52,31 @@ lv_draw_triangle_dsc_t * lv_draw_task_get_triangle_dsc(lv_draw_task_t * task)
     return task->type == LV_DRAW_TASK_TYPE_TRIANGLE ? (lv_draw_triangle_dsc_t *)task->draw_dsc : NULL;
 }
 
-void lv_draw_triangle(lv_layer_t * layer, const lv_draw_triangle_dsc_t * dsc)
+void lv_draw_triangle(lv_layer_t * layer, const lv_draw_triangle_dsc_t * draw_dsc)
 {
-    if(dsc->opa <= LV_OPA_MIN) return;
+    if(draw_dsc->opa <= LV_OPA_MIN) return;
 
     LV_PROFILER_DRAW_BEGIN;
 
     lv_area_t a;
-    a.x1 = (int32_t)LV_MIN3(dsc->p[0].x, dsc->p[1].x, dsc->p[2].x);
-    a.y1 = (int32_t)LV_MIN3(dsc->p[0].y, dsc->p[1].y, dsc->p[2].y);
-    a.x2 = (int32_t)LV_MAX3(dsc->p[0].x, dsc->p[1].x, dsc->p[2].x);
-    a.y2 = (int32_t)LV_MAX3(dsc->p[0].y, dsc->p[1].y, dsc->p[2].y);
+    a.x1 = (int32_t)LV_MIN3(draw_dsc->p[0].x, draw_dsc->p[1].x, draw_dsc->p[2].x);
+    a.y1 = (int32_t)LV_MIN3(draw_dsc->p[0].y, draw_dsc->p[1].y, draw_dsc->p[2].y);
+    a.x2 = (int32_t)LV_MAX3(draw_dsc->p[0].x, draw_dsc->p[1].x, draw_dsc->p[2].x);
+    a.y2 = (int32_t)LV_MAX3(draw_dsc->p[0].y, draw_dsc->p[1].y, draw_dsc->p[2].y);
 
-    if(dsc->base.drop_shadow_opa) {
-        lv_layer_t * ds_layer = lv_draw_layer_create_drop_shadow(layer, &dsc->base, &a);
+    if(draw_dsc->base.drop_shadow_opa) {
+        lv_layer_t * ds_layer = lv_draw_layer_create_drop_shadow(layer, &draw_dsc->base, &a);
         LV_ASSERT_NULL(ds_layer);
-        lv_draw_triangle_dsc_t ds_dsc = *dsc;
+        lv_draw_triangle_dsc_t ds_dsc = *draw_dsc;
         ds_dsc.base.drop_shadow_opa = 0; /*Disable drop shadow so rendering below will render plain triangle*/
         lv_draw_triangle(ds_layer, &ds_dsc);
-        lv_draw_layer_finish_drop_shadow(ds_layer, &dsc->base);
+        lv_draw_layer_finish_drop_shadow(ds_layer, &draw_dsc->base);
     }
 
 
     lv_draw_task_t * t = lv_draw_add_task(layer, &a, LV_DRAW_TASK_TYPE_TRIANGLE);
 
-    lv_memcpy(t->draw_dsc, dsc, sizeof(*dsc));
+    lv_memcpy(t->draw_dsc, draw_dsc, sizeof(*draw_dsc));
 
     lv_draw_finalize_task_creation(layer, t);
     LV_PROFILER_DRAW_END;

--- a/src/draw/lv_draw_vector.c
+++ b/src/draw/lv_draw_vector.c
@@ -213,7 +213,7 @@ static lv_fpoint_t _point_on_ellipse(float rx, float ry, float cos_r, float sin_
     };
 }
 
-void lv_vector_path_arc_to(lv_vector_path_t * path, float rx, float ry, float rotate_angle, bool large_arc,
+void lv_vector_path_arc_to(lv_vector_path_t * path, float radius_x, float radius_y, float rotate_angle, bool large_arc,
                            bool clockwise, const lv_fpoint_t * p)
 {
     LV_ASSERT_NULL(path);
@@ -224,7 +224,7 @@ void lv_vector_path_arc_to(lv_vector_path_t * path, float rx, float ry, float ro
         return;
     }
 
-    if(rx <= 0 || ry <= 0) {
+    if(radius_x <= 0 || radius_y <= 0) {
         /*no needed to draw*/
         return;
     }
@@ -254,15 +254,15 @@ void lv_vector_path_arc_to(lv_vector_path_t * path, float rx, float ry, float ro
     float y1 = -sin_r * dx + cos_r * dy;
 
     /*3. adjust radius*/
-    float lambda_val = (x1 * x1) / (rx * rx) + (y1 * y1) / (ry * ry);
+    float lambda_val = (x1 * x1) / (radius_x * radius_x) + (y1 * y1) / (radius_y * radius_y);
     if(lambda_val > 1.0f) {
-        rx *= sqrtf(lambda_val);
-        ry *= sqrtf(lambda_val);
+        radius_x *= sqrtf(lambda_val);
+        radius_y *= sqrtf(lambda_val);
     }
 
     /*4. calc center point*/
-    float rx_sq = rx * rx;
-    float ry_sq = ry * ry;
+    float rx_sq = radius_x * radius_x;
+    float ry_sq = radius_y * radius_y;
     float x1_sq = x1 * x1;
     float y1_sq = y1 * y1;
 
@@ -275,14 +275,14 @@ void lv_vector_path_arc_to(lv_vector_path_t * path, float rx, float ry, float ro
     float sign = (large_arc == clockwise) ? -1.0f : 1.0f;
     float coef = sign * sqrtf(radicand);
 
-    float cx_prime = (coef * rx * y1) / ry;
-    float cy_prime = -(coef * ry * x1) / rx;
+    float cx_prime = (coef * radius_x * y1) / radius_y;
+    float cy_prime = -(coef * radius_y * x1) / radius_x;
 
     float cx = cos_r * cx_prime - sin_r * cy_prime + (x0 + p->x) * 0.5f;
     float cy = sin_r * cx_prime + cos_r * cy_prime + (y0 + p->y) * 0.5f;
 
-    float ux = (x1 - cx_prime) / rx;
-    float uy = (y1 - cy_prime) / ry;
+    float ux = (x1 - cx_prime) / radius_x;
+    float uy = (y1 - cy_prime) / radius_y;
 
     /*5. calculate the starting angle and ending angle*/
     float n_sq = ux * ux + uy * uy;
@@ -291,8 +291,8 @@ void lv_vector_path_arc_to(lv_vector_path_t * path, float rx, float ry, float ro
         theta1 = atan2f(uy, ux);
     }
 
-    float vx = (-x1 - cx_prime) / rx;
-    float vy = (-y1 - cy_prime) / ry;
+    float vx = (-x1 - cx_prime) / radius_x;
+    float vy = (-y1 - cy_prime) / radius_y;
 
     float n = sqrtf(n_sq * (vx * vx + vy * vy));
     float delta = 0.0f;
@@ -332,9 +332,9 @@ void lv_vector_path_arc_to(lv_vector_path_t * path, float rx, float ry, float ro
             alpha_val = sinf(segment_angle) * (sqrtf(4.0f + 3.0f * tan_half * tan_half) - 1.0f) / 3.0f;
         }
 
-        lv_fpoint_t p1 = _point_on_ellipse(rx, ry, cos_r, sin_r, cx, cy, current_angle, alpha_val);
-        lv_fpoint_t p2 = _point_on_ellipse(rx, ry, cos_r, sin_r, cx, cy, next_angle, -alpha_val);
-        lv_fpoint_t p3 = _point_on_ellipse(rx, ry, cos_r, sin_r, cx, cy, next_angle, 0.0f);
+        lv_fpoint_t p1 = _point_on_ellipse(radius_x, radius_y, cos_r, sin_r, cx, cy, current_angle, alpha_val);
+        lv_fpoint_t p2 = _point_on_ellipse(radius_x, radius_y, cos_r, sin_r, cx, cy, next_angle, -alpha_val);
+        lv_fpoint_t p3 = _point_on_ellipse(radius_x, radius_y, cos_r, sin_r, cx, cy, next_angle, 0.0f);
 
         lv_vector_path_cubic_to(path, &p1, &p2, &p3);
 
@@ -952,7 +952,7 @@ void lv_draw_vector_dsc_skew(lv_draw_vector_dsc_t * dsc, float skew_x, float ske
     lv_matrix_skew(&(dsc->ctx->matrix), skew_x, skew_y);
 }
 
-void lv_vector_for_each_destroy_tasks(lv_ll_t * task_list, vector_draw_task_cb cb, void * data)
+void lv_vector_for_each_destroy_tasks(lv_ll_t * task_list, vector_draw_task_cb cb, void * user_data)
 {
     if(task_list == NULL) return;
 
@@ -964,7 +964,7 @@ void lv_vector_for_each_destroy_tasks(lv_ll_t * task_list, vector_draw_task_cb c
         lv_ll_remove(task_list, task);
 
         if(cb) {
-            cb(data, task->path, &task->ctx);
+            cb(user_data, task->path, &task->ctx);
         }
 
         if(task->path) {

--- a/src/draw/lv_draw_vector_private.h
+++ b/src/draw/lv_draw_vector_private.h
@@ -128,7 +128,7 @@ typedef struct {
  * @param cb            the callback used to iterate through the task
  * @param user_data     a custom pointer that will be passed to the callback
  */
-void lv_vector_for_each_destroy_tasks(lv_ll_t * task_list, vector_draw_task_cb cb, void * used_data);
+void lv_vector_for_each_destroy_tasks(lv_ll_t * task_list, vector_draw_task_cb cb, void * user_data);
 
 /**********************
  *      MACROS

--- a/src/draw/sw/blend/lv_draw_sw_blend.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend.c
@@ -69,14 +69,14 @@ static inline void /* LV_ATTRIBUTE_FAST_MEM */ lv_draw_sw_blend_image(lv_color_f
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_sw_blend(lv_draw_task_t * t, const lv_draw_sw_blend_dsc_t * blend_dsc)
+void lv_draw_sw_blend(lv_draw_task_t * t, const lv_draw_sw_blend_dsc_t * dsc)
 {
     /*Do not draw transparent things*/
-    if(blend_dsc->opa <= LV_OPA_MIN) return;
-    if(blend_dsc->mask_buf && blend_dsc->mask_res == LV_DRAW_SW_MASK_RES_TRANSP) return;
+    if(dsc->opa <= LV_OPA_MIN) return;
+    if(dsc->mask_buf && dsc->mask_res == LV_DRAW_SW_MASK_RES_TRANSP) return;
 
     lv_area_t blend_area;
-    if(!lv_area_intersect(&blend_area, blend_dsc->blend_area, &t->clip_area)) return;
+    if(!lv_area_intersect(&blend_area, dsc->blend_area, &t->clip_area)) return;
 
     LV_PROFILER_DRAW_BEGIN;
     lv_layer_t * layer = t->target_layer;
@@ -84,23 +84,23 @@ void lv_draw_sw_blend(lv_draw_task_t * t, const lv_draw_sw_blend_dsc_t * blend_d
 
     lv_draw_sw_blend_handler_t handler = lv_draw_sw_get_blend_handler(layer->color_format);
     if(handler) {
-        handler(t, blend_dsc);
+        handler(t, dsc);
         LV_PROFILER_DRAW_END;
         return;
     }
 
-    if(blend_dsc->src_buf == NULL) {
+    if(dsc->src_buf == NULL) {
         lv_draw_sw_blend_fill_dsc_t fill_dsc;
         fill_dsc.dest_w = lv_area_get_width(&blend_area);
         fill_dsc.dest_h = lv_area_get_height(&blend_area);
         fill_dsc.dest_stride = layer_stride_byte;
-        fill_dsc.opa = blend_dsc->opa;
-        fill_dsc.color = blend_dsc->color;
+        fill_dsc.opa = dsc->opa;
+        fill_dsc.color = dsc->color;
         fill_dsc.mask_stride = 0;
 
-        if(blend_dsc->mask_buf == NULL) fill_dsc.mask_buf = NULL;
-        else if(blend_dsc->mask_res == LV_DRAW_SW_MASK_RES_FULL_COVER) fill_dsc.mask_buf = NULL;
-        else fill_dsc.mask_buf = blend_dsc->mask_buf;
+        if(dsc->mask_buf == NULL) fill_dsc.mask_buf = NULL;
+        else if(dsc->mask_res == LV_DRAW_SW_MASK_RES_FULL_COVER) fill_dsc.mask_buf = NULL;
+        else fill_dsc.mask_buf = dsc->mask_buf;
 
 
         fill_dsc.relative_area  = blend_area;
@@ -108,20 +108,20 @@ void lv_draw_sw_blend(lv_draw_task_t * t, const lv_draw_sw_blend_dsc_t * blend_d
         fill_dsc.dest_buf = lv_draw_layer_go_to_xy(layer, blend_area.x1 - layer->buf_area.x1,
                                                    blend_area.y1 - layer->buf_area.y1);
         if(fill_dsc.mask_buf) {
-            fill_dsc.mask_stride = blend_dsc->mask_stride == 0  ? lv_area_get_width(blend_dsc->mask_area) : blend_dsc->mask_stride;
-            fill_dsc.mask_buf += fill_dsc.mask_stride * (blend_area.y1 - blend_dsc->mask_area->y1) +
-                                 (blend_area.x1 - blend_dsc->mask_area->x1);
+            fill_dsc.mask_stride = dsc->mask_stride == 0  ? lv_area_get_width(dsc->mask_area) : dsc->mask_stride;
+            fill_dsc.mask_buf += fill_dsc.mask_stride * (blend_area.y1 - dsc->mask_area->y1) +
+                                 (blend_area.x1 - dsc->mask_area->x1);
         }
 
         lv_draw_sw_blend_color(layer->color_format, &fill_dsc);
     }
     else {
-        if(!lv_area_intersect(&blend_area, &blend_area, blend_dsc->src_area)) {
+        if(!lv_area_intersect(&blend_area, &blend_area, dsc->src_area)) {
             LV_PROFILER_DRAW_END;
             return;
         }
 
-        if(blend_dsc->mask_area && !lv_area_intersect(&blend_area, &blend_area, blend_dsc->mask_area)) {
+        if(dsc->mask_area && !lv_area_intersect(&blend_area, &blend_area, dsc->mask_area)) {
             LV_PROFILER_DRAW_END;
             return;
         }
@@ -131,34 +131,34 @@ void lv_draw_sw_blend(lv_draw_task_t * t, const lv_draw_sw_blend_dsc_t * blend_d
         image_dsc.dest_h = lv_area_get_height(&blend_area);
         image_dsc.dest_stride = layer_stride_byte;
 
-        image_dsc.opa = blend_dsc->opa;
-        image_dsc.blend_mode = blend_dsc->blend_mode;
-        image_dsc.src_stride = blend_dsc->src_stride;
-        image_dsc.src_color_format = blend_dsc->src_color_format;
+        image_dsc.opa = dsc->opa;
+        image_dsc.blend_mode = dsc->blend_mode;
+        image_dsc.src_stride = dsc->src_stride;
+        image_dsc.src_color_format = dsc->src_color_format;
 
-        const uint8_t * src_buf = blend_dsc->src_buf;
-        uint32_t src_px_size = lv_color_format_get_bpp(blend_dsc->src_color_format);
-        src_buf += image_dsc.src_stride * (blend_area.y1 - blend_dsc->src_area->y1);
-        src_buf += ((blend_area.x1 - blend_dsc->src_area->x1) * src_px_size) >> 3;
+        const uint8_t * src_buf = dsc->src_buf;
+        uint32_t src_px_size = lv_color_format_get_bpp(dsc->src_color_format);
+        src_buf += image_dsc.src_stride * (blend_area.y1 - dsc->src_area->y1);
+        src_buf += ((blend_area.x1 - dsc->src_area->x1) * src_px_size) >> 3;
         image_dsc.src_buf = src_buf;
         image_dsc.mask_stride = 0;
 
-        if(blend_dsc->mask_buf == NULL) image_dsc.mask_buf = NULL;
-        else if(blend_dsc->mask_res == LV_DRAW_SW_MASK_RES_FULL_COVER) image_dsc.mask_buf = NULL;
-        else image_dsc.mask_buf = blend_dsc->mask_buf;
+        if(dsc->mask_buf == NULL) image_dsc.mask_buf = NULL;
+        else if(dsc->mask_res == LV_DRAW_SW_MASK_RES_FULL_COVER) image_dsc.mask_buf = NULL;
+        else image_dsc.mask_buf = dsc->mask_buf;
 
         if(image_dsc.mask_buf) {
-            LV_ASSERT_NULL(blend_dsc->mask_area);
-            image_dsc.mask_buf = blend_dsc->mask_buf;
-            image_dsc.mask_stride = blend_dsc->mask_stride ? blend_dsc->mask_stride : lv_area_get_width(blend_dsc->mask_area);
-            image_dsc.mask_buf += image_dsc.mask_stride * (blend_area.y1 - blend_dsc->mask_area->y1) +
-                                  (blend_area.x1 - blend_dsc->mask_area->x1);
+            LV_ASSERT_NULL(dsc->mask_area);
+            image_dsc.mask_buf = dsc->mask_buf;
+            image_dsc.mask_stride = dsc->mask_stride ? dsc->mask_stride : lv_area_get_width(dsc->mask_area);
+            image_dsc.mask_buf += image_dsc.mask_stride * (blend_area.y1 - dsc->mask_area->y1) +
+                                  (blend_area.x1 - dsc->mask_area->x1);
         }
 
         image_dsc.relative_area  = blend_area;
         lv_area_move(&image_dsc.relative_area, -layer->buf_area.x1, -layer->buf_area.y1);
 
-        image_dsc.src_area  = *blend_dsc->src_area;
+        image_dsc.src_area  = *dsc->src_area;
         lv_area_move(&image_dsc.src_area, -layer->buf_area.x1, -layer->buf_area.y1);
 
         image_dsc.dest_buf = lv_draw_layer_go_to_xy(layer, blend_area.x1 - layer->buf_area.x1,

--- a/src/draw/sw/blend/lv_draw_sw_blend.h
+++ b/src/draw/sw/blend/lv_draw_sw_blend.h
@@ -44,7 +44,7 @@ typedef struct {
 
 /**
  * Call the blend function of the `layer`.
- * @param draw_unit     pointer to a draw unit
+ * @param t             pointer to a draw unit
  * @param dsc           pointer to an initialized blend descriptor
  */
 void lv_draw_sw_blend(lv_draw_task_t * t, const lv_draw_sw_blend_dsc_t * dsc);

--- a/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.c
@@ -239,13 +239,8 @@ static inline void * /* LV_ATTRIBUTE_FAST_MEM */ drawbuf_next_row(const void * b
  * Supports normal fill, fill with opacity, fill with mask, and fill with mask and opacity.
  * dest_buf and color have native color depth. (RGB565, RGB888, XRGB8888)
  * The background (dest_buf) cannot have alpha channel
- * @param dest_buf
- * @param dest_area
- * @param dest_stride
- * @param color
- * @param opa
- * @param mask
- * @param mask_stride
+ * @param dsc            the fill descriptor holding the destination buffer, area and
+ *                       stride, the fill color, the opacity and the optional mask
  */
 void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_rgb565(lv_draw_sw_blend_fill_dsc_t * dsc)
 {

--- a/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565_swapped.c
+++ b/src/draw/sw/blend/lv_draw_sw_blend_to_rgb565_swapped.c
@@ -235,13 +235,8 @@ static inline void * /* LV_ATTRIBUTE_FAST_MEM */ drawbuf_next_row(const void * b
  * Supports normal fill, fill with opacity, fill with mask, and fill with mask and opacity.
  * dest_buf and color have native color depth. (RGB565, RGB888, XRGB8888)
  * The background (dest_buf) cannot have alpha channel
- * @param dest_buf
- * @param dest_area
- * @param dest_stride
- * @param color
- * @param opa
- * @param mask
- * @param mask_stride
+ * @param dsc            the fill descriptor holding the destination buffer, area and
+ *                       stride, the fill color, the opacity and the optional mask
  */
 void LV_ATTRIBUTE_FAST_MEM lv_draw_sw_blend_color_to_rgb565_swapped(lv_draw_sw_blend_fill_dsc_t * dsc)
 {

--- a/src/draw/sw/lv_draw_sw.h
+++ b/src/draw/sw/lv_draw_sw.h
@@ -124,7 +124,6 @@ void lv_draw_sw_blur(lv_draw_task_t * t, const lv_draw_blur_dsc_t * dsc, const l
  * Mask out a rectangle with radius from a current layer
  * @param t             pointer to a draw task
  * @param dsc           the draw descriptor
- * @param coords        the coordinates of the mask
  */
 void lv_draw_sw_mask_rect(lv_draw_task_t * t, const lv_draw_mask_rect_dsc_t * dsc);
 
@@ -137,12 +136,12 @@ void lv_draw_sw_mask_rect(lv_draw_task_t * t, const lv_draw_mask_rect_dsc_t * ds
  * @param src_stride    source buffer stride in bytes
  * @param draw_dsc      draw descriptor
  * @param sup           supplementary data
- * @param cf            color format of the source buffer
+ * @param src_cf        color format of the source buffer
  * @param dest_buf      the destination buffer
  */
 void lv_draw_sw_transform(const lv_area_t * dest_area, const void * src_buf,
                           int32_t src_w, int32_t src_h, int32_t src_stride,
-                          const lv_draw_image_dsc_t * draw_dsc, const lv_draw_image_sup_t * sup, lv_color_format_t cf, void * dest_buf);
+                          const lv_draw_image_dsc_t * draw_dsc, const lv_draw_image_sup_t * sup, lv_color_format_t src_cf, void * dest_buf);
 
 #if LV_USE_VECTOR_GRAPHIC && LV_USE_THORVG
 /**

--- a/src/draw/sw/lv_draw_sw_box_shadow.c
+++ b/src/draw/sw/lv_draw_sw_box_shadow.c
@@ -34,7 +34,7 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static void /* LV_ATTRIBUTE_FAST_MEM */ shadow_draw_corner_buf(const lv_area_t * coords, uint16_t * sh_buf, int32_t s,
+static void /* LV_ATTRIBUTE_FAST_MEM */ shadow_draw_corner_buf(const lv_area_t * coords, uint16_t * sh_buf, int32_t sw,
                                                                int32_t r);
 static void /* LV_ATTRIBUTE_FAST_MEM */ shadow_blur_corner(int32_t size, int32_t sw, uint16_t * sh_ups_buf);
 

--- a/src/draw/sw/lv_draw_sw_mask.c
+++ b/src/draw/sw/lv_draw_sw_mask.c
@@ -214,7 +214,7 @@ void lv_draw_sw_mask_line_points_init(lv_draw_sw_mask_line_param_t * param, int3
     if(param->steep < 0) param->spx = -param->spx;
 }
 
-void lv_draw_sw_mask_line_angle_init(lv_draw_sw_mask_line_param_t * param, int32_t p1x, int32_t py, int16_t angle,
+void lv_draw_sw_mask_line_angle_init(lv_draw_sw_mask_line_param_t * param, int32_t px, int32_t py, int16_t angle,
                                      lv_draw_sw_mask_line_side_t side)
 {
     /*Find an optimal degree.
@@ -226,10 +226,10 @@ void lv_draw_sw_mask_line_angle_init(lv_draw_sw_mask_line_param_t * param, int32
     int32_t p2x;
     int32_t p2y;
 
-    p2x = (lv_trigo_sin(angle + 90) >> 5) + p1x;
+    p2x = (lv_trigo_sin(angle + 90) >> 5) + px;
     p2y = (lv_trigo_sin(angle) >> 5) + py;
 
-    lv_draw_sw_mask_line_points_init(param, p1x, py, p2x, p2y, side);
+    lv_draw_sw_mask_line_points_init(param, px, py, p2x, p2y, side);
 }
 
 void lv_draw_sw_mask_angle_init(lv_draw_sw_mask_angle_param_t * param, int32_t vertex_x, int32_t vertex_y,

--- a/src/draw/sw/lv_draw_sw_mask_rect.c
+++ b/src/draw/sw/lv_draw_sw_mask_rect.c
@@ -116,9 +116,9 @@ void lv_draw_sw_mask_rect(lv_draw_task_t * t, const lv_draw_mask_rect_dsc_t * ds
 
 #else /*LV_DRAW_SW_COMPLEX*/
 
-void lv_draw_sw_mask_rect(lv_draw_unit_t * draw_unit, const lv_draw_mask_rect_dsc_t * dsc)
+void lv_draw_sw_mask_rect(lv_draw_unit_t * t, const lv_draw_mask_rect_dsc_t * dsc)
 {
-    LV_UNUSED(draw_unit);
+    LV_UNUSED(t);
     LV_UNUSED(dsc);
 
     LV_LOG_WARN("LV_DRAW_SW_COMPLEX needs to be enabled");

--- a/src/draw/vg_lite/lv_vg_lite_stroke.h
+++ b/src/draw/vg_lite/lv_vg_lite_stroke.h
@@ -38,7 +38,8 @@ struct _lv_draw_vg_lite_unit_t;
 
 /**
  * Initialize the stroke module
- * @param unit pointer to the unit
+ * @param unit          pointer to the unit
+ * @param cache_cnt     maximum amount of entries in the cache at the same time
  */
 void lv_vg_lite_stroke_init(struct _lv_draw_vg_lite_unit_t * unit, uint32_t cache_cnt);
 
@@ -69,7 +70,7 @@ struct _lv_vg_lite_path_t * lv_vg_lite_stroke_get_path(lv_cache_entry_t * cache_
 /**
  * Drop the stroke cache entry
  * @param unit pointer to the unit
- * @param stroke pointer to the stroke
+ * @param cache_entry pointer to the stroke cache entry
  */
 void lv_vg_lite_stroke_drop(struct _lv_draw_vg_lite_unit_t * unit, lv_cache_entry_t * cache_entry);
 

--- a/src/drivers/display/drm/lv_linux_drm_egl.c
+++ b/src/drivers/display/drm/lv_linux_drm_egl.c
@@ -95,10 +95,10 @@ lv_display_t * lv_linux_drm_create(void)
     return ctx->display;
 }
 
-lv_result_t lv_linux_drm_set_file(lv_display_t * display, const char * file, int64_t connector_id)
+lv_result_t lv_linux_drm_set_file(lv_display_t * disp, const char * file, int64_t connector_id)
 {
     LV_UNUSED(connector_id);
-    lv_drm_ctx_t * ctx = lv_display_get_driver_data(display);
+    lv_drm_ctx_t * ctx = lv_display_get_driver_data(disp);
 
     lv_result_t err = drm_device_init(ctx, file);
     if(err != LV_RESULT_OK) {
@@ -106,7 +106,7 @@ lv_result_t lv_linux_drm_set_file(lv_display_t * display, const char * file, int
         return LV_RESULT_INVALID;
     }
 
-    lv_display_set_resolution(display, ctx->drm_mode->hdisplay, ctx->drm_mode->vdisplay);
+    lv_display_set_resolution(disp, ctx->drm_mode->hdisplay, ctx->drm_mode->vdisplay);
 
     ctx->egl_interface = drm_get_egl_interface(ctx);
     ctx->egl_ctx = lv_opengles_egl_context_create(&ctx->egl_interface);
@@ -118,7 +118,7 @@ lv_result_t lv_linux_drm_set_file(lv_display_t * display, const char * file, int
     /* Let the opengles texture driver handle the texture lifetime */
     ctx->texture.is_texture_owner = true;
     /*Initialize the draw buffers and texture*/
-    lv_result_t res = lv_opengles_texture_reshape(&ctx->texture, display, ctx->drm_mode->hdisplay, ctx->drm_mode->vdisplay);
+    lv_result_t res = lv_opengles_texture_reshape(&ctx->texture, disp, ctx->drm_mode->hdisplay, ctx->drm_mode->vdisplay);
     if(res != LV_RESULT_OK) {
         LV_LOG_ERROR("Failed to create draw buffers");
         lv_opengles_egl_context_destroy(ctx->egl_ctx);
@@ -126,8 +126,8 @@ lv_result_t lv_linux_drm_set_file(lv_display_t * display, const char * file, int
         return LV_RESULT_INVALID;
     }
 
-    lv_display_set_flush_cb(display, flush_cb);
-    lv_display_set_render_mode(display, LV_USE_DRAW_NANOVG ? LV_DISPLAY_RENDER_MODE_FULL : LV_DISPLAY_RENDER_MODE_DIRECT);
+    lv_display_set_flush_cb(disp, flush_cb);
+    lv_display_set_render_mode(disp, LV_USE_DRAW_NANOVG ? LV_DISPLAY_RENDER_MODE_FULL : LV_DISPLAY_RENDER_MODE_DIRECT);
 
     lv_display_add_event_cb(ctx->display, event_cb, LV_EVENT_RESOLUTION_CHANGED, NULL);
     lv_display_add_event_cb(ctx->display, event_cb, LV_EVENT_DELETE, NULL);

--- a/src/drivers/display/mipi/lv_lcd_generic_mipi.c
+++ b/src/drivers/display/mipi/lv_lcd_generic_mipi.c
@@ -246,7 +246,6 @@ static void set_swap_xy(lv_lcd_generic_mipi_driver_t * drv, bool swap)
 /**
  * Flush display buffer to the LCD
  * @param disp          display object
- * @param hor_res       horizontal resolution
  * @param area          area stored in the buffer
  * @param px_map        buffer containing pixel data
  * @note                transfers pixel data to the LCD controller using the callbacks 'send_cmd' and 'send_color', which were

--- a/src/drivers/opengles/lv_opengles_private.h
+++ b/src/drivers/opengles/lv_opengles_private.h
@@ -144,13 +144,14 @@ void lv_opengles_render(const lv_opengles_render_params_t * params);
 
 /**
  * Render a texture using alternate blending mode, with red and blue channels flipped in the shader.
- * @param texture        OpenGL texture ID
- * @param texture_area   the area in the window to render the texture in
- * @param opa            opacity to blend the texture with existing contents
- * @param disp_w         width of the window/framebuffer being rendered to
- * @param disp_h         height of the window/framebuffer being rendered to
- * @param h_flip         horizontal flip
- * @param v_flip         vertical flip
+ * @param texture               OpenGL texture ID
+ * @param texture_area          the area in the window to render the texture in
+ * @param opa                   opacity to blend the texture with existing contents
+ * @param disp_w                width of the window/framebuffer being rendered to
+ * @param disp_h                height of the window/framebuffer being rendered to
+ * @param texture_clip_area     the area of the texture to draw
+ * @param h_flip                horizontal flip
+ * @param v_flip                vertical flip
  */
 void lv_opengles_render_texture_rbswap(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
                                        int32_t disp_w, int32_t disp_h, const lv_area_t * texture_clip_area,

--- a/src/drivers/wayland/lv_wayland_window.c
+++ b/src/drivers/wayland/lv_wayland_window.c
@@ -206,7 +206,7 @@ void lv_wayland_window_set_minimized(lv_display_t * disp)
     lv_wayland_xdg_set_minimized(&window->xdg);
 }
 
-void lv_wayland_assign_physical_display(lv_display_t * disp, uint8_t display_number)
+void lv_wayland_assign_physical_display(lv_display_t * disp, uint8_t display)
 {
     if(!disp) {
         LV_LOG_ERROR("Invalid display");
@@ -220,11 +220,11 @@ void lv_wayland_assign_physical_display(lv_display_t * disp, uint8_t display_num
         return;
     }
 
-    if(display_number >= lv_wl_ctx.wl_output_count) {
-        LV_LOG_WARN("Invalid display number '%d'. Expected '0'..'%d'", display_number, lv_wl_ctx.wl_output_count - 1);
+    if(display >= lv_wl_ctx.wl_output_count) {
+        LV_LOG_WARN("Invalid display number '%d'. Expected '0'..'%d'", display, lv_wl_ctx.wl_output_count - 1);
         return;
     }
-    window->physical_output = lv_wl_ctx.physical_outputs[display_number].wl_output;
+    window->physical_output = lv_wl_ctx.physical_outputs[display].wl_output;
 }
 
 void lv_wayland_unassign_physical_display(lv_display_t * disp)

--- a/src/font/fmt_txt/lv_font_fmt_txt.c
+++ b/src/font/fmt_txt/lv_font_fmt_txt.c
@@ -411,7 +411,8 @@ static int kern_pair_16_compare(const void * ref, const void * element)
  * The compress a glyph's bitmap
  * @param in the compressed bitmap
  * @param out buffer to store the result
- * @param px_num number of pixels in the glyph (width * height)
+ * @param w width of the glyph in pixels
+ * @param h height of the glyph in pixels
  * @param bpp bit per pixel (bpp = 3 will be converted to bpp = 4)
  * @param prefilter true: the lines are XORed
  */
@@ -606,8 +607,8 @@ static inline uint8_t rle_next(void)
  *
  *  Compares the value of both input arguments.
  *
- *  @param[in]  pRef        Pointer to the reference.
- *  @param[in]  pElement    Pointer to the element to compare.
+ *  @param[in]  ref         Pointer to the reference.
+ *  @param[in]  element     Pointer to the element to compare.
  *
  *  @return Result of comparison.
  *  @retval < 0   Reference is less than element.

--- a/src/font/font_manager/lv_font_manager_recycle.h
+++ b/src/font/font_manager/lv_font_manager_recycle.h
@@ -60,7 +60,8 @@ lv_font_t * lv_font_manager_recycle_get_reuse(lv_font_manager_recycle_t * manage
 /**
  * Set fonts to be reused.
  * @param manager pointer to font recycle manager.
- * @param ft_info font info.
+ * @param font    pointer to the font to reuse
+ * @param ft_info font info
  */
 void lv_font_manager_recycle_set_reuse(lv_font_manager_recycle_t * manager, lv_font_t * font,
                                        const lv_font_info_t * ft_info);

--- a/src/font/lv_font.c
+++ b/src/font/lv_font.c
@@ -88,17 +88,17 @@ void lv_font_glyph_release_draw_data(lv_font_glyph_dsc_t * g_dsc)
     }
 }
 
-bool lv_font_get_glyph_dsc(const lv_font_t * font_p, lv_font_glyph_dsc_t * dsc_out, uint32_t letter,
+bool lv_font_get_glyph_dsc(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, uint32_t letter,
                            uint32_t letter_next)
 {
 
     LV_ASSERT_NULL(dsc_out);
-    LV_ASSERT_NULL(font_p);
+    LV_ASSERT_NULL(font);
 
 #if LV_USE_FONT_PLACEHOLDER
     const lv_font_t * placeholder_font = NULL;
 #endif
-    const lv_font_t * f = font_p;
+    const lv_font_t * f = font;
     const bool has_kerning = f->kerning != LV_FONT_KERNING_NONE;
 
     lv_memzero(dsc_out, sizeof(lv_font_glyph_dsc_t));
@@ -130,7 +130,7 @@ bool lv_font_get_glyph_dsc(const lv_font_t * font_p, lv_font_glyph_dsc_t * dsc_o
 #endif
 
 #if LV_USE_FONT_PLACEHOLDER
-    dsc_out->box_w = font_p->line_height / 2;
+    dsc_out->box_w = font->line_height / 2;
     dsc_out->adv_w = dsc_out->box_w + 2;
 #else
     dsc_out->box_w = 0;
@@ -139,7 +139,7 @@ bool lv_font_get_glyph_dsc(const lv_font_t * font_p, lv_font_glyph_dsc_t * dsc_o
 
     dsc_out->stride = 0;
     dsc_out->resolved_font = NULL;
-    dsc_out->box_h = font_p->line_height;
+    dsc_out->box_h = font->line_height;
     dsc_out->ofs_x = 0;
     dsc_out->ofs_y = 0;
     dsc_out->format = LV_FONT_GLYPH_FORMAT_A1;

--- a/src/fs/lv_fs.c
+++ b/src/fs/lv_fs.c
@@ -536,7 +536,7 @@ void lv_fs_drv_init(lv_fs_drv_t * drv)
     lv_memzero(drv, sizeof(lv_fs_drv_t));
 }
 
-void lv_fs_drv_register(lv_fs_drv_t * drv_p)
+void lv_fs_drv_register(lv_fs_drv_t * drv)
 {
     /*Save the new driver*/
     lv_fs_drv_t ** new_drv;
@@ -544,7 +544,7 @@ void lv_fs_drv_register(lv_fs_drv_t * drv_p)
     LV_ASSERT_MALLOC(new_drv);
     if(new_drv == NULL) return;
 
-    *new_drv = drv_p;
+    *new_drv = drv;
 }
 
 void lv_fs_remove_drive(char letter)

--- a/src/image/lv_bmp.c
+++ b/src/image/lv_bmp.c
@@ -37,7 +37,7 @@ typedef struct {
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * src, lv_image_header_t * header);
+static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc, lv_image_header_t * header);
 static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
 
 static lv_result_t decoder_get_area(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc,

--- a/src/image/lv_libpng.c
+++ b/src/image/lv_libpng.c
@@ -31,7 +31,7 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * src, lv_image_header_t * header);
+static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc, lv_image_header_t * header);
 static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
 static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
 static lv_draw_buf_t * decode_png(lv_image_decoder_dsc_t * dsc);

--- a/src/image/lv_lodepng.c
+++ b/src/image/lv_lodepng.c
@@ -32,9 +32,9 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * src, lv_image_header_t * header);
+static lv_result_t decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc, lv_image_header_t * header);
 static lv_result_t decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
-static void decoder_close(lv_image_decoder_t * dec, lv_image_decoder_dsc_t * dsc);
+static void decoder_close(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc);
 static void convert_color_depth(uint8_t * img_p, uint32_t px_cnt);
 static lv_draw_buf_t * decode_png_data(const void * png_data, size_t png_data_size);
 /**********************
@@ -268,7 +268,7 @@ static lv_draw_buf_t * decode_png_data(const void * png_data, size_t png_data_si
 
 /**
  * Convert subpixel order from LodePNG to LVGL
- * @param img the LodePNG RGBA8888 image to be converted in-place to LVGL BGRA8888
+ * @param img_p the LodePNG RGBA8888 image to be converted in-place to LVGL BGRA8888
  * @param px_cnt number of pixels in `img`
  */
 static void convert_color_depth(uint8_t * img_p, uint32_t px_cnt)

--- a/src/image/svg/lv_svg_render.c
+++ b/src/image/svg/lv_svg_render.c
@@ -2501,11 +2501,11 @@ lv_svg_render_obj_t * lv_svg_render_create(const lv_svg_node_t * svg_doc)
     return state.list;
 }
 
-void lv_svg_render_delete(lv_svg_render_obj_t * list)
+void lv_svg_render_delete(lv_svg_render_obj_t * render)
 {
-    while(list) {
-        lv_svg_render_obj_t * obj = list;
-        list = list->next;
+    while(render) {
+        lv_svg_render_obj_t * obj = render;
+        render = render->next;
 
         _deinit_draw_dsc(&(obj->dsc));
 

--- a/src/image/svg/lv_svg_token.c
+++ b/src/image/svg/lv_svg_token.c
@@ -349,19 +349,19 @@ static bool _svg_parser_tag(_lv_svg_parser_state_t * state, _lv_svg_token_t * to
  *   GLOBAL FUNCTIONS
  **********************/
 
-bool _lv_svg_tokenizer(const char * svg_data, uint32_t data_len, svg_token_process cb, void * data)
+bool _lv_svg_tokenizer(const char * svg_data, uint32_t len, svg_token_process cb, void * user_data)
 {
     LV_ASSERT_NULL(svg_data);
-    LV_ASSERT(data_len > 0);
+    LV_ASSERT(len > 0);
     LV_ASSERT_NULL(cb);
-    LV_ASSERT_NULL(data);
+    LV_ASSERT_NULL(user_data);
 
     _lv_svg_token_t token;
     _lv_svg_token_init(&token);
     _lv_svg_parser_state_t state = {
         .flags = 0,
         .cur = svg_data,
-        .end = svg_data + data_len,
+        .end = svg_data + len,
     };
 
     while(state.cur < state.end) {
@@ -401,7 +401,7 @@ bool _lv_svg_tokenizer(const char * svg_data, uint32_t data_len, svg_token_proce
                         }
                 }
                 // process token
-                if(!_lv_svg_token_process(&token, cb, data)) {
+                if(!_lv_svg_token_process(&token, cb, user_data)) {
                     LV_LOG_ERROR("svg document parser error!");
                     lv_array_deinit(&token.attrs);
                     return false;
@@ -441,7 +441,7 @@ bool _lv_svg_tokenizer(const char * svg_data, uint32_t data_len, svg_token_proce
                 _svg_parser_doctype(&state, &token);
             }
             else if(_is_state(&state, SVG_TAG_MASK)) {
-                if(!_svg_parser_tag(&state, &token, cb, data)) {
+                if(!_svg_parser_tag(&state, &token, cb, user_data)) {
                     LV_LOG_ERROR("svg document parser error!");
                     lv_array_deinit(&token.attrs);
                     return false;

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -423,11 +423,11 @@ void lv_indev_set_gesture_min_distance(lv_indev_t * indev, uint8_t min_distance)
     indev->gesture_min_distance = min_distance;
 }
 
-void lv_indev_set_gesture_min_velocity(lv_indev_t * indev, uint8_t gesture_min_velocity)
+void lv_indev_set_gesture_min_velocity(lv_indev_t * indev, uint8_t min_velocity)
 {
     if(indev == NULL) return;
 
-    indev->gesture_min_velocity = gesture_min_velocity;
+    indev->gesture_min_velocity = min_velocity;
 }
 
 void * lv_indev_get_user_data(const lv_indev_t * indev)
@@ -1214,9 +1214,8 @@ static void indev_encoder_proc(lv_indev_t * i, lv_indev_data_t * data)
 
 /**
  * Process new points from an input device. indev->state.pressed has to be set
- * @param indev pointer to an input device state
- * @param x x coordinate of the next point
- * @param y y coordinate of the next point
+ * @param i pointer to an input device
+ * @param data pointer to the data read from the input device
  */
 static void indev_button_proc(lv_indev_t * i, lv_indev_data_t * data)
 {
@@ -1487,7 +1486,7 @@ static void indev_proc_press(lv_indev_t * indev)
 
 /**
  * Process the released state of LV_INDEV_TYPE_POINTER input devices
- * @param proc pointer to an input device 'proc'
+ * @param indev pointer to an input device 'proc'
  */
 static void indev_proc_release(lv_indev_t * indev)
 {
@@ -1710,9 +1709,6 @@ static lv_obj_t * pointer_search_obj(lv_display_t * disp, lv_point_t * p)
 }
 
 /**
- * Process a new point from LV_INDEV_TYPE_BUTTON input device
- * @param i pointer to an input device
- * @param data pointer to the data read from the input device
  * Reset input device if a reset query has been sent to it
  * @param indev pointer to an input device
  */
@@ -1752,7 +1748,7 @@ static void indev_proc_reset_query_handler(lv_indev_t * indev)
 
 /**
  * Handle focus/defocus on click for POINTER input devices
- * @param proc pointer to the state of the indev
+ * @param indev pointer to the state of the indev
  */
 static void indev_click_focus(lv_indev_t * indev)
 {
@@ -1876,7 +1872,7 @@ static void indev_gesture(lv_indev_t * indev)
 
 /**
  * Checks if the reset_query flag has been set. If so, perform necessary global indev cleanup actions
- * @param proc pointer to an input device 'proc'
+ * @param indev pointer to an input device 'proc'
  * @return true if indev query should be immediately truncated.
  */
 static bool indev_reset_check(lv_indev_t * indev)

--- a/src/indev/lv_indev_gesture.c
+++ b/src/indev/lv_indev_gesture.c
@@ -824,7 +824,7 @@ static void process_touch_event(lv_indev_touch_data_t * touch, lv_indev_gesture_
 /**
  * Calculate the center point of a gesture, called when there
  * is a probability for the gesture to occur
- * @param touch             a pointer to a touch data structure
+ * @param gesture           a pointer to a touch data structure
  * @param touch_points_nb   The number of contact point to take into account
  */
 static void gesture_update_center_point(lv_indev_gesture_t * gesture, int touch_points_nb)

--- a/src/layouts/flex/lv_flex.c
+++ b/src/layouts/flex/lv_flex.c
@@ -111,11 +111,11 @@ void lv_obj_set_flex_flow(lv_obj_t * obj, lv_flex_flow_t flow)
 }
 
 void lv_obj_set_flex_align(lv_obj_t * obj, lv_flex_align_t main_place, lv_flex_align_t cross_place,
-                           lv_flex_align_t track_place)
+                           lv_flex_align_t track_cross_place)
 {
     lv_obj_set_style_flex_main_place(obj, main_place, 0);
     lv_obj_set_style_flex_cross_place(obj, cross_place, 0);
-    lv_obj_set_style_flex_track_place(obj, track_place, 0);
+    lv_obj_set_style_flex_track_place(obj, track_cross_place, 0);
     lv_obj_set_style_layout(obj, LV_LAYOUT_FLEX, 0);
 }
 

--- a/src/layouts/grid/lv_grid.c
+++ b/src/layouts/grid/lv_grid.c
@@ -54,7 +54,7 @@ typedef struct {
  *  STATIC PROTOTYPES
  **********************/
 static void grid_update(lv_obj_t * cont, void * user_data);
-static lv_result_t calc(lv_obj_t * obj, lv_grid_calc_t * calc);
+static lv_result_t calc(lv_obj_t * cont, lv_grid_calc_t * calc_out);
 static void calc_free(lv_grid_calc_t * calc);
 static lv_result_t calc_cols(lv_obj_t * cont, lv_grid_calc_t * c);
 static lv_result_t calc_rows(lv_obj_t * cont, lv_grid_calc_t * c);
@@ -162,16 +162,16 @@ void lv_obj_set_grid_align(lv_obj_t * obj, lv_grid_align_t column_align, lv_grid
 
 }
 
-void lv_obj_set_grid_cell(lv_obj_t * obj, lv_grid_align_t x_align, int32_t col_pos, int32_t col_span,
-                          lv_grid_align_t y_align, int32_t row_pos, int32_t row_span)
+void lv_obj_set_grid_cell(lv_obj_t * obj, lv_grid_align_t column_align, int32_t col_pos, int32_t col_span,
+                          lv_grid_align_t row_align, int32_t row_pos, int32_t row_span)
 
 {
     lv_obj_set_style_grid_cell_column_pos(obj, col_pos, 0);
     lv_obj_set_style_grid_cell_row_pos(obj, row_pos, 0);
-    lv_obj_set_style_grid_cell_x_align(obj, x_align, 0);
+    lv_obj_set_style_grid_cell_x_align(obj, column_align, 0);
     lv_obj_set_style_grid_cell_column_span(obj, col_span, 0);
     lv_obj_set_style_grid_cell_row_span(obj, row_span, 0);
-    lv_obj_set_style_grid_cell_y_align(obj, y_align, 0);
+    lv_obj_set_style_grid_cell_y_align(obj, row_align, 0);
 
     lv_obj_mark_layout_as_dirty(lv_obj_get_parent(obj));
 }
@@ -228,7 +228,7 @@ static void grid_update(lv_obj_t * cont, void * user_data)
 /**
  * Calculate the grid cells coordinates
  * @param cont an object that has a grid
- * @param calc store the calculated cells sizes here
+ * @param calc_out store the calculated cells sizes here
  * @note `lv_grid_calc_free(calc_out)` needs to be called when `calc_out` is not needed anymore
  */
 static lv_result_t calc(lv_obj_t * cont, lv_grid_calc_t * calc_out)
@@ -481,9 +481,8 @@ static lv_result_t calc_rows(lv_obj_t * cont, lv_grid_calc_t * c)
 /**
  * Reposition a grid item in its cell
  * @param item a grid item to reposition
- * @param calc the calculated grid of `cont`
- * @param child_id_ext helper value if the ID of the child is know (order from the oldest) else -1
- * @param grid_abs helper value, the absolute position of the grid, NULL if unknown
+ * @param c the calculated grid of the container
+ * @param hint helper values cached across the items of the same container
  */
 static void item_repos(lv_obj_t * item, lv_grid_calc_t * c, item_repos_hint_t * hint)
 {

--- a/src/libs/gltf/gltf_data/lv_gltf_data.cpp
+++ b/src/libs/gltf/gltf_data/lv_gltf_data.cpp
@@ -115,16 +115,16 @@ const char * lv_gltf_get_filename(const lv_gltf_model_t * data)
     return data->filename;
 }
 
-size_t lv_gltf_model_get_image_count(const lv_gltf_model_t * data)
+size_t lv_gltf_model_get_image_count(const lv_gltf_model_t * model)
 {
-    LV_ASSERT_NULL(data);
-    return data->asset.images.size();
+    LV_ASSERT_NULL(model);
+    return model->asset.images.size();
 }
 
-size_t lv_gltf_model_get_texture_count(const lv_gltf_model_t * data)
+size_t lv_gltf_model_get_texture_count(const lv_gltf_model_t * model)
 {
-    LV_ASSERT_NULL(data);
-    return data->asset.textures.size();
+    LV_ASSERT_NULL(model);
+    return model->asset.textures.size();
 }
 
 GLuint lv_gltf_data_get_texture(lv_gltf_model_t * data, size_t index)
@@ -134,35 +134,35 @@ GLuint lv_gltf_data_get_texture(lv_gltf_model_t * data, size_t index)
     return data->textures[index];
 }
 
-size_t lv_gltf_model_get_material_count(const lv_gltf_model_t * data)
+size_t lv_gltf_model_get_material_count(const lv_gltf_model_t * model)
 {
-    LV_ASSERT_NULL(data);
-    return data->asset.materials.size();
+    LV_ASSERT_NULL(model);
+    return model->asset.materials.size();
 }
-size_t lv_gltf_model_get_camera_count(const lv_gltf_model_t * data)
+size_t lv_gltf_model_get_camera_count(const lv_gltf_model_t * model)
 {
-    LV_ASSERT_NULL(data);
-    return data->asset.cameras.size();
+    LV_ASSERT_NULL(model);
+    return model->asset.cameras.size();
 }
-size_t lv_gltf_model_get_node_count(const lv_gltf_model_t * data)
+size_t lv_gltf_model_get_node_count(const lv_gltf_model_t * model)
 {
-    LV_ASSERT_NULL(data);
-    return data->asset.nodes.size();
+    LV_ASSERT_NULL(model);
+    return model->asset.nodes.size();
 }
-size_t lv_gltf_model_get_mesh_count(const lv_gltf_model_t * data)
+size_t lv_gltf_model_get_mesh_count(const lv_gltf_model_t * model)
 {
-    LV_ASSERT_NULL(data);
-    return data->asset.meshes.size();
+    LV_ASSERT_NULL(model);
+    return model->asset.meshes.size();
 }
-size_t lv_gltf_model_get_scene_count(const lv_gltf_model_t * data)
+size_t lv_gltf_model_get_scene_count(const lv_gltf_model_t * model)
 {
-    LV_ASSERT_NULL(data);
-    return data->asset.scenes.size();
+    LV_ASSERT_NULL(model);
+    return model->asset.scenes.size();
 }
-size_t lv_gltf_model_get_animation_count(const lv_gltf_model_t * data)
+size_t lv_gltf_model_get_animation_count(const lv_gltf_model_t * model)
 {
-    LV_ASSERT_NULL(data);
-    return data->asset.animations.size();
+    LV_ASSERT_NULL(model);
+    return model->asset.animations.size();
 }
 
 lv_result_t lv_gltf_model_play_animation(lv_gltf_model_t * model, size_t index)
@@ -221,10 +221,10 @@ fastgltf::Asset * lv_gltf_data_get_asset(lv_gltf_model_t * data)
     LV_ASSERT_NULL(data);
     return &data->asset;
 }
-double lv_gltf_data_get_radius(const lv_gltf_model_t * data)
+double lv_gltf_data_get_radius(const lv_gltf_model_t * model)
 {
-    LV_ASSERT_NULL(data);
-    return data->bound_radius;
+    LV_ASSERT_NULL(model);
+    return model->bound_radius;
 }
 fastgltf::math::fvec3 lv_gltf_data_get_center(const lv_gltf_model_t * data)
 {

--- a/src/libs/gltf/gltf_data/lv_gltf_data_internal.h
+++ b/src/libs/gltf/gltf_data/lv_gltf_data_internal.h
@@ -192,7 +192,7 @@ lv_gltf_compiled_shader_t * lv_gltf_get_compiled_shader(lv_gltf_model_t * data, 
 /**
  * @brief Retrieve the radius of the GLTF data object.
  *
- * @param D Pointer to the lv_gltf_data_t object from which to get the radius.
+ * @param model Pointer to the lv_gltf_data_t object from which to get the radius.
  * @return The radius of the GLTF data object.
  */
 double lv_gltf_data_get_radius(const lv_gltf_model_t * model);

--- a/src/libs/gltf/gltf_data/lv_gltf_data_internal.hpp
+++ b/src/libs/gltf/gltf_data/lv_gltf_data_internal.hpp
@@ -166,7 +166,7 @@ fastgltf::math::fvec3 lv_gltf_data_get_bounds_min(const lv_gltf_model_t * data);
 /**
  * @brief Retrieve the maximum bounds (X/Y/Z) of the model from the GLTF data.
  *
- * @param D Pointer to the lv_gltf_data_t object containing the model data.
+ * @param data Pointer to the lv_gltf_data_t object containing the model data.
  * @return Pointer to a 3-element float array representing the maximum bounds.
  */
 fastgltf::math::fvec3 lv_gltf_data_get_bounds_max(const lv_gltf_model_t * data);
@@ -174,7 +174,7 @@ fastgltf::math::fvec3 lv_gltf_data_get_bounds_max(const lv_gltf_model_t * data);
 /**
  * @brief Retrieve the center coordinates of the GLTF data object.
  *
- * @param D Pointer to the lv_gltf_data_t object from which to get the center.
+ * @param data Pointer to the lv_gltf_data_t object from which to get the center.
  * @return Pointer to an array containing the center coordinates (x, y, z).
  */
 fastgltf::math::fvec3 lv_gltf_data_get_center(const lv_gltf_model_t * data);
@@ -182,7 +182,7 @@ fastgltf::math::fvec3 lv_gltf_data_get_center(const lv_gltf_model_t * data);
 /**
  * @brief Retrieve the filename of the GLTF model.
  *
- * @param D Pointer to the lv_gltf_data_t object containing the model data.
+ * @param data Pointer to the lv_gltf_data_t object containing the model data.
  * @return Pointer to a constant character string representing the filename.
  */
 const char * lv_gltf_get_filename(const lv_gltf_model_t * data);
@@ -200,16 +200,16 @@ bool lv_gltf_data_centerpoint_cache_contains(lv_gltf_model_t * data, size_t inde
 /**
  * @brief Retrieve a specific primitive from a mesh.
  *
- * @param M Pointer to the MeshData structure containing the mesh data.
- * @param I The index of the primitive to retrieve.
+ * @param mesh Pointer to the MeshData structure containing the mesh data.
+ * @param index The index of the primitive to retrieve.
  * @return Pointer to the primitive data.
  */
-lv_gltf_primitive_t * lv_gltf_data_get_primitive_from_mesh(lv_gltf_mesh_data_t * M, size_t I);
+lv_gltf_primitive_t * lv_gltf_data_get_primitive_from_mesh(lv_gltf_mesh_data_t * mesh, size_t index);
 
 /**
  * @brief Retrieve the asset associated with the GLTF model data.
  *
- * @param D Pointer to the lv_gltf_data_t object containing the model data.
+ * @param data Pointer to the lv_gltf_data_t object containing the model data.
  * @return Pointer to the asset data.
  */
 fastgltf::Asset * lv_gltf_data_get_asset(lv_gltf_model_t * data);
@@ -217,8 +217,8 @@ fastgltf::Asset * lv_gltf_data_get_asset(lv_gltf_model_t * data);
 /**
  * @brief Retrieve mesh data for a specific index from the GLTF model data.
  *
- * @param D Pointer to the lv_gltf_data_t object containing the model data.
- * @param I The index of the mesh data to retrieve.
+ * @param data Pointer to the lv_gltf_data_t object containing the model data.
+ * @param index The index of the mesh data to retrieve.
  * @return Pointer to the MeshData structure containing the mesh data.
  */
 lv_gltf_mesh_data_t * lv_gltf_data_get_mesh(lv_gltf_model_t * data, size_t index);
@@ -252,10 +252,10 @@ void lv_gltf_data_validate_skin(lv_gltf_model_t * data, size_t index);
 /**
  * @brief Add an opaque node primitive to the GLTF model data.
  *
- * @param D Pointer to the lv_gltf_data_t object containing the model data.
- * @param I The index of the primitive to add.
- * @param N Pointer to the NodePtr representing the node to add.
- * @param P The specific parameter associated with the primitive.
+ * @param data Pointer to the lv_gltf_data_t object containing the model data.
+ * @param index The index of the primitive to add.
+ * @param node Pointer to the NodePtr representing the node to add.
+ * @param primitive_index The specific parameter associated with the primitive.
  */
 void lv_gltf_data_add_opaque_node_primitive(lv_gltf_model_t * data, size_t index, fastgltf::Node * node,
                                             size_t primitive_index);
@@ -263,18 +263,18 @@ void lv_gltf_data_add_opaque_node_primitive(lv_gltf_model_t * data, size_t index
 /**
  * @brief Add a blended node primitive to the GLTF model data.
  *
- * @param D Pointer to the lv_gltf_data_t object containing the model data.
- * @param I The index of the primitive to add.
- * @param N Pointer to the NodePtr representing the node to add.
- * @param P The specific parameter associated with the primitive.
+ * @param data Pointer to the lv_gltf_data_t object containing the model data.
+ * @param material_index  The index of the material to add.
+ * @param node Pointer to the NodePtr representing the node to add.
+ * @param primitive_index The specific parameter associated with the primitive.
  */
-void lv_gltf_data_add_blended_node_primitive(lv_gltf_model_t * data, size_t mesh_index, fastgltf::Node * node,
+void lv_gltf_data_add_blended_node_primitive(lv_gltf_model_t * data, size_t material_index, fastgltf::Node * node,
                                              size_t primitive_index);
 
 /**
  * @brief Retrieve the size of the skins in the GLTF model data.
  *
- * @param D Pointer to the lv_gltf_data_t object containing the model data.
+ * @param data Pointer to the lv_gltf_data_t object containing the model data.
  * @return The size of the skins.
  */
 size_t lv_gltf_data_get_skins_size(lv_gltf_model_t * data);
@@ -282,8 +282,8 @@ size_t lv_gltf_data_get_skins_size(lv_gltf_model_t * data);
 /**
  * @brief Retrieve a specific skin from the GLTF model data.
  *
- * @param D Pointer to the lv_gltf_data_t object containing the model data.
- * @param I The index of the skin to retrieve.
+ * @param data Pointer to the lv_gltf_data_t object containing the model data.
+ * @param index The index of the skin to retrieve.
  * @return The skin index.
  */
 size_t lv_gltf_data_get_skin(lv_gltf_model_t * data, size_t index);
@@ -291,7 +291,7 @@ size_t lv_gltf_data_get_skin(lv_gltf_model_t * data, size_t index);
 /**
  * @brief Ingest and discover defines for a specific node and primitive in the GLTF model data.
  *
- * @param data_obj Pointer to the lv_gltf_data_t object containing the model data.
+ * @param data     Pointer to the lv_gltf_data_t object containing the model data.
  * @param node Pointer to the node for which to ingest defines.
  * @param prim Pointer to the primitive for which to ingest defines.
  */
@@ -302,7 +302,7 @@ void lv_gltf_data_injest_discover_defines(lv_gltf_model_t * data, fastgltf::Node
  *
  * @param gltf_data Pointer to the lv_gltf_data_t object containing the model data.
  * @param matrix The transformation matrix to apply when calculating the center point.
- * @param meshIndex The index of the mesh from which to retrieve the center point.
+ * @param mesh_index The index of the mesh from which to retrieve the center point.
  * @param elem The specific element index within the mesh.
  * @return The center point as a fastgltf::math::fvec3 structure.
  */

--- a/src/libs/gltf/gltf_data/lv_gltf_data_primitive.cpp
+++ b/src/libs/gltf/gltf_data/lv_gltf_data_primitive.cpp
@@ -47,10 +47,10 @@ void lv_gltf_data_add_opaque_node_primitive(lv_gltf_model_t * data, size_t index
         std::make_pair(node, primitive_index));
 }
 
-void lv_gltf_data_add_blended_node_primitive(lv_gltf_model_t * data, size_t index,
+void lv_gltf_data_add_blended_node_primitive(lv_gltf_model_t * data, size_t material_index,
                                              fastgltf::Node * node, size_t primitive_index)
 {
-    data->blended_nodes_by_material_index[index].push_back(
+    data->blended_nodes_by_material_index[material_index].push_back(
         std::make_pair(node, primitive_index));
 }
 

--- a/src/libs/gltf/gltf_data/lv_gltf_data_texture.cpp
+++ b/src/libs/gltf/gltf_data/lv_gltf_data_texture.cpp
@@ -50,32 +50,32 @@ GLuint lv_gltf_data_create_texture(lv_gltf_model_t * data)
     return texture;
 }
 
-void lv_gltf_data_rgb_to_bgr(uint8_t * pixels, size_t byte_total_count, bool has_alpha)
+void lv_gltf_data_rgb_to_bgr(uint8_t * pixel_buffer, size_t byte_total_count, bool has_alpha)
 {
     size_t bytes_per_pixel = has_alpha ? 4 : 3;
     size_t pixel_count = (byte_total_count / bytes_per_pixel);
     if(bytes_per_pixel == 4) {
         for(size_t p = 0; p < pixel_count; p++) {
             size_t index = p << 2;
-            uint8_t r = pixels[index + 0];
-            uint8_t g = pixels[index + 1];
-            uint8_t b = pixels[index + 2];
-            uint8_t a = pixels[index + 3];
-            pixels[index + 0] = b;
-            pixels[index + 1] = g;
-            pixels[index + 2] = r;
-            pixels[index + 3] = a;
+            uint8_t r = pixel_buffer[index + 0];
+            uint8_t g = pixel_buffer[index + 1];
+            uint8_t b = pixel_buffer[index + 2];
+            uint8_t a = pixel_buffer[index + 3];
+            pixel_buffer[index + 0] = b;
+            pixel_buffer[index + 1] = g;
+            pixel_buffer[index + 2] = r;
+            pixel_buffer[index + 3] = a;
         }
     }
     else {
         for(size_t p = 0; p < pixel_count; p++) {
             size_t index = p * 3;
-            uint8_t r = pixels[index + 0];
-            uint8_t g = pixels[index + 1];
-            uint8_t b = pixels[index + 2];
-            pixels[index + 0] = b;
-            pixels[index + 1] = g;
-            pixels[index + 2] = r;
+            uint8_t r = pixel_buffer[index + 0];
+            uint8_t g = pixel_buffer[index + 1];
+            uint8_t b = pixel_buffer[index + 2];
+            pixel_buffer[index + 0] = b;
+            pixel_buffer[index + 1] = g;
+            pixel_buffer[index + 2] = r;
         }
     }
 }

--- a/src/libs/gltf/gltf_environment/lv_gltf_ibl_sampler.c
+++ b/src/libs/gltf/gltf_environment/lv_gltf_ibl_sampler.c
@@ -167,11 +167,11 @@ lv_gltf_environment_t * lv_gltf_environment_create(lv_gltf_ibl_sampler_t * sampl
     return env;
 }
 
-void lv_gltf_environment_delete(lv_gltf_environment_t * env)
+void lv_gltf_environment_delete(lv_gltf_environment_t * environment)
 {
-    const unsigned int d[3] = { env->diffuse, env->specular, env->sheen };
+    const unsigned int d[3] = { environment->diffuse, environment->specular, environment->sheen };
     GL_CALL(glDeleteTextures(3, d));
-    lv_free(env);
+    lv_free(environment);
 }
 
 

--- a/src/libs/gltf/gltf_view/lv_gltf_view.cpp
+++ b/src/libs/gltf/gltf_view/lv_gltf_view.cpp
@@ -158,11 +158,11 @@ lv_result_t lv_gltf_add_model(lv_obj_t * obj, lv_gltf_model_t * model)
     return add_model(viewer, model, false) != NULL ? LV_RESULT_OK : LV_RESULT_INVALID;
 }
 
-void lv_gltf_set_environment(lv_obj_t * obj, lv_gltf_environment_t * env)
+void lv_gltf_set_environment(lv_obj_t * obj, lv_gltf_environment_t * environment)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return);
     lv_gltf_t * gltf = (lv_gltf_t *)obj;
-    if(env == NULL) {
+    if(environment == NULL) {
         LV_LOG_WARN("Refusing to assign a NULL environment to the glTF object");
         return;
     }
@@ -171,7 +171,7 @@ void lv_gltf_set_environment(lv_obj_t * obj, lv_gltf_environment_t * env)
         lv_gltf_environment_delete(gltf->environment);
         gltf->environment = NULL;
     }
-    gltf->environment = env;
+    gltf->environment = environment;
     gltf->owns_environment = false;
 }
 

--- a/src/misc/cache/class/lv_cache_class.h
+++ b/src/misc/cache/class/lv_cache_class.h
@@ -1,5 +1,5 @@
 /**
- * @file lv_cache_clazz.h
+ * @file lv_cache_class.h
  *
  */
 

--- a/src/misc/lv_circle_buf_private.h
+++ b/src/misc/lv_circle_buf_private.h
@@ -109,7 +109,6 @@ bool lv_circle_buf_is_full(const lv_circle_buf_t * circle_buf);
 /**
  * Reset the buffer
  * @param circle_buf pointer to buffer
- * @return LV_RESULT_OK: the buffer is reset; LV_RESULT_INVALID: the buffer is not reset
  */
 void lv_circle_buf_reset(lv_circle_buf_t * circle_buf);
 

--- a/src/misc/lv_color.c
+++ b/src/misc/lv_color.c
@@ -88,9 +88,9 @@ uint8_t lv_color_format_get_bpp(lv_color_format_t cf)
     }
 }
 
-bool lv_color_format_has_alpha(lv_color_format_t cf)
+bool lv_color_format_has_alpha(lv_color_format_t src_cf)
 {
-    switch(cf) {
+    switch(src_cf) {
         case LV_COLOR_FORMAT_A1:
         case LV_COLOR_FORMAT_A2:
         case LV_COLOR_FORMAT_A4:
@@ -253,9 +253,9 @@ lv_color_hsv_t lv_color_rgb_to_hsv(uint8_t r8, uint8_t g8, uint8_t b8)
  * @param color color
  * @return the given color in HSV
  */
-lv_color_hsv_t lv_color_to_hsv(lv_color_t c)
+lv_color_hsv_t lv_color_to_hsv(lv_color_t color)
 {
-    return lv_color_rgb_to_hsv(c.red, c.green, c.blue);
+    return lv_color_rgb_to_hsv(color.red, color.green, color.blue);
 }
 
 uint8_t lv_color_format_get_size(lv_color_format_t cf)

--- a/src/misc/lv_grad.c
+++ b/src/misc/lv_grad.c
@@ -31,19 +31,19 @@
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-void lv_grad_init_stops(lv_grad_dsc_t * dsc, const lv_color_t colors[], const lv_opa_t opa[],
+void lv_grad_init_stops(lv_grad_dsc_t * grad, const lv_color_t colors[], const lv_opa_t opa[],
                         const uint8_t fracs[], int num_stops)
 {
     LV_ASSERT(num_stops <= LV_GRADIENT_MAX_STOPS);
     LV_ASSERT(num_stops > 1);
-    LV_ASSERT_NULL(dsc);
+    LV_ASSERT_NULL(grad);
     LV_ASSERT_NULL(colors);
 
-    dsc->stops_count = num_stops;
+    grad->stops_count = num_stops;
     for(int i = 0; i < num_stops; i++) {
-        dsc->stops[i].color = colors[i];
-        dsc->stops[i].opa = opa != NULL ? opa[i] : LV_OPA_COVER;
-        dsc->stops[i].frac = fracs != NULL ? fracs[i] : 255 * i / (num_stops - 1);
+        grad->stops[i].color = colors[i];
+        grad->stops[i].opa = opa != NULL ? opa[i] : LV_OPA_COVER;
+        grad->stops[i].frac = fracs != NULL ? fracs[i] : 255 * i / (num_stops - 1);
     }
 }
 

--- a/src/misc/lv_matrix.c
+++ b/src/misc/lv_matrix.c
@@ -55,19 +55,19 @@ void lv_matrix_identity(lv_matrix_t * matrix)
     matrix->m[2][2] = 1.0f;
 }
 
-void lv_matrix_translate(lv_matrix_t * matrix, float dx, float dy)
+void lv_matrix_translate(lv_matrix_t * matrix, float tx, float ty)
 {
     LV_CHECK_ARG(matrix != NULL, return);
     if(lv_matrix_is_identity_or_translation(matrix)) {
         /*optimization for matrix translation.*/
-        matrix->m[0][2] += dx;
-        matrix->m[1][2] += dy;
+        matrix->m[0][2] += tx;
+        matrix->m[1][2] += ty;
         return;
     }
 
     lv_matrix_t tlm = {{
-            {1.0f, 0.0f, dx},
-            {0.0f, 1.0f, dy},
+            {1.0f, 0.0f, tx},
+            {0.0f, 1.0f, ty},
             {0.0f, 0.0f, 1.0f},
         }
     };

--- a/src/misc/lv_text.c
+++ b/src/misc/lv_text.c
@@ -211,7 +211,7 @@ bool lv_text_is_cmd(lv_text_cmd_state_t * state, uint32_t c)
  * @param font pointer to a font
  * @param letter_space letter space
  * @param max_width max width of the text (break the lines to fit this size). Set COORD_MAX to avoid line breaks
- * @param flags settings for the text from 'txt_flag_type' enum
+ * @param flag  settings for the text from 'txt_flag_type' enum
  * @param[out] word_w_ptr width (in pixels) of the parsed word. May be NULL.
  * @param cmd_state Pointer to a lv_text_cmd_state_t variable which stored the current state of command processing
  * @return the index of the first char of the next word (in byte index not letter index. With UTF-8 they are different)

--- a/src/widgets/arc/lv_arc.c
+++ b/src/widgets/arc/lv_arc.c
@@ -1018,7 +1018,7 @@ static void get_knob_area(lv_obj_t * obj, const lv_point_t * center, int32_t r, 
 
 /**
  * Used internally to update arc angles after a value change
- * @param arc pointer to an arc object
+ * @param obj pointer to an arc object
  */
 static void value_update(lv_obj_t * obj)
 {

--- a/src/widgets/bar/lv_bar.c
+++ b/src/widgets/bar/lv_bar.c
@@ -153,7 +153,7 @@ void lv_bar_set_value(lv_obj_t * obj, int32_t value, lv_anim_enable_t anim)
     lv_bar_set_value_with_anim(obj, value, &bar->cur_value, &bar->cur_value_anim, anim);
 }
 
-void lv_bar_set_start_value(lv_obj_t * obj, int32_t value, lv_anim_enable_t anim)
+void lv_bar_set_start_value(lv_obj_t * obj, int32_t start_value, lv_anim_enable_t anim)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return);
 
@@ -163,12 +163,12 @@ void lv_bar_set_start_value(lv_obj_t * obj, int32_t value, lv_anim_enable_t anim
         return;
     }
 
-    value = LV_CLAMP(bar->min_value, value, bar->max_value);
-    value = value > bar->cur_value ? bar->cur_value : value; /*Can't be greater than the right value*/
+    start_value = LV_CLAMP(bar->min_value, start_value, bar->max_value);
+    start_value = start_value > bar->cur_value ? bar->cur_value : start_value; /*Can't be greater than the right value*/
 
-    if(bar->start_value == value) return;
+    if(bar->start_value == start_value) return;
 
-    lv_bar_set_value_with_anim(obj, value, &bar->start_value, &bar->start_value_anim, anim);
+    lv_bar_set_value_with_anim(obj, start_value, &bar->start_value, &bar->start_value_anim, anim);
 }
 
 void lv_bar_set_range(lv_obj_t * obj, int32_t min, int32_t max)

--- a/src/widgets/buttonmatrix/lv_buttonmatrix.c
+++ b/src/widgets/buttonmatrix/lv_buttonmatrix.c
@@ -795,7 +795,7 @@ static void draw_main(lv_event_t * e)
 /**
  * Create the required number of buttons and control bytes according to a map
  * @param obj pointer to button matrix object
- * @param map_p pointer to a string array
+ * @param map   pointer to a string array
  */
 static void allocate_button_areas_and_controls(const lv_obj_t * obj, const char * const * map)
 {

--- a/src/widgets/chart/lv_chart.c
+++ b/src/widgets/chart/lv_chart.c
@@ -1750,8 +1750,8 @@ static void draw_cursors(lv_obj_t * obj, lv_layer_t * layer)
 
 /**
  * Get the nearest index to an X coordinate
- * @param chart pointer to a chart object
- * @param coord the coordination of the point relative to the series area.
+ * @param obj   pointer to a chart object
+ * @param x     the coordination of the point relative to the series area.
  * @return the found index
  */
 static uint32_t get_index_from_x(lv_obj_t * obj, int32_t x)

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -1271,7 +1271,7 @@ static lv_result_t btn_release_handler(lv_obj_t * obj)
 
 /**
  * Called when a drop down list is released to open it or set new option
- * @param list pointer to the drop down list's list
+ * @param list_obj pointer to the drop down list's list
  * @return LV_RESULT_INVALID if the list is not being deleted in the user callback. Else LV_RESULT_OK
  */
 static lv_result_t list_release_handler(lv_obj_t * list_obj)
@@ -1347,7 +1347,8 @@ static uint32_t get_id_on_point(lv_obj_t * dropdown_obj, int32_t y)
 
 /**
  * Set the position of list when it is closed to show the selected item
- * @param ddlist pointer to a drop down list
+ * @param dropdown_obj pointer to a drop down list
+ * @param anim_en whether to animate the position change
  */
 static void position_to_selected(lv_obj_t * dropdown_obj, lv_anim_enable_t anim_en)
 {

--- a/src/widgets/ffmpeg/lv_ffmpeg.c
+++ b/src/widgets/ffmpeg/lv_ffmpeg.c
@@ -279,14 +279,14 @@ void lv_ffmpeg_player_set_auto_restart(lv_obj_t * obj, bool en)
     player->auto_restart = en;
 }
 
-void lv_ffmpeg_player_set_decoder(lv_obj_t * obj, const char * name)
+void lv_ffmpeg_player_set_decoder(lv_obj_t * obj, const char * decoder_name)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return);
     lv_ffmpeg_player_t * player = (lv_ffmpeg_player_t *)obj;
     if(player->decoder_name) {
         lv_free((void *)player->decoder_name);
     }
-    player->decoder_name = name ? lv_strdup(name) : NULL;
+    player->decoder_name = decoder_name ? lv_strdup(decoder_name) : NULL;
 }
 
 /**********************

--- a/src/widgets/gif/lv_gif.c
+++ b/src/widgets/gif/lv_gif.c
@@ -500,13 +500,13 @@ static void gif_initialize(lv_gif_t * gifobj)
  * Only disposal method 2 ("restore to background") is handled in this function.
  *
  * @param gif      Pointer to the GIFIMAGE structure representing the current GIF frame.
- * @param drawbuf  Pointer to the draw buffer where the frame is rendered.
+ * @param draw_buf Pointer to the draw buffer where the frame is rendered.
  *
  * Assumptions:
  *   - The coordinates and dimensions (iX, iY, iWidth, iHeight) are within the bounds of the draw buffer.
  *   - The palette type and background color are valid for the current GIF frame.
  */
-static void gif_disposal_last_frame(GIFIMAGE * gif, lv_draw_buf_t * drawbuf)
+static void gif_disposal_last_frame(GIFIMAGE * gif, lv_draw_buf_t * draw_buf)
 {
     LV_PROFILER_DECODER_BEGIN;
 
@@ -519,7 +519,7 @@ static void gif_disposal_last_frame(GIFIMAGE * gif, lv_draw_buf_t * drawbuf)
 
     /* Bounds validation to prevent out-of-bounds access */
     if(x < 0 || y < 0 || w <= 0 || h <= 0 ||
-       x + w > drawbuf->header.w || y + h > drawbuf->header.h) {
+       x + w > draw_buf->header.w || y + h > draw_buf->header.h) {
         LV_PROFILER_DECODER_END;
         return;
     }
@@ -539,7 +539,7 @@ static void gif_disposal_last_frame(GIFIMAGE * gif, lv_draw_buf_t * drawbuf)
                     if(gif->ucGIFBits & 1) color = 0;
 
                     for(i = y; i < y + h; i++) {
-                        uint8_t * dst = drawbuf->data + drawbuf->header.stride * i;
+                        uint8_t * dst = draw_buf->data + draw_buf->header.stride * i;
                         for(j = x; j < x + w; j++) {
                             *(uint16_t *)(dst + 2 * j) = color;
                         }
@@ -559,7 +559,7 @@ static void gif_disposal_last_frame(GIFIMAGE * gif, lv_draw_buf_t * drawbuf)
                     }
 
                     for(i = y; i < y + h; i++) {
-                        uint8_t * dst = drawbuf->data + drawbuf->header.stride * i;
+                        uint8_t * dst = draw_buf->data + draw_buf->header.stride * i;
                         for(j = x; j < x + w; j++) {
                             dst[3 * j] = r;
                             dst[3 * j + 1] = g;
@@ -577,7 +577,7 @@ static void gif_disposal_last_frame(GIFIMAGE * gif, lv_draw_buf_t * drawbuf)
                     }
 
                     for(i = y; i < y + h; i++) {
-                        uint8_t * dst = drawbuf->data + drawbuf->header.stride * i;
+                        uint8_t * dst = draw_buf->data + draw_buf->header.stride * i;
                         for(j = x; j < x + w; j++) {
                             *(lv_color32_t *)(dst + 4 * j) = bg_color;
                         }

--- a/src/widgets/imagebutton/lv_imagebutton.c
+++ b/src/widgets/imagebutton/lv_imagebutton.c
@@ -295,7 +295,7 @@ static void refr_image(lv_obj_t * obj)
 /**
  * If `src` is not defined for the current state try to get a state which is related to the current but has `src`.
  * E.g. if the PRESSED src is not set but the RELEASED does, use the RELEASED.
- * @param imagebutton pointer to an image button
+ * @param obj         pointer to an image button
  * @param state the state to convert
  * @return the suggested state
  */

--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -1149,7 +1149,7 @@ static void update_layout_completed_cb(lv_event_t * e)
 
 /**
  * Refresh the label with its text stored in its extended data
- * @param label pointer to a label object
+ * @param obj   pointer to a label object
  */
 static void lv_label_refr_text(lv_obj_t * obj)
 {

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -41,9 +41,9 @@ static void lv_roller_label_event(const lv_obj_class_t * class_p, lv_event_t * e
 static void draw_main(lv_event_t * e);
 static void draw_label(lv_event_t * e);
 static void get_sel_area(lv_obj_t * obj, lv_area_t * sel_area);
-static void refr_position(lv_obj_t * obj, lv_anim_enable_t animen);
+static void refr_position(lv_obj_t * obj, lv_anim_enable_t anim_en);
 static lv_result_t release_handler(lv_obj_t * obj);
-static void inf_normalize(lv_obj_t * obj_scrl);
+static void inf_normalize(lv_obj_t * obj);
 static lv_obj_t * get_label(const lv_obj_t * obj);
 static int32_t get_selected_label_width(const lv_obj_t * obj);
 static void scroll_anim_completed_cb(lv_anim_t * a);
@@ -279,7 +279,7 @@ void lv_roller_get_selected_str(const lv_obj_t * obj, char * buf, uint32_t buf_s
 
 /**
  * Get the options of a roller
- * @param roller pointer to roller object
+ * @param obj    pointer to roller object
  * @return the options separated by '\n'-s (E.g. "Option1\nOption2\nOption3")
  */
 const char * lv_roller_get_options(const lv_obj_t * obj)
@@ -698,7 +698,7 @@ static void get_sel_area(lv_obj_t * obj, lv_area_t * sel_area)
 
 /**
  * Refresh the position of the roller. It uses the id stored in: roller->ddlist.selected_option_id
- * @param roller pointer to a roller object
+ * @param obj    pointer to a roller object
  * @param anim_en LV_ANIM_ON: refresh with animation; LV_ANIM_OFF: without animation
  */
 static void refr_position(lv_obj_t * obj, lv_anim_enable_t anim_en)
@@ -849,7 +849,7 @@ static lv_result_t release_handler(lv_obj_t * obj)
 
 /**
  * Set the middle page for the roller if infinite is enabled
- * @param roller pointer to a roller object
+ * @param obj    pointer to a roller object
  */
 static void inf_normalize(lv_obj_t * obj)
 {

--- a/src/widgets/scale/lv_scale.c
+++ b/src/widgets/scale/lv_scale.c
@@ -1511,7 +1511,7 @@ static void scale_get_label_coords(lv_obj_t * obj, lv_draw_label_dsc_t * label_d
  *
  * @param obj       pointer to a scale object
  * @param line_dsc  pointer to line descriptor
- * @param items_section_style  pointer to indicator section style
+ * @param section_style        pointer to indicator section style
  * @param part      line part, example: LV_PART_INDICATOR, LV_PART_ITEMS, LV_PART_MAIN
  */
 static void scale_set_line_properties(lv_obj_t * obj, lv_draw_line_dsc_t * line_dsc, const lv_style_t * section_style,
@@ -1562,7 +1562,7 @@ static void scale_set_line_properties(lv_obj_t * obj, lv_draw_line_dsc_t * line_
  *
  * @param obj       pointer to a scale object
  * @param arc_dsc  pointer to arc descriptor
- * @param items_section_style  pointer to indicator section style
+ * @param section_style        pointer to indicator section style
  */
 static void scale_set_arc_properties(lv_obj_t * obj, lv_draw_arc_dsc_t * arc_dsc, const lv_style_t * section_style)
 {
@@ -1631,7 +1631,7 @@ static void scale_set_arc_properties(lv_obj_t * obj, lv_draw_arc_dsc_t * arc_dsc
  *
  * @param obj       pointer to a scale object
  * @param label_dsc  pointer to label descriptor
- * @param items_section_style  pointer to indicator section style
+ * @param indicator_section_style pointer to indicator section style
  */
 static void scale_set_indicator_label_properties(lv_obj_t * obj, lv_draw_label_dsc_t * label_dsc,
                                                  const lv_style_t * indicator_section_style)

--- a/src/widgets/slider/lv_slider.c
+++ b/src/widgets/slider/lv_slider.c
@@ -155,9 +155,9 @@ void lv_slider_set_min_value(lv_obj_t * obj, int32_t min)
     lv_bar_set_min_value(obj, min);
 }
 
-void lv_slider_set_max_value(lv_obj_t * obj, int32_t min)
+void lv_slider_set_max_value(lv_obj_t * obj, int32_t max)
 {
-    lv_bar_set_max_value(obj, min);
+    lv_bar_set_max_value(obj, max);
 }
 
 void lv_slider_set_mode(lv_obj_t * obj, lv_slider_mode_t mode)
@@ -198,9 +198,9 @@ lv_slider_mode_t lv_slider_get_mode(lv_obj_t * slider)
     else return LV_SLIDER_MODE_NORMAL;
 }
 
-lv_slider_orientation_t lv_slider_get_orientation(lv_obj_t * slider)
+lv_slider_orientation_t lv_slider_get_orientation(lv_obj_t * obj)
 {
-    lv_bar_orientation_t ori = lv_bar_get_orientation(slider);
+    lv_bar_orientation_t ori = lv_bar_get_orientation(obj);
     if(ori == LV_BAR_ORIENTATION_HORIZONTAL) return LV_SLIDER_ORIENTATION_HORIZONTAL;
     else if(ori == LV_BAR_ORIENTATION_VERTICAL) return LV_SLIDER_ORIENTATION_VERTICAL;
     else return LV_SLIDER_ORIENTATION_AUTO;

--- a/src/widgets/span/lv_span.c
+++ b/src/widgets/span/lv_span.c
@@ -153,9 +153,9 @@ void lv_span_stack_deinit(void)
     lv_free(snippet_stack);
 }
 
-lv_obj_t * lv_spangroup_create(lv_obj_t * par)
+lv_obj_t * lv_spangroup_create(lv_obj_t * parent)
 {
-    lv_obj_t * obj = lv_obj_class_create_obj(&lv_spangroup_class, par);
+    lv_obj_t * obj = lv_obj_class_create_obj(&lv_spangroup_class, parent);
     lv_obj_class_init_obj(obj);
     return obj;
 }
@@ -1078,9 +1078,8 @@ static int32_t convert_indent_pct(lv_obj_t * obj, int32_t width)
 
 /**
  * draw span group
- * @param spans obj handle
- * @param coords coordinates of the label
- * @param mask the label will be drawn only in this area
+ * @param obj pointer to a spangroup object
+ * @param layer pointer to the layer to draw into
  */
 static void lv_draw_span(lv_obj_t * obj, lv_layer_t * layer)
 {

--- a/src/widgets/tabview/lv_tabview.c
+++ b/src/widgets/tabview/lv_tabview.c
@@ -297,14 +297,14 @@ uint32_t lv_tabview_get_tab_count(lv_obj_t * obj)
     return lv_obj_get_child_count_by_type(tab_bar, &lv_button_class);
 }
 
-lv_obj_t * lv_tabview_get_content(lv_obj_t * tv)
+lv_obj_t * lv_tabview_get_content(lv_obj_t * obj)
 {
-    return lv_obj_get_child(tv, 1);
+    return lv_obj_get_child(obj, 1);
 }
 
-lv_obj_t * lv_tabview_get_tab_bar(lv_obj_t * tv)
+lv_obj_t * lv_tabview_get_tab_bar(lv_obj_t * obj)
 {
-    return lv_obj_get_child(tv, 0);
+    return lv_obj_get_child(obj, 0);
 }
 
 lv_dir_t lv_tabview_get_tab_bar_position(lv_obj_t * obj)

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -949,8 +949,8 @@ static void label_event_cb(lv_event_t * e)
 
 /**
  * Called to blink the cursor
- * @param ta pointer to a text area
- * @param hide 1: hide the cursor, 0: show it
+ * @param obj pointer to a text area
+ * @param show 1: show the cursor, 0: hide it
  */
 static void cursor_blink_anim_cb(void * obj, int32_t show)
 {
@@ -971,7 +971,7 @@ static void cursor_blink_anim_cb(void * obj, int32_t show)
  * Dummy function to animate char hiding in pwd mode.
  * Does nothing, but a function is required in car hiding anim.
  * (pwd_char_hider callback do the real job)
- * @param ta unused
+ * @param obj unused
  * @param x unused
  */
 static void pwd_char_hider_anim(void * obj, int32_t x)
@@ -992,7 +992,7 @@ static void pwd_char_hider_anim_completed(lv_anim_t * a)
 
 /**
  * Hide all characters (convert them to '*')
- * @param ta pointer to text area object
+ * @param obj pointer to text area object
  */
 static void pwd_char_hider(lv_obj_t * obj)
 {
@@ -1026,7 +1026,7 @@ static void pwd_char_hider(lv_obj_t * obj)
 
 /**
  * Test a unicode character if it is accepted or not. Checks max length and accepted char list.
- * @param ta pointer to a test area object
+ * @param obj pointer to a test area object
  * @param c a unicode character
  * @return true: accepted; false: rejected
  */


### PR DESCRIPTION
This PR enables doxygen to treat warnings as errors and fixes all of the underlying warnings

Using `refactor` instead of `docs` here since for some of the cases the correct way to fix it was to change the function code itself by renaming 
