### PR TITLE
chore(idf): pull optional libraries via conditional component deps

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -3,3 +3,24 @@ url: https://lvgl.io/
 repository: https://github.com/lvgl/lvgl.git
 documentation: https://docs.lvgl.io/
 issues: https://github.com/lvgl/lvgl/issues
+dependencies:
+  espressif/freetype:
+    require: private
+    version: "^2.14.3"
+    rules:
+      - if: "idf_version >=6.0 && $CONFIG{LV_USE_FREETYPE} == True"
+  espressif/libjpeg-turbo:
+    require: private
+    version: "^3.1.1"
+    rules:
+      - if: "idf_version >=6.0 && $CONFIG{LV_USE_LIBJPEG_TURBO} == True"
+  espressif/libpng:
+    require: private
+    version: "^1.6.58"
+    rules:
+      - if: "idf_version >=6.0 && $CONFIG{LV_USE_LIBPNG} == True"
+  espressif/lz4:
+    require: private
+    version: "^1.10.0"
+    rules:
+      - if: "idf_version >=6.0 && $CONFIG{LV_USE_LZ4} == True && $CONFIG{LV_USE_LZ4_INTERNAL} == False"


### PR DESCRIPTION
## Summary
- Add Kconfig-gated `idf_component.yml` dependencies so ESP-IDF pulls `espressif/freetype`, `espressif/libpng`, `espressif/libjpeg-turbo`, and `espressif/lz4` only when the matching `LV_USE_*` options are enabled (ESP-IDF >= 6.0).
- LZ4 is pulled only for the external path (`LV_USE_LZ4=y` and `LV_USE_LZ4_INTERNAL=n`); the bundled copy does not download the registry component.
- All four are `require: private` because their headers are used only inside LVGL, not by downstream public APIs.

This should fix the issue that user reported in https://github.com/espressif/idf-extra-components/issues/510