### PR TITLE
 fix(check_arg): make check_arg c99 compliant

### DIFF
--- a/docs/src/contributing/assertions.mdx
+++ b/docs/src/contributing/assertions.mdx
@@ -131,30 +131,33 @@ This macro is useful for:
 
 ### Usage
 
-<ApiLink name="LV_CHECK_ARG" /> takes a condition, an action to execute on failure,
-and optional printf-style arguments for the log message:
+<ApiLink name="LV_CHECK_ARG" /> takes a condition and an action to execute on
+failure. <ApiLink name="LV_CHECK_ARG_MSG" /> also takes a message and
+<ApiLink name="LV_CHECK_ARG_FORMAT_MSG" /> a printf-style format string with its
+arguments:
 
 ```c
 void draw_to_display(lv_obj_t * display, int len)
 {
     /* Return early if display is NULL */
-    LV_CHECK_ARG(display != NULL, return, ": display must be provided");
+    LV_CHECK_ARG_MSG(display != NULL, return, "display must be provided");
 
     /* Return if len is invalid, logging the actual value */
-    LV_CHECK_ARG(len % 2 == 0, return, ": need even data points, but got %d", (int)len);
+    LV_CHECK_ARG_FORMAT_MSG(len % 2 == 0, return, "need even data points, but got %d", (int)len);
 }
 
 int get_width(lv_obj_t * obj)
 {
     /* Return -1 if obj is NULL */
-    LV_CHECK_ARG(obj != NULL, return -1, "tried to get width of NULL object");
+    LV_CHECK_ARG(obj != NULL, return -1);
     /* ... */
 }
 ```
 
 The condition is stringified and included in the log message, so you can see
-exactly what check failed. Only supply a format string and arguments if you want
-to include additional context beyond the condition itself.
+exactly what check failed. Only supply a message, or a format string and
+arguments, if you want to include additional context beyond the condition
+itself.
 
 ---
 

