### PR TITLE
ci(labeler): allow PR to run in mutliple PRs at the same time

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
`gihub-ref` is the target branch, so it would be `master` for all PRs targetting master which causes the workflow to be cancelled and the PR checks status to show up as red
