### PR TITLE
fix(draw_sdl): don't claim draw task types the SDL unit cannot render

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1109,6 +1109,7 @@ endmenu
 menu "SDL"
 config LV_USE_DRAW_SDL
 	bool "SDL renderer"
+	select LV_USE_DRAW_SW
 	default n
 	help
 		Render with the SDL renderer API, caching widgets and images as SDL textures.

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -611,7 +611,10 @@
 
 #endif /*LV_USE_DRAW_OPENGLES*/
 
-/** Render with the SDL renderer API, caching widgets and images as SDL textures. */
+/** Render with the SDL renderer API, caching widgets and images as SDL textures.
+ *
+ *  Enable: LV_USE_DRAW_SW
+ */
 #define LV_USE_DRAW_SDL 0
 
 

--- a/src/draw/sdl/Kconfig
+++ b/src/draw/sdl/Kconfig
@@ -1,5 +1,6 @@
 config LV_USE_DRAW_SDL
 	bool "SDL renderer"
+	select LV_USE_DRAW_SW
 	default n
 	help
 		Render with the SDL renderer API, caching widgets and images as SDL textures.

--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -334,6 +334,7 @@ static bool draw_to_texture(lv_draw_sdl_unit_t * u, cache_data_t * cache_data)
                 break;
             }
         default:
+            /*Keep in sync with evaluate(): every type it claims must have a case above*/
             LV_UNREACHABLE();
     }
 

--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -36,12 +36,6 @@ typedef struct {
     int32_t w;
     int32_t h;
     SDL_Texture * texture;
-    /*A freshly added cache node is a byte copy of the search key (see
-     *alloc_new_node() in lv_cache_lru_rb.c), so on entry `draw_dsc` still points
-     *at the *draw task's* dsc, which is an interior pointer into the task
-     *allocation (lv_draw.c: t->draw_dsc = (uint8_t *)t + sizeof(...)) and must
-     *never be freed. Only draw_to_texture() replacing it with its own lv_malloc
-     *copy makes it ours to free.*/
     bool dsc_owned;
 } cache_data_t;
 
