### PR TITLE
docs(doxygen): introduce @nullable alias

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -238,7 +238,7 @@ TAB_SIZE               = 4
 # "Side Effects:". You can put \n's in the value part of an alias to insert
 # newlines.
 
-ALIASES                =
+ALIASES  = "nullable=@b Optional: may be `NULL`."
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"


### PR DESCRIPTION
Can and will be used as a way to document if a parameter can be NULL e.g.

```c
/* 
 * @param obj parent of the object. @nullable
 */
void foo(lv_obj_t* obj);
```
