### PR TITLE
docs: remove "optional" from @nullable alias

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -238,7 +238,7 @@ TAB_SIZE               = 4
 # "Side Effects:". You can put \n's in the value part of an alias to insert
 # newlines.
 
-ALIASES  = "nullable=@b Optional: may be `NULL`."
+ALIASES  = "nullable=@b May be `NULL`."
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"


### PR DESCRIPTION
If someone is using C++ `optional` might mean the parameter isn't required which is not true
