### PR TITLE
fix(libinput): add a helper function to clear the device cache

### DIFF
--- a/include/lvgl/drivers/indev/lv_libinput.h
+++ b/include/lvgl/drivers/indev/lv_libinput.h
@@ -75,6 +75,15 @@ char * lv_libinput_find_dev(lv_libinput_capability capabilities, bool force_resc
 size_t lv_libinput_find_devs(lv_libinput_capability capabilities, char ** found, size_t count, bool force_rescan);
 
 /**
+ * Clear the device cache.
+ *
+ * This frees the cached device path strings, so any pointers previously
+ * returned by lv_libinput_find_dev() or lv_libinput_find_devs() become
+ * invalid after this call.
+ */
+void lv_libinput_clear_devs(void);
+
+/**
  * Create a new libinput input device
  * @param indev_type LV_INDEV_TYPE_POINTER or LV_INDEV_TYPE_KEYPAD
  * @param dev_path device path, e.g. /dev/input/event0

--- a/src/drivers/libinput/lv_libinput.c
+++ b/src/drivers/libinput/lv_libinput.c
@@ -146,6 +146,11 @@ size_t lv_libinput_find_devs(lv_libinput_capability capabilities, char ** found,
     return num_found;
 }
 
+void lv_libinput_clear_devs(void)
+{
+    _reset_scanned_devices();
+}
+
 lv_indev_t * lv_libinput_create(lv_indev_type_t indev_type, const char * dev_path)
 {
     lv_libinput_t * dsc = lv_malloc_zeroed(sizeof(lv_libinput_t));


### PR DESCRIPTION
The lv_libinput_find_dev and lv_libinput_find_devs populate the (global) device cache, but there is no function to clear the cache again. This results in a small memory leak, which can't be fixed in the application.

Split off from #9855

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

