### PR TITLE
refactor(svg): rename private _lv_svg_parser_state_t in lv_svg_token.c to avoid collision

### DIFF
--- a/src/image/svg/lv_svg_token.c
+++ b/src/image/svg/lv_svg_token.c
@@ -59,37 +59,37 @@ typedef struct {
     uint32_t flags;
     const char * cur;
     const char * end;
-} _lv_svg_parser_state_t;
+} _lv_svg_token_state_t;
 
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static void _set_state(_lv_svg_parser_state_t * state, uint32_t bit)
+static void _set_state(_lv_svg_token_state_t * state, uint32_t bit)
 {
     state->flags |= bit;
 }
 
-static void _clear_state(_lv_svg_parser_state_t * state, uint32_t bit)
+static void _clear_state(_lv_svg_token_state_t * state, uint32_t bit)
 {
     state->flags &= ~bit;
 }
 
-static bool _is_state(_lv_svg_parser_state_t * state, uint32_t bit)
+static bool _is_state(_lv_svg_token_state_t * state, uint32_t bit)
 {
     return state->flags & bit;
 }
 
-static void _set_tag_state(_lv_svg_parser_state_t * state, uint32_t bit)
+static void _set_tag_state(_lv_svg_token_state_t * state, uint32_t bit)
 {
     state->flags = (state->flags & ~SVG_TAG_MASK) | bit;
 }
 
-static void _set_quote_state(_lv_svg_parser_state_t * state, uint32_t bit)
+static void _set_quote_state(_lv_svg_token_state_t * state, uint32_t bit)
 {
     state->flags = (state->flags & ~SVG_QUOTE_MASK) | (bit << 3);
 }
 
-static bool _special_handle(_lv_svg_parser_state_t * state)
+static bool _special_handle(_lv_svg_token_state_t * state)
 {
     return state->flags & (SVG_TAG | SVG_SEARCH | SVG_TAG_MASK | SVG_COMMENT | SVG_DOCTYPE | SVG_XMLINST);
 }
@@ -136,7 +136,7 @@ static _lv_svg_token_attr_t * _new_svg_attr(_lv_svg_token_t * token)
     return attr;
 }
 
-static void _svg_parser_xml_inst(_lv_svg_parser_state_t * state, _lv_svg_token_t * token)
+static void _svg_parser_xml_inst(_lv_svg_token_state_t * state, _lv_svg_token_t * token)
 {
     LV_UNUSED(token);
 
@@ -151,7 +151,7 @@ static void _svg_parser_xml_inst(_lv_svg_parser_state_t * state, _lv_svg_token_t
     }
 }
 
-static void _svg_parser_comment(_lv_svg_parser_state_t * state, _lv_svg_token_t * token)
+static void _svg_parser_comment(_lv_svg_token_state_t * state, _lv_svg_token_t * token)
 {
     LV_UNUSED(token);
 
@@ -166,7 +166,7 @@ static void _svg_parser_comment(_lv_svg_parser_state_t * state, _lv_svg_token_t 
     }
 }
 
-static void _svg_parser_doctype(_lv_svg_parser_state_t * state, _lv_svg_token_t * token)
+static void _svg_parser_doctype(_lv_svg_token_state_t * state, _lv_svg_token_t * token)
 {
     LV_UNUSED(token);
 
@@ -182,7 +182,7 @@ static void _svg_parser_doctype(_lv_svg_parser_state_t * state, _lv_svg_token_t 
     }
 }
 
-static bool _svg_parser_tag(_lv_svg_parser_state_t * state, _lv_svg_token_t * token, svg_token_process cb, void * data)
+static bool _svg_parser_tag(_lv_svg_token_state_t * state, _lv_svg_token_t * token, svg_token_process cb, void * data)
 {
     while(state->cur <= state->end) {
         switch(state->flags & SVG_TAG_MASK) {
@@ -358,7 +358,7 @@ bool _lv_svg_tokenizer(const char * svg_data, uint32_t len, svg_token_process cb
 
     _lv_svg_token_t token;
     _lv_svg_token_init(&token);
-    _lv_svg_parser_state_t state = {
+    _lv_svg_token_state_t state = {
         .flags = 0,
         .cur = svg_data,
         .end = svg_data + len,


### PR DESCRIPTION
## Description

In `src/image/svg/lv_svg_token.c`, a file-private struct is defined with the name `_lv_svg_parser_state_t` (line 62), which shadows the public enum `_lv_svg_parser_state_t` defined in `src/image/svg/lv_svg_parser.h` (line 31).

While the tokenizer currently compiles successfully due to include isolation (it only includes `lv_svg_token.h`), this violates the module-prefix naming convention (it should be `_lv_svg_token_state_t` to match its module).

More importantly, if a translation unit ever includes both `lv_svg_parser.h` and exposes the internal state of the tokenizer (for example, through an aggregator header like `lvgl_private.h`), it will lead to a type redefinition or shadowing compilation error.

## Change

Rename the internal struct in `lv_svg_token.c` from `_lv_svg_parser_state_t` to `_lv_svg_token_state_t` and update its usages within that file. This is a pure rename, no behavior change.

Closes #10502


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

