### PR TITLE
fix(tiny_ttf): handle missing glyphs without cache errors

### DIFF
--- a/src/font/tiny_ttf/lv_tiny_ttf.c
+++ b/src/font/tiny_ttf/lv_tiny_ttf.c
@@ -325,6 +325,9 @@ static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * d
     if(entry == NULL) {
         if(!dsc->cache_size) {  /* no cache, do everything directly */
             int g1 = stbtt_FindGlyphIndex(&dsc->info, (int)unicode_letter);
+            if(g1 == 0) {
+                return false;
+            }
             tiny_ttf_glyph_cache_create_cb(&search_key, dsc);
             *dsc_out = search_key.glyph_dsc;
             adv_w = search_key.adv_w;
@@ -349,6 +352,10 @@ static bool ttf_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * d
     *dsc_out = data->glyph_dsc;
     adv_w = data->adv_w;
     lv_cache_release(dsc->glyph_cache, entry, NULL);
+
+    if(dsc_out->gid.index == 0) {
+        return false;
+    }
 
     /*Kerning correction*/
     if(font->kerning == LV_FONT_KERNING_NORMAL &&
@@ -576,7 +583,10 @@ static bool tiny_ttf_glyph_cache_create_cb(tiny_ttf_glyph_cache_data_t * node, v
     int g1 = stbtt_FindGlyphIndex(&dsc->info, (int)unicode_letter);
     if(g1 == 0) {
         /* Glyph not found */
-        return false;
+        lv_memzero(dsc_out, sizeof(*dsc_out));
+        node->adv_w = 0;
+        dsc_out->gid.index = 0;
+        return true;
     }
     int x1, y1, x2, y2;
 

--- a/tests/src/test_cases/libs/test_tiny_ttf.c
+++ b/tests/src/test_cases/libs/test_tiny_ttf.c
@@ -4,6 +4,15 @@
 
 #include "unity/unity.h"
 
+#include <string.h>
+
+static uint32_t cache_error_count;
+
+static void count_cache_errors_cb(lv_log_level_t level, const char * buf)
+{
+    if(level == LV_LOG_LEVEL_ERROR && strstr(buf, "cache not allocated") != NULL) cache_error_count++;
+}
+
 /* NanoVG's GPU rasterization produces glyph metrics that differ between architectures
  * beyond a usable tolerance, so it keeps a per-architecture reference set. The SW
  * renderer is architecture-stable and shares a single reference image. */
@@ -90,6 +99,36 @@ void test_tiny_ttf_kerning(void)
     lv_obj_delete(cont);
     lv_tiny_ttf_destroy(font_normal);
     lv_tiny_ttf_destroy(font_none);
+#else
+    TEST_PASS();
+#endif
+}
+
+void test_tiny_ttf_missing_glyph_uses_fallback(void)
+{
+#if LV_USE_TINY_TTF && LV_FONT_MONTSERRAT_14
+    extern const uint8_t test_ubuntu_font[];
+    extern size_t test_ubuntu_font_size;
+    const size_t cache_sizes[] = {0, 1};
+
+    cache_error_count = 0;
+    lv_log_register_print_cb(count_cache_errors_cb);
+
+    for(size_t i = 0; i < LV_ARRAY_SIZE(cache_sizes); i++) {
+        lv_font_t * font = lv_tiny_ttf_create_data_ex(test_ubuntu_font, test_ubuntu_font_size, 30,
+                                                      LV_FONT_KERNING_NORMAL, cache_sizes[i]);
+        TEST_ASSERT_NOT_NULL(font);
+        font->fallback = &lv_font_montserrat_14;
+
+        lv_font_glyph_dsc_t glyph_dsc;
+        TEST_ASSERT_TRUE(lv_font_get_glyph_dsc(font, &glyph_dsc, 0xf55a, 0));
+        TEST_ASSERT_EQUAL_PTR(&lv_font_montserrat_14, glyph_dsc.resolved_font);
+
+        lv_tiny_ttf_destroy(font);
+    }
+
+    lv_log_register_print_cb(NULL);
+    TEST_ASSERT_EQUAL_UINT32(0, cache_error_count);
 #else
     TEST_PASS();
 #endif

--- a/tests/src/test_cases/libs/test_tiny_ttf.c
+++ b/tests/src/test_cases/libs/test_tiny_ttf.c
@@ -108,7 +108,6 @@ void test_tiny_ttf_kerning(void)
 
 void test_tiny_ttf_missing_glyph_uses_fallback(void)
 {
-#if LV_USE_TINY_TTF && LV_FONT_MONTSERRAT_14
     extern const uint8_t test_ubuntu_font[];
     extern size_t test_ubuntu_font_size;
     const size_t cache_sizes[] = {0, 1};
@@ -127,9 +126,6 @@ void test_tiny_ttf_missing_glyph_uses_fallback(void)
     }
 
     TEST_ASSERT_EQUAL_UINT32(0, cache_error_count);
-#else
-    TEST_PASS();
-#endif
 }
 
 void test_tiny_ttf_gpos(void)

--- a/tests/src/test_cases/libs/test_tiny_ttf.c
+++ b/tests/src/test_cases/libs/test_tiny_ttf.c
@@ -11,6 +11,7 @@ static uint32_t cache_error_count;
 static void count_cache_errors_cb(lv_log_level_t level, const char * buf)
 {
     if(level == LV_LOG_LEVEL_ERROR && strstr(buf, "cache not allocated") != NULL) cache_error_count++;
+    if(level >= LV_LOG_LEVEL_WARN) TEST_PRINTF(buf);
 }
 
 /* NanoVG's GPU rasterization produces glyph metrics that differ between architectures
@@ -28,12 +29,13 @@ static void count_cache_errors_cb(lv_log_level_t level, const char * buf)
 
 void setUp(void)
 {
-    /* Function run before every test */
+    cache_error_count = 0;
+    lv_log_register_print_cb(count_cache_errors_cb);
 }
 
 void tearDown(void)
 {
-    /* Function run after every test */
+    lv_log_register_print_cb(NULL);
 }
 
 void test_tiny_ttf_rendering_test(void)
@@ -111,9 +113,6 @@ void test_tiny_ttf_missing_glyph_uses_fallback(void)
     extern size_t test_ubuntu_font_size;
     const size_t cache_sizes[] = {0, 1};
 
-    cache_error_count = 0;
-    lv_log_register_print_cb(count_cache_errors_cb);
-
     for(size_t i = 0; i < sizeof(cache_sizes) / sizeof(cache_sizes[0]); i++) {
         lv_font_t * font = lv_tiny_ttf_create_data_ex(test_ubuntu_font, test_ubuntu_font_size, 30,
                                                       LV_FONT_KERNING_NORMAL, cache_sizes[i]);
@@ -127,7 +126,6 @@ void test_tiny_ttf_missing_glyph_uses_fallback(void)
         lv_tiny_ttf_destroy(font);
     }
 
-    lv_log_register_print_cb(NULL);
     TEST_ASSERT_EQUAL_UINT32(0, cache_error_count);
 #else
     TEST_PASS();

--- a/tests/src/test_cases/libs/test_tiny_ttf.c
+++ b/tests/src/test_cases/libs/test_tiny_ttf.c
@@ -114,7 +114,7 @@ void test_tiny_ttf_missing_glyph_uses_fallback(void)
     cache_error_count = 0;
     lv_log_register_print_cb(count_cache_errors_cb);
 
-    for(size_t i = 0; i < LV_ARRAY_SIZE(cache_sizes); i++) {
+    for(size_t i = 0; i < sizeof(cache_sizes) / sizeof(cache_sizes[0]); i++) {
         lv_font_t * font = lv_tiny_ttf_create_data_ex(test_ubuntu_font, test_ubuntu_font_size, 30,
                                                       LV_FONT_KERNING_NORMAL, cache_sizes[i]);
         TEST_ASSERT_NOT_NULL(font);


### PR DESCRIPTION
Related to #6741

Tiny TTF treats a missing glyph as a cache allocation failure when the glyph cache is enabled. This produces a misleading `cache not allocated` error before LVGL tries the fallback font.

When the cache is disabled, glyph index 0 is incorrectly treated as a valid glyph, which prevents fallback lookup.

This change:

- stores missing glyphs as valid negative cache entries;
- returns `false` for missing glyphs in both cached and non-cached modes, allowing fallback lookup;
- adds a regression test covering both modes and verifying that no cache allocation error is logged.

Testing:

- Built and ran a minimal Tiny TTF reproducer against the updated LVGL.
- Verified that the missing glyph is resolved by the fallback font without the `cache not allocated` error.
- The full 32-bit and 64-bit test suites pass in CI.