### PR TITLE
feat(opengl): use display color format instead of lv_color_depth

### DIFF
--- a/src/drivers/display/drm/lv_linux_drm_egl.c
+++ b/src/drivers/display/drm/lv_linux_drm_egl.c
@@ -110,6 +110,8 @@ lv_result_t lv_linux_drm_set_file(lv_display_t * disp, const char * file, int64_
 
     lv_display_set_resolution(disp, ctx->drm_mode->hdisplay, ctx->drm_mode->vdisplay);
 
+    lv_opengles_egl_set_display_color_format(disp);
+
     ctx->egl_interface = drm_get_egl_interface(ctx);
     ctx->egl_ctx = lv_opengles_egl_context_create(&ctx->egl_interface);
     if(!ctx->egl_ctx) {

--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -157,42 +157,89 @@ void lv_opengles_render_params_init(lv_opengles_render_params_t * params)
 {
     LV_ASSERT(params != NULL);
     lv_memzero(params, sizeof(lv_opengles_render_params_t));
+    params->cf = LV_COLOR_FORMAT_ARGB8888;
 }
 
-void lv_opengles_texture_upload_buf(unsigned int texture_id, const void * buf, int32_t w, int32_t h,
-                                    uint32_t stride)
+lv_result_t lv_opengles_gl_format_from_color_format(lv_color_format_t cf, lv_opengles_gl_format_t * gl_format)
 {
-    const uint8_t px_size = lv_color_format_get_size(LV_COLOR_FORMAT_DEFAULT);
+    LV_ASSERT(gl_format != NULL);
+
+    switch(cf) {
+        case LV_COLOR_FORMAT_L8:
+            gl_format->internal_format = GL_R8;
+            gl_format->format = GL_RED;
+            gl_format->type = GL_UNSIGNED_BYTE;
+            gl_format->rb_swap = false;
+            return LV_RESULT_OK;
+        case LV_COLOR_FORMAT_RGB565:
+            gl_format->internal_format = GL_RGB565;
+            gl_format->format = GL_RGB;
+            gl_format->type = GL_UNSIGNED_SHORT_5_6_5;
+            gl_format->rb_swap = false;
+            return LV_RESULT_OK;
+        case LV_COLOR_FORMAT_RGB565_SWAPPED:
+            gl_format->internal_format = GL_RGB565;
+            gl_format->format = GL_RGB;
+            gl_format->type = GL_UNSIGNED_SHORT_5_6_5;
+            gl_format->rb_swap = true;
+            return LV_RESULT_OK;
+        case LV_COLOR_FORMAT_RGB888:
+            gl_format->internal_format = GL_RGB;
+            gl_format->format = GL_RGB;
+            gl_format->type = GL_UNSIGNED_BYTE;
+            /* RGB is actually stored as BGR in memory */
+            gl_format->rb_swap = true;
+            return LV_RESULT_OK;
+        case LV_COLOR_FORMAT_XRGB8888:
+        case LV_COLOR_FORMAT_ARGB8888:
+        case LV_COLOR_FORMAT_ARGB8888_PREMULTIPLIED:
+            gl_format->internal_format = GL_RGBA;
+            gl_format->format = GL_RGBA;
+            gl_format->type = GL_UNSIGNED_BYTE;
+            /* RGB is actually stored as BGR in memory */
+            gl_format->rb_swap = true;
+            return LV_RESULT_OK;
+        default:
+            LV_LOG_WARN("Color format 0x%02x has no OpenGL equivalent", cf);
+            return LV_RESULT_INVALID;
+    }
+}
+
+bool lv_opengles_color_format_is_rb_swap(lv_color_format_t cf)
+{
+    lv_opengles_gl_format_t gl_format;
+    if(lv_opengles_gl_format_from_color_format(cf, &gl_format) != LV_RESULT_OK) {
+        return false;
+    }
+    return gl_format.rb_swap;
+}
+
+lv_result_t lv_opengles_texture_upload_buf(unsigned int texture_id, const void * buf, int32_t w, int32_t h,
+                                           uint32_t stride, lv_color_format_t cf)
+{
+    lv_opengles_gl_format_t gl_format;
+    if(lv_opengles_gl_format_from_color_format(cf, &gl_format) != LV_RESULT_OK) {
+        return LV_RESULT_INVALID;
+    }
 
     LV_PROFILER_DRAW_BEGIN;
     GL_CALL(glBindTexture(GL_TEXTURE_2D, texture_id));
     GL_CALL(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
-    GL_CALL(glPixelStorei(GL_UNPACK_ROW_LENGTH, (GLint)(stride / px_size)));
-
-    /*Color depth: 8 (L8), 16 (RGB565), 24 (RGB888), 32 (XRGB8888)*/
-#if LV_COLOR_DEPTH == 8
-    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_R8, w, h, 0, GL_RED, GL_UNSIGNED_BYTE, buf));
-#elif LV_COLOR_DEPTH == 16
-    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB565, w, h, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5, buf));
-#elif LV_COLOR_DEPTH == 24
-    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, w, h, 0, GL_RGB, GL_UNSIGNED_BYTE, buf));
-#elif LV_COLOR_DEPTH == 32
-    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, buf));
-#else
-#error("Unsupported color format")
-#endif
+    GL_CALL(glPixelStorei(GL_UNPACK_ROW_LENGTH, (GLint)(stride / lv_color_format_get_size(cf))));
+    GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, gl_format.internal_format, w, h, 0, gl_format.format, gl_format.type, buf));
 
     GL_CALL(glPixelStorei(GL_UNPACK_ROW_LENGTH, 0));
     LV_PROFILER_DRAW_END;
