### PR TITLE
refactor(opengles): share duplicated flush callback logic

### DIFF
--- a/src/drivers/display/drm/lv_linux_drm_egl.c
+++ b/src/drivers/display/drm/lv_linux_drm_egl.c
@@ -21,7 +21,6 @@
 #include <time.h>
 #include <unistd.h>
 #include "lv_linux_drm_egl_private.h"
-#include "../../opengles/lv_opengles_debug.h"
 #include "../../opengles/lv_opengles_private.h"
 
 /**********************
@@ -58,7 +57,6 @@ static void drm_flip_cb(void * driver_data, bool vsync);
 static void * drm_create_window(void * driver_data, const lv_egl_native_window_properties_t * properties);
 static void drm_destroy_window(void * driver_data, void * native_window);
 static size_t drm_egl_select_config_cb(void * driver_data, const lv_egl_config_t * configs, size_t config_count);
-static inline void set_viewport(lv_display_t * display);
 
 /**********************
  *  STATIC VARIABLES
@@ -187,79 +185,17 @@ static uint32_t tick_cb(void)
     return ts.tv_sec * 1000 + (ts.tv_nsec / 1000000);;
 }
 
-static inline void set_viewport(lv_display_t * display)
-{
-    const lv_display_rotation_t rotation = lv_display_get_rotation(display);
-    int32_t disp_width, disp_height;
-    if(rotation == LV_DISPLAY_ROTATION_0 || rotation == LV_DISPLAY_ROTATION_180) {
-        disp_width = lv_display_get_horizontal_resolution(display);
-        disp_height = lv_display_get_vertical_resolution(display);
-    }
-    else {
-        disp_width = lv_display_get_vertical_resolution(display) ;
-        disp_height = lv_display_get_horizontal_resolution(display) ;
-    }
-    lv_opengles_viewport(0, 0, disp_width, disp_height);
-}
-
-#if LV_USE_DRAW_OPENGLES || LV_USE_DRAW_NANOVG
-
 static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_map)
 {
     LV_UNUSED(area);
     LV_UNUSED(px_map);
     if(lv_display_flush_is_last(disp)) {
-        set_viewport(disp);
         lv_drm_ctx_t * ctx = lv_display_get_driver_data(disp);
-#if LV_USE_DRAW_OPENGLES
-        lv_opengles_render_display_texture_internal(disp, false, true);
-#endif /*LV_USE_DRAW_OPENGLES*/
+        lv_opengles_texture_render_display(&ctx->texture, disp);
         lv_opengles_egl_update(ctx->egl_ctx);
     }
     lv_display_flush_ready(disp);
 }
-
-#else
-
-static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_map)
-{
-    LV_UNUSED(px_map);
-    LV_UNUSED(area);
-    if(lv_display_flush_is_last(disp)) {
-        lv_drm_ctx_t * ctx = lv_display_get_driver_data(disp);
-        int32_t disp_width = lv_display_get_horizontal_resolution(disp);
-        int32_t disp_height = lv_display_get_vertical_resolution(disp);
-
-        set_viewport(disp);
-
-        lv_color_format_t cf = lv_display_get_color_format(disp);
-        uint32_t stride = lv_draw_buf_width_to_stride(lv_display_get_horizontal_resolution(disp), cf);
-        GL_CALL(glBindTexture(GL_TEXTURE_2D, ctx->texture.texture_id));
-
-        GL_CALL(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
-        GL_CALL(glPixelStorei(GL_UNPACK_ROW_LENGTH, stride / lv_color_format_get_size(cf)));
-        /*Color depth: 16 (RGB565), 32 (ARGB8888)*/
-#if LV_COLOR_DEPTH == 16
-        GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB565, disp_width, disp_height, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5,
-                             ctx->texture.fb1));
-#elif LV_COLOR_DEPTH == 32
-        GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, disp_width, disp_height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
-                             ctx->texture.fb1));
-#else
-#error("Unsupported color format")
-#endif
-
-        lv_opengles_render_params_t params = {
-            .h_flip = false,
-            .v_flip = false,
-            .rb_swap = LV_COLOR_DEPTH == 32,
-        };
-        lv_opengles_render_display(disp, &params);
-        lv_opengles_egl_update(ctx->egl_ctx);
-    }
-    lv_display_flush_ready(disp);
-}
-#endif
 
 void drm_device_deinit(lv_drm_ctx_t * ctx)
 {

--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -159,6 +159,42 @@ void lv_opengles_render_params_init(lv_opengles_render_params_t * params)
     lv_memzero(params, sizeof(lv_opengles_render_params_t));
 }
 
