### PR TITLE
docs: remove api docs from public API function definitions

### DIFF
--- a/src/drivers/uefi/lv_uefi_indev_pointer.c
+++ b/src/drivers/uefi/lv_uefi_indev_pointer.c
@@ -62,12 +62,6 @@ static EFI_GUID _uefi_guid_simple_pointer = EFI_SIMPLE_POINTER_PROTOCOL_GUID;
  *   GLOBAL FUNCTIONS
  **********************/
 
-/**
- * @brief Create an indev object.
- * @param display_res The resolution of the display in pixels, needed to scale the input.
- * If NULL the resolution of the current default display will be used.
- * @return The created LVGL indev object.
-*/
 lv_indev_t * lv_uefi_simple_pointer_indev_create(lv_point_t * display_res)
 {
     lv_indev_t * indev = NULL;

--- a/src/drivers/uefi/lv_uefi_indev_touch.c
+++ b/src/drivers/uefi/lv_uefi_indev_touch.c
@@ -63,11 +63,6 @@ static EFI_GUID _uefi_guid_absolute_pointer = EFI_ABSOLUTE_POINTER_PROTOCOL_GUID
  *   GLOBAL FUNCTIONS
  **********************/
 
-/**
- * @brief Create a LVGL indev object.
- * @param display_res The resolution of the display in pixels, needed to scale the input.
- * @return The created LVGL indev object.
-*/
 lv_indev_t * lv_uefi_absolute_pointer_indev_create(lv_point_t * display_res)
 {
     lv_indev_t * indev = NULL;

--- a/src/image/lv_bin_decoder.c
+++ b/src/image/lv_bin_decoder.c
@@ -176,12 +176,6 @@ lv_result_t lv_bin_decoder_info(lv_image_decoder_t * decoder, lv_image_decoder_d
     return LV_RESULT_OK;
 }
 
-/**
- * Decode an image from a binary file
- * @param decoder pointer to the decoder
- * @param dsc     pointer to the decoder descriptor
- * @return LV_RESULT_OK: no error; LV_RESULT_INVALID: can't open the image
- */
 lv_result_t lv_bin_decoder_open(lv_image_decoder_t * decoder, lv_image_decoder_dsc_t * dsc)
 {
     LV_UNUSED(decoder);

--- a/src/misc/lv_bidi.c
+++ b/src/misc/lv_bidi.c
@@ -98,16 +98,6 @@ void lv_bidi_process(const char * str_in, char * str_out, lv_base_dir_t base_dir
     str_out[par_start] = '\0';
 }
 
-/**
- * Auto-detect the base direction of a text by scanning all strong characters.
- * RTL takes priority: if any RTL strong character is found, `LV_BASE_DIR_RTL` is returned
- * immediately. Otherwise, `LV_BASE_DIR_LTR` is returned if any LTR strong character is found.
- * If no strong character is present, falls back to `LV_BIDI_BASE_DIR_DEF` (except when
- * `LV_BIDI_BASE_DIR_DEF` is `LV_BASE_DIR_AUTO`, in which case `LV_BASE_DIR_LTR` is used).
- * @param txt the text to process
- * @return `LV_BASE_DIR_RTL`, `LV_BASE_DIR_LTR`, or the configured `LV_BIDI_BASE_DIR_DEF`
- *         (with `LV_BASE_DIR_LTR` used when `LV_BIDI_BASE_DIR_DEF == LV_BASE_DIR_AUTO`)
- */
 lv_base_dir_t lv_bidi_detect_base_dir(const char * txt)
 {
     uint32_t i = 0;


### PR DESCRIPTION
These functions are already documented on the public header so remove them from the definition to avoid mismatches when one part is updated