+    return LV_RESULT_OK;
 }
 
-void lv_opengles_texture_upload_display_buf(unsigned int texture_id, lv_display_t * display, const void * buf)
+lv_result_t lv_opengles_texture_upload_display_buf(unsigned int texture_id, lv_display_t * display, const void * buf)
 {
     LV_ASSERT(display != NULL);
     const lv_color_format_t cf = lv_display_get_color_format(display);
     const int32_t w = lv_display_get_horizontal_resolution(display);
     const int32_t h = lv_display_get_vertical_resolution(display);
-    lv_opengles_texture_upload_buf(texture_id, buf, w, h, lv_draw_buf_width_to_stride(w, cf));
+    return lv_opengles_texture_upload_buf(texture_id, buf, w, h, lv_draw_buf_width_to_stride(w, cf), cf);
 }
 
 void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa, int32_t disp_w,
@@ -247,6 +294,29 @@ void lv_opengles_render_texture_rbswap(unsigned int texture, const lv_area_t * t
     LV_PROFILER_DRAW_END;
 }
 
+void lv_opengles_render_texture_cf(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
+                                   int32_t disp_w, int32_t disp_h, const lv_area_t * texture_clip_area,
+                                   bool h_flip, bool v_flip, lv_color_format_t cf)
+{
+    LV_ASSERT(texture_area != NULL);
+    LV_ASSERT(texture_clip_area != NULL);
+    LV_PROFILER_DRAW_BEGIN;
+    lv_opengles_render_params_t params;
+    lv_opengles_render_params_init(&params);
+    params.texture = texture;
+    params.texture_area = texture_area;
+    params.opa = opa;
+    params.disp_w = disp_w;
+    params.disp_h = disp_h;
+    params.texture_clip_area = texture_clip_area;
+    params.h_flip = h_flip;
+    params.v_flip = v_flip;
+    params.rb_swap = lv_opengles_color_format_is_rb_swap(cf);
+    params.cf = cf;
+    lv_opengles_render(&params);
+    LV_PROFILER_DRAW_END;
+}
+
 void lv_opengles_render_fill(lv_color_t color, const lv_area_t * area, lv_opa_t opa, int32_t disp_w, int32_t disp_h)
 {
     LV_CHECK_ARG(area != NULL, return);
@@ -296,7 +366,7 @@ void lv_opengles_render_display(lv_display_t * display, const lv_opengles_render
     };
 
     lv_opengles_shader_bind();
-    lv_opengles_shader_set_uniform1f("u_ColorDepth", LV_COLOR_DEPTH);
+    lv_opengles_shader_set_uniform1f("u_ColorDepth", lv_color_format_get_bpp(params->cf));
     lv_opengles_shader_set_uniform1i("u_Texture", 0);
     lv_opengles_shader_set_uniformmatrix3fv("u_VertexTransform", 1, transposed_matrix);
     lv_opengles_shader_set_uniform1f("u_Opa", 1);
@@ -318,11 +388,17 @@ void lv_opengles_render_display_texture(lv_display_t * display, bool h_flip, boo
 void lv_opengles_render_display_texture_internal(lv_display_t * display, bool h_flip, bool v_flip)
 {
     LV_ASSERT(display != NULL);
-    lv_opengles_render_params_t params = {
-        .v_flip = v_flip,
-        .h_flip = h_flip,
-        .rb_swap = true
-    };
+    lv_opengles_render_params_t params;
+    lv_opengles_render_params_init(&params);
+    params.h_flip = h_flip;
+    params.v_flip = v_flip;
+#if LV_USE_DRAW_OPENGLES
+    params.rb_swap = true;
+#else
+    /*The texture was uploaded from the buffer of the display*/
+    params.cf = lv_display_get_color_format(display);
+    params.rb_swap = lv_opengles_color_format_is_rb_swap(params.cf);
+#endif /*LV_USE_DRAW_OPENGLES*/
     lv_opengles_render_display(display, &params);
 }
 
@@ -467,7 +543,7 @@ void lv_opengles_render(const lv_opengles_render_params_t * params)
 
     lv_opengles_shader_bind();
     lv_opengles_enable_blending(params->blend_opt);
-    lv_opengles_shader_set_uniform1f("u_ColorDepth", LV_COLOR_DEPTH);
+    lv_opengles_shader_set_uniform1f("u_ColorDepth", lv_color_format_get_bpp(params->cf));
     lv_opengles_shader_set_uniform1i("u_Texture", 0);
     lv_opengles_shader_set_uniformmatrix3fv("u_VertexTransform", 1, (float *)&gl_matrix);
     lv_opengles_shader_set_uniform1f("u_Opa", (float)params->opa / (float)LV_OPA_100);

--- a/src/drivers/opengles/lv_opengles_egl.c
+++ b/src/drivers/opengles/lv_opengles_egl.c
@@ -43,6 +43,7 @@ static lv_result_t lv_egl_config_from_egl_config(lv_opengles_egl_t * ctx, lv_egl
 static void * create_native_window(lv_opengles_egl_t * ctx);
 static lv_result_t get_native_config(lv_opengles_egl_t * ctx, EGLint * native_id, uint64_t ** mods, size_t * count);
 static GLADapiproc glad_egl_load_cb(void * userdata, const char * name);
+static bool egl_config_cf_matches(const lv_egl_config_t * config, lv_color_format_t cf);
 
 /**********************
 *  STATIC VARIABLES
@@ -145,17 +146,12 @@ void lv_opengles_egl_update(lv_opengles_egl_t * ctx)
 size_t lv_opengles_egl_display_select_config(lv_display_t * display, const lv_egl_config_t * configs,
                                              size_t config_count)
 {
-    int32_t target_w = lv_display_get_horizontal_resolution(display);
-    int32_t target_h = lv_display_get_vertical_resolution(display);
+    LV_ASSERT(display != NULL);
+    LV_ASSERT(configs != NULL);
 
-#if LV_COLOR_DEPTH == 16
-    lv_color_format_t target_cf = LV_COLOR_FORMAT_RGB565;
-#elif LV_COLOR_DEPTH == 32
-    lv_color_format_t target_cf = LV_COLOR_FORMAT_ARGB8888;
-#else
-#error("Unsupported color format")
-#endif
-
+    const int32_t target_w = lv_display_get_horizontal_resolution(display);
+    const int32_t target_h = lv_display_get_vertical_resolution(display);
+    const lv_color_format_t target_cf = lv_display_get_color_format(display);
 
     for(size_t i = 0; i < config_count; ++i) {
         LV_LOG_TRACE("Got config %zu %#x %dx%d %d %d %d %d buffer size %d depth %d  samples %d stencil %d surface type %d",
@@ -165,22 +161,40 @@ size_t lv_opengles_egl_display_select_config(lv_display_t * display, const lv_eg
     }
 
     for(size_t i = 0; i < config_count; ++i) {
-        lv_color_format_t config_cf = lv_opengles_egl_color_format_from_egl_config(&configs[i]);
-        const bool resolution_matches = configs[i].max_width >= target_w &&
-                                        configs[i].max_height >= target_h;
-        const bool is_nanovg_compatible = (configs[i].renderable_type & EGL_OPENGL_ES2_BIT) != 0 &&
-                                          configs[i].stencil == 8 && configs[i].samples == 4;
-        const bool is_window = (configs[i].surface_type & EGL_WINDOW_BIT) != 0;
+        const lv_egl_config_t * config = &configs[i];
+        const bool resolution_matches = config->max_width >= target_w && config->max_height >= target_h;
+        const bool is_nanovg_compatible = (config->renderable_type & EGL_OPENGL_ES2_BIT) != 0 &&
+                                          config->stencil == 8 && config->samples == 4;
+        const bool is_window = (config->surface_type & EGL_WINDOW_BIT) != 0;
         const bool is_compatible_with_draw_unit = is_nanovg_compatible || !LV_USE_DRAW_NANOVG;
 
-        if(is_window && resolution_matches && config_cf == target_cf && is_compatible_with_draw_unit) {
-            LV_LOG_TRACE("Choosing config %zu", i);
+        if(is_window && resolution_matches && is_compatible_with_draw_unit &&
+           egl_config_cf_matches(config, target_cf)) {
+            LV_LOG_INFO("Choosing EGL config %zu (id %#x) for color format %d", i, config->id, target_cf);
             return i;
         }
     }
+
+    LV_LOG_WARN("No EGL config matches %" LV_PRId32 "x%" LV_PRId32 " in color format %d",
+                target_w, target_h, target_cf);
     return config_count;
 }
 
+lv_color_format_t lv_opengles_egl_set_display_color_format(lv_display_t * display)
+{
+    LV_ASSERT(display != NULL);
+
+    const lv_color_format_t cf = lv_display_get_color_format(display);
+    lv_opengles_gl_format_t gl_format;
+
+    if(cf != LV_COLOR_FORMAT_L8 && lv_opengles_gl_format_from_color_format(cf, &gl_format) == LV_RESULT_OK) {
+        return cf;
+    }
+
+    LV_LOG_WARN("Color format 0x%02x can't back an EGL surface. Falling back to ARGB8888", cf);
+    lv_display_set_color_format(display, LV_COLOR_FORMAT_ARGB8888);
+    return LV_COLOR_FORMAT_ARGB8888;
+}
 
 /**********************
 *   STATIC FUNCTIONS
@@ -559,6 +573,25 @@ lv_color_format_t lv_opengles_egl_color_format_from_egl_config(const lv_egl_conf
     LV_LOG_INFO("Unhandled color format (RGBA) (%d %d %d %d)", config->r_bits, config->g_bits, config->b_bits,
                 config->a_bits);
     return LV_COLOR_FORMAT_UNKNOWN;
+}
+
+static bool egl_config_cf_matches(const lv_egl_config_t * config, lv_color_format_t cf)
+{
+    const lv_color_format_t config_cf = lv_opengles_egl_color_format_from_egl_config(config);
+
+    if(config_cf == cf) {
+        return true;
+    }
+
+    switch(cf) {
+        case LV_COLOR_FORMAT_ARGB8888_PREMULTIPLIED:
+            return config_cf == LV_COLOR_FORMAT_ARGB8888;
+        case LV_COLOR_FORMAT_XRGB8888:
+        case LV_COLOR_FORMAT_RGB888:
+            return config_cf == LV_COLOR_FORMAT_ARGB8888 || config_cf == LV_COLOR_FORMAT_RGB888;
+        default:
+            return false;
+    }
 }
 
 static lv_result_t lv_egl_config_from_egl_config(lv_opengles_egl_t * ctx, lv_egl_config_t * lv_egl_config,

--- a/src/drivers/opengles/lv_opengles_egl.h
+++ b/src/drivers/opengles/lv_opengles_egl.h
@@ -45,6 +45,14 @@ lv_color_format_t lv_opengles_egl_color_format_from_egl_config(const lv_egl_conf
  */
 uint8_t lv_opengles_egl_get_gles_version(lv_opengles_egl_t * ctx);
 
+/**
+ * Modifies display color format to ensure the selected color format is opengl
+ * compatible else it falls back to `LV_COLOR_FORMAT_ARGB8888` and logs a warning.
+ * @param display   the display to check
+ * @return          the color format the display uses after the call
+ */
+lv_color_format_t lv_opengles_egl_set_display_color_format(lv_display_t * display);
+
 void lv_opengles_egl_update(lv_opengles_egl_t * ctx);
 void lv_opengles_egl_clear(lv_opengles_egl_t * ctx);
 void lv_opengles_egl_context_destroy(lv_opengles_egl_t * ctx);

--- a/src/drivers/opengles/lv_opengles_glfw.c
+++ b/src/drivers/opengles/lv_opengles_glfw.c
@@ -533,18 +533,21 @@ static void window_update_handler(lv_timer_t * t)
                 ensure_init_window_display_texture();
 
                 /* set the dimensions and format to complete the texture */
+                const lv_color_format_t cf = lv_display_get_color_format(texture->disp);
                 const int32_t tex_w = lv_area_get_width(&texture->area);
                 const int32_t tex_h = lv_area_get_height(&texture->area);
-                const uint32_t tex_stride = lv_draw_buf_width_to_stride(tex_w, lv_display_get_color_format(texture->disp));
-                lv_opengles_texture_upload_buf(window_display_texture, texture->fb, tex_w, tex_h, tex_stride);
+                if(lv_opengles_texture_upload_buf(window_display_texture, texture->fb, tex_w, tex_h,
+                                                  lv_draw_buf_width_to_stride(tex_w, cf), cf) != LV_RESULT_OK) {
+                    continue;
+                }
 
                 GL_CALL(glGenerateMipmap(GL_TEXTURE_2D));
 
                 GL_CALL(glBindTexture(GL_TEXTURE_2D, 0));
 
-                lv_opengles_render_texture_rbswap(window_display_texture, &texture->area, texture->opa, window->hor_res,
-                                                  window->ver_res,
-                                                  &texture->area, window->h_flip, window->v_flip);
+                lv_opengles_render_texture_cf(window_display_texture, &texture->area, texture->opa, window->hor_res,
+                                              window->ver_res,
+                                              &texture->area, window->h_flip, window->v_flip, cf);
 #endif
             }
             else {
@@ -561,11 +564,21 @@ static void window_update_handler(lv_timer_t * t)
                 }
 
 #if LV_USE_DRAW_OPENGLES
+                /*The draw unit rendered into the texture, in the OpenGL channel order*/
                 lv_opengles_render_texture_rbswap(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
                                                   &texture->area, window->h_flip, texture->disp == NULL ? window->v_flip : !window->v_flip);
 #else
-                lv_opengles_render_texture_rbswap(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
-                                                  &texture->area, window->h_flip, window->v_flip);
+                if(texture->disp != NULL) {
+                    /*The texture display uploaded its buffer, so its color format tells the channel order*/
+                    lv_opengles_render_texture_cf(texture->texture_id, &texture->area, texture->opa, window->hor_res,
+                                                  window->ver_res, &texture->area, window->h_flip, window->v_flip,
+                                                  lv_display_get_color_format(texture->disp));
+                }
+                else {
+                    /*A texture of the application, assume the OpenGL channel order*/
+                    lv_opengles_render_texture_rbswap(texture->texture_id, &texture->area, texture->opa, window->hor_res,
+                                                      window->ver_res, &texture->area, window->h_flip, window->v_flip);
+                }
 #endif
             }
         }

