### PR TITLE
fix(label): refresh text when set_text_static is called with NULL

### DIFF
--- a/src/widgets/label/lv_label.c
+++ b/src/widgets/label/lv_label.c
@@ -174,6 +174,10 @@ void lv_label_set_text_static(lv_obj_t * obj, const char * text)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return);
     lv_label_t * label = (lv_label_t *)obj;
+    if(!text) {
+        lv_label_mark_need_refr_text(obj);
+        return;
+    }
 
     remove_translation_tag(obj);
     if(label->static_txt == 0 && label->text != NULL) {


### PR DESCRIPTION
As documented in the function API docs:

```c
 * @param text          pointer to a text. NULL to refresh with the current text.
```

Previously it would not refresh the text if the text wasn't static
