### PR TITLE
fix(draw): suppress cppcheck autoVariables false positives in draw_letter

### DIFF
--- a/src/draw/lv_draw_label.c
+++ b/src/draw/lv_draw_label.c
@@ -596,6 +596,8 @@ void lv_draw_unit_draw_letter(lv_draw_task_t * t, lv_draw_glyph_dsc_t * dsc,  co
 
     LV_PROFILER_DRAW_BEGIN;
     if(dsc->g == NULL) {
+        /*The local glyph dsc never outlives this call: dsc->g is reset to NULL at exit*/
+        /*cppcheck-suppress autoVariables*/
         dsc->g = &g;
         /*If the glyph dsc is not set then get it from the font*/
         bool g_ret = lv_font_get_glyph_dsc(font, &g, letter, 0);
@@ -657,6 +659,8 @@ void lv_draw_unit_draw_letter(lv_draw_task_t * t, lv_draw_glyph_dsc_t * dsc,  co
         dsc->format = LV_FONT_GLYPH_FORMAT_NONE;
     }
 
+    /*Points to a local, but cb() consumes it synchronously before this call returns*/
+    /*cppcheck-suppress autoVariables*/
     dsc->letter_coords = &letter_coords;
     cb(t, dsc, NULL, NULL);
 


### PR DESCRIPTION

cppcheck reports two autoVariables errors in
`lv_draw_unit_draw_letter()` and the CI cppcheck gate fails any PR
that touches `lv_draw_label.c` because the changed-file scan picks
them up.

Both are false positives. The function stores the address of a stack
variable in the glyph dsc, the callback consumes it synchronously,
and the pointer is reset before return (`dsc->g = NULL` at exit).
`lv_scale.c` already suppresses the same pattern with an inline
comment; do the same here.

No functional change. `python3 scripts/check_cppcheck.py --file
src/draw/lv_draw_label.c` goes from 2 errors to 0.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

