### PR TITLE
chore(idf): lower conditional dependency gate to esp-idf 5.5

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -8,19 +8,19 @@ dependencies:
     require: private
     version: "^2.14.3"
     rules:
-      - if: "idf_version >=6.0 && $CONFIG{LV_USE_FREETYPE} == True"
+      - if: "idf_version >=5.5 && $CONFIG{LV_USE_FREETYPE} == True"
   espressif/libjpeg-turbo:
     require: private
     version: "^3.1.1"
     rules:
-      - if: "idf_version >=6.0 && $CONFIG{LV_USE_LIBJPEG_TURBO} == True"
+      - if: "idf_version >=5.5 && $CONFIG{LV_USE_LIBJPEG_TURBO} == True"
   espressif/libpng:
     require: private
     version: "^1.6.58"
     rules:
-      - if: "idf_version >=6.0 && $CONFIG{LV_USE_LIBPNG} == True"
+      - if: "idf_version >=5.5 && $CONFIG{LV_USE_LIBPNG} == True"
   espressif/lz4:
     require: private
     version: "^1.10.0"
     rules:
-      - if: "idf_version >=6.0 && $CONFIG{LV_USE_LZ4} == True && $CONFIG{LV_USE_LZ4_INTERNAL} == False"
+      - if: "idf_version >=5.5 && $CONFIG{LV_USE_LZ4} == True && $CONFIG{LV_USE_LZ4_INTERNAL} == False"


### PR DESCRIPTION
Follow-up to #10546, as requested in the discussion there.

ESP-IDF 5.5 is the first release that passes `--sdkconfig_json_file` to `prepare_dependencies`, so it is the earliest version where `$CONFIG{}` in a manifest rule can be resolved at all. With the gate at `>=6.0`, every 5.x user still hits the missing-header build failure that motivated #10546 (espressif/idf-extra-components#510).

Tested on four installs, esp32s3 target, LVGL consumed via `override_path`:

| ESP-IDF | component manager | result |
|---|---|---|
| 6.1 | 3.1.1 | resolves, unchanged |
| 5.5 | 2.4.10 | now resolves freetype / libpng / lz4 / zlib and builds |
| 5.3.5 | 2.5.1 | skipped cleanly, configure fine, no change |
| 5.0.9 | 2.5.1 | skipped cleanly, configure fine, no change |

One trade-off though: this needs `idf-component-manager >= 2.3.0`. On ESP-IDF 5.5 with component manager 2.2.2 this hard-fails at configure with `MissingKconfigError: LV_USE_FREETYPE`, where the `>=6.0` gate skipped. ESP-IDF 5.5 pins `~=2.2`, so this affects anyone who installed 5.5 between its release (2025-07-18) and componen manager 2.3.0 (2025-08-14) and has not re-run `install.sh` since. Re-running `install.sh` resolves it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