@@ -190,16 +184,6 @@ static int32_t evaluate(lv_draw_unit_t * draw_unit, lv_draw_task_t * task)
 {
     LV_UNUSED(draw_unit);
 
-    /*Claim only what execute_drawing()/draw_to_texture() can render. Claiming
-     *anything else makes the texture cache's create_cb fail, and
-     *lv_cache_acquire_or_create() then calls free_cb on a node whose draw_dsc is
-     *still the task's own (never heap-allocated) dsc -- a wild free that trips
-     *the TLSF integrity assert and, with LV_ASSERT_HANDLER as a spin, hangs the
-     *UI thread. LV_DRAW_TASK_TYPE_MASK_RECTANGLE reaches this from lv_refr.c's
-     *clip_corner path, i.e. from every widget the default theme gives
-     *`clip_corner` to (dropdown list, msgbox, list, win, menu) and from lv_bar;
-     *LV_DRAW_TASK_TYPE_LETTER from lv_draw_character(). Both are left to the SW
-     *unit, which handles them.*/
     switch(task->type) {
         case LV_DRAW_TASK_TYPE_FILL:
         case LV_DRAW_TASK_TYPE_BORDER:
@@ -350,13 +334,7 @@ static bool draw_to_texture(lv_draw_sdl_unit_t * u, cache_data_t * cache_data)
                 break;
             }
         default:
-            /*Unreachable as long as evaluate() only claims the types above, but
-             *keep the exit clean: the SEND_DRAW_TASK_EVENTS flag cleared above
-             *would otherwise stay off on this object forever.*/
-            if(obj) {
-                lv_obj_set_send_draw_task_events(obj, original_send_draw_task_event);
-            }
-            return false;
+            LV_UNREACHABLE();
     }
 
     while(dest_layer.draw_task_head) {

--- a/src/draw/sdl/lv_draw_sdl.c
+++ b/src/draw/sdl/lv_draw_sdl.c
@@ -36,6 +36,13 @@ typedef struct {
     int32_t w;
     int32_t h;
     SDL_Texture * texture;
+    /*A freshly added cache node is a byte copy of the search key (see
+     *alloc_new_node() in lv_cache_lru_rb.c), so on entry `draw_dsc` still points
+     *at the *draw task's* dsc, which is an interior pointer into the task
+     *allocation (lv_draw.c: t->draw_dsc = (uint8_t *)t + sizeof(...)) and must
+     *never be freed. Only draw_to_texture() replacing it with its own lv_malloc
+     *copy makes it ours to free.*/
+    bool dsc_owned;
 } cache_data_t;
 
 /**********************
@@ -73,8 +80,9 @@ static void sdl_texture_cache_free_cb(cache_data_t * cached_data, void * user_da
 {
     LV_UNUSED(user_data);
 
-    lv_free(cached_data->draw_dsc);
+    if(cached_data->dsc_owned) lv_free(cached_data->draw_dsc);
     SDL_DestroyTexture(cached_data->texture);
+    cached_data->dsc_owned = false;
     cached_data->draw_dsc = NULL;
     cached_data->texture = NULL;
 }
@@ -181,6 +189,31 @@ static int32_t dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 static int32_t evaluate(lv_draw_unit_t * draw_unit, lv_draw_task_t * task)
 {
     LV_UNUSED(draw_unit);
+
+    /*Claim only what execute_drawing()/draw_to_texture() can render. Claiming
+     *anything else makes the texture cache's create_cb fail, and
+     *lv_cache_acquire_or_create() then calls free_cb on a node whose draw_dsc is
+     *still the task's own (never heap-allocated) dsc -- a wild free that trips
+     *the TLSF integrity assert and, with LV_ASSERT_HANDLER as a spin, hangs the
+     *UI thread. LV_DRAW_TASK_TYPE_MASK_RECTANGLE reaches this from lv_refr.c's
+     *clip_corner path, i.e. from every widget the default theme gives
+     *`clip_corner` to (dropdown list, msgbox, list, win, menu) and from lv_bar;
+     *LV_DRAW_TASK_TYPE_LETTER from lv_draw_character(). Both are left to the SW
+     *unit, which handles them.*/
+    switch(task->type) {
+        case LV_DRAW_TASK_TYPE_FILL:
+        case LV_DRAW_TASK_TYPE_BORDER:
+        case LV_DRAW_TASK_TYPE_BOX_SHADOW:
+        case LV_DRAW_TASK_TYPE_LABEL:
+        case LV_DRAW_TASK_TYPE_IMAGE:
+        case LV_DRAW_TASK_TYPE_LAYER:
+        case LV_DRAW_TASK_TYPE_LINE:
+        case LV_DRAW_TASK_TYPE_ARC:
+        case LV_DRAW_TASK_TYPE_TRIANGLE:
+            break;
+        default:
+            return 0;
+    }
 
     if(task->type == LV_DRAW_TASK_TYPE_IMAGE &&
        ((lv_draw_image_dsc_t *)task->draw_dsc)->header.cf >= LV_COLOR_FORMAT_PROPRIETARY_START) {
@@ -317,6 +350,12 @@ static bool draw_to_texture(lv_draw_sdl_unit_t * u, cache_data_t * cache_data)
                 break;
             }
         default:
+            /*Unreachable as long as evaluate() only claims the types above, but
+             *keep the exit clean: the SEND_DRAW_TASK_EVENTS flag cleared above
+             *would otherwise stay off on this object forever.*/
+            if(obj) {
+                lv_obj_set_send_draw_task_events(obj, original_send_draw_task_event);
+            }
             return false;
     }
 
@@ -336,6 +375,7 @@ static bool draw_to_texture(lv_draw_sdl_unit_t * u, cache_data_t * cache_data)
 
     cache_data->draw_dsc = lv_malloc(base_dsc->dsc_size);
     lv_memcpy((void *)cache_data->draw_dsc, base_dsc, base_dsc->dsc_size);
+    cache_data->dsc_owned = true;
     cache_data->w = texture_w;
     cache_data->h = texture_h;
     cache_data->texture = texture;
@@ -395,6 +435,7 @@ static void draw_from_cached_texture(lv_draw_sdl_unit_t * u)
     data_to_find.w = lv_area_get_width(&t->_real_area);
     data_to_find.h = lv_area_get_height(&t->_real_area);
     data_to_find.texture = NULL;
+    data_to_find.dsc_owned = false;
 
     /*user_data stores the renderer to differentiate it from SW rendered tasks.
      *However the cached texture is independent from the renderer so use NULL user_data*/

--- a/src/lv_conf_check.c
+++ b/src/lv_conf_check.c
@@ -46,6 +46,10 @@
     #error "LV_USE_THORVG must be enabled: Kconfig selects it from LV_USE_VG_LITE_THORVG && LV_USE_DRAW_VG_LITE"
 #endif
 