--- a/src/drivers/opengles/lv_opengles_private.h
+++ b/src/drivers/opengles/lv_opengles_private.h
@@ -134,7 +134,18 @@ typedef struct {
     lv_color_t fill_color;
     bool blend_opt;
     const lv_matrix_t * matrix;
+    lv_color_format_t cf;
 } lv_opengles_render_params_t;
+
+/**
+ * The `glTexImage2D` arguments describing an LVGL color format
+ */
+typedef struct {
+    int32_t internal_format;    /**< the `internalformat` argument of `glTexImage2D` */
+    uint32_t format;            /**< the `format` argument of `glTexImage2D` */
+    uint32_t type;              /**< the `type` argument of `glTexImage2D` */
+    bool rb_swap;               /**< the red and blue channels have to be swapped while rendering */
+} lv_opengles_gl_format_t;
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -168,6 +179,23 @@ void lv_opengles_render_texture_rbswap(unsigned int texture, const lv_area_t * t
                                        bool h_flip, bool v_flip);
 
 /**
+ * Render a texture holding pixels of an LVGL color format, using alternate blending mode.
+ * The channel order and the grayscale handling are derived from `cf`.
+ * @param texture               OpenGL texture ID
+ * @param texture_area          the area in the window to render the texture in
+ * @param opa                   opacity to blend the texture with existing contents
+ * @param disp_w                width of the window/framebuffer being rendered to
+ * @param disp_h                height of the window/framebuffer being rendered to
+ * @param texture_clip_area     the area of the texture to draw
+ * @param h_flip                horizontal flip
+ * @param v_flip                vertical flip
+ * @param cf                    the LVGL color format the texture was uploaded from
+ */
+void lv_opengles_render_texture_cf(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
+                                   int32_t disp_w, int32_t disp_h, const lv_area_t * texture_clip_area,
+                                   bool h_flip, bool v_flip, lv_color_format_t cf);
+
+/**
  * Set the OpenGL viewport, with vertical co-ordinate conversion
  * @param x        x position of the viewport
  * @param y        y position of the viewport
@@ -192,23 +220,39 @@ void lv_opengles_render_texture_internal(unsigned int texture, const lv_area_t *
 void lv_opengles_render_display_texture_internal(lv_display_t * display, bool h_flip, bool v_flip);
 
 /**
+ * Get the `glTexImage2D` arguments to upload a buffer of an LVGL color format with
+ * @param cf            the LVGL color format
+ * @param gl_format     pointer to the struct to fill
+ * @return              `LV_RESULT_OK` on success, `LV_RESULT_INVALID` if `cf` has no OpenGL equivalent
+ */
+lv_result_t lv_opengles_gl_format_from_color_format(lv_color_format_t cf, lv_opengles_gl_format_t * gl_format);
+
+bool lv_opengles_color_format_is_rb_swap(lv_color_format_t cf);
+
+/**
  * Upload a pixel buffer into an OpenGL texture
  * @param texture_id    the OpenGL texture ID to upload into
  * @param buf           the pixel buffer. @nullable. Can be `NULL` to only define the size and the format
  * @param w             width of the buffer in pixels
  * @param h             height of the buffer in pixels
  * @param stride        stride of the buffer in bytes. Ignored when `buf` is `NULL`
+ * @param cf            the LVGL color format of the buffer
+ * @return              `LV_RESULT_OK` on success, `LV_RESULT_INVALID` if `cf` has no OpenGL equivalent
  */
