### PR TITLE
fix(fs/arduino): correctly return NULL on open with unsupported mode

### DIFF
--- a/src/fs/lv_fs_arduino_esp_littlefs.cpp
+++ b/src/fs/lv_fs_arduino_esp_littlefs.cpp
@@ -76,6 +76,10 @@ static void * fs_open(lv_fs_drv_t * drv, const char * path, lv_fs_mode_t mode)
         flags = FILE_READ;
     else if(mode == (LV_FS_MODE_WR | LV_FS_MODE_RD))
         flags = FILE_WRITE;
+    else {
+        LV_LOG_WARN("Unsupported mode: 0x%x", (unsigned)mode);
+        return NULL;
+    }
 
     char buf[LV_FS_MAX_PATH_LEN];
     lv_snprintf(buf, sizeof(buf), LV_FS_ARDUINO_ESP_LITTLEFS_PATH "%s", path);

--- a/src/fs/lv_fs_arduino_sd.cpp
+++ b/src/fs/lv_fs_arduino_sd.cpp
@@ -68,6 +68,10 @@ static void * fs_open(lv_fs_drv_t * drv, const char * path, lv_fs_mode_t mode)
         flags = FILE_READ;
     else if(mode == (LV_FS_MODE_WR | LV_FS_MODE_RD))
         flags = FILE_WRITE;
+    else {
+        LV_LOG_WARN("Unsupported mode: 0x%x", (unsigned)mode);
+        return NULL;
+    }
 
     char buf[LV_FS_MAX_PATH_LEN];
     lv_snprintf(buf, sizeof(buf), LV_FS_ARDUINO_SD_PATH "%s", path);


### PR DESCRIPTION
As the title says