+void lv_opengles_texture_upload_buf(unsigned int texture_id, const void * buf, int32_t w, int32_t h,
+                                    uint32_t stride)
+{
+    const uint8_t px_size = lv_color_format_get_size(LV_COLOR_FORMAT_DEFAULT);
+
+    LV_PROFILER_DRAW_BEGIN;
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, texture_id));
+    GL_CALL(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
+    GL_CALL(glPixelStorei(GL_UNPACK_ROW_LENGTH, (GLint)(stride / px_size)));
+
+    /*Color depth: 8 (L8), 16 (RGB565), 24 (RGB888), 32 (XRGB8888)*/
+#if LV_COLOR_DEPTH == 8
+    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_R8, w, h, 0, GL_RED, GL_UNSIGNED_BYTE, buf));
+#elif LV_COLOR_DEPTH == 16
+    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB565, w, h, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5, buf));
+#elif LV_COLOR_DEPTH == 24
+    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, w, h, 0, GL_RGB, GL_UNSIGNED_BYTE, buf));
+#elif LV_COLOR_DEPTH == 32
+    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, buf));
+#else
+#error("Unsupported color format")
+#endif
+
+    GL_CALL(glPixelStorei(GL_UNPACK_ROW_LENGTH, 0));
+    LV_PROFILER_DRAW_END;
+}
+
+void lv_opengles_texture_upload_display_buf(unsigned int texture_id, lv_display_t * display, const void * buf)
+{
+    LV_ASSERT(display != NULL);
+    const lv_color_format_t cf = lv_display_get_color_format(display);
+    const int32_t w = lv_display_get_horizontal_resolution(display);
+    const int32_t h = lv_display_get_vertical_resolution(display);
+    lv_opengles_texture_upload_buf(texture_id, buf, w, h, lv_draw_buf_width_to_stride(w, cf));
+}
+
 void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa, int32_t disp_w,
                                 int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip)
 {

--- a/src/drivers/opengles/lv_opengles_glfw.c
+++ b/src/drivers/opengles/lv_opengles_glfw.c
@@ -532,26 +532,11 @@ static void window_update_handler(lv_timer_t * t)
 #if !LV_USE_DRAW_OPENGLES
                 ensure_init_window_display_texture();
 
-                GL_CALL(glBindTexture(GL_TEXTURE_2D, window_display_texture));
-
                 /* set the dimensions and format to complete the texture */
-                /* Color depth: 8 (L8), 16 (RGB565), 24 (RGB888), 32 (XRGB8888) */
-#if LV_COLOR_DEPTH == 8
-                GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_R8, lv_area_get_width(&texture->area), lv_area_get_height(&texture->area), 0,
-                                     GL_RED, GL_UNSIGNED_BYTE, texture->fb));
-#elif LV_COLOR_DEPTH == 16
-                GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, lv_area_get_width(&texture->area), lv_area_get_height(&texture->area),
-                                     0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5,
-                                     texture->fb));
-#elif LV_COLOR_DEPTH == 24
-                GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, lv_area_get_width(&texture->area), lv_area_get_height(&texture->area), 0,
-                                     GL_RGB, GL_UNSIGNED_BYTE, texture->fb));
-#elif LV_COLOR_DEPTH == 32
-                GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, lv_area_get_width(&texture->area), lv_area_get_height(&texture->area),
-                                     0, GL_RGBA, GL_UNSIGNED_BYTE, texture->fb));
-#else
-#error("Unsupported color format")
-#endif
+                const int32_t tex_w = lv_area_get_width(&texture->area);
+                const int32_t tex_h = lv_area_get_height(&texture->area);
+                const uint32_t tex_stride = lv_draw_buf_width_to_stride(tex_w, lv_display_get_color_format(texture->disp));
+                lv_opengles_texture_upload_buf(window_display_texture, texture->fb, tex_w, tex_h, tex_stride);
 
                 GL_CALL(glGenerateMipmap(GL_TEXTURE_2D));
 

