### PR TITLE
docs(imgfont): disable broken online example embed

### DIFF
--- a/docs/src/main-modules/fonts/imgfont.mdx
+++ b/docs/src/main-modules/fonts/imgfont.mdx
@@ -34,5 +34,7 @@ To destroy the *imgfont* that is no longer used, use <ApiLink name="lv_imgfont_d
 
 ### Use emojis in a text.
 
-<LvglExample name="lv_example_imgfont_1" path="others/imgfont/lv_example_imgfont_1" />
+This example loads an emoji image from a file, which the online example environment
+does not provide, so it is not embedded here. The source is available in the
+repository at `examples/others/imgfont/lv_example_imgfont_1.c`.
 


### PR DESCRIPTION
Fixes #10219

## What changed

The `imgfont` documentation page embedded the `lv_example_imgfont_1` example online via `<LvglExample>`. That example loads the emoji image for `U+F600` from a file path (`examples/assets/emoji/F600.png`), but the online example environment does not load file-based assets, so the glyph renders as a broken image on the docs page.

This PR removes the online embed and replaces it with a short note pointing readers to the example source in the repository.

## Why disable the embed rather than guard it

In #10219 the two suggested options were disabling the example or adding a guard for online examples. The guard would require changes to the `LvglExample` component, which lives in the website repository rather than this one, so this PR takes the disable route here.

Embedding the image as a C array (the approach tried in #10274) was closed without merging, and the discussion in #10219 points away from that direction as well.

## Notes

The example itself still works in native builds where the asset file is present — only the online embedding is removed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

