### PR TITLE
feat(barcode): rename lv_barcode_update() to lv_barcode_set_text()

### DIFF
--- a/docs/src/changelog/migration-v10.mdx
+++ b/docs/src/changelog/migration-v10.mdx
@@ -507,6 +507,21 @@ Calling the following functions with `NULL` as the display parameter is deprecat
 
 ## Widgets
 
+### lv_barcode
+
+- `lv_barcode_update()` is renamed to `lv_barcode_set_text()`. Same argument, same return
+  value.
+
+  ```c
+  /* Before */
+  lv_barcode_update(barcode, "https://lvgl.io");
+
+  /* After */
+  lv_barcode_set_text(barcode, "https://lvgl.io");
+  ```
+
+- New: `lv_barcode_get_text()` reads the stored text back.
+
 ### lv_qrcode
 
 - No API change, but a behavioral one: `lv_qrcode_set_size()` and

--- a/docs/src/libs/barcode.mdx
+++ b/docs/src/libs/barcode.mdx
@@ -12,7 +12,7 @@ The LVGL Barcode utility enables you to generate Code-128 bar codes.  It uses th
 Set <ApiLink name="LV_USE_BARCODE" /> to `1` in `lv_conf.h`.
 
 Use <ApiLink name="lv_barcode_create" /> to create a barcode object, and use
-<ApiLink name="lv_barcode_update" /> to generate a barcode.
+<ApiLink name="lv_barcode_update" /> to set the data to encode.
 
 Call <ApiLink name="lv_barcode_set_scale" /> to adjust scaling,
 call <ApiLink name="lv_barcode_set_dark_color" /> and <ApiLink name="lv_barcode_set_light_color" />
@@ -24,21 +24,74 @@ and strips `[FCN1]` and spaces. Optionally use
 <ApiLink name="lv_barcode_set_encoding" /> to set
 <ApiLink name="LV_BARCODE_ENCODING_CODE128_RAW" />.
 
-After any of a bar code's settings have changed, call
-<ApiLink name="lv_barcode_update" /> again to regenerate it.
+These can all be called in any order, before or after the data. The Widget keeps a copy of
+the data - costing its length in bytes - so any change, including a resize, regenerates the
+bars automatically.
+
+### Update mode
+
+Every change except the colors regenerates the bars.
+<ApiLink name="lv_barcode_set_update_mode" /> chooses when:
+
+- `LV_BARCODE_UPDATE_MODE_IMMEDIATE` (default) regenerates inside the setter.
+- `LV_BARCODE_UPDATE_MODE_DEFERRED` marks the bars out of date instead, so several changes
+  collapse into one regeneration. Call <ApiLink name="lv_barcode_render" /> when done - it
+  regenerates from the stored data and returns the result.
+
+```c
+lv_barcode_set_update_mode(barcode, LV_BARCODE_UPDATE_MODE_DEFERRED);
+lv_barcode_set_scale(barcode, 2);
+lv_barcode_set_direction(barcode, LV_DIR_VER);
+
+lv_barcode_render(barcode);   /* generate once, here, and get the result */
+```
+
+Forgetting that call still gives the right bitmap - the redraw fills the bars in and warns -
+but the work lands on that refresh and no caller is left to see a failure.
+
+Two things to know about deferred mode:
+
+- The canvas is resized in the setter in both modes, because the draw pass cannot
+  reallocate it. Only the fill is deferred.
+- <ApiLink name="lv_barcode_update" /> obeys the mode too, so in deferred mode its return
+  value reports only the resize.
+
+Switching back to `LV_BARCODE_UPDATE_MODE_IMMEDIATE` while out of date also regenerates, but
+that setter returns `void`, so a failure is only logged. Render first to get the result.
+
+### Detecting a failed regeneration
+
+<ApiLink name="lv_barcode_render" /> returns its result, and so does
+<ApiLink name="lv_barcode_update" /> in immediate mode. The rest cannot: the property
+setters return `void`, resizes happen in an event handler, and a deferred fill happens in
+the draw pass. <ApiLink name="lv_barcode_get_render_failed" /> covers those:
+
+```c
+lv_obj_set_height(barcode, 0);   /* leaves no room for a horizontal barcode */
+if(lv_barcode_get_render_failed(barcode)) {
+    /* the bitmap is blank; give the object a height */
+}
+```
+
+It is also `true` before any data is set, and `false` again after a success. A failure is
+not retried every redraw - only a change makes the Widget try again.
 
 ## Notes
 
 - It is best not to manually set the width of the barcode, because when
    the width of the Widget is lower than the width of the barcode, the
    display will be incomplete due to truncation.
+- A horizontal barcode is as tall as the Widget and a vertical one as wide, so that
+   dimension must be set. Until it is, nothing can be generated - but the data is
+   remembered, so the barcode appears once the Widget has a size.
 - The scale adjustment can only be an integer multiple, for example,
    <ApiLink name="lv_barcode_set_scale" display="lv_barcode_set_scale(barcode, 2)" /> means 2x scaling.
 - The direction setting can be <ApiLink name="LV_DIR_HOR" /> or <ApiLink name="LV_DIR_VER" />.
+- Changing the color (dark or light) only updates the palette, so it is cheap
+   and never regenerates the bars.
 
 ## Example
 
 ### Create a Barcode
 
 <LvglExample name="lv_example_barcode_1" path="libs/barcode/lv_example_barcode_1" />
-

--- a/docs/src/libs/barcode.mdx
+++ b/docs/src/libs/barcode.mdx
@@ -12,7 +12,8 @@ The LVGL Barcode utility enables you to generate Code-128 bar codes.  It uses th
 Set <ApiLink name="LV_USE_BARCODE" /> to `1` in `lv_conf.h`.
 
 Use <ApiLink name="lv_barcode_create" /> to create a barcode object, and use
-<ApiLink name="lv_barcode_update" /> to set the data to encode.
+<ApiLink name="lv_barcode_set_text" /> to set the text to encode.
+<ApiLink name="lv_barcode_get_text" /> reads it back.
 
 Call <ApiLink name="lv_barcode_set_scale" /> to adjust scaling,
 call <ApiLink name="lv_barcode_set_dark_color" /> and <ApiLink name="lv_barcode_set_light_color" />
@@ -24,8 +25,8 @@ and strips `[FCN1]` and spaces. Optionally use
 <ApiLink name="lv_barcode_set_encoding" /> to set
 <ApiLink name="LV_BARCODE_ENCODING_CODE128_RAW" />.
 
-These can all be called in any order, before or after the data. The Widget keeps a copy of
-the data - costing its length in bytes - so any change, including a resize, regenerates the
+These can all be called in any order, before or after the text. The Widget keeps a copy of
+the text - costing its length in bytes - so any change, including a resize, regenerates the
 bars automatically.
 
 ### Update mode
@@ -36,7 +37,7 @@ Every change except the colors regenerates the bars.
 - `LV_BARCODE_UPDATE_MODE_IMMEDIATE` (default) regenerates inside the setter.
 - `LV_BARCODE_UPDATE_MODE_DEFERRED` marks the bars out of date instead, so several changes
   collapse into one regeneration. Call <ApiLink name="lv_barcode_render" /> when done - it
-  regenerates from the stored data and returns the result.
+  regenerates from the stored text and returns the result.
 
 ```c
 lv_barcode_set_update_mode(barcode, LV_BARCODE_UPDATE_MODE_DEFERRED);
@@ -53,7 +54,7 @@ Two things to know about deferred mode:
 
 - The canvas is resized in the setter in both modes, because the draw pass cannot
   reallocate it. Only the fill is deferred.
-- <ApiLink name="lv_barcode_update" /> obeys the mode too, so in deferred mode its return
+- <ApiLink name="lv_barcode_set_text" /> obeys the mode too, so in deferred mode its return
   value reports only the resize.
 
 Switching back to `LV_BARCODE_UPDATE_MODE_IMMEDIATE` while out of date also regenerates, but
@@ -62,7 +63,7 @@ that setter returns `void`, so a failure is only logged. Render first to get the
 ### Detecting a failed regeneration
 
 <ApiLink name="lv_barcode_render" /> returns its result, and so does
-<ApiLink name="lv_barcode_update" /> in immediate mode. The rest cannot: the property
+<ApiLink name="lv_barcode_set_text" /> in immediate mode. The rest cannot: the property
 setters return `void`, resizes happen in an event handler, and a deferred fill happens in
 the draw pass. <ApiLink name="lv_barcode_get_render_failed" /> covers those:
 
@@ -73,7 +74,7 @@ if(lv_barcode_get_render_failed(barcode)) {
 }
 ```
 
-It is also `true` before any data is set, and `false` again after a success. A failure is
+It is also `true` before any text is set, and `false` again after a success. A failure is
 not retried every redraw - only a change makes the Widget try again.
 
 ## Notes
@@ -82,7 +83,7 @@ not retried every redraw - only a change makes the Widget try again.
    the width of the Widget is lower than the width of the barcode, the
    display will be incomplete due to truncation.
 - A horizontal barcode is as tall as the Widget and a vertical one as wide, so that
-   dimension must be set. Until it is, nothing can be generated - but the data is
+   dimension must be set. Until it is, nothing can be generated - but the text is
    remembered, so the barcode appears once the Widget has a size.
 - The scale adjustment can only be an integer multiple, for example,
    <ApiLink name="lv_barcode_set_scale" display="lv_barcode_set_scale(barcode, 2)" /> means 2x scaling.

--- a/examples/libs/barcode/lv_example_barcode_1.c
+++ b/examples/libs/barcode/lv_example_barcode_1.c
@@ -9,7 +9,7 @@
  * `lv_barcode_set_dark_color` and `lv_barcode_set_light_color` use darkened and
  * lightened entries from `LV_PALETTE_BLUE` and `LV_PALETTE_LIGHT_BLUE` for the
  * bars and background, a matching border color is applied, and
- * `lv_barcode_update` encodes `https://lvgl.io`.
+ * `lv_barcode_set_text` encodes `https://lvgl.io`.
  */
 void lv_example_barcode_1(void)
 {
@@ -27,8 +27,8 @@ void lv_example_barcode_1(void)
     /*Add a border with bg_color*/
     lv_obj_set_style_border_color(barcode, bg_color, 0);
 
-    /*Set data*/
-    lv_barcode_update(barcode, "https://lvgl.io");
+    /*Set the text to encode*/
+    lv_barcode_set_text(barcode, "https://lvgl.io");
 }
 
 #endif

--- a/include/lvgl/widgets/lv_barcode.h
+++ b/include/lvgl/widgets/lv_barcode.h
@@ -39,6 +39,15 @@ typedef enum {
     LV_BARCODE_ENCODING_CODE128_RAW,
 } lv_barcode_encoding_t;
 