--- a/src/drivers/opengles/lv_opengles_private.h
+++ b/src/drivers/opengles/lv_opengles_private.h
@@ -87,6 +87,16 @@ extern "C" {
 #define GL_RGB565 GL_RGB
 #endif
 
+/* Desktop GL uploads single channel textures as GL_R8/GL_RED.
+ * GLES2 has no such format, GL_LUMINANCE is the equivalent there. */
+#ifndef GL_R8
+#define GL_R8 GL_LUMINANCE
+#endif /*GL_R8*/
+
+#ifndef GL_RED
+#define GL_RED GL_LUMINANCE
+#endif /*GL_RED*/
+
 #if !defined(glClearDepthf) && defined(glClearDepth)
 #define glClearDepthf glClearDepth
 #endif
@@ -180,6 +190,26 @@ void lv_opengles_render_texture_internal(unsigned int texture, const lv_area_t *
  * Internal implementation of @ref lv_opengles_render_display_texture
  */
 void lv_opengles_render_display_texture_internal(lv_display_t * display, bool h_flip, bool v_flip);
+
+/**
+ * Upload a pixel buffer into an OpenGL texture
+ * @param texture_id    the OpenGL texture ID to upload into
+ * @param buf           the pixel buffer. @nullable. Can be `NULL` to only define the size and the format
+ * @param w             width of the buffer in pixels
+ * @param h             height of the buffer in pixels
+ * @param stride        stride of the buffer in bytes. Ignored when `buf` is `NULL`
+ */
+void lv_opengles_texture_upload_buf(unsigned int texture_id, const void * buf, int32_t w, int32_t h,
+                                    uint32_t stride);
+
+/**
+ * Upload the rendered buffer of a display into an OpenGL texture.
+ * @param texture_id    the OpenGL texture ID to upload into
+ * @param display       the display the buffer belongs to
+ * @param buf           the pixel buffer. @nullable. Can be `NULL` to only define the size and the format
+ */
+void lv_opengles_texture_upload_display_buf(unsigned int texture_id, lv_display_t * display, const void * buf);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/drivers/opengles/lv_opengles_texture.c
+++ b/src/drivers/opengles/lv_opengles_texture.c
@@ -161,6 +161,36 @@ void lv_opengles_texture_deinit(lv_opengles_texture_t * texture)
     }
 }
 
+void lv_opengles_texture_render_display(lv_opengles_texture_t * texture, lv_display_t * display)
+{
+    LV_ASSERT(texture != NULL);
+    LV_ASSERT(display != NULL);
+
+    /*The rotation is applied while rendering, so the viewport is never rotated*/
+    lv_opengles_viewport(0, 0, lv_display_get_original_horizontal_resolution(display),
+                         lv_display_get_original_vertical_resolution(display));
+
+#if LV_USE_DRAW_OPENGLES
+    /*The draw unit has rendered into the texture of the display already*/
+    LV_UNUSED(texture);
+    lv_opengles_render_display_texture_internal(display, false, true);
+#elif LV_USE_DRAW_NANOVG
+    /*NanoVG has rendered into the framebuffer directly*/
+    LV_UNUSED(texture);
+#else
+    /*Upload the software rendered buffer of the display, then render it*/
+    lv_opengles_texture_upload_display_buf(texture->texture_id, display, texture->fb1);
+
+    lv_opengles_render_params_t params = {
+        .h_flip = false,
+        .v_flip = false,
+        /*LVGL stores RGB888 as B, G, R and XRGB8888 as B, G, R, X in memory*/
+        .rb_swap = LV_COLOR_DEPTH == 24 || LV_COLOR_DEPTH == 32,
+    };
+    lv_opengles_render_display(display, &params);
+#endif /*LV_USE_DRAW_OPENGLES*/
+}
+
 unsigned int lv_opengles_texture_get_texture_id(lv_display_t * disp)
 {
     LV_CHECK_ARG(disp != NULL, return 0);
@@ -222,18 +252,9 @@ static unsigned int create_texture(int32_t w, int32_t h)
     GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
     GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
     GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
-    GL_CALL(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
 
     /* set the dimensions and format to complete the texture */
-    /* Color depth: 16 (RGB565), 32 (XRGB8888) */
-#if LV_COLOR_DEPTH == 16
-    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, w, h, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5,
-                         NULL));
-#elif LV_COLOR_DEPTH == 32
-    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL));
-#else
-#error("Unsupported color format")
-#endif
+    lv_opengles_texture_upload_buf(texture, NULL, w, h, 0);
 
 #if 0
     GL_CALL(glGenerateMipmap(GL_TEXTURE_2D));