+#if (LV_USE_DRAW_SDL) && !LV_USE_DRAW_SW
+    #error "LV_USE_DRAW_SW must be enabled: Kconfig selects it from LV_USE_DRAW_SDL"
+#endif
+
 #if LV_USE_DRAW_ARM2D_SYNC && !(LV_USE_DRAW_SW)
     #error "LV_USE_DRAW_ARM2D_SYNC requires LV_USE_DRAW_SW (Kconfig depends on)"
 #endif


### PR DESCRIPTION
Fixes #10258

The SDL draw unit's evaluate() claims every draw task type whose base.user_data is NULL, but draw_to_texture() only renders FILL, BORDER, BOX_SHADOW, LABEL, ARC, LINE, TRIANGLE and IMAGE (LAYER is intercepted earlier in execute_drawing()). Anything else hits default: return false, so the texture cache's create_cb fails and lv_cache_acquire_or_create() calls free_cb on the half-built entry.

At that point the entry payload is still the byte copy of the search key made by alloc_new_node(), so cached_data->draw_dsc is the draw task's own dsc — an interior pointer into the task allocation:

new_task->draw_dsc = (uint8_t *)new_task + LV_ALIGN_UP(sizeof(lv_draw_task_t), 8);
lv_free() on that is a wild free, not a free of a heap block. TLSF decodes a bogus header a few words before the real one and asserts on the first free with block already marked as free — which is why it reads like a double free when nothing was freed twice. Under LV_STDLIB_CLIB glibc reports munmap_chunk(): invalid pointer for the same event. With the default LV_ASSERT_HANDLER of while(1); the process does not even terminate: the UI thread spins and the display freezes while the service still looks alive to an init system.

LV_DRAW_TASK_TYPE_MASK_RECTANGLE reaches this from lv_obj_redraw()'s clip_corner branch — so from any clip_corner object with children (issue #10258's three-line repro), from the default theme's lv_msgbox, lv_win, menu_bg, menu_section and list_bg, and from lv_bar's direct lv_draw_mask_rect() call. LV_DRAW_TASK_TYPE_LETTER and LV_DRAW_TASK_TYPE_BLUR are also reachable and unrenderable here.

The change
evaluate() claims only the types this unit can render, so create_cb cannot fail. MASK_RECTANGLE, LETTER and BLUR fall through to the SW unit, which handles them. The hand-off does not depend on draw-unit registration order: SW claims at preference score 100 only when nothing has bid lower, and SDL bids 0 for what it takes.

cache_data_t::dsc_owned, set only where draw_to_texture() installs its own lv_malloc copy, so free_cb can never free a dsc this unit did not allocate — even if a task type is added later and someone forgets this file. Deliberately not implemented by NULLing draw_dsc on the failure path: the entry is still linked into the LRU red-black tree there and is ordered by that dsc, so mutating the sort key underneath the tree would strand the node. (The existing draw_dsc == NULL guard in sdl_texture_cache_compare_cb suggests that road was already partly travelled.)

Unrelated but adjacent: the default: arm of draw_to_texture() returned without restoring LV_OBJ_FLAG_SEND_DRAW_TASK_EVENTS, which it clears on entry — leaving it off on that object forever. Uses lv_obj_set_send_draw_task_events() to match the surrounding code after #10316.

Verification
Hardware A/B on an i.MX8M Plus board, SDL over KMSDRM/GLES2, LV_USE_DRAW_SDL + LV_STDLIB_BUILTIN. Two binaries differing only in lv_draw_sdl.c — the control links a pristine object ahead of the archive so the patched member is never pulled, and the difference was confirmed in the disassembly before running. The test renders a clip_corner container with a child and an lv_dropdown opened with lv_dropdown_open(), so no input is involved:

CONTROL  [Error] (0.105,+105) lv_tlsf_free: Asserted at expression:
                 !block_is_free(block) && "block already marked as free"  lv_tlsf.c:1166
         killed by timeout, exit 137 -- it never exited on its own
PATCHED  90 frames rendered, dropdown list open, no assert, exit 0
scripts/code-format.py's astyle 3.4.12 configuration reports no changes to the file.

Notes
No config options added, so no lv_conf_template.h / Kconfig regeneration needed.
I did not add a test: the existing suite runs the SW renderer and I could not see an LV_USE_DRAW_SDL path in CI to hook into. Happy to add one if you can point me at the right place.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