+/**
+ * Controls when a change is turned into a new barcode bitmap. Applies to the data too.
+ * The colors are always a palette-only write, so they are never affected.
+ */
+typedef enum {
+    LV_BARCODE_UPDATE_MODE_IMMEDIATE = 0,   /**< Re-generate as soon as a property changes (default) */
+    LV_BARCODE_UPDATE_MODE_DEFERRED,        /**< Only mark the bitmap out of date and re-generate once, on the next redraw */
+} lv_barcode_update_mode_t;
+
 LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_barcode_class;
 
 /**********************
@@ -54,54 +63,109 @@ LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_barcode_class;
 lv_obj_t * lv_barcode_create(lv_obj_t * parent);
 
 /**
- * Set the dark color of a barcode object
+ * Set the dark color of a barcode object.
+ * Only rewrites the palette, so it takes effect before or after the data and never
+ * regenerates the bars.
  * @param obj pointer to barcode object
  * @param color dark color of the barcode
  */
 void lv_barcode_set_dark_color(lv_obj_t * obj, lv_color_t color);
 
 /**
- * Set the light color of a barcode object
+ * Set the light color of a barcode object.
+ * Only rewrites the palette, so it takes effect before or after the data and never
+ * regenerates the bars.
  * @param obj pointer to barcode object
  * @param color light color of the barcode
  */
 void lv_barcode_set_light_color(lv_obj_t * obj, lv_color_t color);
 
 /**
- * Set the scale of a barcode object
+ * Set the scale of a barcode object, i.e. the pixel width of a single bar.
+ * The stored data is re-generated, so this may be called before or after the data.
  * @param obj pointer to barcode object
- * @param scale scale factor
+ * @param scale scale factor; must be at least 1
  */
 void lv_barcode_set_scale(lv_obj_t * obj, uint16_t scale);
 
 /**
- * Set the direction of a barcode object
+ * Set the direction of a barcode object.
+ * The stored data is re-generated, so this may be called before or after the data.
  * @param obj pointer to barcode object
- * @param direction draw direction (`LV_DIR_HOR` or `LB_DIR_VER`)
+ * @param direction draw direction (`LV_DIR_HOR` or `LV_DIR_VER`)
  */
 void lv_barcode_set_direction(lv_obj_t * obj, lv_dir_t direction);
 
 /**
- * Set the tiled mode of a barcode object
+ * Set the tiled mode of a barcode object.
+ * The stored data is re-generated, so this may be called before or after the data.
  * @param obj pointer to barcode object
  * @param tiled true: tiled mode, false: normal mode (default)
  */
 void lv_barcode_set_tiled(lv_obj_t * obj, bool tiled);
 
 /**
- * Set the encoding of a barcode object
+ * Set the encoding of a barcode object.
+ * The stored data is re-generated, so this may be called before or after the data.
  * @param obj pointer to barcode object
- * @param encoding encoding (default is `LV_BARCODE_CODE128_GS1`)
+ * @param encoding encoding (default is `LV_BARCODE_ENCODING_CODE128_GS1`)
  */
 void lv_barcode_set_encoding(lv_obj_t * obj, lv_barcode_encoding_t encoding);
 
 /**
- * Set the data of a barcode object
- * @param obj pointer to barcode object
- * @param data data to display
+ * Set the data of a barcode object and generate the bitmap.
+ * A copy is stored, so a later property change or resize can regenerate it; the properties
+ * may be set before or after the data, in any order.
+ * @note Obeys the update mode. In DEFERRED the canvas is only resized here, so the return
+ *       value reports that resize, not the bars.
+ * @param obj  pointer to barcode object
+ * @param data data to display as a NUL terminated string
  * @return LV_RESULT_OK: if no error; LV_RESULT_INVALID: on error
  */
 lv_result_t lv_barcode_update(lv_obj_t * obj, const char * data);
+
+/**
+ * (Re)generate the barcode bitmap from the stored data, whether or not anything changed.
+ * Needs no data argument, which is how deferred changes are applied.
+ * @param obj pointer to barcode object
+ * @return LV_RESULT_OK: if no error; LV_RESULT_INVALID: on error (e.g. no data set, or
+ *         the bars do not fit the current object size)
+ */
+lv_result_t lv_barcode_render(lv_obj_t * obj);
+
+/**
+ * Set when a change is turned into a new barcode bitmap. Applies to the data and to the
+ * scale, direction, tiled mode and encoding; the colors are never affected.
+ * @note Only the fill is deferred. The canvas is resized in the setter in both modes,
+ *       because the draw pass cannot reallocate it.
+ * @note Deferred mode expects an explicit `lv_barcode_render()`, which returns the result.
+ *       Forgetting it still gives the right bitmap, but the redraw does the work and warns,
+ *       and no caller is left to see a failure.
+ * @note Switching back to IMMEDIATE while out of date also regenerates, but this returns
+ *       void, so a failure is only logged. Render first to get the result.
+ * @param obj  pointer to barcode object
+ * @param mode the mode to use
+ */
+void lv_barcode_set_update_mode(lv_obj_t * obj, lv_barcode_update_mode_t mode);
+
+/**
+ * Get when a property change is turned into a new barcode bitmap.
+ * @param obj pointer to barcode object
+ * @return the update mode currently in use
+ */
+lv_barcode_update_mode_t lv_barcode_get_update_mode(lv_obj_t * obj);
+
+/**
+ * Get whether the last attempt to generate the bitmap failed. `lv_barcode_render()`, and
+ * `lv_barcode_update()` in IMMEDIATE mode, return their result directly; the rest cannot -
+ * they run in a void setter, the resize handler, or a deferred fill in the draw pass. Use
+ * this for those, e.g. after shrinking the object below the size its data needs.
+ * @note A failure is not retried every redraw; only a change makes the Widget try again.
+ * @param obj pointer to barcode object
+ * @return true: the last generation attempt failed, or no data has been set yet;
+ *         false: the bitmap holds a valid barcode
+ */
+bool lv_barcode_get_render_failed(lv_obj_t * obj);
 
 /**
  * Get the dark color of a barcode object

--- a/include/lvgl/widgets/lv_barcode.h
+++ b/include/lvgl/widgets/lv_barcode.h
@@ -113,22 +113,30 @@ void lv_barcode_set_tiled(lv_obj_t * obj, bool tiled);
 void lv_barcode_set_encoding(lv_obj_t * obj, lv_barcode_encoding_t encoding);
 
 /**
- * Set the data of a barcode object and generate the bitmap.
+ * Set the text a barcode object encodes, and generate the bitmap.
  * A copy is stored, so a later property change or resize can regenerate it; the properties
- * may be set before or after the data, in any order.
+ * may be set before or after the text, in any order.
  * @note Obeys the update mode. In DEFERRED the canvas is only resized here, so the return
  *       value reports that resize, not the bars.
  * @param obj  pointer to barcode object
- * @param data data to display as a NUL terminated string
+ * @param text text to encode, as a non-empty NUL terminated string
  * @return LV_RESULT_OK: if no error; LV_RESULT_INVALID: on error
  */
-lv_result_t lv_barcode_update(lv_obj_t * obj, const char * data);
+lv_result_t lv_barcode_set_text(lv_obj_t * obj, const char * text);
+
+/**
+ * Get the text a barcode object encodes.
+ * @param obj pointer to barcode object
+ * @return the stored text, or NULL if none is set. Owned by the barcode object and
+ *         invalidated by the next `lv_barcode_set_text()`.
+ */
+const char * lv_barcode_get_text(lv_obj_t * obj);
 
 /**
  * (Re)generate the barcode bitmap from the stored data, whether or not anything changed.
  * Needs no data argument, which is how deferred changes are applied.
  * @param obj pointer to barcode object
- * @return LV_RESULT_OK: if no error; LV_RESULT_INVALID: on error (e.g. no data set, or
+ * @return LV_RESULT_OK: if no error; LV_RESULT_INVALID: on error (e.g. no text set, or
  *         the bars do not fit the current object size)
  */
 lv_result_t lv_barcode_render(lv_obj_t * obj);
@@ -157,12 +165,12 @@ lv_barcode_update_mode_t lv_barcode_get_update_mode(lv_obj_t * obj);
 
 /**
  * Get whether the last attempt to generate the bitmap failed. `lv_barcode_render()`, and
- * `lv_barcode_update()` in IMMEDIATE mode, return their result directly; the rest cannot -
+ * `lv_barcode_set_text()` in IMMEDIATE mode, return their result directly; the rest cannot -
  * they run in a void setter, the resize handler, or a deferred fill in the draw pass. Use
  * this for those, e.g. after shrinking the object below the size its data needs.
  * @note A failure is not retried every redraw; only a change makes the Widget try again.
  * @param obj pointer to barcode object
- * @return true: the last generation attempt failed, or no data has been set yet;
+ * @return true: the last generation attempt failed, or no text has been set yet;
  *         false: the bitmap holds a valid barcode
  */
 bool lv_barcode_get_render_failed(lv_obj_t * obj);