-void lv_opengles_texture_upload_buf(unsigned int texture_id, const void * buf, int32_t w, int32_t h,
-                                    uint32_t stride);
+lv_result_t lv_opengles_texture_upload_buf(unsigned int texture_id, const void * buf, int32_t w, int32_t h,
+                                           uint32_t stride, lv_color_format_t cf);
 
 /**
  * Upload the rendered buffer of a display into an OpenGL texture.
+ * The size and the color format are taken from the display.
  * @param texture_id    the OpenGL texture ID to upload into
  * @param display       the display the buffer belongs to
  * @param buf           the pixel buffer. @nullable. Can be `NULL` to only define the size and the format
+ * @return              `LV_RESULT_OK` on success, `LV_RESULT_INVALID` if the color format of the
+ *                      display has no OpenGL equivalent
  */
-void lv_opengles_texture_upload_display_buf(unsigned int texture_id, lv_display_t * display, const void * buf);
+lv_result_t lv_opengles_texture_upload_display_buf(unsigned int texture_id, lv_display_t * display,
+                                                   const void * buf);
 
 /**********************
  *      MACROS

--- a/src/drivers/opengles/lv_opengles_texture.c
+++ b/src/drivers/opengles/lv_opengles_texture.c
@@ -34,7 +34,7 @@
 static lv_display_t * lv_opengles_texture_create_common(int32_t w, int32_t h);
 static lv_result_t lv_opengles_texture_create_draw_buffers(lv_opengles_texture_t * texture, lv_display_t * display);
 static void lv_opengles_texture_attach_to_display(lv_opengles_texture_t * texture, lv_display_t * disp);
-static unsigned int create_texture(int32_t w, int32_t h);
+static unsigned int create_texture(int32_t w, int32_t h, lv_color_format_t cf);
 static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_map);
 static void release_disp_cb(lv_event_t * e);
 static inline unsigned int lv_opengles_texture_get_texture_id_internal(lv_display_t * disp);
@@ -59,7 +59,12 @@ lv_display_t * lv_opengles_texture_create(int32_t w, int32_t h)
         return NULL;
     }
     lv_opengles_texture_t * texture = lv_display_get_driver_data(display);
-    unsigned int texture_id = create_texture(w, h);
+    unsigned int texture_id = create_texture(w, h, lv_display_get_color_format(display));
+    if(texture_id == GL_NONE) {
+        LV_LOG_ERROR("Failed to create texture");
+        lv_display_delete(display);
+        return NULL;
+    }
     texture->texture_id = texture_id;
     texture->is_texture_owner = true;
     /* Attach the texture to the display after the texture id has been set*/