@@ -261,23 +282,7 @@ static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_m
     if(lv_display_flush_is_last(disp)) {
 
         lv_opengles_texture_t * texture = lv_display_get_driver_data(disp);
-        lv_color_format_t cf = lv_display_get_color_format(disp);
-        uint32_t stride = lv_draw_buf_width_to_stride(lv_display_get_horizontal_resolution(disp), cf);
-
-        GL_CALL(glBindTexture(GL_TEXTURE_2D, texture->texture_id));
-
-        GL_CALL(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
-        GL_CALL(glPixelStorei(GL_UNPACK_ROW_LENGTH, stride / lv_color_format_get_size(cf)));
-        /*Color depth: 16 (RGB565), 32 (XRGB8888)*/
-#if LV_COLOR_DEPTH == 16
-        GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB565, disp->hor_res, disp->ver_res, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5,
-                             texture->fb1));
-#elif LV_COLOR_DEPTH == 32
-        GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, disp->hor_res, disp->ver_res, 0, GL_BGRA, GL_UNSIGNED_BYTE,
-                             texture->fb1));
-#else
-#error("Unsupported color format")
-#endif
+        lv_opengles_texture_upload_display_buf(texture->texture_id, disp, texture->fb1);
     }
 #endif /* !LV_USE_DRAW_OPENGLES */
 

--- a/src/drivers/opengles/lv_opengles_texture_private.h
+++ b/src/drivers/opengles/lv_opengles_texture_private.h
@@ -42,6 +42,14 @@ lv_result_t lv_opengles_texture_reshape(lv_opengles_texture_t * texture, lv_disp
                                         int32_t width, int32_t height);
 void lv_opengles_texture_deinit(lv_opengles_texture_t * texture);
 
+/**
+ * Render the display content to the current OpenGL framebuffer
+ * Handles NanoVG, OpenGL and SW rendering
+ * @param texture   the texture of the display
+ * @param display   the display to render
+ */
+void lv_opengles_texture_render_display(lv_opengles_texture_t * texture, lv_display_t * display);
+
 /**********************
  *      MACROS
  **********************/

--- a/src/drivers/sdl/lv_sdl_egl.c
+++ b/src/drivers/sdl/lv_sdl_egl.c
@@ -193,12 +193,7 @@ static void flush_cb(lv_display_t * display, const lv_area_t * area, uint8_t * p
     LV_ASSERT(ddata != NULL);
 
     if(lv_display_flush_is_last(display)) {
-#if LV_USE_DRAW_OPENGLES
-        lv_opengles_viewport(0, 0,
-                             lv_display_get_original_horizontal_resolution(display),
-                             lv_display_get_original_vertical_resolution(display));
-        lv_opengles_render_display_texture_internal(display, false, true);
-#endif /*LV_USE_DRAW_OPENGLES*/
+        lv_opengles_texture_render_display(&ddata->opengles_texture, display);
         lv_opengles_egl_update(ddata->egl_ctx);
     }
     lv_display_flush_ready(display);

--- a/src/drivers/wayland/lv_wayland_backend_egl.c
+++ b/src/drivers/wayland/lv_wayland_backend_egl.c
@@ -13,7 +13,6 @@
 #include "../../display/lv_display_private.h"
 #include "../opengles/lv_opengles_texture_private.h"
 #include "../opengles/lv_opengles_egl_private.h"
-#include "../opengles/lv_opengles_debug.h"
 
 #include <wayland-egl.h>
 
@@ -185,15 +184,11 @@ static void flush_wait_cb(lv_display_t * disp)
     }
 }
 