--- a/scripts/gdb/lvglgdb/lvgl/widgets/lv_barcode.py
+++ b/scripts/gdb/lvglgdb/lvgl/widgets/lv_barcode.py
@@ -6,7 +6,7 @@ Do not edit manually. Regenerate from the GDB script root with:
 """
 
 from .lv_canvas import LVCanvas
-from ._helpers import safe_color
+from ._helpers import ptr_or_none, safe_color, safe_string
 
 
 class LVBarcode(LVCanvas):
@@ -26,7 +26,22 @@ class LVBarcode(LVCanvas):
         return safe_color(self._wv_lv_barcode_t, "light_color")
 
     @property
+    def data(self):
+        """Copy of the payload, kept so the bitmap can be regenerated on a property change"""
+        return safe_string(self._wv_lv_barcode_t, "data")
+
+    @property
+    def pattern(self):
+        return ptr_or_none(self._wv_lv_barcode_t.safe_field("pattern"))
+
+    @property
+    def bar_count(self):
+        """Bars `data` encodes to; 0 when it is not known and has to be encoded"""
+        return int(self._wv_lv_barcode_t.safe_field("bar_count", 0))
+
+    @property
     def scale(self):
+        """Pixel width of a single bar"""
         return int(self._wv_lv_barcode_t.safe_field("scale", 0))
 
     @property
@@ -34,12 +49,33 @@ class LVBarcode(LVCanvas):
         return int(self._wv_lv_barcode_t.safe_field("direction", 0))
 
     @property
+    def encoding(self):
+        return int(self._wv_lv_barcode_t.safe_field("encoding", 0))
+
+    @property
     def tiled(self):
+        """Draw a one bar wide bitmap and let the image tiling repeat it"""
         return int(self._wv_lv_barcode_t.safe_field("tiled", 0))
 
     @property
-    def encoding(self):
-        return int(self._wv_lv_barcode_t.safe_field("encoding", 0))
+    def update_mode(self):
+        """lv_barcode_update_mode_t: when a property change is regenerated"""
+        return int(self._wv_lv_barcode_t.safe_field("update_mode", 0))
+
+    @property
+    def needs_update(self):
+        """The bitmap is out of date; filled in on the next redraw (deferred mode)"""
+        return int(self._wv_lv_barcode_t.safe_field("needs_update", 0))
+
+    @property
+    def render_failed(self):
+        """The last generation attempt failed (or none has run yet)"""
+        return int(self._wv_lv_barcode_t.safe_field("render_failed", 0))
+
+    @property
+    def fitting(self):
+        """Guard against the re-entrant resize our own reallocation triggers"""
+        return int(self._wv_lv_barcode_t.safe_field("fitting", 0))
 
     def snapshot(self, include_children=False, include_styles=False):
         """Snapshot with widget-specific fields in widget_data."""
@@ -47,9 +83,16 @@ class LVBarcode(LVCanvas):
         d = s.get('widget_data') or {}
         d["dark_color"] = self.dark_color
         d["light_color"] = self.light_color
+        d["data"] = self.data
+        d["pattern"] = self.pattern
+        d["bar_count"] = self.bar_count
         d["scale"] = self.scale
         d["direction"] = self.direction
-        d["tiled"] = self.tiled
         d["encoding"] = self.encoding
+        d["tiled"] = self.tiled
+        d["update_mode"] = self.update_mode
+        d["needs_update"] = self.needs_update
+        d["render_failed"] = self.render_failed
+        d["fitting"] = self.fitting
         s['widget_data'] = d
         return s

--- a/scripts/gdb/scripts/generators/widget_specs.json
+++ b/scripts/gdb/scripts/generators/widget_specs.json
@@ -136,10 +136,17 @@
       "fields": {
         "dark_color": "color",
         "light_color": "color",
+        "data": "string",
+        "pattern": "pointer",
+        "bar_count": "int",
         "scale": "int",
         "direction": "int",
+        "encoding": "int",
         "tiled": "bool",
-        "encoding": "int"
+        "update_mode": "bool",
+        "needs_update": "bool",
+        "render_failed": "bool",
+        "fitting": "bool"
       }
     }
   },

--- a/src/widgets/barcode/lv_barcode.c
+++ b/src/widgets/barcode/lv_barcode.c
@@ -29,8 +29,19 @@
  **********************/
 static void lv_barcode_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj);
 static void lv_barcode_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj);
+static void lv_barcode_event(const lv_obj_class_t * class_p, lv_event_t * e);
 static bool lv_barcode_change_buf_size(lv_obj_t * obj, int32_t w, int32_t h);
 static void lv_barcode_clear(lv_obj_t * obj);
+static bool barcode_store_data(lv_barcode_t * barcode, const char * data);
+static void barcode_forget_data(lv_barcode_t * barcode);
+static void barcode_drop_encoded(lv_barcode_t * barcode);
+static uint8_t * barcode_encode(const lv_barcode_t * barcode, int32_t * bar_count);
+static bool barcode_fit(lv_obj_t * obj);
+static bool barcode_fit_needed(lv_obj_t * obj);
+static bool barcode_fit_only(lv_obj_t * obj);
+static lv_result_t barcode_fill(lv_obj_t * obj);
+static lv_result_t barcode_render(lv_obj_t * obj);
+static lv_result_t barcode_mark_dirty(lv_obj_t * obj);
 
 /**********************
  *  STATIC VARIABLES
@@ -39,6 +50,7 @@ static void lv_barcode_clear(lv_obj_t * obj);
 const lv_obj_class_t lv_barcode_class = {
     .constructor_cb = lv_barcode_constructor,
     .destructor_cb = lv_barcode_destructor,
+    .event_cb = lv_barcode_event,
     .width_def = LV_SIZE_CONTENT,
     .instance_size = sizeof(lv_barcode_t),
     .base_class = &lv_canvas_class,
@@ -66,7 +78,15 @@ void lv_barcode_set_dark_color(lv_obj_t * obj, lv_color_t color)
     LV_CHECK_OBJ(obj, MY_CLASS, return);
 
     lv_barcode_t * barcode = (lv_barcode_t *)obj;
+
+    if(lv_color_eq(barcode->dark_color, color)) return;
     barcode->dark_color = color;
+
+    /*Write the palette now so the color also applies to bars that are already drawn*/
+    lv_draw_buf_t * draw_buf = lv_canvas_get_draw_buf(obj);
+    if(draw_buf == NULL) return;
+    lv_canvas_set_palette(obj, 1, lv_color_to_32(color, LV_OPA_COVER));
+    lv_image_cache_drop(draw_buf);
 }
 
 void lv_barcode_set_light_color(lv_obj_t * obj, lv_color_t color)
@@ -74,19 +94,27 @@ void lv_barcode_set_light_color(lv_obj_t * obj, lv_color_t color)
     LV_CHECK_OBJ(obj, MY_CLASS, return);
 
     lv_barcode_t * barcode = (lv_barcode_t *)obj;
+
+    if(lv_color_eq(barcode->light_color, color)) return;
     barcode->light_color = color;
+
+    /*Write the palette now so the color also applies to bars that are already drawn*/
+    lv_draw_buf_t * draw_buf = lv_canvas_get_draw_buf(obj);
+    if(draw_buf == NULL) return;
+    lv_canvas_set_palette(obj, 0, lv_color_to_32(color, LV_OPA_COVER));
+    lv_image_cache_drop(draw_buf);
 }
 
 void lv_barcode_set_scale(lv_obj_t * obj, uint16_t scale)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return);
-
-    if(scale == 0) {
-        scale = 1;
-    }
+    LV_CHECK_ARG(scale > 0, return);
 
     lv_barcode_t * barcode = (lv_barcode_t *)obj;
+
+    if(barcode->scale == scale) return;
     barcode->scale = scale;
+    barcode_mark_dirty(obj);
 }
 
 void lv_barcode_set_direction(lv_obj_t * obj, lv_dir_t direction)
@@ -94,7 +122,10 @@ void lv_barcode_set_direction(lv_obj_t * obj, lv_dir_t direction)
     LV_CHECK_OBJ(obj, MY_CLASS, return);
 
     lv_barcode_t * barcode = (lv_barcode_t *)obj;
+
+    if(barcode->direction == direction) return;
     barcode->direction = direction;
+    barcode_mark_dirty(obj);
 }
 
 void lv_barcode_set_tiled(lv_obj_t * obj, bool tiled)
@@ -102,8 +133,11 @@ void lv_barcode_set_tiled(lv_obj_t * obj, bool tiled)
     LV_CHECK_OBJ(obj, MY_CLASS, return);
 
     lv_barcode_t * barcode = (lv_barcode_t *)obj;
+
+    if((bool)barcode->tiled == tiled) return;
     barcode->tiled = tiled;
     lv_image_set_inner_align(obj, tiled ? LV_IMAGE_ALIGN_TILE : LV_IMAGE_ALIGN_DEFAULT);
+    barcode_mark_dirty(obj);
 }
 
 void lv_barcode_set_encoding(lv_obj_t * obj, lv_barcode_encoding_t encoding)
@@ -111,7 +145,11 @@ void lv_barcode_set_encoding(lv_obj_t * obj, lv_barcode_encoding_t encoding)
     LV_CHECK_OBJ(obj, MY_CLASS, return);
 
     lv_barcode_t * barcode = (lv_barcode_t *)obj;
+
+    if(barcode->encoding == encoding) return;
     barcode->encoding = encoding;
+    barcode_drop_encoded(barcode);
+    barcode_mark_dirty(obj);
 }
 
 lv_result_t lv_barcode_update(lv_obj_t * obj, const char * data)
@@ -119,114 +157,68 @@ lv_result_t lv_barcode_update(lv_obj_t * obj, const char * data)
     LV_CHECK_OBJ(obj, MY_CLASS, return LV_RESULT_INVALID);
     LV_CHECK_ARG(data != NULL, return LV_RESULT_INVALID);
 
-    if(lv_strlen(data) == 0) {
+    lv_barcode_t * barcode = (lv_barcode_t *)obj;
+
+    if(data[0] == '\0') {
         LV_LOG_WARN("data is empty");
+        barcode_forget_data(barcode);
+        barcode->needs_update = false;
+        barcode->render_failed = true;
         lv_barcode_clear(obj);
         return LV_RESULT_INVALID;
     }
 
-    size_t len = code128_estimate_len(data);
-    LV_LOG_INFO("data: %s, len = %zu", data, len);
+    if(!barcode_store_data(barcode, data)) return LV_RESULT_INVALID;
 
-    char * out_buf = lv_malloc(len);
-    LV_ASSERT_MALLOC(out_buf);
-    if(!out_buf) {
-        LV_LOG_ERROR("malloc failed for out_buf");
-        lv_barcode_clear(obj);
-        return LV_RESULT_INVALID;
-    }
+    return barcode_mark_dirty(obj);
+}
+
+lv_result_t lv_barcode_render(lv_obj_t * obj)
+{
+    LV_CHECK_OBJ(obj, MY_CLASS, return LV_RESULT_INVALID);
+
+    lv_result_t res = barcode_render(obj);
+
+    if(res != LV_RESULT_OK) lv_barcode_clear(obj);
+    else lv_obj_invalidate(obj);
+
+    return res;
+}
+
+void lv_barcode_set_update_mode(lv_obj_t * obj, lv_barcode_update_mode_t mode)
+{
+    LV_CHECK_OBJ(obj, MY_CLASS, return);
 
     lv_barcode_t * barcode = (lv_barcode_t *)obj;
 
-    int32_t barcode_w = 0;
-    switch(barcode->encoding) {
-        case LV_BARCODE_ENCODING_CODE128_GS1:
-            barcode_w = (int32_t) code128_encode_gs1(data, out_buf, len);
-            break;
-        case LV_BARCODE_ENCODING_CODE128_RAW:
-            barcode_w = (int32_t) code128_encode_raw(data, out_buf, len);
-            break;
-    }
-    LV_LOG_INFO("barcode width = %" LV_PRId32, barcode_w);
-
-    LV_ASSERT(barcode->scale > 0);
-    uint16_t scale = barcode->scale;
-
-    int32_t buf_w;
-    int32_t buf_h;
-
-    if(barcode->tiled) {
-        buf_w = (barcode->direction == LV_DIR_HOR) ? barcode_w * scale : 1;
-        buf_h = (barcode->direction == LV_DIR_VER) ? barcode_w * scale : 1;
-    }
-    else {
-        lv_obj_update_layout(obj);
-        buf_w = (barcode->direction == LV_DIR_HOR) ? barcode_w * scale : lv_obj_get_width(obj);
-        buf_h = (barcode->direction == LV_DIR_VER) ? barcode_w * scale : lv_obj_get_height(obj);
-    }
-
-    if(!lv_barcode_change_buf_size(obj, buf_w, buf_h)) {
-        lv_barcode_clear(obj);
-        lv_free(out_buf);
-        return LV_RESULT_INVALID;
-    }
-
-    /* Temporarily disable invalidation to improve the efficiency of lv_canvas_set_px */
-    lv_display_enable_invalidation(lv_obj_get_display(obj), false);
-
-    lv_draw_buf_t * draw_buf = lv_canvas_get_draw_buf(obj);
-    uint32_t stride = draw_buf->header.stride;
-    const lv_color_t color = lv_color_hex(1);
-
-    /* Clear the canvas */
-    lv_draw_buf_clear(draw_buf, NULL);
-
-    /* Set the palette */
-    lv_canvas_set_palette(obj, 0, lv_color_to_32(barcode->light_color, LV_OPA_COVER));
-    lv_canvas_set_palette(obj, 1, lv_color_to_32(barcode->dark_color, LV_OPA_COVER));
-
-    for(int32_t x = 0; x < barcode_w; x++) {
-        /*skip empty data*/
-        if(out_buf[x] == 0) {
-            continue;
+    if(mode == LV_BARCODE_UPDATE_MODE_IMMEDIATE && barcode->needs_update && barcode->data != NULL) {
+        if(lv_barcode_render(obj) != LV_RESULT_OK) {
+            LV_LOG_ERROR("regenerating on the switch to immediate update mode failed; "
+                         "call lv_barcode_render() before switching the mode to get the result");
         }
-
-        for(uint16_t i = 0; i < scale; i++) {
-            int32_t offset = x * scale + i;
-            if(barcode->direction == LV_DIR_HOR) {
-                lv_canvas_set_px(obj, offset, 0, color, LV_OPA_COVER);
-            }
-            else { /*LV_DIR_VER*/
-                if(barcode->tiled) {
-                    lv_canvas_set_px(obj, 0, offset, color, LV_OPA_COVER);
-                }
-                else {
-                    uint8_t * dest = lv_draw_buf_goto_xy(draw_buf, 0, offset);
-                    lv_memset(dest, 0xFF, stride);
-                }
-            }
+        else {
+            LV_LOG_WARN("switching to immediate update mode while the bitmap was out of date; "
+                        "call lv_barcode_render() before switching the mode to get the result");
         }
     }
 
-    /* Copy pixels by row */
-    if(!barcode->tiled && barcode->direction == LV_DIR_HOR && buf_h > 1) {
-        /* Skip the first row */
-        int32_t h = buf_h - 1;
-        const uint8_t * src = lv_draw_buf_goto_xy(draw_buf, 0, 0);
-        uint8_t * dest = lv_draw_buf_goto_xy(draw_buf, 0, 1);
-        while(h--) {
-            lv_memcpy(dest, src, stride);
-            dest += stride;
-        }
-    }
+    barcode->update_mode = mode;
+}
 
-    /* invalidate the canvas to refresh it */
-    lv_display_enable_invalidation(lv_obj_get_display(obj), true);
-    lv_obj_invalidate(obj);
+lv_barcode_update_mode_t lv_barcode_get_update_mode(lv_obj_t * obj)
+{
+    LV_CHECK_OBJ(obj, MY_CLASS, return LV_BARCODE_UPDATE_MODE_IMMEDIATE);
 
-    lv_free(out_buf);
+    lv_barcode_t * barcode = (lv_barcode_t *)obj;
+    return (lv_barcode_update_mode_t)barcode->update_mode;
+}
 
-    return LV_RESULT_OK;
+bool lv_barcode_get_render_failed(lv_obj_t * obj)
+{
+    LV_CHECK_OBJ(obj, MY_CLASS, return true);
+
+    lv_barcode_t * barcode = (lv_barcode_t *)obj;
+    return barcode->render_failed;
 }
 
 lv_color_t lv_barcode_get_dark_color(lv_obj_t * obj)
@@ -277,9 +269,17 @@ static void lv_barcode_constructor(const lv_obj_class_t * class_p, lv_obj_t * ob
     lv_barcode_t * barcode = (lv_barcode_t *)obj;
     barcode->dark_color = lv_color_black();
     barcode->light_color = lv_color_white();
+    barcode->data = NULL;
+    barcode->pattern = NULL;
+    barcode->bar_count = 0;
     barcode->scale = 1;
     barcode->direction = LV_DIR_HOR;
     barcode->encoding = LV_BARCODE_ENCODING_CODE128_GS1;
+    barcode->tiled = false;
+    barcode->update_mode = LV_BARCODE_UPDATE_MODE_IMMEDIATE;
+    barcode->needs_update = false;
+    barcode->render_failed = true;   /*Nothing generated yet*/
+    barcode->fitting = false;
     lv_image_set_inner_align(obj, LV_IMAGE_ALIGN_DEFAULT);
 }
 
@@ -287,6 +287,9 @@ static void lv_barcode_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj
 {
     LV_UNUSED(class_p);
     LV_ASSERT(obj != NULL);
+
+    lv_barcode_t * barcode = (lv_barcode_t *)obj;
+    barcode_forget_data(barcode);
 
     lv_draw_buf_t * draw_buf = lv_canvas_get_draw_buf(obj);
     if(draw_buf == NULL) return;
@@ -296,15 +299,67 @@ static void lv_barcode_destructor(const lv_obj_class_t * class_p, lv_obj_t * obj
     lv_draw_buf_destroy(draw_buf);
 }
 
+static void lv_barcode_event(const lv_obj_class_t * class_p, lv_event_t * e)
+{
+    LV_UNUSED(class_p);
+
+    lv_event_code_t code = lv_event_get_code(e);
+
+    /*Call the ancestor's event handler*/
+    lv_result_t res = lv_obj_event_base(MY_CLASS, e);
+    if(res != LV_RESULT_OK) return;
+
+    lv_obj_t * obj = lv_event_get_current_target(e);
+    lv_barcode_t * barcode = (lv_barcode_t *)obj;
+
+    if(code == LV_EVENT_SIZE_CHANGED) {
+        /*Refitting reallocates the canvas, which is itself a content size change and comes
+         *back here: `fitting` catches that echo within the call, barcode_fit_needed() the
+         *one a layout pass later. An out of date bitmap is always refitted, so a size that
+         *could not be fitted before gets another go.*/
+        if(!barcode->fitting && (barcode->needs_update || barcode_fit_needed(obj))) {
+            barcode_mark_dirty(obj);
+        }
+    }
+    else if(code == LV_EVENT_DRAW_MAIN_BEGIN) {
+        /*A failed state is not retried here; only a change clears `render_failed`*/
+        if(barcode->needs_update && !barcode->render_failed) {
+            LV_ASSERT(barcode->update_mode == LV_BARCODE_UPDATE_MODE_DEFERRED);
+
+            /*Safe: the setter already resized the canvas, so nothing is reallocated here*/
+            LV_LOG_WARN("filling in the barcode during the redraw because lv_barcode_render() "
+                        "was not called after the property changes; this adds the work to the "
+                        "refresh and its result cannot be reported");
+
+            if(barcode_fill(obj) != LV_RESULT_OK) {
+                barcode->render_failed = true;
+                LV_LOG_ERROR("the barcode could not be filled in during the redraw "
+                             "(scale %d, %s); the bitmap is left blank",
+                             (int)barcode->scale, barcode->direction == LV_DIR_VER ? "vertical" : "horizontal");
+            }
+        }
+    }
+}
+
 static bool lv_barcode_change_buf_size(lv_obj_t * obj, int32_t w, int32_t h)
 {
-    LV_ASSERT(obj != NULL);
+    LV_ASSERT_NULL(obj);
     if(w <= 0 || h <= 0) {
         LV_LOG_WARN("invalid size: %" LV_PRId32 " x %" LV_PRId32, w, h);
         return false;
     }
 
     lv_draw_buf_t * old_buf = lv_canvas_get_draw_buf(obj);
+
+    /*Reuse the buffer at an unchanged geometry, to avoid the invalidation and relayout a
+     *reallocation triggers*/
+    if(old_buf != NULL &&
+       (int32_t)old_buf->header.w == w &&
+       (int32_t)old_buf->header.h == h &&
+       old_buf->header.cf == LV_COLOR_FORMAT_I1) {
+        return true;
+    }
+
     lv_draw_buf_t * new_buf = lv_draw_buf_create(w, h, LV_COLOR_FORMAT_I1, LV_STRIDE_AUTO);
     if(new_buf == NULL) {
         LV_LOG_ERROR("malloc failed for canvas buffer");
@@ -320,7 +375,7 @@ static bool lv_barcode_change_buf_size(lv_obj_t * obj, int32_t w, int32_t h)
 
 static void lv_barcode_clear(lv_obj_t * obj)
 {
-    LV_ASSERT(obj != NULL);
+    LV_ASSERT_NULL(obj);
     lv_draw_buf_t * draw_buf = lv_canvas_get_draw_buf(obj);
     if(!draw_buf) {
         return;
@@ -329,6 +384,268 @@ static void lv_barcode_clear(lv_obj_t * obj)
     lv_draw_buf_clear(draw_buf, NULL);
     lv_image_cache_drop(draw_buf);
     lv_obj_invalidate(obj);
+}
+
+static bool barcode_store_data(lv_barcode_t * barcode, const char * data)
+{
+    const size_t len = lv_strlen(data);
+
+    /*Assign only on success, so a failed realloc leaves the previous data owned by
+     *`barcode`. lv_realloc(NULL, n) allocates, so the first call needs no special case.*/
+    char * new_data = lv_realloc(barcode->data, len + 1);
+    LV_ASSERT_MALLOC(new_data);
+    if(new_data == NULL) return false;
+
+    lv_memcpy(new_data, data, len);
+    new_data[len] = '\0';
+
+    barcode->data = new_data;
+
+    barcode_drop_encoded(barcode);
+    return true;
+}
+
+static void barcode_forget_data(lv_barcode_t * barcode)
+{
+    lv_free(barcode->data);
+    barcode->data = NULL;
+    barcode_drop_encoded(barcode);
+}
+
+static void barcode_drop_encoded(lv_barcode_t * barcode)
+{
+    lv_free(barcode->pattern);
+    barcode->pattern = NULL;
+    barcode->bar_count = 0;
+}
+
+static uint8_t * barcode_encode(const lv_barcode_t * barcode, int32_t * bar_count)
+{
+    const char * data = barcode->data;
+    LV_ASSERT_NULL(data);
+
+    size_t len = code128_estimate_len(data);
+    LV_LOG_INFO("data: %s, len = %zu", data, len);
+
+    uint8_t * pattern = lv_malloc(len);
+    LV_ASSERT_MALLOC(pattern);
+    if(pattern == NULL) {
+        LV_LOG_ERROR("malloc failed for the bar pattern");
+        return NULL;
+    }
+
+    int32_t w = 0;
+    switch(barcode->encoding) {
+        case LV_BARCODE_ENCODING_CODE128_GS1:
+            w = (int32_t) code128_encode_gs1(data, (char *)pattern, len);
+            break;
+        case LV_BARCODE_ENCODING_CODE128_RAW:
+            w = (int32_t) code128_encode_raw(data, (char *)pattern, len);
+            break;
+    }
+    LV_LOG_INFO("barcode width = %" LV_PRId32, w);
+
+    if(w <= 0) {
+        LV_LOG_WARN("the data could not be encoded");
+        lv_free(pattern);
+        return NULL;
+    }
+
+    *bar_count = w;
+    return pattern;
+}
+
+static bool barcode_fit(lv_obj_t * obj)
+{
+    lv_barcode_t * barcode = (lv_barcode_t *)obj;
+
+    if(barcode->bar_count == 0) {
+        barcode->pattern = barcode_encode(barcode, &barcode->bar_count);
+        if(barcode->pattern == NULL) return false;
+    }
+
+    const int32_t bar_count = barcode->bar_count;
+    const int32_t scale = barcode->scale;
+
+    if(bar_count > INT32_MAX / scale) {
+        LV_LOG_WARN("%" LV_PRId32 " bars at scale %" LV_PRId32 " do not fit an int32_t",
+                    bar_count, scale);
+        return false;
+    }
+    const int32_t bars_px = bar_count * scale;
+
+    int32_t buf_w;
+    int32_t buf_h;
+
+    if(barcode->tiled) {
+        buf_w = (barcode->direction == LV_DIR_HOR) ? bars_px : 1;
+        buf_h = (barcode->direction == LV_DIR_VER) ? bars_px : 1;
+    }
+    else {
+        lv_obj_update_layout(obj);
+        buf_w = (barcode->direction == LV_DIR_HOR) ? bars_px : lv_obj_get_width(obj);
+        buf_h = (barcode->direction == LV_DIR_VER) ? bars_px : lv_obj_get_height(obj);
+    }
+
+    /*Reallocating changes the content size, which comes straight back as SIZE_CHANGED*/
+    barcode->fitting = true;
+    bool ok = lv_barcode_change_buf_size(obj, buf_w, buf_h);
+    barcode->fitting = false;
+
+    return ok;
+}
+
+static bool barcode_fit_needed(lv_obj_t * obj)
+{
+    lv_barcode_t * barcode = (lv_barcode_t *)obj;
+
+    if(barcode->data == NULL) return false;
+
+    if(barcode->tiled) return false;
+
+    lv_draw_buf_t * draw_buf = lv_canvas_get_draw_buf(obj);
+    if(draw_buf == NULL) return true;
+
+    const bool hor = (barcode->direction == LV_DIR_HOR);
+    const int32_t have = hor ? (int32_t)draw_buf->header.h : (int32_t)draw_buf->header.w;
+    const int32_t want = hor ? lv_obj_get_height(obj) : lv_obj_get_width(obj);
+    return have != want;
+}
+
+static bool barcode_fit_only(lv_obj_t * obj)
+{
+    lv_barcode_t * barcode = (lv_barcode_t *)obj;
+
+    barcode->render_failed = true;
+    barcode->needs_update = true;
+
+    if(barcode->data == NULL) return false;
+    if(!barcode_fit(obj)) return false;
+
+    barcode->render_failed = false;
+    return true;
+}
+
+static lv_result_t barcode_fill(lv_obj_t * obj)
+{
+    lv_barcode_t * barcode = (lv_barcode_t *)obj;
+
+    if(barcode->data == NULL) return LV_RESULT_INVALID;
+
+    lv_draw_buf_t * draw_buf = lv_canvas_get_draw_buf(obj);
+    if(draw_buf == NULL) return LV_RESULT_INVALID;
+
+    uint8_t * pattern = barcode->pattern;
+    barcode->pattern = NULL;
+    if(pattern == NULL) {
+        pattern = barcode_encode(barcode, &barcode->bar_count);
+        if(pattern == NULL) return LV_RESULT_INVALID;
+    }
+
+    const int32_t bar_count = barcode->bar_count;
+    const int32_t scale = barcode->scale;
+    const int32_t buf_w = (int32_t)draw_buf->header.w;
+    const int32_t buf_h = (int32_t)draw_buf->header.h;
+
+    const int32_t avail = (barcode->direction == LV_DIR_HOR) ? buf_w : buf_h;
+    if(bar_count > INT32_MAX / scale || bar_count * scale > avail) {
+        LV_LOG_WARN("the bars (%" LV_PRId32 " x %" LV_PRId32 " px) do not fit the %"
+                    LV_PRId32 " px canvas", bar_count, scale, avail);
+        lv_free(pattern);
+        return LV_RESULT_INVALID;
+    }
+
+    /*Temporarily disable invalidation to improve the efficiency of lv_canvas_set_px*/
+    lv_display_enable_invalidation(lv_obj_get_display(obj), false);
+
+    uint32_t stride = draw_buf->header.stride;
+    const lv_color_t color = lv_color_hex(1);
+
+    lv_draw_buf_clear(draw_buf, NULL);
+
+    /*Set the palette on the draw buffer, not via lv_canvas_set_palette(), to avoid an
+     *invalidation here - the caller or the draw pass refreshes the object*/
+    lv_draw_buf_set_palette(draw_buf, 0, lv_color_to_32(barcode->light_color, LV_OPA_COVER));
+    lv_draw_buf_set_palette(draw_buf, 1, lv_color_to_32(barcode->dark_color, LV_OPA_COVER));
+
+    for(int32_t x = 0; x < bar_count; x++) {
+        /*skip empty data*/
+        if(pattern[x] == 0) {
+            continue;
+        }
+
+        for(int32_t i = 0; i < scale; i++) {
+            int32_t offset = x * scale + i;
+            if(barcode->direction == LV_DIR_HOR) {
+                lv_canvas_set_px(obj, offset, 0, color, LV_OPA_COVER);
+            }
+            else { /*LV_DIR_VER*/
+                if(barcode->tiled) {
+                    lv_canvas_set_px(obj, 0, offset, color, LV_OPA_COVER);
+                }
+                else {
+                    uint8_t * dest = lv_draw_buf_goto_xy(draw_buf, 0, offset);
+                    lv_memset(dest, 0xFF, stride);
+                }
+            }
+        }
+    }
+
+    if(!barcode->tiled && barcode->direction == LV_DIR_HOR && buf_h > 1) {
+        int32_t h = buf_h - 1;
+        const uint8_t * src = lv_draw_buf_goto_xy(draw_buf, 0, 0);
+        uint8_t * dest = lv_draw_buf_goto_xy(draw_buf, 0, 1);
+        while(h--) {
+            lv_memcpy(dest, src, stride);
+            dest += stride;
+        }
+    }
+
+    lv_display_enable_invalidation(lv_obj_get_display(obj), true);
+    lv_image_cache_drop(draw_buf);
+
+    lv_free(pattern);
+
+    barcode->needs_update = false;
+    barcode->render_failed = false;
+    return LV_RESULT_OK;
+}
+
+static lv_result_t barcode_render(lv_obj_t * obj)
+{
+    lv_barcode_t * barcode = (lv_barcode_t *)obj;
+
+    /*Assume failure so no early return can forget to record it; only barcode_fill()'s
+     *success path clears these. `needs_update` survives a failure on purpose - the bitmap
+     *still does not match the properties - and `render_failed` keeps the draw hook from
+     *retrying a known-bad state every frame. Nothing is logged here: the result is
+     *returned, and the caller reports it if nothing else will.*/
+    barcode->render_failed = true;
+    barcode->needs_update = true;
+
+    if(barcode->data == NULL) return LV_RESULT_INVALID;
+    if(!barcode_fit(obj)) return LV_RESULT_INVALID;
+
+    return barcode_fill(obj);
+}
+
+static lv_result_t barcode_mark_dirty(lv_obj_t * obj)
+{
+    lv_barcode_t * barcode = (lv_barcode_t *)obj;
+
+    if(barcode->data == NULL) return LV_RESULT_INVALID;
+
+    barcode->render_failed = false;
+
+    /*The canvas is resized in both modes, because the draw pass cannot do it*/
+    const bool ok = (barcode->update_mode == LV_BARCODE_UPDATE_MODE_IMMEDIATE)
+                    ? (barcode_render(obj) == LV_RESULT_OK)
+                    : barcode_fit_only(obj);
+
+    if(ok) lv_obj_invalidate(obj);
+    else lv_barcode_clear(obj);
+
+    return ok ? LV_RESULT_OK : LV_RESULT_INVALID;
 }
 
 #endif /*LV_USE_BARCODE*/

--- a/src/widgets/barcode/lv_barcode.c
+++ b/src/widgets/barcode/lv_barcode.c
@@ -152,15 +152,15 @@ void lv_barcode_set_encoding(lv_obj_t * obj, lv_barcode_encoding_t encoding)
     barcode_mark_dirty(obj);
 }
 
-lv_result_t lv_barcode_update(lv_obj_t * obj, const char * data)
+lv_result_t lv_barcode_set_text(lv_obj_t * obj, const char * text)
 {
     LV_CHECK_OBJ(obj, MY_CLASS, return LV_RESULT_INVALID);
-    LV_CHECK_ARG(data != NULL, return LV_RESULT_INVALID);
+    LV_CHECK_ARG(text != NULL, return LV_RESULT_INVALID);
 
     lv_barcode_t * barcode = (lv_barcode_t *)obj;
 
-    if(data[0] == '\0') {
-        LV_LOG_WARN("data is empty");
+    if(text[0] == '\0') {
+        LV_LOG_WARN("text is empty");
         barcode_forget_data(barcode);
         barcode->needs_update = false;
         barcode->render_failed = true;
@@ -168,9 +168,17 @@ lv_result_t lv_barcode_update(lv_obj_t * obj, const char * data)
         return LV_RESULT_INVALID;
     }
 
-    if(!barcode_store_data(barcode, data)) return LV_RESULT_INVALID;
+    if(!barcode_store_data(barcode, text)) return LV_RESULT_INVALID;
 
     return barcode_mark_dirty(obj);
+}
+
+const char * lv_barcode_get_text(lv_obj_t * obj)
+{
+    LV_CHECK_OBJ(obj, MY_CLASS, return NULL);
+
+    lv_barcode_t * barcode = (lv_barcode_t *)obj;
+    return barcode->data;
 }
 
 lv_result_t lv_barcode_render(lv_obj_t * obj)

--- a/src/widgets/barcode/lv_barcode_private.h
+++ b/src/widgets/barcode/lv_barcode_private.h
@@ -33,10 +33,20 @@ struct _lv_barcode_t {
     lv_canvas_t canvas;
     lv_color_t dark_color;
     lv_color_t light_color;
-    uint16_t scale;
+    char * data;                    /*Copy of the payload, kept so the bitmap can be regenerated on a property change*/
+    /*The encoded bars, one byte each - 0 for a light bar, 0xFF for a dark one - handed
+     *from the sizing pass to the fill so that one regeneration never encodes the payload
+     *twice. NULL when the fill has to encode it itself.*/
+    uint8_t * pattern;
+    int32_t bar_count;              /*Bars `data` encodes to; 0 when it is not known and has to be encoded*/
+    uint16_t scale;                 /*Pixel width of a single bar*/
     lv_dir_t direction;
-    bool tiled;
     lv_barcode_encoding_t encoding;
+    uint8_t tiled : 1;              /*Draw a one bar wide bitmap and let the image tiling repeat it*/
+    uint8_t update_mode : 1;        /*lv_barcode_update_mode_t: when a property change is regenerated*/
+    uint8_t needs_update : 1;       /*The bitmap is out of date; filled in on the next redraw (deferred mode)*/
+    uint8_t render_failed : 1;      /*The last generation attempt failed (or none has run yet)*/
+    uint8_t fitting : 1;            /*Guard against the re-entrant resize our own reallocation triggers*/
 };
 
 

--- a/tests/src/test_cases/libs/test_barcode.c
+++ b/tests/src/test_cases/libs/test_barcode.c
@@ -6,15 +6,31 @@
 
 #if LV_USE_BARCODE
 
+#include <string.h>
+
 static lv_obj_t * active_screen = NULL;
+static uint32_t redraw_warning_cnt;
+static uint32_t encode_cnt;
+
+static void count_barcode_logs_cb(lv_log_level_t level, const char * buf)
+{
+    LV_UNUSED(level);
+    /*Emitted by the draw hook when a deferred change was not applied explicitly*/
+    if(strstr(buf, "was not called after the property changes") != NULL) redraw_warning_cnt++;
+    /*Emitted by barcode_encode(), i.e. once per pass over the code128 encoder*/
+    if(strstr(buf, "barcode width = ") != NULL) encode_cnt++;
+}
 
 void setUp(void)
 {
     active_screen = lv_screen_active();
+    redraw_warning_cnt = 0;
+    encode_cnt = 0;
 }
 
 void tearDown(void)
 {
+    lv_log_register_print_cb(NULL);
     lv_obj_clean(active_screen);
 }
 
@@ -67,6 +83,382 @@ void test_barcode_normal(void)
     res = lv_barcode_update(barcode, "https://lvgl.io");
     TEST_ASSERT_EQUAL(res, LV_RESULT_OK);
     TEST_ASSERT_EQUAL_SCREENSHOT("libs/barcode_tiled_2.png");
+}
+
+void test_barcode_properties_after_data(void)
+{
+    lv_obj_t * barcode = lv_barcode_create(active_screen);
+    TEST_ASSERT_NOT_NULL(barcode);
+    lv_obj_center(barcode);
+
+    /*Needed before anything can be generated - see test_barcode_data_before_size_recovers()*/
+    lv_obj_set_height(barcode, 50);
+
+    /*Properties set after the data used to be dropped. The result has to be the same
+     *bitmap test_barcode_normal() gets by setting them first.*/
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+
+    lv_barcode_set_dark_color(barcode, lv_color_black());
+    lv_barcode_set_light_color(barcode, lv_color_white());
+    lv_barcode_set_scale(barcode, 2);
+    lv_barcode_set_direction(barcode, LV_DIR_HOR);
+    TEST_ASSERT_EQUAL_SCREENSHOT("libs/barcode_1.png");
+
+    /*Direction and object size*/
+    lv_barcode_set_direction(barcode, LV_DIR_VER);
+    lv_obj_set_size(barcode, 50, LV_SIZE_CONTENT);
+    TEST_ASSERT_EQUAL_SCREENSHOT("libs/barcode_2.png");
+
+    /*Tiled mode*/
+    lv_barcode_set_tiled(barcode, true);
+    lv_barcode_set_direction(barcode, LV_DIR_HOR);
+    lv_obj_set_size(barcode, LV_SIZE_CONTENT, 50);
+    TEST_ASSERT_EQUAL_SCREENSHOT("libs/barcode_tiled_1.png");
+
+    lv_barcode_set_direction(barcode, LV_DIR_VER);
+    lv_obj_set_size(barcode, 50, LV_SIZE_CONTENT);
+    TEST_ASSERT_EQUAL_SCREENSHOT("libs/barcode_tiled_2.png");
+}
+
+void test_barcode_data_before_size_recovers(void)
+{
+    lv_obj_t * barcode = lv_barcode_create(active_screen);
+    TEST_ASSERT_NOT_NULL(barcode);
+    lv_obj_center(barcode);
+    lv_barcode_set_scale(barcode, 2);
+
+    /*A barcode sizes itself to its content, so with no height there is no canvas to
+     *allocate. This could not succeed before the change either.*/
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_barcode_update(barcode, "https://lvgl.io"));
+    TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
+
+    /*New: the data is remembered, so it appears once there is a height to fit it to*/
+    lv_barcode_set_dark_color(barcode, lv_color_black());
+    lv_barcode_set_light_color(barcode, lv_color_white());
+    lv_obj_set_height(barcode, 50);
+    lv_obj_update_layout(barcode);
+    TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_EQUAL_SCREENSHOT("libs/barcode_1.png");
+}
+
+void test_barcode_encoding_after_data(void)
+{
+    lv_obj_t * barcode = lv_barcode_create(active_screen);
+    TEST_ASSERT_NOT_NULL(barcode);
+    lv_obj_center(barcode);
+    lv_obj_set_height(barcode, 50);
+    lv_barcode_set_scale(barcode, 2);
+
+    /*GS1 strips spaces, raw encodes them, so the bar count differs*/
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "LVGL 10"));
+    TEST_ASSERT_EQUAL(LV_BARCODE_ENCODING_CODE128_GS1, lv_barcode_get_encoding(barcode));
+    lv_obj_update_layout(barcode);
+    const int32_t gs1_w = lv_obj_get_width(barcode);
+
+    lv_barcode_set_encoding(barcode, LV_BARCODE_ENCODING_CODE128_RAW);
+    TEST_ASSERT_EQUAL(LV_BARCODE_ENCODING_CODE128_RAW, lv_barcode_get_encoding(barcode));
+    lv_obj_update_layout(barcode);
+    TEST_ASSERT_NOT_EQUAL(gs1_w, lv_obj_get_width(barcode));
+    TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
+
+    /*Switching back returns to the original geometry*/
+    lv_barcode_set_encoding(barcode, LV_BARCODE_ENCODING_CODE128_GS1);
+    lv_obj_update_layout(barcode);
+    TEST_ASSERT_EQUAL(gs1_w, lv_obj_get_width(barcode));
+}
+
+void test_barcode_resize_regenerates(void)
+{
+    lv_obj_t * barcode = lv_barcode_create(active_screen);
+    TEST_ASSERT_NOT_NULL(barcode);
+    lv_obj_center(barcode);
+    lv_obj_set_height(barcode, 50);
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+
+    /*Used to keep the height it had when the data was set*/
+    const lv_draw_buf_t * draw_buf = lv_canvas_get_draw_buf(barcode);
+    TEST_ASSERT_NOT_NULL(draw_buf);
+    TEST_ASSERT_EQUAL(50, draw_buf->header.h);
+
+    lv_obj_set_height(barcode, 80);
+    lv_obj_update_layout(barcode);
+
+    draw_buf = lv_canvas_get_draw_buf(barcode);
+    TEST_ASSERT_NOT_NULL(draw_buf);
+    TEST_ASSERT_EQUAL(80, draw_buf->header.h);
+    TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
+}
+
+void test_barcode_scale_resizes_the_canvas(void)
+{
+    lv_obj_t * barcode = lv_barcode_create(active_screen);
+    TEST_ASSERT_NOT_NULL(barcode);
+    lv_obj_center(barcode);
+    lv_obj_set_height(barcode, 50);
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+
+    const int32_t w1 = (int32_t)lv_canvas_get_draw_buf(barcode)->header.w;
+
+    /*Scale is the pixel width of one bar*/
+    lv_barcode_set_scale(barcode, 2);
+    TEST_ASSERT_EQUAL(2, lv_barcode_get_scale(barcode));
+    TEST_ASSERT_EQUAL(w1 * 2, (int32_t)lv_canvas_get_draw_buf(barcode)->header.w);
+    TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
+}
+
+void test_barcode_update_mode_default_is_immediate(void)
+{
+    lv_obj_t * barcode = lv_barcode_create(active_screen);
+    TEST_ASSERT_NOT_NULL(barcode);
+
+    /*Immediate keeps existing code's behaviour*/
+    TEST_ASSERT_EQUAL(LV_BARCODE_UPDATE_MODE_IMMEDIATE, lv_barcode_get_update_mode(barcode));
+
+    lv_barcode_set_update_mode(barcode, LV_BARCODE_UPDATE_MODE_DEFERRED);
+    TEST_ASSERT_EQUAL(LV_BARCODE_UPDATE_MODE_DEFERRED, lv_barcode_get_update_mode(barcode));
+
+    lv_barcode_set_update_mode(barcode, LV_BARCODE_UPDATE_MODE_IMMEDIATE);
+    TEST_ASSERT_EQUAL(LV_BARCODE_UPDATE_MODE_IMMEDIATE, lv_barcode_get_update_mode(barcode));
+}
+
+void test_barcode_update_mode_deferred_fills_on_redraw(void)
+{
+    lv_obj_t * barcode = lv_barcode_create(active_screen);
+    TEST_ASSERT_NOT_NULL(barcode);
+    lv_obj_center(barcode);
+    lv_obj_set_height(barcode, 50);
+    lv_barcode_set_dark_color(barcode, lv_color_black());
+    lv_barcode_set_light_color(barcode, lv_color_white());
+
+    /*Deliberately omit the explicit lv_barcode_render() to cover the fallback: the redraw
+     *warns and fills the bars in anyway, so the bitmap must still be correct.*/
+    lv_log_register_print_cb(count_barcode_logs_cb);
+    lv_barcode_set_update_mode(barcode, LV_BARCODE_UPDATE_MODE_DEFERRED);
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+    lv_barcode_set_scale(barcode, 2);
+
+    TEST_ASSERT_EQUAL_SCREENSHOT("libs/barcode_1.png");
+    lv_log_register_print_cb(NULL);
+
+#if LV_USE_LOG
+    TEST_ASSERT_EQUAL(1, redraw_warning_cnt);
+#endif
+}
+
+void test_barcode_deferred_data_is_not_filled_until_render(void)
+{
+    lv_obj_t * barcode = lv_barcode_create(active_screen);
+    TEST_ASSERT_NOT_NULL(barcode);
+    lv_obj_center(barcode);
+    lv_obj_set_height(barcode, 50);
+    lv_barcode_set_dark_color(barcode, lv_color_black());
+    lv_barcode_set_light_color(barcode, lv_color_white());
+    lv_barcode_set_scale(barcode, 2);
+
+    lv_barcode_set_update_mode(barcode, LV_BARCODE_UPDATE_MODE_DEFERRED);
+
+    /*Setting the data obeys the mode too: the canvas is sized, so this reports OK, but the
+     *bars are still pending*/
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+    TEST_ASSERT_TRUE(((lv_barcode_t *)barcode)->needs_update);
+    TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
+
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_render(barcode));
+    TEST_ASSERT_FALSE(((lv_barcode_t *)barcode)->needs_update);
+    TEST_ASSERT_EQUAL_SCREENSHOT("libs/barcode_1.png");
+}
+
+void test_barcode_render_applies_deferred_changes(void)
+{
+    lv_obj_t * barcode = lv_barcode_create(active_screen);
+    TEST_ASSERT_NOT_NULL(barcode);
+    lv_obj_center(barcode);
+    lv_obj_set_height(barcode, 50);
+    lv_barcode_set_dark_color(barcode, lv_color_black());
+    lv_barcode_set_light_color(barcode, lv_color_white());
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+
+    lv_log_register_print_cb(count_barcode_logs_cb);
+
+    /*The intended flow: change the properties, then generate once explicitly*/
+    lv_barcode_set_update_mode(barcode, LV_BARCODE_UPDATE_MODE_DEFERRED);
+    lv_barcode_set_scale(barcode, 2);
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_render(barcode));
+
+    TEST_ASSERT_EQUAL_SCREENSHOT("libs/barcode_1.png");
+    lv_log_register_print_cb(NULL);
+
+    /*Nothing left for the redraw to do*/
+#if LV_USE_LOG
+    TEST_ASSERT_EQUAL(0, redraw_warning_cnt);
+#endif
+}
+
+void test_barcode_render_before_switching_mode_reports_result(void)
+{
+    lv_obj_t * barcode = lv_barcode_create(active_screen);
+    TEST_ASSERT_NOT_NULL(barcode);
+    lv_obj_center(barcode);
+    lv_obj_set_height(barcode, 50);
+    lv_barcode_set_dark_color(barcode, lv_color_black());
+    lv_barcode_set_light_color(barcode, lv_color_white());
+
+    lv_barcode_set_update_mode(barcode, LV_BARCODE_UPDATE_MODE_DEFERRED);
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+    lv_barcode_set_scale(barcode, 2);
+
+    /*render() reports the result, so the mode switch afterwards has nothing left to do*/
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_render(barcode));
+    lv_barcode_set_update_mode(barcode, LV_BARCODE_UPDATE_MODE_IMMEDIATE);
+
+    TEST_ASSERT_EQUAL_SCREENSHOT("libs/barcode_1.png");
+}
+
+void test_barcode_update_mode_immediate_applies_pending_change(void)
+{
+    lv_obj_t * barcode = lv_barcode_create(active_screen);
+    TEST_ASSERT_NOT_NULL(barcode);
+    lv_obj_center(barcode);
+    lv_obj_set_height(barcode, 50);
+    lv_barcode_set_dark_color(barcode, lv_color_black());
+    lv_barcode_set_light_color(barcode, lv_color_white());
+
+    lv_barcode_set_update_mode(barcode, LV_BARCODE_UPDATE_MODE_DEFERRED);
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+    lv_barcode_set_scale(barcode, 2);
+
+    /*Must still apply the deferred change. The draw hook asserts a bitmap is only out of
+     *date in deferred mode, so if it did not, the redraw below would abort the test.*/
+    lv_barcode_set_update_mode(barcode, LV_BARCODE_UPDATE_MODE_IMMEDIATE);
+
+    TEST_ASSERT_EQUAL_SCREENSHOT("libs/barcode_1.png");
+}
+
+void test_barcode_failed_render_is_detectable(void)
+{
+    lv_obj_t * barcode = lv_barcode_create(active_screen);
+    TEST_ASSERT_NOT_NULL(barcode);
+    lv_obj_center(barcode);
+
+    /*Nothing generated yet*/
+    TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
+
+    lv_obj_set_height(barcode, 50);
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+    TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
+
+    /*Zero height leaves no canvas to allocate, and the resize handler returns void, so
+     *this flag is the only way to notice*/
+    lv_obj_set_height(barcode, 0);
+    lv_obj_update_layout(barcode);
+    TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
+
+    /*Growing it back succeeds*/
+    lv_obj_set_height(barcode, 50);
+    lv_obj_update_layout(barcode);
+    TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
+}
+
+void test_barcode_failed_render_is_not_retried_every_frame(void)
+{
+    lv_obj_t * barcode = lv_barcode_create(active_screen);
+    TEST_ASSERT_NOT_NULL(barcode);
+    lv_obj_center(barcode);
+    lv_obj_set_height(barcode, 50);
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+    lv_refr_now(NULL);
+
+    lv_barcode_set_update_mode(barcode, LV_BARCODE_UPDATE_MODE_DEFERRED);
+
+    /*A known-bad state must not be retried on every redraw, so the draw hook stays quiet*/
+    lv_obj_set_height(barcode, 0);
+    lv_obj_update_layout(barcode);
+    TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_TRUE(((lv_barcode_t *)barcode)->needs_update);
+
+    lv_log_register_print_cb(count_barcode_logs_cb);
+    for(int i = 0; i < 5; i++) {
+        lv_obj_invalidate(barcode);
+        lv_refr_now(NULL);
+    }
+    lv_log_register_print_cb(NULL);
+
+    TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
+#if LV_USE_LOG
+    TEST_ASSERT_EQUAL(0, redraw_warning_cnt);
+#endif
+
+    /*A property change is what allows another attempt - proven by one that can succeed*/
+    lv_obj_set_height(barcode, 50);
+    lv_obj_update_layout(barcode);
+    lv_refr_now(NULL);
+    TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_FALSE(((lv_barcode_t *)barcode)->needs_update);
+}
+
+#if LV_USE_LOG && LV_LOG_LEVEL <= LV_LOG_LEVEL_INFO
+
+void test_barcode_regeneration_encodes_the_data_once(void)
+{
+    lv_obj_t * barcode = lv_barcode_create(active_screen);
+    TEST_ASSERT_NOT_NULL(barcode);
+    lv_obj_center(barcode);
+    lv_obj_set_height(barcode, 50);
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+    lv_refr_now(NULL);
+
+    /*The pattern is handed from the sizing pass to the fill, so a regeneration is a single
+     *pass over the code128 encoder rather than one per stage*/
+    lv_log_register_print_cb(count_barcode_logs_cb);
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_render(barcode));
+    lv_log_register_print_cb(NULL);
+    TEST_ASSERT_EQUAL(1, encode_cnt);
+
+    /*A scale change is fitted from the cached bar count - one encode, for the fill*/
+    encode_cnt = 0;
+    lv_log_register_print_cb(count_barcode_logs_cb);
+    lv_barcode_set_scale(barcode, 2);
+    lv_log_register_print_cb(NULL);
+    TEST_ASSERT_EQUAL(1, encode_cnt);
+
+    /*Deferred mode collapses several property changes into a single encode*/
+    lv_barcode_set_update_mode(barcode, LV_BARCODE_UPDATE_MODE_DEFERRED);
+    encode_cnt = 0;
+    lv_log_register_print_cb(count_barcode_logs_cb);
+    lv_barcode_set_scale(barcode, 3);
+    lv_barcode_set_scale(barcode, 4);
+    lv_barcode_set_direction(barcode, LV_DIR_VER);
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_render(barcode));
+    lv_log_register_print_cb(NULL);
+    TEST_ASSERT_EQUAL(1, encode_cnt);
+}
+
+#endif /*LV_USE_LOG && LV_LOG_LEVEL <= LV_LOG_LEVEL_INFO*/
+
+void test_barcode_update_rejects_invalid_data(void)
+{
+    lv_obj_t * barcode = lv_barcode_create(active_screen);
+    TEST_ASSERT_NOT_NULL(barcode);
+    lv_obj_set_height(barcode, 50);
+
+#if LV_USE_CHECK_ARG
+    /*Without the argument check the data is dereferenced, so only assert this when it is on*/
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_barcode_update(barcode, NULL));
+    TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
+#endif
+
+    /*Nothing to encode*/
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_barcode_update(barcode, ""));
+    TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
+
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+    TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
+
+    /*Emptying forgets the data, so a property change cannot bring the old barcode back*/
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_barcode_update(barcode, ""));
+    TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
+    lv_barcode_set_scale(barcode, 2);
+    TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
 }
 
 #else

--- a/tests/src/test_cases/libs/test_barcode.c
+++ b/tests/src/test_cases/libs/test_barcode.c
@@ -57,14 +57,14 @@ void test_barcode_normal(void)
     /* Test horizontal mode */
     lv_barcode_set_direction(barcode, LV_DIR_HOR);
     lv_obj_set_height(barcode, 50);
-    res = lv_barcode_update(barcode, "https://lvgl.io");
+    res = lv_barcode_set_text(barcode, "https://lvgl.io");
     TEST_ASSERT_EQUAL(res, LV_RESULT_OK);
     TEST_ASSERT_EQUAL_SCREENSHOT("libs/barcode_1.png");
 
     /* Test vertical mode */
     lv_barcode_set_direction(barcode, LV_DIR_VER);
     lv_obj_set_size(barcode, 50, LV_SIZE_CONTENT);
-    res = lv_barcode_update(barcode, "https://lvgl.io");
+    res = lv_barcode_set_text(barcode, "https://lvgl.io");
     TEST_ASSERT_EQUAL(res, LV_RESULT_OK);
     TEST_ASSERT_EQUAL_SCREENSHOT("libs/barcode_2.png");
 
@@ -73,30 +73,30 @@ void test_barcode_normal(void)
     lv_barcode_set_direction(barcode, LV_DIR_HOR);
     lv_obj_set_size(barcode, LV_SIZE_CONTENT, 50);
 
-    res = lv_barcode_update(barcode, "https://lvgl.io");
+    res = lv_barcode_set_text(barcode, "https://lvgl.io");
     TEST_ASSERT_EQUAL(res, LV_RESULT_OK);
     TEST_ASSERT_EQUAL_SCREENSHOT("libs/barcode_tiled_1.png");
 
     /* Test tiled + vertical mode */
     lv_barcode_set_direction(barcode, LV_DIR_VER);
     lv_obj_set_size(barcode, 50, LV_SIZE_CONTENT);
-    res = lv_barcode_update(barcode, "https://lvgl.io");
+    res = lv_barcode_set_text(barcode, "https://lvgl.io");
     TEST_ASSERT_EQUAL(res, LV_RESULT_OK);
     TEST_ASSERT_EQUAL_SCREENSHOT("libs/barcode_tiled_2.png");
 }
 
-void test_barcode_properties_after_data(void)
+void test_barcode_properties_after_text(void)
 {
     lv_obj_t * barcode = lv_barcode_create(active_screen);
     TEST_ASSERT_NOT_NULL(barcode);
     lv_obj_center(barcode);
 
-    /*Needed before anything can be generated - see test_barcode_data_before_size_recovers()*/
+    /*Needed before anything can be generated - see test_barcode_text_before_size_recovers()*/
     lv_obj_set_height(barcode, 50);
 
     /*Properties set after the data used to be dropped. The result has to be the same
      *bitmap test_barcode_normal() gets by setting them first.*/
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_set_text(barcode, "https://lvgl.io"));
 
     lv_barcode_set_dark_color(barcode, lv_color_black());
     lv_barcode_set_light_color(barcode, lv_color_white());
@@ -120,7 +120,7 @@ void test_barcode_properties_after_data(void)
     TEST_ASSERT_EQUAL_SCREENSHOT("libs/barcode_tiled_2.png");
 }
 
-void test_barcode_data_before_size_recovers(void)
+void test_barcode_text_before_size_recovers(void)
 {
     lv_obj_t * barcode = lv_barcode_create(active_screen);
     TEST_ASSERT_NOT_NULL(barcode);
@@ -129,7 +129,7 @@ void test_barcode_data_before_size_recovers(void)
 
     /*A barcode sizes itself to its content, so with no height there is no canvas to
      *allocate. This could not succeed before the change either.*/
-    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_barcode_update(barcode, "https://lvgl.io"));
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_barcode_set_text(barcode, "https://lvgl.io"));
     TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
 
     /*New: the data is remembered, so it appears once there is a height to fit it to*/
@@ -141,7 +141,7 @@ void test_barcode_data_before_size_recovers(void)
     TEST_ASSERT_EQUAL_SCREENSHOT("libs/barcode_1.png");
 }
 
-void test_barcode_encoding_after_data(void)
+void test_barcode_encoding_after_text(void)
 {
     lv_obj_t * barcode = lv_barcode_create(active_screen);
     TEST_ASSERT_NOT_NULL(barcode);
@@ -150,7 +150,7 @@ void test_barcode_encoding_after_data(void)
     lv_barcode_set_scale(barcode, 2);
 
     /*GS1 strips spaces, raw encodes them, so the bar count differs*/
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "LVGL 10"));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_set_text(barcode, "LVGL 10"));
     TEST_ASSERT_EQUAL(LV_BARCODE_ENCODING_CODE128_GS1, lv_barcode_get_encoding(barcode));
     lv_obj_update_layout(barcode);
     const int32_t gs1_w = lv_obj_get_width(barcode);
@@ -173,7 +173,7 @@ void test_barcode_resize_regenerates(void)
     TEST_ASSERT_NOT_NULL(barcode);
     lv_obj_center(barcode);
     lv_obj_set_height(barcode, 50);
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_set_text(barcode, "https://lvgl.io"));
 
     /*Used to keep the height it had when the data was set*/
     const lv_draw_buf_t * draw_buf = lv_canvas_get_draw_buf(barcode);
@@ -195,7 +195,7 @@ void test_barcode_scale_resizes_the_canvas(void)
     TEST_ASSERT_NOT_NULL(barcode);
     lv_obj_center(barcode);
     lv_obj_set_height(barcode, 50);
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_set_text(barcode, "https://lvgl.io"));
 
     const int32_t w1 = (int32_t)lv_canvas_get_draw_buf(barcode)->header.w;
 
@@ -234,7 +234,7 @@ void test_barcode_update_mode_deferred_fills_on_redraw(void)
      *warns and fills the bars in anyway, so the bitmap must still be correct.*/
     lv_log_register_print_cb(count_barcode_logs_cb);
     lv_barcode_set_update_mode(barcode, LV_BARCODE_UPDATE_MODE_DEFERRED);
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_set_text(barcode, "https://lvgl.io"));
     lv_barcode_set_scale(barcode, 2);
 
     TEST_ASSERT_EQUAL_SCREENSHOT("libs/barcode_1.png");
@@ -245,7 +245,7 @@ void test_barcode_update_mode_deferred_fills_on_redraw(void)
 #endif
 }
 
-void test_barcode_deferred_data_is_not_filled_until_render(void)
+void test_barcode_deferred_text_is_not_filled_until_render(void)
 {
     lv_obj_t * barcode = lv_barcode_create(active_screen);
     TEST_ASSERT_NOT_NULL(barcode);
@@ -259,7 +259,7 @@ void test_barcode_deferred_data_is_not_filled_until_render(void)
 
     /*Setting the data obeys the mode too: the canvas is sized, so this reports OK, but the
      *bars are still pending*/
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_set_text(barcode, "https://lvgl.io"));
     TEST_ASSERT_TRUE(((lv_barcode_t *)barcode)->needs_update);
     TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
 
@@ -276,7 +276,7 @@ void test_barcode_render_applies_deferred_changes(void)
     lv_obj_set_height(barcode, 50);
     lv_barcode_set_dark_color(barcode, lv_color_black());
     lv_barcode_set_light_color(barcode, lv_color_white());
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_set_text(barcode, "https://lvgl.io"));
 
     lv_log_register_print_cb(count_barcode_logs_cb);
 
@@ -304,7 +304,7 @@ void test_barcode_render_before_switching_mode_reports_result(void)
     lv_barcode_set_light_color(barcode, lv_color_white());
 
     lv_barcode_set_update_mode(barcode, LV_BARCODE_UPDATE_MODE_DEFERRED);
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_set_text(barcode, "https://lvgl.io"));
     lv_barcode_set_scale(barcode, 2);
 
     /*render() reports the result, so the mode switch afterwards has nothing left to do*/
@@ -324,7 +324,7 @@ void test_barcode_update_mode_immediate_applies_pending_change(void)
     lv_barcode_set_light_color(barcode, lv_color_white());
 
     lv_barcode_set_update_mode(barcode, LV_BARCODE_UPDATE_MODE_DEFERRED);
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_set_text(barcode, "https://lvgl.io"));
     lv_barcode_set_scale(barcode, 2);
 
     /*Must still apply the deferred change. The draw hook asserts a bitmap is only out of
@@ -344,7 +344,7 @@ void test_barcode_failed_render_is_detectable(void)
     TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
 
     lv_obj_set_height(barcode, 50);
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_set_text(barcode, "https://lvgl.io"));
     TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
 
     /*Zero height leaves no canvas to allocate, and the resize handler returns void, so
@@ -365,7 +365,7 @@ void test_barcode_failed_render_is_not_retried_every_frame(void)
     TEST_ASSERT_NOT_NULL(barcode);
     lv_obj_center(barcode);
     lv_obj_set_height(barcode, 50);
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_set_text(barcode, "https://lvgl.io"));
     lv_refr_now(NULL);
 
     lv_barcode_set_update_mode(barcode, LV_BARCODE_UPDATE_MODE_DEFERRED);
@@ -398,13 +398,13 @@ void test_barcode_failed_render_is_not_retried_every_frame(void)
 
 #if LV_USE_LOG && LV_LOG_LEVEL <= LV_LOG_LEVEL_INFO
 
-void test_barcode_regeneration_encodes_the_data_once(void)
+void test_barcode_regeneration_encodes_the_text_once(void)
 {
     lv_obj_t * barcode = lv_barcode_create(active_screen);
     TEST_ASSERT_NOT_NULL(barcode);
     lv_obj_center(barcode);
     lv_obj_set_height(barcode, 50);
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_set_text(barcode, "https://lvgl.io"));
     lv_refr_now(NULL);
 
     /*The pattern is handed from the sizing pass to the fill, so a regeneration is a single
@@ -435,27 +435,51 @@ void test_barcode_regeneration_encodes_the_data_once(void)
 
 #endif /*LV_USE_LOG && LV_LOG_LEVEL <= LV_LOG_LEVEL_INFO*/
 
-void test_barcode_update_rejects_invalid_data(void)
+void test_barcode_text_round_trip(void)
+{
+    lv_obj_t * barcode = lv_barcode_create(active_screen);
+    TEST_ASSERT_NOT_NULL(barcode);
+    lv_obj_set_height(barcode, 50);
+
+    TEST_ASSERT_NULL(lv_barcode_get_text(barcode));
+
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_set_text(barcode, "https://lvgl.io"));
+    TEST_ASSERT_EQUAL_STRING("https://lvgl.io", lv_barcode_get_text(barcode));
+
+    /*The copy is reallocated in place, so a shorter text must not leave the old tail*/
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_set_text(barcode, "LVGL"));
+    TEST_ASSERT_EQUAL_STRING("LVGL", lv_barcode_get_text(barcode));
+
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_set_text(barcode, "LVGL 10 barcode widget"));
+    TEST_ASSERT_EQUAL_STRING("LVGL 10 barcode widget", lv_barcode_get_text(barcode));
+
+    lv_barcode_set_scale(barcode, 2);
+    TEST_ASSERT_EQUAL_STRING("LVGL 10 barcode widget", lv_barcode_get_text(barcode));
+    TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
+}
+
+void test_barcode_set_text_rejects_invalid_text(void)
 {
     lv_obj_t * barcode = lv_barcode_create(active_screen);
     TEST_ASSERT_NOT_NULL(barcode);
     lv_obj_set_height(barcode, 50);
 
 #if LV_USE_CHECK_ARG
-    /*Without the argument check the data is dereferenced, so only assert this when it is on*/
-    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_barcode_update(barcode, NULL));
+    /*Without the argument check the text is dereferenced, so only assert this when it is on*/
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_barcode_set_text(barcode, NULL));
     TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
 #endif
 
     /*Nothing to encode*/
-    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_barcode_update(barcode, ""));
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_barcode_set_text(barcode, ""));
     TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_NULL(lv_barcode_get_text(barcode));
 
-    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
+    TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_set_text(barcode, "https://lvgl.io"));
     TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
 
     /*Emptying forgets the data, so a property change cannot bring the old barcode back*/
-    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_barcode_update(barcode, ""));
+    TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_barcode_set_text(barcode, ""));
     TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
     lv_barcode_set_scale(barcode, 2);
     TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));


### PR DESCRIPTION
`lv_barcode_update()` sets the payload; generating the bitmap is a consequence, and
`lv_barcode_render()` is what regenerates. Renamed to `lv_barcode_set_text()`, with the same
argument and return value, plus `lv_barcode_get_text()` to read it back.

| Before | After |
| --- | --- |
| `lv_result_t lv_barcode_update(obj, const char *)` | `lv_result_t lv_barcode_set_text(obj, const char *)` |
| — | `const char * lv_barcode_get_text(obj)` |

There is no binary setter, unlike `lv_qrcode_set_data()`. Code 128 encodes a C string:
`code128_encode_gs1()` and `code128_encode_raw()` take a `const char *` and stop at the
terminator, so a payload cannot hold an embedded `NUL` and a length-taking setter could only
reject one. Every other byte is encodable, including `CODE128_FNC1`..`CODE128_FNC4`.

`lv_barcode_update_mode_t` and `lv_barcode_set_update_mode()` keep their names.

Depends on #10360 and should merge after it; the diff here shrinks to the rename once that
lands.

### Tests

`test_barcode_text_round_trip` covers set and read-back, replacing a payload with a shorter
then a longer one, and that a property change regenerates without disturbing the stored
text. `test_barcode_set_text_rejects_invalid_text` gained `lv_barcode_get_text()` assertions.

182/182 on `OPTIONS_TEST_DEFHEAP` and `OPTIONS_TEST_SYSHEAP`, all five build-only configs,
format clean.

### Also

`lv_example_barcode_1`, the docs page, and a `migration-v10.mdx` entry.
