### PR TITLE
fix(text): prevent out-of-bounds access in lv_text_cut

### DIFF
--- a/src/misc/lv_text.c
+++ b/src/misc/lv_text.c
@@ -504,7 +504,10 @@ void lv_text_cut(char * txt, uint32_t pos, uint32_t len)
     size_t old_len = lv_strlen(txt);
 
     pos = lv_text_encoded_get_byte_id(txt, pos); /*Convert to byte index instead of letter index*/
+    if(pos >= old_len) return;
+
     len = lv_text_encoded_get_byte_id(&txt[pos], len);
+    if(len > old_len - pos) len = old_len - pos; /*Don't cut more than what's left*/
 
     /*Copy the second part into the end to make place to text to insert*/
     uint32_t i;

--- a/tests/src/test_cases/test_txt.c
+++ b/tests/src/test_cases/test_txt.c
@@ -56,6 +56,24 @@ void test_txt_cut_should_handle_len_longer_than_string_length(void)
     TEST_ASSERT_EQUAL_UINT8(msg[0], 0x00);
 }
 
+void test_txt_cut_should_handle_len_longer_than_remaining_string(void)
+{
+    char msg[] = "Hello World";
+
+    lv_text_cut(msg, 6, 30);
+
+    TEST_ASSERT_EQUAL_STRING("Hello ", msg);
+}
+
+void test_txt_cut_should_handle_pos_beyond_string_length(void)
+{
+    char msg[] = "Hello World";
+
+    lv_text_cut(msg, 30, 1);
+
+    TEST_ASSERT_EQUAL_STRING("Hello World", msg);
+}
+
 void test_txt_get_encoded_next_should_decode_valid_ascii(void)
 {
     char msg[] = "Hello World!";


### PR DESCRIPTION
Fixes #10558.

Clamp `pos` and `len` in `lv_text_cut()` to prevent unsigned underflow and
out-of-bounds access when the requested range exceeds the remaining text.

This is observable with `LV_TXT_ENC_ASCII`, whose byte-index conversion does
not clamp indices to the string length.

Tests cover an oversized cut length and a position beyond the end of the
string.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