-#if LV_USE_DRAW_OPENGLES || LV_USE_DRAW_NANOVG
-
 static void egl_flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_map)
 {
     LV_UNUSED(area);
     LV_UNUSED(px_map);
 
-    int32_t disp_width = lv_display_get_horizontal_resolution(disp);
-    int32_t disp_height = lv_display_get_vertical_resolution(disp);
     if(!lv_display_flush_is_last(disp)) {
         lv_display_flush_ready(disp);
         return;
@@ -207,11 +202,7 @@ static void egl_flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * 
         return;
     }
 
-#if LV_USE_DRAW_OPENGLES
-    lv_opengles_viewport(0, 0, lv_display_get_original_horizontal_resolution(disp),
-                         lv_display_get_original_vertical_resolution(disp));
-    lv_opengles_render_display_texture_internal(disp, false, true);
-#endif /*LV_USE_DRAW_OPENGLES*/
+    lv_opengles_texture_render_display(&ddata->texture, disp);
 
     /* Swap buffers through EGL */
     lv_opengles_egl_update(ddata->egl_ctx);
@@ -219,68 +210,10 @@ static void egl_flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * 
     /* Request frame callback for vsync */
     struct wl_callback * callback = wl_surface_frame(surface);
     wl_callback_add_listener(callback, &frame_listener, disp);
-    wl_surface_damage(surface, 0, 0, disp_width, disp_height);
+    wl_surface_damage(surface, 0, 0, lv_display_get_horizontal_resolution(disp),
+                      lv_display_get_vertical_resolution(disp));
     wl_surface_commit(surface);
 }
-
-#else /*Software rendering*/
-
-static void egl_flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_map)
-{
-    LV_UNUSED(area);
-    LV_UNUSED(px_map);
-
-    if(!lv_display_flush_is_last(disp)) {
-        lv_display_flush_ready(disp);
-        return;
-    }
-
-    lv_wl_egl_display_data_t * ddata = lv_wayland_get_backend_display_data(disp);
-    struct wl_surface * surface = lv_wayland_get_window_surface(disp);
-
-    if(!surface) {
-        lv_display_flush_ready(disp);
-        return;
-    }
-
-    int32_t disp_width = lv_display_get_horizontal_resolution(disp);
-    int32_t disp_height = lv_display_get_vertical_resolution(disp);
-
-    lv_opengles_viewport(0, 0, lv_display_get_original_horizontal_resolution(disp),
-                         lv_display_get_original_vertical_resolution(disp));
-
-    lv_color_format_t cf = lv_display_get_color_format(disp);
-    uint32_t stride = lv_draw_buf_width_to_stride(disp_width, cf);
-
-    GL_CALL(glBindTexture(GL_TEXTURE_2D, ddata->texture.texture_id));
-    GL_CALL(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
-    GL_CALL(glPixelStorei(GL_UNPACK_ROW_LENGTH, stride / lv_color_format_get_size(cf)));
-
-#if LV_COLOR_DEPTH == 16
-    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB565, disp_width, disp_height, 0, GL_RGB,
-                         GL_UNSIGNED_SHORT_5_6_5, ddata->texture.fb1));
-#elif LV_COLOR_DEPTH == 32
-    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, disp_width, disp_height, 0, GL_RGBA,
-                         GL_UNSIGNED_BYTE, ddata->texture.fb1));
-#else
-#error("Unsupported color format")
-#endif
-    lv_opengles_render_params_t params = {
-        .h_flip = false,
-        .v_flip = false,
-        .rb_swap = LV_COLOR_DEPTH == 32,
-    };
-    lv_opengles_render_display(disp, &params);
-    lv_opengles_egl_update(ddata->egl_ctx);
-
-    struct wl_callback * callback = wl_surface_frame(surface);
-    wl_callback_add_listener(callback, &frame_listener, disp);
-
-    wl_surface_damage(surface, 0, 0, disp_width, disp_height);
-    wl_surface_commit(surface);
-}
-
-#endif
 
 static void * wl_egl_init_display(void * backend_ctx, lv_display_t * display, int32_t width, int32_t height)
 {


### PR DESCRIPTION
Move the opengl flush callback logic to opengles_texture so it can be used by DRM, wayland, SDL and GLFW instead of having the same logic across multiple places