--- a/include/lvgl/debugging/lv_check_arg.h
+++ b/include/lvgl/debugging/lv_check_arg.h
@@ -57,24 +57,36 @@ extern "C" {
 /*----------------------------------------------------------------------
  * Internal helper: log output
  * Controlled by LV_CHECK_ARG_LOG_MODE.
- * In all modes the macro accepts (cond_str, ...) so that
- * LV_CHECK_ARG_INTERNAL_ can call it uniformly.
+ * `cond_str` is logged as an argument of `%s` instead of being pasted into
+ * the format string, because a `%` in the condition would otherwise be read
+ * as a conversion specifier.
  *---------------------------------------------------------------------*/
 #  if LV_CHECK_ARG_LOG_MODE == LV_CHECK_ARG_LOG_MODE_VERBOSE
-#    define LV_CHECK_ARG_LOG_(cond_str, ...) LV_LOG_WARN("Check failed: " cond_str " " __VA_ARGS__)
+#    define LV_CHECK_ARG_LOG_(cond_str, msg) LV_LOG_WARN("Check failed: %s" msg, cond_str)
+#    define LV_CHECK_ARG_LOG_FORMAT_(cond_str, format, ...) \
+    LV_LOG_WARN("Check failed: %s" format, cond_str, __VA_ARGS__)
 #  elif LV_CHECK_ARG_LOG_MODE == LV_CHECK_ARG_LOG_MODE_MINIMAL
-#    define LV_CHECK_ARG_LOG_(cond_str, ...) LV_LOG_WARN("Check failed")
+#    define LV_CHECK_ARG_LOG_(cond_str, msg) LV_LOG_WARN("Check failed")
+#    define LV_CHECK_ARG_LOG_FORMAT_(cond_str, format, ...) LV_LOG_WARN("Check failed")
 #  else /* LV_CHECK_ARG_LOG_MODE_NONE */
-#    define LV_CHECK_ARG_LOG_(cond_str, ...) do {} while(0)
+#    define LV_CHECK_ARG_LOG_(cond_str, msg) do {} while(0)
+#    define LV_CHECK_ARG_LOG_FORMAT_(cond_str, format, ...) do {} while(0)
 #  endif
 
 /*----------------------------------------------------------------------
- * Internal macro: single definition, behaviour driven by the helpers above.
- * Do not use directly; use LV_CHECK_ARG instead.
+ * Internal macros: behaviour driven by the helpers above.
+ * Do not use directly; use LV_CHECK_ARG and friends instead.
  *---------------------------------------------------------------------*/
-#  define LV_CHECK_ARG_INTERNAL_(cond, cond_str, action_on_fail, ...)  \
+#  define LV_CHECK_ARG_INTERNAL_(cond, cond_str, action_on_fail, msg)   \
     if(LV_UNLIKELY(!(cond))) {                                          \
-        LV_CHECK_ARG_LOG_(cond_str, __VA_ARGS__);                       \
+        LV_CHECK_ARG_LOG_(cond_str, msg);                               \
+        LV_CHECK_ARG_ASSERT_HANDLER_;                                   \
+        action_on_fail;                                                 \
+    } else {}
+
+#  define LV_CHECK_ARG_FORMAT_INTERNAL_(cond, cond_str, action_on_fail, format, ...) \
+    if(LV_UNLIKELY(!(cond))) {                                          \
+        LV_CHECK_ARG_LOG_FORMAT_(cond_str, format, __VA_ARGS__);        \
         LV_CHECK_ARG_ASSERT_HANDLER_;                                   \
         action_on_fail;                                                 \
     } else {}
@@ -82,15 +94,14 @@ extern "C" {
 #else
 
 /** LV_CHECK_ARG is disabled; all checks compile to nothing. */
-#  define LV_CHECK_ARG_INTERNAL_(cond, cond_str, action_on_fail, ...) ((void)0)
+#  define LV_CHECK_ARG_INTERNAL_(cond, cond_str, action_on_fail, msg) ((void)0)
+#  define LV_CHECK_ARG_FORMAT_INTERNAL_(cond, cond_str, action_on_fail, format, ...) ((void)0)
 
 #endif /*LV_USE_CHECK_ARG*/
 
 /**
  * Check that a condition is true. If the condition is false, log a warning
  * and execute `action_on_fail` (e.g. `return`, `return val`, `break`).
- * Additional printf-style arguments are appended to the log message when
- * LV_CHECK_ARG_LOG_MODE is set to VERBOSE.
  *
  * Can be disabled entirely by setting LV_USE_CHECK_ARG to 0 in lv_conf.h.
  * If LV_CHECK_ARG_ASSERT_ON_FAIL is 1, LV_ASSERT_HANDLER is also invoked
@@ -100,17 +111,47 @@ extern "C" {
  *
  * Example:
  * @code
- * LV_CHECK_ARG(ptr != NULL, return, "pointer must not be NULL");
- * LV_CHECK_ARG(len > 0, return -1, "len=%d", (int)len);
+ * LV_CHECK_ARG(ptr != NULL, return);
  * @endcode
  *
  * @param cond              condition to check
  * @param action_on_fail    statement to execute on failure (e.g. `return`, `return 0`, `break`)
- * @param ...               optional printf-style format string and arguments appended to the log
- *                          (only used when LV_CHECK_ARG_LOG_MODE == LV_CHECK_ARG_LOG_MODE_VERBOSE)
  */
-#define LV_CHECK_ARG(cond, action_on_fail, ...)                                                \
-    LV_CHECK_ARG_INTERNAL_(cond, #cond, action_on_fail, __VA_ARGS__)
+#define LV_CHECK_ARG(cond, action_on_fail) \
+    LV_CHECK_ARG_INTERNAL_(cond, #cond, action_on_fail, "")
+
+/**
+ * Same as LV_CHECK_ARG but a message is appended to the log. The message is
+ * only used when LV_CHECK_ARG_LOG_MODE is set to VERBOSE.
+ *
+ * Example:
+ * @code
+ * LV_CHECK_ARG_MSG(ptr != NULL, return, "pointer must not be NULL");
+ * @endcode
+ *
+ * @param cond              condition to check
+ * @param action_on_fail    statement to execute on failure (e.g. `return`, `return 0`, `break`)
+ * @param msg               string literal appended to the log message
+ */
+#define LV_CHECK_ARG_MSG(cond, action_on_fail, msg) \
+    LV_CHECK_ARG_INTERNAL_(cond, #cond, action_on_fail, " " msg)
+
+/**
+ * Same as LV_CHECK_ARG but a printf-style message is appended to the log. The
+ * message is only used when LV_CHECK_ARG_LOG_MODE is set to VERBOSE.
+ *
+ * Example:
+ * @code
+ * LV_CHECK_ARG_FORMAT_MSG(len > 0, return -1, "len=%d", (int)len);
+ * @endcode
+ *
+ * @param cond              condition to check
+ * @param action_on_fail    statement to execute on failure (e.g. `return`, `return 0`, `break`)
+ * @param format            format string literal appended to the log message
+ * @param ...               arguments of `format`; at least one is required
+ */
+#define LV_CHECK_ARG_FORMAT_MSG(cond, action_on_fail, format, ...) \
+    LV_CHECK_ARG_FORMAT_INTERNAL_(cond, #cond, action_on_fail, " " format, __VA_ARGS__)
 
 #ifdef __cplusplus
 } /*extern "C"*/

--- a/src/core/lv_obj.c
+++ b/src/core/lv_obj.c
@@ -1308,7 +1308,7 @@ void lv_obj_add_screen_load_event(lv_obj_t * obj, lv_event_code_t trigger, lv_ob
                                   lv_screen_load_anim_t anim_type, uint32_t duration, uint32_t delay)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return);
-    LV_CHECK_ARG(screen != NULL, return, "can't load a non-existing screen");
+    LV_CHECK_ARG_MSG(screen != NULL, return, "can't load a non-existing screen");
     LV_CHECK_ARG(duration > 0 || anim_type == LV_SCREEN_LOAD_ANIM_NONE, return);
 
     screen_load_anim_dsc_t * dsc = lv_malloc(sizeof(screen_load_anim_dsc_t));

--- a/src/core/lv_obj_class.c
+++ b/src/core/lv_obj_class.c
@@ -190,7 +190,7 @@ bool lv_obj_is_group_def(const lv_obj_t * obj)
 #if LV_USE_EXT_DATA
 void lv_obj_set_external_data(lv_obj_t * obj, void * data, void (* free_cb)(void * data))
 {
-    LV_CHECK_ARG(obj != NULL, return, "Can't attach external user data and destructor callback to a NULL object");
+    LV_CHECK_ARG_MSG(obj != NULL, return, "Can't attach external user data and destructor callback to a NULL object");
 
     obj->ext_data.data = data;
     obj->ext_data.free_cb = free_cb;

--- a/src/core/lv_obj_event.c
+++ b/src/core/lv_obj_event.c
@@ -215,8 +215,10 @@ lv_indev_t * lv_event_get_indev(lv_event_t * e)
         LV_EVENT_HOVER_OVER,        LV_EVENT_HOVER_LEAVE,
     };
 #endif
-    LV_CHECK_ARG(event_code_in_array(e->code, indev_codes, sizeof(indev_codes) / sizeof(indev_codes[0])),
-                 return NULL, "invalid event code %" LV_PRId32, (int32_t)e->code);
+    LV_CHECK_ARG_FORMAT_MSG(
+        event_code_in_array(e->code, indev_codes, sizeof(indev_codes) / sizeof(indev_codes[0])),
+        return NULL,
+        "invalid event code %" LV_PRId32, (int32_t)e->code);
     return lv_event_get_param(e);
 }
 
@@ -229,24 +231,28 @@ lv_layer_t * lv_event_get_layer(lv_event_t * e)
         LV_EVENT_DRAW_POST,     LV_EVENT_DRAW_POST_BEGIN,   LV_EVENT_DRAW_POST_END,
     };
 #endif
-    LV_CHECK_ARG(event_code_in_array(e->code, draw_codes, sizeof(draw_codes) / sizeof(draw_codes[0])),
-                 return NULL, "invalid event code %" LV_PRId32, (int32_t)e->code);
+    LV_CHECK_ARG_FORMAT_MSG(
+        event_code_in_array(e->code, draw_codes, sizeof(draw_codes) / sizeof(draw_codes[0])),
+        return NULL,
+        "invalid event code %" LV_PRId32, (int32_t)e->code);
     return lv_event_get_param(e);
 }
 
 const lv_area_t * lv_event_get_old_size(lv_event_t * e)
 {
     LV_CHECK_ARG(e != NULL, return NULL);
-    LV_CHECK_ARG(e->code == LV_EVENT_SIZE_CHANGED, return NULL,
-                 "invalid event code %" LV_PRId32, (int32_t)e->code);
+    LV_CHECK_ARG_FORMAT_MSG(e->code == LV_EVENT_SIZE_CHANGED,
+                            return NULL,
+                            "invalid event code %" LV_PRId32, (int32_t)e->code);
     return lv_event_get_param(e);
 }
 
 uint32_t lv_event_get_key(lv_event_t * e)
 {
     LV_CHECK_ARG(e != NULL, return 0);
-    LV_CHECK_ARG(e->code == LV_EVENT_KEY, return 0,
-                 "invalid event code %" LV_PRId32, (int32_t)e->code);
+    LV_CHECK_ARG_FORMAT_MSG(e->code == LV_EVENT_KEY,
+                            return 0,
+                            "invalid event code %" LV_PRId32, (int32_t)e->code);
     uint32_t * k = lv_event_get_param(e);
     return k ? *k : 0;
 }
@@ -254,8 +260,9 @@ uint32_t lv_event_get_key(lv_event_t * e)
 int32_t lv_event_get_rotary_diff(lv_event_t * e)
 {
     LV_CHECK_ARG(e != NULL, return 0);
-    LV_CHECK_ARG(e->code == LV_EVENT_ROTARY, return 0,
-                 "invalid event code %" LV_PRId32, (int32_t)e->code);
+    LV_CHECK_ARG_FORMAT_MSG(e->code == LV_EVENT_ROTARY,
+                            return 0,
+                            "invalid event code %" LV_PRId32, (int32_t)e->code);
     int32_t * r = lv_event_get_param(e);
     return r ? *r : 0;
 }
@@ -263,16 +270,18 @@ int32_t lv_event_get_rotary_diff(lv_event_t * e)
 lv_anim_t * lv_event_get_scroll_anim(lv_event_t * e)
 {
     LV_CHECK_ARG(e != NULL, return NULL);
-    LV_CHECK_ARG(e->code == LV_EVENT_SCROLL_BEGIN, return NULL,
-                 "invalid event code %" LV_PRId32, (int32_t)e->code);
+    LV_CHECK_ARG_FORMAT_MSG(e->code == LV_EVENT_SCROLL_BEGIN,
+                            return NULL,
+                            "invalid event code %" LV_PRId32, (int32_t)e->code);
     return lv_event_get_param(e);
 }
 
 void lv_event_set_ext_draw_size(lv_event_t * e, int32_t size)
 {
     LV_CHECK_ARG(e != NULL, return);
-    LV_CHECK_ARG(e->code == LV_EVENT_REFR_EXT_DRAW_SIZE, return,
-                 "invalid event code %" LV_PRId32, (int32_t)e->code);
+    LV_CHECK_ARG_FORMAT_MSG(e->code == LV_EVENT_REFR_EXT_DRAW_SIZE,
+                            return,
+                            "invalid event code %" LV_PRId32, (int32_t)e->code);
     int32_t * cur_size = lv_event_get_param(e);
     *cur_size = LV_MAX(*cur_size, size);
 }
@@ -280,24 +289,27 @@ void lv_event_set_ext_draw_size(lv_event_t * e, int32_t size)
 lv_point_t * lv_event_get_self_size_info(lv_event_t * e)
 {
     LV_CHECK_ARG(e != NULL, return NULL);
-    LV_CHECK_ARG(e->code == LV_EVENT_GET_SELF_SIZE, return NULL,
-                 "invalid event code %" LV_PRId32, (int32_t)e->code);
+    LV_CHECK_ARG_FORMAT_MSG(e->code == LV_EVENT_GET_SELF_SIZE,
+                            return NULL,
+                            "invalid event code %" LV_PRId32, (int32_t)e->code);
     return lv_event_get_param(e);
 }
 
 lv_hit_test_info_t * lv_event_get_hit_test_info(lv_event_t * e)
 {
     LV_CHECK_ARG(e != NULL, return NULL);
-    LV_CHECK_ARG(e->code == LV_EVENT_HIT_TEST, return NULL,
-                 "invalid event code %" LV_PRId32, (int32_t)e->code);
+    LV_CHECK_ARG_FORMAT_MSG(e->code == LV_EVENT_HIT_TEST,
+                            return NULL,
+                            "invalid event code %" LV_PRId32, (int32_t)e->code);
     return lv_event_get_param(e);
 }
 
 const lv_area_t * lv_event_get_cover_area(lv_event_t * e)
 {
     LV_CHECK_ARG(e != NULL, return NULL);
-    LV_CHECK_ARG(e->code == LV_EVENT_COVER_CHECK, return NULL,
-                 "invalid event code %" LV_PRId32, (int32_t)e->code);
+    LV_CHECK_ARG_FORMAT_MSG(e->code == LV_EVENT_COVER_CHECK,
+                            return NULL,
+                            "invalid event code %" LV_PRId32, (int32_t)e->code);
     lv_cover_check_info_t * p = lv_event_get_param(e);
     return p->area;
 }
@@ -305,8 +317,9 @@ const lv_area_t * lv_event_get_cover_area(lv_event_t * e)
 void lv_event_set_cover_res(lv_event_t * e, lv_cover_res_t res)
 {
     LV_CHECK_ARG(e != NULL, return);
-    LV_CHECK_ARG(e->code == LV_EVENT_COVER_CHECK, return,
-                 "invalid event code %" LV_PRId32, (int32_t)e->code);
+    LV_CHECK_ARG_FORMAT_MSG(e->code == LV_EVENT_COVER_CHECK,
+                            return,
+                            "invalid event code %" LV_PRId32, (int32_t)e->code);
     lv_cover_check_info_t * p = lv_event_get_param(e);
     if(res > p->res) p->res = res;  /*Save only "stronger" results*/
 }
@@ -314,16 +327,18 @@ void lv_event_set_cover_res(lv_event_t * e, lv_cover_res_t res)
 lv_draw_task_t * lv_event_get_draw_task(lv_event_t * e)
 {
     LV_CHECK_ARG(e != NULL, return NULL);
-    LV_CHECK_ARG(e->code == LV_EVENT_DRAW_TASK_ADDED, return NULL,
-                 "invalid event code %" LV_PRId32, (int32_t)e->code);
+    LV_CHECK_ARG_FORMAT_MSG(e->code == LV_EVENT_DRAW_TASK_ADDED,
+                            return NULL,
+                            "invalid event code %" LV_PRId32, (int32_t)e->code);
     return lv_event_get_param(e);
 }
 
 lv_state_t lv_event_get_prev_state(lv_event_t * e)
 {
     LV_CHECK_ARG(e != NULL, return 0);
-    LV_CHECK_ARG(e->code == LV_EVENT_STATE_CHANGED, return 0,
-                 "invalid event code %" LV_PRId32, (int32_t)e->code);
+    LV_CHECK_ARG_FORMAT_MSG(e->code == LV_EVENT_STATE_CHANGED,
+                            return 0,
+                            "invalid event code %" LV_PRId32, (int32_t)e->code);
     lv_state_t * state = lv_event_get_param(e);
     return state ? *state : 0;
 }

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -110,8 +110,8 @@ void lv_obj_add_style(lv_obj_t * obj, const lv_style_t * style, lv_style_selecto
 {
     LV_CHECK_ARG(obj != NULL, return);
     LV_CHECK_ARG(style != NULL, return);
-    LV_CHECK_ARG(obj->style_cnt < 63, return,
-                 "obj->style_cnt is restricted to 6 bits, so we can't store more than 63 styles");
+    LV_CHECK_ARG_MSG(obj->style_cnt < 63, return,
+                     "obj->style_cnt is restricted to 6 bits, so we can't store more than 63 styles");
 
     trans_delete(obj, selector, LV_STYLE_PROP_ANY, NULL);
 

--- a/src/core/lv_observer.c
+++ b/src/core/lv_observer.c
@@ -719,7 +719,8 @@ lv_observer_t * lv_obj_bind_flag_if_eq(lv_obj_t * obj, lv_subject_t * subject, l
 {
     LV_CHECK_ARG(obj != NULL, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d",
+                            subject->type);
 
     lv_observer_t * observable = bind_to_bitfield(subject, obj, obj_flag_observer_cb, flag, ref_value, false, FLAG_COND_EQ);
     return observable;
@@ -730,7 +731,8 @@ lv_observer_t * lv_obj_bind_flag_if_not_eq(lv_obj_t * obj, lv_subject_t * subjec
 {
     LV_CHECK_ARG(obj != NULL, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d",
+                            subject->type);
 
     lv_observer_t * observable = bind_to_bitfield(subject, obj, obj_flag_observer_cb, flag, ref_value, true, FLAG_COND_EQ);
     return observable;
@@ -739,7 +741,8 @@ lv_observer_t * lv_obj_bind_flag_if_gt(lv_obj_t * obj, lv_subject_t * subject, l
 {
     LV_CHECK_ARG(obj != NULL, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d",
+                            subject->type);
 
     lv_observer_t * observable = bind_to_bitfield(subject, obj, obj_flag_observer_cb, flag, ref_value, false, FLAG_COND_GT);
     return observable;
@@ -749,7 +752,8 @@ lv_observer_t * lv_obj_bind_flag_if_ge(lv_obj_t * obj, lv_subject_t * subject, l
 {
     LV_CHECK_ARG(obj != NULL, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d",
+                            subject->type);
 
     lv_observer_t * observable = bind_to_bitfield(subject, obj, obj_flag_observer_cb, flag, ref_value, false, FLAG_COND_GE);
     return observable;
@@ -759,7 +763,8 @@ lv_observer_t * lv_obj_bind_flag_if_lt(lv_obj_t * obj, lv_subject_t * subject, l
 {
     LV_CHECK_ARG(obj != NULL, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d",
+                            subject->type);
 
     /* a < b == !(a >= b) */
     lv_observer_t * observable = bind_to_bitfield(subject, obj, obj_flag_observer_cb, flag, ref_value, true, FLAG_COND_GE);
@@ -770,7 +775,8 @@ lv_observer_t * lv_obj_bind_flag_if_le(lv_obj_t * obj, lv_subject_t * subject, l
 {
     LV_CHECK_ARG(obj != NULL, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d",
+                            subject->type);
 
     /* a <= b == !(a > b) */
     lv_observer_t * observable = bind_to_bitfield(subject, obj, obj_flag_observer_cb, flag, ref_value, true, FLAG_COND_GT);
@@ -782,7 +788,8 @@ lv_observer_t * lv_obj_bind_state_if_eq(lv_obj_t * obj, lv_subject_t * subject, 
 {
     LV_CHECK_ARG(obj != NULL, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d",
+                            subject->type);
 
     lv_observer_t * observable = bind_to_bitfield(subject, obj, obj_state_observer_cb, state, ref_value, false,
                                                   FLAG_COND_EQ);
@@ -794,7 +801,8 @@ lv_observer_t * lv_obj_bind_state_if_not_eq(lv_obj_t * obj, lv_subject_t * subje
 {
     LV_CHECK_ARG(obj != NULL, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d",
+                            subject->type);
 
     lv_observer_t * observable = bind_to_bitfield(subject, obj, obj_state_observer_cb, state, ref_value, true,
                                                   FLAG_COND_EQ);
@@ -805,7 +813,8 @@ lv_observer_t * lv_obj_bind_state_if_gt(lv_obj_t * obj, lv_subject_t * subject, 
 {
     LV_CHECK_ARG(obj != NULL, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d",
+                            subject->type);
 
     lv_observer_t * observable = bind_to_bitfield(subject, obj, obj_state_observer_cb, state, ref_value, false,
                                                   FLAG_COND_GT);
@@ -816,7 +825,8 @@ lv_observer_t * lv_obj_bind_state_if_ge(lv_obj_t * obj, lv_subject_t * subject, 
 {
     LV_CHECK_ARG(obj != NULL, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d",
+                            subject->type);
 
     lv_observer_t * observable = bind_to_bitfield(subject, obj, obj_state_observer_cb, state, ref_value, false,
                                                   FLAG_COND_GE);
@@ -827,7 +837,8 @@ lv_observer_t * lv_obj_bind_state_if_lt(lv_obj_t * obj, lv_subject_t * subject, 
 {
     LV_CHECK_ARG(obj != NULL, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d",
+                            subject->type);
 
     /* a < b == !(a >= b) */
     lv_observer_t * observable = bind_to_bitfield(subject, obj, obj_state_observer_cb, state, ref_value, true,
@@ -840,7 +851,8 @@ lv_observer_t * lv_obj_bind_state_if_le(lv_obj_t * obj, lv_subject_t * subject, 
 {
     LV_CHECK_ARG(obj != NULL, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d",
+                            subject->type);
 
     /* a <= b == !(a > b) */
     lv_observer_t * observable = bind_to_bitfield(subject, obj, obj_state_observer_cb, state, ref_value, true,
@@ -853,7 +865,8 @@ lv_observer_t * lv_obj_bind_checked(lv_obj_t * obj, lv_subject_t * subject)
 {
     LV_CHECK_ARG(obj != NULL, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d",
+                            subject->type);
 
     lv_observer_t * observable = bind_to_bitfield(subject, obj, obj_state_observer_cb, LV_STATE_CHECKED, 0, true,
                                                   FLAG_COND_EQ);

--- a/src/display/lv_display.c
+++ b/src/display/lv_display.c
@@ -508,8 +508,8 @@ void lv_display_set_3rd_draw_buffer(lv_display_t * disp, lv_draw_buf_t * buf3)
     }
     if(disp == NULL) return;
     LV_CHECK_ARG(disp != NULL, return);
-    LV_CHECK_ARG(disp->buf_1 != NULL, return, "buf1 should already exist in order to provide a third buffer");
-    LV_CHECK_ARG(disp->buf_2 != NULL, return, "buf2 should already exist in order to provide a third buffer");
+    LV_CHECK_ARG_MSG(disp->buf_1 != NULL, return, "buf1 should already exist in order to provide a third buffer");
+    LV_CHECK_ARG_MSG(disp->buf_2 != NULL, return, "buf2 should already exist in order to provide a third buffer");
 
     disp->buf_3 = buf3;
 }
@@ -532,11 +532,12 @@ void lv_display_set_buffers_with_stride(lv_display_t * disp, void * buf1, void *
     uint32_t w = lv_display_get_original_horizontal_resolution(disp);
     uint32_t h = lv_display_get_original_vertical_resolution(disp);
 
-    LV_CHECK_ARG(w != 0 && h != 0, return, "display resolution is 0");
+    LV_CHECK_ARG_MSG(w != 0 && h != 0, return, "display resolution is 0");
 
     /* buf1 or buf2 is not aligned according to LV_DRAW_BUF_ALIGN */
-    LV_CHECK_ARG(buf1 == lv_draw_buf_align(buf1, cf), return, "buf1 is not properly aligned: %p", buf1);
-    LV_CHECK_ARG(buf2 == NULL || buf2 == lv_draw_buf_align(buf2, cf), return, "buf2 is not properly aligned: %p", buf2);
+    LV_CHECK_ARG_FORMAT_MSG(buf1 == lv_draw_buf_align(buf1, cf), return, "buf1 is not properly aligned: %p", buf1);
+    LV_CHECK_ARG_FORMAT_MSG(buf2 == NULL ||
+                            buf2 == lv_draw_buf_align(buf2, cf), return, "buf2 is not properly aligned: %p", buf2);
 
     bool is_auto_stride = stride == LV_STRIDE_AUTO;
     if(is_auto_stride) {
@@ -544,14 +545,14 @@ void lv_display_set_buffers_with_stride(lv_display_t * disp, void * buf1, void *
     }
 
     if(render_mode == LV_DISPLAY_RENDER_MODE_PARTIAL) {
-        LV_CHECK_ARG(stride != 0, return, "stride is 0, check your color format %d and width: %" LV_PRIu32, cf, w);
+        LV_CHECK_ARG_FORMAT_MSG(stride != 0, return, "stride is 0, check your color format %d and width: %" LV_PRIu32, cf, w);
         /* for partial mode, we calculate the height based on the buf_size and stride */
         h = buf_size / stride;
-        LV_CHECK_ARG(h, return, "the buffer is too small");
+        LV_CHECK_ARG_MSG(h, return, "the buffer is too small");
     }
     else {
-        LV_CHECK_ARG(stride * h <= buf_size, return, "%s mode requires screen sized buffer(s)",
-                     render_mode == LV_DISPLAY_RENDER_MODE_FULL ? "FULL" : "DIRECT");
+        LV_CHECK_ARG_FORMAT_MSG(stride * h <= buf_size, return, "%s mode requires screen sized buffer(s)",
+                                render_mode == LV_DISPLAY_RENDER_MODE_FULL ? "FULL" : "DIRECT");
     }
 
     lv_draw_buf_init(&disp->_static_buf1, w, h, cf, stride, buf1, buf_size);
@@ -670,7 +671,8 @@ void lv_display_set_tile_cnt(lv_display_t * disp, uint32_t tile_cnt)
         disp = lv_display_get_default();
     }
     LV_CHECK_ARG(disp != NULL, return);
-    LV_CHECK_ARG(tile_cnt < 256, return, "tile_cnt must be smaller than 256 (%" LV_PRId32 " was used)", tile_cnt);
+    LV_CHECK_ARG_FORMAT_MSG(tile_cnt < 256, return, "tile_cnt must be smaller than 256 (%" LV_PRId32 " was used)",
+                            tile_cnt);
 
     disp->tile_cnt = tile_cnt;
 }
@@ -1101,15 +1103,15 @@ lv_display_rotation_t lv_display_get_rotation(lv_display_t * disp)
 
 void lv_display_set_matrix_rotation(lv_display_t * disp, bool enable)
 {
-    LV_CHECK_ARG(LV_DRAW_TRANSFORM_USE_MATRIX == 1, return, "LV_DRAW_TRANSFORM_USE_MATRIX is not enabled");
+    LV_CHECK_ARG_MSG(LV_DRAW_TRANSFORM_USE_MATRIX == 1, return, "LV_DRAW_TRANSFORM_USE_MATRIX is not enabled");
 
     if(disp == NULL) {
         LOG_NULL_DISPLAY_DEPRECATED_MESSAGE();
         disp = lv_display_get_default();
     }
     LV_CHECK_ARG(disp != NULL, return);
-    LV_CHECK_ARG(disp->render_mode == LV_DISPLAY_RENDER_MODE_DIRECT ||
-                 disp->render_mode == LV_DISPLAY_RENDER_MODE_FULL, return, "Unsupported rendering mode: %d", disp->render_mode);
+    LV_CHECK_ARG_FORMAT_MSG(disp->render_mode == LV_DISPLAY_RENDER_MODE_DIRECT ||
+                            disp->render_mode == LV_DISPLAY_RENDER_MODE_FULL, return, "Unsupported rendering mode: %d", disp->render_mode);
 
     disp->matrix_rotation = enable;
 }
@@ -1121,7 +1123,7 @@ bool lv_display_get_matrix_rotation(lv_display_t * disp)
         disp = lv_display_get_default();
     }
     LV_CHECK_ARG(disp != NULL, return false);
-    LV_CHECK_ARG(LV_DRAW_TRANSFORM_USE_MATRIX == 1, return false, "LV_DRAW_TRANSFORM_USE_MATRIX is not enabled");
+    LV_CHECK_ARG_MSG(LV_DRAW_TRANSFORM_USE_MATRIX == 1, return false, "LV_DRAW_TRANSFORM_USE_MATRIX is not enabled");
     return disp->matrix_rotation;
 }
 

--- a/src/draw/lv_draw_buf.c
+++ b/src/draw/lv_draw_buf.c
@@ -233,10 +233,10 @@ lv_result_t lv_draw_buf_init(lv_draw_buf_t * draw_buf, uint32_t w, uint32_t h, l
 
     if(stride == LV_STRIDE_AUTO) stride = lv_draw_buf_width_to_stride(w, cf);
 
-    LV_CHECK_ARG(data_size >= stride * h,
-                 return LV_RESULT_INVALID,
-                 "Data size too small, required: %" LV_PRId32 ", provided: %" LV_PRId32,
-                 stride * h, data_size);
+    LV_CHECK_ARG_FORMAT_MSG(data_size >= stride * h,
+                            return LV_RESULT_INVALID,
+                            "Data size too small, required: %" LV_PRId32 ", provided: %" LV_PRId32,
+                            stride * h, data_size);
 
     lv_image_header_t * header = &draw_buf->header;
     header->w = w;
@@ -409,10 +409,10 @@ bool lv_draw_buf_is_position_valid(const lv_draw_buf_t * buf, uint32_t x, uint32
 void * lv_draw_buf_goto_xy(const lv_draw_buf_t * buf, uint32_t x, uint32_t y)
 {
     LV_CHECK_ARG(buf != NULL, return NULL);
-    LV_CHECK_ARG(lv_draw_buf_is_position_valid(buf, x, y),
-                 return NULL,
-                 "coordinates out of range, x: %" LV_PRIu32 ", y: %"LV_PRIu32", w: %"LV_PRIu32", h: %"LV_PRIu32,
-                 x, y, (uint32_t)buf->header.w, (uint32_t)buf->header.h);
+    LV_CHECK_ARG_FORMAT_MSG(lv_draw_buf_is_position_valid(buf, x, y),
+                            return NULL,
+                            "coordinates out of range, x: %" LV_PRIu32 ", y: %"LV_PRIu32", w: %"LV_PRIu32", h: %"LV_PRIu32,
+                            x, y, (uint32_t)buf->header.w, (uint32_t)buf->header.h);
     LV_CHECK_ARG(buf->data != NULL, return NULL);
 
     uint8_t * data = buf->data;
@@ -526,7 +526,7 @@ void lv_draw_buf_set_palette(lv_draw_buf_t * draw_buf, uint8_t index, lv_color32
 {
     LV_CHECK_ARG(draw_buf != NULL, return);
     LV_CHECK_ARG(draw_buf->data != NULL, return);
-    LV_CHECK_ARG(LV_COLOR_FORMAT_IS_INDEXED(draw_buf->header.cf), return, "Color format is not indexed");
+    LV_CHECK_ARG_MSG(LV_COLOR_FORMAT_IS_INDEXED(draw_buf->header.cf), return, "Color format is not indexed");
 
     lv_color32_t * palette = (lv_color32_t *)draw_buf->data;
     palette[index] = color;

--- a/src/drivers/display/drm/lv_linux_drm_egl.c
+++ b/src/drivers/display/drm/lv_linux_drm_egl.c
@@ -102,7 +102,7 @@ lv_result_t lv_linux_drm_set_file(lv_display_t * disp, const char * file, int64_
     LV_UNUSED(connector_id);
     lv_drm_ctx_t * ctx = lv_display_get_driver_data(disp);
 
-    LV_CHECK_ARG(ctx != NULL, return LV_RESULT_INVALID, "Invalid display");
+    LV_CHECK_ARG_MSG(ctx != NULL, return LV_RESULT_INVALID, "Invalid display");
 
     lv_result_t err = drm_device_init(ctx, file);
     if(err != LV_RESULT_OK) {
@@ -143,7 +143,7 @@ void lv_linux_drm_set_mode_cb(lv_display_t * disp, lv_linux_drm_select_mode_cb_t
 {
     LV_CHECK_ARG(disp != NULL, return);
     lv_drm_ctx_t * ctx = lv_display_get_driver_data(disp);
-    LV_CHECK_ARG(ctx != NULL, return, "Invalid display");
+    LV_CHECK_ARG_MSG(ctx != NULL, return, "Invalid display");
     ctx->mode_select_cb = callback;
 }
 

--- a/src/drivers/sdl/lv_sdl_window.c
+++ b/src/drivers/sdl/lv_sdl_window.c
@@ -105,7 +105,7 @@ void lv_sdl_window_set_resizeable(lv_display_t * disp, bool value)
 {
     LV_CHECK_ARG(disp != NULL, return);
     lv_sdl_window_t * dsc = lv_display_get_driver_data(disp);
-    LV_CHECK_ARG(dsc != NULL, return, "Invalid display");
+    LV_CHECK_ARG_MSG(dsc != NULL, return, "Invalid display");
     SDL_SetWindowResizable(dsc->window, value);
 }
 
@@ -113,7 +113,7 @@ void lv_sdl_window_set_size(lv_display_t * disp, int32_t hor_res, int32_t ver_re
 {
     LV_CHECK_ARG(disp != NULL, return);
     lv_sdl_window_t * dsc = lv_display_get_driver_data(disp);
-    LV_CHECK_ARG(dsc != NULL, return, "Invalid display");
+    LV_CHECK_ARG_MSG(dsc != NULL, return, "Invalid display");
     SDL_SetWindowSize(dsc->window, hor_res, ver_res);
 }
 
@@ -121,7 +121,7 @@ void lv_sdl_window_set_zoom(lv_display_t * disp, float zoom)
 {
     LV_CHECK_ARG(disp != NULL, return);
     lv_sdl_window_t * dsc = lv_display_get_driver_data(disp);
-    LV_CHECK_ARG(dsc != NULL, return, "Invalid display");
+    LV_CHECK_ARG_MSG(dsc != NULL, return, "Invalid display");
     dsc->zoom = zoom;
     lv_display_send_event(disp, LV_EVENT_RESOLUTION_CHANGED, NULL);
     lv_refr_now(disp);
@@ -131,7 +131,7 @@ float lv_sdl_window_get_zoom(lv_display_t * disp)
 {
     LV_CHECK_ARG(disp != NULL, return 0.f);
     lv_sdl_window_t * dsc = lv_display_get_driver_data(disp);
-    LV_CHECK_ARG(dsc != NULL, return 0.f, "Invalid display");
+    LV_CHECK_ARG_MSG(dsc != NULL, return 0.f, "Invalid display");
     return dsc->zoom;
 }
 
@@ -155,7 +155,7 @@ void lv_sdl_window_set_title(lv_display_t * disp, const char * title)
     LV_CHECK_ARG(title != NULL, return);
 
     lv_sdl_window_t * dsc = lv_display_get_driver_data(disp);
-    LV_CHECK_ARG(dsc != NULL, return, "Invalid display");
+    LV_CHECK_ARG_MSG(dsc != NULL, return, "Invalid display");
     SDL_SetWindowTitle(dsc->window, title);
 }
 
@@ -164,7 +164,7 @@ void lv_sdl_window_set_icon(lv_display_t * disp, void * icon, int32_t width, int
     LV_CHECK_ARG(icon != NULL, return);
 
     lv_sdl_window_t * dsc = lv_display_get_driver_data(disp);
-    LV_CHECK_ARG(dsc != NULL, return, "Invalid display");
+    LV_CHECK_ARG_MSG(dsc != NULL, return, "Invalid display");
     SDL_Surface * iconSurface = SDL_CreateRGBSurfaceWithFormatFrom(icon, width, height, 32, width * 4,
                                                                    SDL_PIXELFORMAT_ARGB8888);
     SDL_SetWindowIcon(dsc->window, iconSurface);
@@ -181,7 +181,7 @@ struct SDL_Window * lv_sdl_window_get_window(lv_display_t * disp)
 {
     LV_CHECK_ARG(disp != NULL, return NULL);
     lv_sdl_window_t * dsc = lv_display_get_driver_data(disp);
-    LV_CHECK_ARG(dsc != NULL, return NULL, "Invalid display");
+    LV_CHECK_ARG_MSG(dsc != NULL, return NULL, "Invalid display");
     return dsc->window;
 }
 

--- a/src/drivers/wayland/lv_wayland_keyboard.c
+++ b/src/drivers/wayland/lv_wayland_keyboard.c
@@ -90,7 +90,7 @@ lv_indev_t * lv_wayland_get_keyboard(lv_display_t * display)
 {
     LV_CHECK_ARG(display != NULL, return NULL);
     lv_wl_window_t * window = lv_display_get_driver_data(display);
-    LV_CHECK_ARG(window != NULL, return NULL, "Invalid display");
+    LV_CHECK_ARG_MSG(window != NULL, return NULL, "Invalid display");
     return window->lv_indev_keyboard;
 }
 

--- a/src/drivers/wayland/lv_wayland_pointer.c
+++ b/src/drivers/wayland/lv_wayland_pointer.c
@@ -92,7 +92,7 @@ lv_indev_t * lv_wayland_get_pointer(lv_display_t * display)
 {
     LV_CHECK_ARG(display != NULL, return NULL);
     lv_wl_window_t * window = lv_display_get_driver_data(display);
-    LV_CHECK_ARG(window != NULL, return NULL, "Invalid display");
+    LV_CHECK_ARG_MSG(window != NULL, return NULL, "Invalid display");
     return window->lv_indev_pointer;
 }
 
@@ -112,7 +112,7 @@ lv_indev_t * lv_wayland_get_pointeraxis(lv_display_t * display)
 {
     LV_CHECK_ARG(display != NULL, return NULL);
     lv_wl_window_t * window = lv_display_get_driver_data(display);
-    LV_CHECK_ARG(window != NULL, return NULL, "Invalid display");
+    LV_CHECK_ARG_MSG(window != NULL, return NULL, "Invalid display");
     return window->lv_indev_pointeraxis;
 }
 

--- a/src/drivers/wayland/lv_wayland_touch.c
+++ b/src/drivers/wayland/lv_wayland_touch.c
@@ -74,7 +74,7 @@ lv_indev_t * lv_wayland_get_touchscreen(lv_display_t * display)
 {
     LV_CHECK_ARG(display != NULL, return NULL);
     lv_wl_window_t * window = lv_display_get_driver_data(display);
-    LV_CHECK_ARG(window != NULL, return NULL, "Invalid display");
+    LV_CHECK_ARG_MSG(window != NULL, return NULL, "Invalid display");
     return window->lv_indev_touch;
 }
 

--- a/src/drivers/wayland/lv_wayland_window.c
+++ b/src/drivers/wayland/lv_wayland_window.c
@@ -187,7 +187,7 @@ bool lv_wayland_window_is_open(lv_display_t * display)
 {
     LV_CHECK_ARG(display != NULL, return false);
     lv_wl_window_t * window = lv_display_get_driver_data(display);
-    LV_CHECK_ARG(window != NULL, return false, "Invalid display");
+    LV_CHECK_ARG_MSG(window != NULL, return false, "Invalid display");
     return window->xdg.configured;
 }
 
@@ -195,7 +195,7 @@ void lv_wayland_window_set_maximized(lv_display_t * display, bool maximized)
 {
     LV_CHECK_ARG(display != NULL, return);
     lv_wl_window_t * window = lv_display_get_driver_data(display);
-    LV_CHECK_ARG(window != NULL, return, "Invalid display");
+    LV_CHECK_ARG_MSG(window != NULL, return, "Invalid display");
     if(window->maximized == maximized) {
         return;
     }
@@ -206,7 +206,7 @@ void lv_wayland_window_set_minimized(lv_display_t * display)
 {
     LV_CHECK_ARG(display != NULL, return);
     lv_wl_window_t * window = lv_display_get_driver_data(display);
-    LV_CHECK_ARG(window != NULL, return, "Invalid display");
+    LV_CHECK_ARG_MSG(window != NULL, return, "Invalid display");
     lv_wayland_xdg_set_minimized(&window->xdg);
 }
 
@@ -214,9 +214,10 @@ void lv_wayland_assign_physical_display(lv_display_t * display, uint8_t phys_dis
 {
     LV_CHECK_ARG(display != NULL, return);
     lv_wl_window_t * window = lv_display_get_driver_data(display);
-    LV_CHECK_ARG(window != NULL, return, "Invalid display");
-    LV_CHECK_ARG(phys_display < lv_wl_ctx.wl_output_count, return, "Invalid display number '%d'. Expected '0'..'%d'",
-                 phys_display, lv_wl_ctx.wl_output_count - 1);
+    LV_CHECK_ARG_MSG(window != NULL, return, "Invalid display");
+    LV_CHECK_ARG_FORMAT_MSG(phys_display < lv_wl_ctx.wl_output_count, return,
+                            "Invalid display number '%d'. Expected '0'..'%d'",
+                            phys_display, lv_wl_ctx.wl_output_count - 1);
 
     window->physical_output = lv_wl_ctx.physical_outputs[phys_display].wl_output;
 }
@@ -225,7 +226,7 @@ void lv_wayland_unassign_physical_display(lv_display_t * display)
 {
     LV_CHECK_ARG(display != NULL, return);
     lv_wl_window_t * window = lv_display_get_driver_data(display);
-    LV_CHECK_ARG(window != NULL, return, "Invalid display");
+    LV_CHECK_ARG_MSG(window != NULL, return, "Invalid display");
     window->physical_output = NULL;
 }
 
@@ -233,7 +234,7 @@ void lv_wayland_window_set_fullscreen(lv_display_t * display, bool fullscreen)
 {
     LV_CHECK_ARG(display != NULL, return);
     lv_wl_window_t * window = lv_display_get_driver_data(display);
-    LV_CHECK_ARG(window != NULL, return, "Invalid display");
+    LV_CHECK_ARG_MSG(window != NULL, return, "Invalid display");
 
     if(window->fullscreen == fullscreen) {
         return;

--- a/src/drivers/x11/lv_x11_input.c
+++ b/src/drivers/x11/lv_x11_input.c
@@ -307,7 +307,7 @@ void lv_x11_inputs_create(lv_display_t * disp, lv_image_dsc_t const * mouse_img)
 {
     LV_CHECK_ARG(disp != NULL, return);
     x11_inp_data_t * xd = x11_input_get_user_data(disp);
-    LV_CHECK_ARG(xd != NULL, return, "Invalid display");
+    LV_CHECK_ARG_MSG(xd != NULL, return, "Invalid display");
     xd->inp_group = lv_group_create();
     lv_group_set_default(xd->inp_group);
 

--- a/src/font/font_manager/lv_font_manager.c
+++ b/src/font/font_manager/lv_font_manager.c
@@ -86,7 +86,7 @@ static bool lv_font_manager_add_src_core(lv_font_manager_t * manager, const char
 
 lv_font_manager_t * lv_font_manager_create(uint32_t recycle_cache_size)
 {
-    LV_CHECK_ARG(recycle_cache_size > 0, return NULL, "recycle_cache_size must be greater than 0");
+    LV_CHECK_ARG_MSG(recycle_cache_size > 0, return NULL, "recycle_cache_size must be greater than 0");
     lv_font_manager_t * manager = lv_malloc_zeroed(sizeof(lv_font_manager_t));
     LV_ASSERT_MALLOC(manager);
     if(!manager) {

--- a/src/image/lv_bin_decoder.c
+++ b/src/image/lv_bin_decoder.c
@@ -409,7 +409,7 @@ lv_result_t lv_bin_decoder_get_area(lv_image_decoder_t * decoder, lv_image_decod
 
     LV_UNUSED(decoder);
     lv_color_format_t cf = dsc->header.cf;
-    LV_CHECK_ARG(
+    LV_CHECK_ARG_FORMAT_MSG(
         LV_COLOR_FORMAT_IS_INDEXED(cf)
         || cf == LV_COLOR_FORMAT_ARGB8888
         || cf == LV_COLOR_FORMAT_XRGB8888
@@ -419,9 +419,9 @@ lv_result_t lv_bin_decoder_get_area(lv_image_decoder_t * decoder, lv_image_decod
         || cf == LV_COLOR_FORMAT_ARGB8565
         || cf == LV_COLOR_FORMAT_RGB565A8,
         return LV_RESULT_INVALID, "Unsupported color format 0x%02x", cf);
-    LV_CHECK_ARG(full_area->x1 >= 0 && full_area->x2 < (int32_t)dsc->header.w && full_area->y1 >= 0 &&
-                 full_area->y2 < (int32_t)dsc->header.h, return LV_RESULT_INVALID, "Area outside image bounds");
-    LV_CHECK_ARG(dsc->user_data, return LV_RESULT_INVALID, "decoder data unavailable");
+    LV_CHECK_ARG_MSG(full_area->x1 >= 0 && full_area->x2 < (int32_t)dsc->header.w && full_area->y1 >= 0 &&
+                     full_area->y2 < (int32_t)dsc->header.h, return LV_RESULT_INVALID, "Area outside image bounds");
+    LV_CHECK_ARG_MSG(dsc->user_data, return LV_RESULT_INVALID, "decoder data unavailable");
 
     lv_fs_res_t res = LV_FS_RES_UNKNOWN;
     decoder_data_t * decoder_data = dsc->user_data;

--- a/src/indev/lv_indev.c
+++ b/src/indev/lv_indev.c
@@ -703,8 +703,8 @@ lv_result_t lv_indev_send_event(lv_indev_t * indev, lv_event_code_t code, void *
 
 void lv_indev_set_key_remap_cb(lv_indev_t * indev, lv_indev_key_remap_cb_t remap_cb)
 {
-    LV_CHECK_ARG(indev != NULL, return,
-                 "Can't remap key on a NULL indev");
+    LV_CHECK_ARG_MSG(indev != NULL, return,
+                     "Can't remap key on a NULL indev");
 
     indev->key_remap_cb = remap_cb;
 }
@@ -735,8 +735,8 @@ bool lv_indev_get_ccw(const lv_indev_t * indev)
 #if LV_USE_EXT_DATA
 void lv_indev_set_external_data(lv_indev_t * indev, void * data, void (* free_cb)(void * data))
 {
-    LV_CHECK_ARG(indev != NULL, return,
-                 "Can't attach external user data and free_cb callback to a NULL indev");
+    LV_CHECK_ARG_MSG(indev != NULL, return,
+                     "Can't attach external user data and free_cb callback to a NULL indev");
 
     indev->ext_data.data = data;
     indev->ext_data.free_cb = free_cb;

--- a/src/layouts/grid/lv_grid.c
+++ b/src/layouts/grid/lv_grid.c
@@ -162,10 +162,10 @@ void lv_obj_set_grid_dsc_array(lv_obj_t * obj, const int32_t col_dsc[], const in
 void lv_obj_set_grid_align(lv_obj_t * obj, lv_grid_align_t column_align, lv_grid_align_t row_align)
 {
     LV_CHECK_OBJ(obj, &lv_obj_class, return);
-    LV_CHECK_ARG(column_align != LV_GRID_ALIGN_STRETCH, return,
-                 "LV_GRID_ALIGN_STRETCH is not supported for column tracks");
-    LV_CHECK_ARG(row_align != LV_GRID_ALIGN_STRETCH, return,
-                 "LV_GRID_ALIGN_STRETCH is not supported for row tracks");
+    LV_CHECK_ARG_MSG(column_align != LV_GRID_ALIGN_STRETCH, return,
+                     "LV_GRID_ALIGN_STRETCH is not supported for column tracks");
+    LV_CHECK_ARG_MSG(row_align != LV_GRID_ALIGN_STRETCH, return,
+                     "LV_GRID_ALIGN_STRETCH is not supported for row tracks");
 
     lv_obj_set_style_grid_column_align(obj, column_align, 0);
     lv_obj_set_style_grid_row_align(obj, row_align, 0);

--- a/src/libs/gltf/gltf_data/lv_gltf_model_node.cpp
+++ b/src/libs/gltf/gltf_data/lv_gltf_model_node.cpp
@@ -78,7 +78,8 @@ lv_gltf_model_node_t * lv_gltf_model_node_get_by_index(lv_gltf_model_t * model, 
 {
     LV_CHECK_ARG(model != NULL, return nullptr);
     const uint32_t count = lv_array_size(&model->nodes);
-    LV_CHECK_ARG(index < count, return nullptr, "Invalid index %zu. Max should be %" LV_PRIu32, index, count - 1);
+    LV_CHECK_ARG_FORMAT_MSG(index < count, return nullptr, "Invalid index %zu. Max should be %" LV_PRIu32, index,
+                            count - 1);
 
     return (lv_gltf_model_node_t *)lv_array_at(&model->nodes, index);
 }
@@ -145,9 +146,9 @@ lv_event_dsc_t * lv_gltf_model_node_add_event_cb(lv_gltf_model_node_t * node, lv
 {
     LV_CHECK_ARG(node != NULL, return nullptr);
     LV_CHECK_ARG(cb != NULL, return nullptr);
-    LV_CHECK_ARG(filter_list == LV_EVENT_ALL || (filter_list & LV_EVENT_VALUE_CHANGED) != 0,
-                 return nullptr,
-                 "Only LV_EVENT_VALUE_CHANGED events will ever be sent");
+    LV_CHECK_ARG_MSG(filter_list == LV_EVENT_ALL || (filter_list & LV_EVENT_VALUE_CHANGED) != 0,
+                     return nullptr,
+                     "Only LV_EVENT_VALUE_CHANGED events will ever be sent");
 
     if(!node->read_attrs) {
         node->read_attrs = (lv_gltf_model_node_attr_t *) lv_zalloc(sizeof(*node->read_attrs));
@@ -167,9 +168,9 @@ lv_event_dsc_t * lv_gltf_model_node_add_event_cb_with_world_position(lv_gltf_mod
 {
     LV_CHECK_ARG(node != NULL, return nullptr);
     LV_CHECK_ARG(cb != NULL, return nullptr);
-    LV_CHECK_ARG(filter_list == LV_EVENT_ALL || (filter_list & LV_EVENT_VALUE_CHANGED) != 0,
-                 return nullptr,
-                 "Only LV_EVENT_VALUE_CHANGED events will ever be sent");
+    LV_CHECK_ARG_MSG(filter_list == LV_EVENT_ALL || (filter_list & LV_EVENT_VALUE_CHANGED) != 0,
+                     return nullptr,
+                     "Only LV_EVENT_VALUE_CHANGED events will ever be sent");
     lv_event_dsc_t * dsc = lv_gltf_model_node_add_event_cb(node, cb, filter_list, user_data);
     if(!dsc) {
         return nullptr;

--- a/src/misc/lv_ll.c
+++ b/src/misc/lv_ll.c
@@ -42,7 +42,7 @@ static void node_set_next(lv_ll_t * ll_p, lv_ll_node_t * act, lv_ll_node_t * nex
 void lv_ll_init(lv_ll_t * ll_p, uint32_t node_size)
 {
     LV_CHECK_ARG(ll_p != NULL, return);
-    LV_CHECK_ARG(node_size > 0, return, "cannot initialize a linked list with empty nodes");
+    LV_CHECK_ARG_MSG(node_size > 0, return, "cannot initialize a linked list with empty nodes");
     ll_p->head = NULL;
     ll_p->tail = NULL;
 #ifdef LV_ARCH_64

--- a/src/misc/lv_palette.c
+++ b/src/misc/lv_palette.c
@@ -43,7 +43,7 @@ lv_color_t lv_palette_main(lv_palette_t p)
         LV_COLOR_MAKE(0x79, 0x55, 0x48), LV_COLOR_MAKE(0x60, 0x7D, 0x8B), LV_COLOR_MAKE(0x9E, 0x9E, 0x9E)
     };
 
-    LV_CHECK_ARG(p < LV_PALETTE_LAST, return lv_color_black(), "invalid palette: %d", p);
+    LV_CHECK_ARG_FORMAT_MSG(p < LV_PALETTE_LAST, return lv_color_black(), "invalid palette: %d", p);
 
     return colors[p];
 
@@ -73,9 +73,9 @@ lv_color_t lv_palette_lighten(lv_palette_t p, uint8_t lvl)
         {LV_COLOR_MAKE(0xBD, 0xBD, 0xBD), LV_COLOR_MAKE(0xE0, 0xE0, 0xE0), LV_COLOR_MAKE(0xEE, 0xEE, 0xEE), LV_COLOR_MAKE(0xF5, 0xF5, 0xF5), LV_COLOR_MAKE(0xFA, 0xFA, 0xFA)},
     };
 
-    LV_CHECK_ARG(p < LV_PALETTE_LAST, return lv_color_black(), "invalid palette: %d", p);
+    LV_CHECK_ARG_FORMAT_MSG(p < LV_PALETTE_LAST, return lv_color_black(), "invalid palette: %d", p);
 
-    LV_CHECK_ARG(lvl >= 1 && lvl <= 5, return lv_color_black(), "invalid level: %d, must be 1..5", lvl);
+    LV_CHECK_ARG_FORMAT_MSG(lvl >= 1 && lvl <= 5, return lv_color_black(), "invalid level: %d, must be 1..5", lvl);
 
     lvl--;
 
@@ -106,9 +106,9 @@ lv_color_t lv_palette_darken(lv_palette_t p, uint8_t lvl)
         {LV_COLOR_MAKE(0x75, 0x75, 0x75), LV_COLOR_MAKE(0x61, 0x61, 0x61), LV_COLOR_MAKE(0x42, 0x42, 0x42), LV_COLOR_MAKE(0x21, 0x21, 0x21)},
     };
 
-    LV_CHECK_ARG(p < LV_PALETTE_LAST, return lv_color_black(), "invalid palette: %d", p);
+    LV_CHECK_ARG_FORMAT_MSG(p < LV_PALETTE_LAST, return lv_color_black(), "invalid palette: %d", p);
 
-    LV_CHECK_ARG(lvl >= 1 && lvl <= 4, return lv_color_black(), "invalid level: %d, must be 1..4", lvl);
+    LV_CHECK_ARG_FORMAT_MSG(lvl >= 1 && lvl <= 4, return lv_color_black(), "invalid level: %d, must be 1..4", lvl);
 
     lvl--;
 

--- a/src/others/translation/lv_translation.c
+++ b/src/others/translation/lv_translation.c
@@ -242,7 +242,7 @@ lv_translation_tag_dsc_t * lv_translation_add_tag(lv_translation_pack_t * pack, 
 {
     LV_CHECK_ARG(pack != NULL, return NULL);
     LV_CHECK_ARG(tag_name != NULL, return NULL);
-    LV_CHECK_ARG(!pack->is_static, return NULL, "Can't add tag `%s` to static translation pack", tag_name);
+    LV_CHECK_ARG_FORMAT_MSG(!pack->is_static, return NULL, "Can't add tag `%s` to static translation pack", tag_name);
 
     lv_translation_tag_dsc_t tag;
     tag.tag = lv_strdup(tag_name);
@@ -275,11 +275,12 @@ lv_result_t lv_translation_set_tag_translation(lv_translation_pack_t * pack, lv_
     LV_CHECK_ARG(pack != NULL, return LV_RESULT_INVALID);
     LV_CHECK_ARG(tag != NULL, return LV_RESULT_INVALID);
     LV_CHECK_ARG(trans != NULL, return LV_RESULT_INVALID);
-    LV_CHECK_ARG(!pack->is_static, return LV_RESULT_INVALID, "Can't set tag translation `%s` in static translation pack",
-                 trans);
-    LV_CHECK_ARG(lang_idx < pack->language_cnt, return LV_RESULT_INVALID,
-                 "Can't set the translation for language %" LV_PRIu32 " as there are only %" LV_PRIu32 " languages defined",
-                 lang_idx, pack->language_cnt);
+    LV_CHECK_ARG_FORMAT_MSG(!pack->is_static, return LV_RESULT_INVALID,
+                            "Can't set tag translation `%s` in static translation pack",
+                            trans);
+    LV_CHECK_ARG_FORMAT_MSG(lang_idx < pack->language_cnt, return LV_RESULT_INVALID,
+                            "Can't set the translation for language %" LV_PRIu32 " as there are only %" LV_PRIu32 " languages defined",
+                            lang_idx, pack->language_cnt);
     LV_UNUSED(pack);
 
     size_t new_len = lv_strlen(trans) + 1;

--- a/src/themes/lv_theme.c
+++ b/src/themes/lv_theme.c
@@ -122,7 +122,7 @@ lv_color_t lv_theme_get_color_secondary(lv_obj_t * obj)
 #if LV_USE_EXT_DATA
 void lv_theme_set_external_data(lv_theme_t * theme, void * user_data, void (* free_cb)(void * data))
 {
-    LV_CHECK_ARG(theme != NULL, return, "can't attach external data to a NULL theme");
+    LV_CHECK_ARG_MSG(theme != NULL, return, "can't attach external data to a NULL theme");
 
     theme->ext_data.data = user_data;
     theme->ext_data.free_cb = free_cb;

--- a/src/widgets/arc/lv_arc.c
+++ b/src/widgets/arc/lv_arc.c
@@ -471,9 +471,10 @@ lv_observer_t * lv_arc_bind_value(lv_obj_t * obj, lv_subject_t * subject)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type == LV_SUBJECT_TYPE_INT || subject->type == LV_SUBJECT_TYPE_FLOAT,
-                 return NULL,
-                 "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(
+        subject->type == LV_SUBJECT_TYPE_INT || subject->type == LV_SUBJECT_TYPE_FLOAT,
+        return NULL,
+        "Incompatible subject type: %d", subject->type);
 
 
     lv_obj_add_event_cb(obj, arc_value_changed_event_cb, LV_EVENT_VALUE_CHANGED, subject);

--- a/src/widgets/bar/lv_bar.c
+++ b/src/widgets/bar/lv_bar.c
@@ -305,9 +305,10 @@ lv_observer_t * lv_bar_bind_value(lv_obj_t * obj, lv_subject_t * subject)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type == LV_SUBJECT_TYPE_INT || subject->type == LV_SUBJECT_TYPE_FLOAT,
-                 return NULL,
-                 "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(
+        subject->type == LV_SUBJECT_TYPE_INT || subject->type == LV_SUBJECT_TYPE_FLOAT,
+        return NULL,
+        "Incompatible subject type: %d", subject->type);
 
     lv_observer_t * observer = lv_subject_add_observer_obj(subject, bar_value_observer_cb, obj, NULL);
     return observer;

--- a/src/widgets/canvas/lv_canvas.c
+++ b/src/widgets/canvas/lv_canvas.c
@@ -94,7 +94,7 @@ void lv_canvas_set_draw_buf(lv_obj_t * obj, lv_draw_buf_t * draw_buf)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return);
     LV_CHECK_ARG(draw_buf != NULL, return);
-    LV_CHECK_ARG(draw_buf->handlers != NULL, return, "draw_buf has no handlers, is it initialized?");
+    LV_CHECK_ARG_MSG(draw_buf->handlers != NULL, return, "draw_buf has no handlers, is it initialized?");
 
     lv_canvas_t * canvas = (lv_canvas_t *)obj;
     canvas->draw_buf = draw_buf;
@@ -294,7 +294,7 @@ void lv_canvas_copy_buf(lv_obj_t * obj, const lv_area_t * canvas_area, lv_draw_b
     LV_CHECK_ARG(src_buf != NULL, return);
     lv_canvas_t * canvas = (lv_canvas_t *)obj;
     LV_CHECK_ARG(canvas->draw_buf != NULL, return);
-    LV_CHECK_ARG(canvas->draw_buf->header.cf == src_buf->header.cf, return, "Color formats must be the same");
+    LV_CHECK_ARG_MSG(canvas->draw_buf->header.cf == src_buf->header.cf, return, "Color formats must be the same");
 
     lv_draw_buf_copy(canvas->draw_buf, canvas_area, src_buf, src_area);
 }

--- a/src/widgets/dropdown/lv_dropdown.c
+++ b/src/widgets/dropdown/lv_dropdown.c
@@ -670,8 +670,10 @@ lv_observer_t * lv_dropdown_bind_value(lv_obj_t * obj, lv_subject_t * subject)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type == LV_SUBJECT_TYPE_INT, return NULL,
-                 "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(
+        subject->type == LV_SUBJECT_TYPE_INT,
+        return NULL,
+        "Incompatible subject type: %d", subject->type);
 
     lv_obj_add_event_cb(obj, dropdown_value_changed_event_cb, LV_EVENT_VALUE_CHANGED, subject);
 

--- a/src/widgets/image/lv_image.c
+++ b/src/widgets/image/lv_image.c
@@ -655,8 +655,10 @@ lv_observer_t * lv_image_bind_src(lv_obj_t * obj, lv_subject_t * subject)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type == LV_SUBJECT_TYPE_POINTER, return NULL,
-                 "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(
+        subject->type == LV_SUBJECT_TYPE_POINTER,
+        return NULL,
+        "Incompatible subject type: %d", subject->type);
 
     lv_observer_t * observer = lv_subject_add_observer_obj(subject, image_src_observer_cb, obj, NULL);
     return observer;

--- a/src/widgets/menu/lv_menu.c
+++ b/src/widgets/menu/lv_menu.c
@@ -164,10 +164,10 @@ lv_obj_t * lv_menu_cont_create(lv_obj_t * parent)
 {
     LV_LOG_DEPRECATED(LV_MENU_DEPRECATED_MSG);
     LV_CHECK_ARG(parent != NULL, return NULL);
-    LV_CHECK_ARG(lv_obj_has_class(parent, &lv_menu_page_class)
-                 || lv_obj_has_class(parent, &lv_menu_section_class),
-                 return NULL,
-                 "Invalid parent object type for menu container object");
+    LV_CHECK_ARG_MSG(lv_obj_has_class(parent, &lv_menu_page_class)
+                     || lv_obj_has_class(parent, &lv_menu_section_class),
+                     return NULL,
+                     "Invalid parent object type for menu container object");
 
     LV_LOG_INFO("begin");
     lv_obj_t * obj = lv_obj_class_create_obj(&lv_menu_cont_class, parent);

--- a/src/widgets/qrcode/lv_qrcode.c
+++ b/src/widgets/qrcode/lv_qrcode.c
@@ -124,10 +124,10 @@ void lv_qrcode_set_light_color(lv_obj_t * obj, lv_color_t color)
 lv_result_t lv_qrcode_update(lv_obj_t * obj, const void * data, uint32_t data_len)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return LV_RESULT_INVALID);
-    LV_CHECK_ARG(data != NULL, return LV_RESULT_INVALID, "data must not be NULL");
-    LV_CHECK_ARG(data_len <= qrcodegen_BUFFER_LEN_MAX, return LV_RESULT_INVALID,
-                 "data_len %u exceeds the maximum %u",
-                 (unsigned)data_len, (unsigned)qrcodegen_BUFFER_LEN_MAX);
+    LV_CHECK_ARG_MSG(data != NULL, return LV_RESULT_INVALID, "data must not be NULL");
+    LV_CHECK_ARG_FORMAT_MSG(data_len <= qrcodegen_BUFFER_LEN_MAX, return LV_RESULT_INVALID,
+                            "data_len %u exceeds the maximum %u",
+                            (unsigned)data_len, (unsigned)qrcodegen_BUFFER_LEN_MAX);
 
     lv_qrcode_t * qrcode = (lv_qrcode_t *)obj;
 
@@ -145,7 +145,7 @@ lv_result_t lv_qrcode_update(lv_obj_t * obj, const void * data, uint32_t data_le
 void lv_qrcode_set_data(lv_obj_t * obj, const char * data)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return);
-    LV_CHECK_ARG(data != NULL, return, "data must not be NULL");
+    LV_CHECK_ARG_MSG(data != NULL, return, "data must not be NULL");
 
     lv_qrcode_update(obj, data, lv_strlen(data));
 }

--- a/src/widgets/roller/lv_roller.c
+++ b/src/widgets/roller/lv_roller.c
@@ -316,7 +316,10 @@ lv_observer_t * lv_roller_bind_value(lv_obj_t * obj, lv_subject_t * subject)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
     LV_CHECK_ARG(subject, return NULL);
-    LV_CHECK_ARG(subject->type == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(
+        subject->type == LV_SUBJECT_TYPE_INT,
+        return NULL, "Incompatible subject type: %d",
+        subject->type);
 
     lv_obj_add_event_cb(obj, roller_value_changed_event_cb, LV_EVENT_VALUE_CHANGED, subject);
 

--- a/src/widgets/scale/lv_scale.c
+++ b/src/widgets/scale/lv_scale.c
@@ -605,7 +605,10 @@ lv_observer_t * lv_scale_bind_section_min_value(lv_obj_t * obj, lv_scale_section
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
     LV_CHECK_ARG(section != NULL, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type  == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(
+        subject->type  == LV_SUBJECT_TYPE_INT,
+        return NULL,
+        "Incompatible subject type: %d", subject->type);
 
     lv_observer_t * observer = lv_subject_add_observer_obj(subject, scale_section_min_value_observer_cb, obj, section);
 
@@ -617,7 +620,10 @@ lv_observer_t * lv_scale_bind_section_max_value(lv_obj_t * obj, lv_scale_section
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
     LV_CHECK_ARG(section != NULL, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type  == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(
+        subject->type  == LV_SUBJECT_TYPE_INT,
+        return NULL,
+        "Incompatible subject type: %d", subject->type);
 
     lv_observer_t * observer = lv_subject_add_observer_obj(subject, scale_section_max_value_observer_cb, obj, section);
 
@@ -630,7 +636,9 @@ lv_observer_t * lv_scale_bind_line_needle_value(lv_obj_t * obj, lv_obj_t * needl
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
     LV_CHECK_ARG(needle_line != NULL, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type  == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(
+        subject->type  == LV_SUBJECT_TYPE_INT,
+        return NULL, "Incompatible subject type: %d", subject->type);
 
     bind_element_needle_t * user_data = lv_zalloc(sizeof(bind_element_needle_t));
     LV_ASSERT_MALLOC(user_data);
@@ -660,7 +668,10 @@ lv_observer_t * lv_scale_bind_image_needle_value(lv_obj_t * obj, lv_obj_t * need
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
     LV_CHECK_ARG(needle_img != NULL, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type  == LV_SUBJECT_TYPE_INT, return NULL, "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(
+        subject->type  == LV_SUBJECT_TYPE_INT,
+        return NULL,
+        "Incompatible subject type: %d", subject->type);
 
     lv_observer_t * observer = lv_subject_add_observer_obj(subject, scale_image_needle_value_observer_cb, obj, needle_img);
 

--- a/src/widgets/slider/lv_slider.c
+++ b/src/widgets/slider/lv_slider.c
@@ -245,9 +245,10 @@ lv_observer_t * lv_slider_bind_value(lv_obj_t * obj, lv_subject_t * subject)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type == LV_SUBJECT_TYPE_INT || subject->type == LV_SUBJECT_TYPE_FLOAT,
-                 return NULL,
-                 "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(
+        subject->type == LV_SUBJECT_TYPE_INT || subject->type == LV_SUBJECT_TYPE_FLOAT,
+        return NULL,
+        "Incompatible subject type: %d", subject->type);
 
     lv_obj_add_event_cb(obj, slider_value_changed_event_cb, LV_EVENT_VALUE_CHANGED, subject);
     lv_observer_t * observer = lv_subject_add_observer_obj(subject, slider_value_observer_cb, obj, NULL);

--- a/src/widgets/spinbox/lv_spinbox.c
+++ b/src/widgets/spinbox/lv_spinbox.c
@@ -410,9 +410,10 @@ lv_observer_t * lv_spinbox_bind_value(lv_obj_t * obj, lv_subject_t * subject)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
     LV_CHECK_ARG(subject != NULL, return NULL);
-    LV_CHECK_ARG(subject->type == LV_SUBJECT_TYPE_INT || subject->type == LV_SUBJECT_TYPE_FLOAT,
-                 return NULL,
-                 "Incompatible subject type: %d", subject->type);
+    LV_CHECK_ARG_FORMAT_MSG(
+        subject->type == LV_SUBJECT_TYPE_INT || subject->type == LV_SUBJECT_TYPE_FLOAT,
+        return NULL,
+        "Incompatible subject type: %d", subject->type);
 
     lv_obj_add_event_cb(obj, spinbox_value_changed_event_cb, LV_EVENT_VALUE_CHANGED, subject);
 

--- a/tests/src/test_cases/test_check_arg.c
+++ b/tests/src/test_cases/test_check_arg.c
@@ -62,14 +62,14 @@ static void log_cb(lv_log_level_t level, const char * buf)
 
 static int helper_return_val_on_null(void * ptr)
 {
-    LV_CHECK_ARG(ptr != NULL, return -1, "ptr is NULL");
+    LV_CHECK_ARG_MSG(ptr != NULL, return -1, "ptr is NULL");
     LV_UNUSED(ptr);
     return 42;
 }
 
 static void helper_return_void_on_null(void * ptr, bool * was_reached)
 {
-    LV_CHECK_ARG(ptr != NULL, return, "ptr is NULL");
+    LV_CHECK_ARG_MSG(ptr != NULL, return, "ptr is NULL");
     LV_UNUSED(ptr);
     *was_reached = true;
 }
@@ -82,7 +82,7 @@ static void helper_return_void_on_null(void * ptr, bool * was_reached)
 void test_check_arg_condition_true(void)
 {
     int x = 0;
-    LV_CHECK_ARG(1 == 1, x = -1, ": should not fire");
+    LV_CHECK_ARG_MSG(1 == 1, x = -1, ": should not fire");
     TEST_ASSERT_EQUAL_INT(0, x);
     TEST_ASSERT_FALSE(log_warned);
 }
@@ -95,7 +95,7 @@ void test_check_arg_condition_true(void)
 void test_check_arg_condition_false(void)
 {
     int x = 0;
-    LV_CHECK_ARG(1 == 0, x = -1, ": test failure action");
+    LV_CHECK_ARG_MSG(1 == 0, x = -1, ": test failure action");
     TEST_ASSERT_EQUAL_INT(-1, x);
 #if LV_CHECK_ARG_LOG_MODE != LV_CHECK_ARG_LOG_MODE_NONE
     TEST_ASSERT_TRUE(log_warned);
@@ -113,7 +113,7 @@ void test_check_arg_printf_args(void)
     int x = 0;
     int val = 7;
     LV_UNUSED(val);
-    LV_CHECK_ARG(val > 10, x = -1, ": val=%d", val);
+    LV_CHECK_ARG_FORMAT_MSG(val > 10, x = -1, ": val=%d", val);
     TEST_ASSERT_EQUAL_INT(-1, x);
 #if LV_CHECK_ARG_LOG_MODE != LV_CHECK_ARG_LOG_MODE_NONE
     TEST_ASSERT_TRUE(log_warned);
@@ -130,7 +130,7 @@ void test_check_arg_action_break(void)
 {
     int i;
     for(i = 0; i < 5; i++) {
-        LV_CHECK_ARG(i < 3, break, ": breaking at i=%d", i);
+        LV_CHECK_ARG_FORMAT_MSG(i < 3, break, ": breaking at i=%d", i);
     }
     TEST_ASSERT_EQUAL_INT(3, i);
 #if LV_CHECK_ARG_LOG_MODE != LV_CHECK_ARG_LOG_MODE_NONE
@@ -195,10 +195,10 @@ void test_check_arg_return_val_condition_false(void)
 void test_check_arg_multiple_in_sequence(void)
 {
     int x = 0;
-    LV_CHECK_ARG(1 == 1, x = 1, ": first");
+    LV_CHECK_ARG_MSG(1 == 1, x = 1, ": first");
     TEST_ASSERT_FALSE(log_warned);
 
-    LV_CHECK_ARG(1 == 0, x = 2, ": second");
+    LV_CHECK_ARG_MSG(1 == 0, x = 2, ": second");
     TEST_ASSERT_EQUAL_INT(2, x);
 #if LV_CHECK_ARG_LOG_MODE != LV_CHECK_ARG_LOG_MODE_NONE
     TEST_ASSERT_TRUE(log_warned);
@@ -209,7 +209,7 @@ void test_check_arg_multiple_in_sequence(void)
 /* Complex expression as error value in return */
 static int helper_return_val_complex_expr(void * ptr)
 {
-    LV_CHECK_ARG(ptr != NULL, return (1 > 0 ? -100 : -200), "complex expr");
+    LV_CHECK_ARG_MSG(ptr != NULL, return (1 > 0 ? -100 : -200), "complex expr");
     LV_UNUSED(ptr);
     return 42;
 }
@@ -227,7 +227,7 @@ void test_check_arg_return_val_complex_expr(void)
 /* Zero as error return value is not confused with success */
 static int helper_return_val_zero(void * ptr)
 {
-    LV_CHECK_ARG(ptr != NULL, return 0, "returns zero");
+    LV_CHECK_ARG_MSG(ptr != NULL, return 0, "returns zero");
     LV_UNUSED(ptr);
     return 42;
 }


### PR DESCRIPTION
The current master version of `LV_CHECK_ARG` relies on passing zero args to __VA_ARGS__ which is not c99 compliant

So this follow the LV_ASSERT approach by adding

`LV_CHECK_ARG_MSG`  and `LV_CHECK_ARG_FORMAT_MSG` (alongside the existing `LV_CHECK_ARG`) to be c99 compliant

It also modifies the call-sites accordingly

Example:

```c
LV_CHECK_ARG(x > 0, return);
LV_CHECK_ARG_MSG(x > 0, return, "x must be positive");
LV_CHECK_ARG_FORMAT_MSG(x > 0, return, "x must be positive. was %d", x);
```