@@ -87,7 +92,7 @@ lv_result_t lv_opengles_texture_reshape(lv_opengles_texture_t * texture, lv_disp
 {
     LV_ASSERT(display != NULL);
     LV_ASSERT(texture != NULL);
-    unsigned int new_texture = create_texture(width, height);
+    unsigned int new_texture = create_texture(width, height, lv_display_get_color_format(display));
     if(new_texture == GL_NONE) {
         LV_LOG_ERROR("Failed to reshape texture. Couldn't acquire new texture from GPU");
         return LV_RESULT_INVALID;
@@ -179,14 +184,17 @@ void lv_opengles_texture_render_display(lv_opengles_texture_t * texture, lv_disp
     LV_UNUSED(texture);
 #else
     /*Upload the software rendered buffer of the display, then render it*/
-    lv_opengles_texture_upload_display_buf(texture->texture_id, display, texture->fb1);
+    if(lv_opengles_texture_upload_display_buf(texture->texture_id, display, texture->fb1) != LV_RESULT_OK) {
+        return;
+    }
 
-    lv_opengles_render_params_t params = {
-        .h_flip = false,
-        .v_flip = false,
-        /*LVGL stores RGB888 as B, G, R and XRGB8888 as B, G, R, X in memory*/
-        .rb_swap = LV_COLOR_DEPTH == 24 || LV_COLOR_DEPTH == 32,
-    };
+    const lv_color_format_t cf = lv_display_get_color_format(display);
+    lv_opengles_render_params_t params;
+    lv_opengles_render_params_init(&params);
+    params.h_flip = false;
+    params.v_flip = false;
+    params.rb_swap = lv_opengles_color_format_is_rb_swap(cf);
+    params.cf = cf;
     lv_opengles_render_display(display, &params);
 #endif /*LV_USE_DRAW_OPENGLES*/
 }
@@ -243,7 +251,7 @@ static lv_display_t * lv_opengles_texture_create_common(int32_t w, int32_t h)
     return disp;
 }
 
-static unsigned int create_texture(int32_t w, int32_t h)
+static unsigned int create_texture(int32_t w, int32_t h, lv_color_format_t cf)
 {
     unsigned int texture;
     GL_CALL(glGenTextures(1, &texture));
@@ -254,7 +262,10 @@ static unsigned int create_texture(int32_t w, int32_t h)
     GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
 
     /* set the dimensions and format to complete the texture */
-    lv_opengles_texture_upload_buf(texture, NULL, w, h, 0);
+    if(lv_opengles_texture_upload_buf(texture, NULL, w, h, 0, cf) != LV_RESULT_OK) {
+        GL_CALL(glDeleteTextures(1, &texture));
+        return GL_NONE;
+    }
 
 #if 0
     GL_CALL(glGenerateMipmap(GL_TEXTURE_2D));

--- a/src/drivers/sdl/lv_sdl_egl.c
+++ b/src/drivers/sdl/lv_sdl_egl.c
@@ -69,6 +69,8 @@ const lv_sdl_backend_ops_t lv_sdl_backend_ops = {
 
 static lv_result_t init_display(lv_display_t * display)
 {
+    lv_opengles_egl_set_display_color_format(display);
+
     lv_egl_interface_t ifc = lv_sdl_get_egl_interface(display);
     lv_sdl_egl_display_data_t * ddata = lv_malloc_zeroed(sizeof(*ddata));
     if(!ddata) {

--- a/src/drivers/wayland/lv_wayland_backend_egl.c
+++ b/src/drivers/wayland/lv_wayland_backend_egl.c
@@ -130,6 +130,8 @@ static lv_wl_egl_display_data_t * egl_create_display_data(lv_display_t * display
      * in the EGL window creation callback */
     lv_wayland_set_backend_display_data(display, ddata);
 
+    lv_opengles_egl_set_display_color_format(display);
+
     /* Create EGL context */
     lv_egl_interface_t egl_interface = wl_egl_get_interface(display);
     ddata->egl_ctx = lv_opengles_egl_context_create(&egl_interface);


### PR DESCRIPTION
Previously the opengl integration used LV_COLOR_DEPTH to decide the parameters passed to glTexImage2D, this PR changes it to instead use the display color format which is the more accurate way of handling it