### PR TITLE
fix(windows): make the display usable from the first frame

### DIFF
--- a/src/core/lv_refr.c
+++ b/src/core/lv_refr.c
@@ -370,12 +370,6 @@ void lv_display_refr_timer(lv_timer_t * timer)
 
     if(timer) {
         disp_refr = timer->user_data;
-        /* Ensure the timer does not run again automatically.
-         * This is done before refreshing in case refreshing invalidates something else.
-         * However if the performance monitor is enabled keep the timer running to count the FPS.*/
-#if !LV_USE_PERF_MONITOR
-        lv_timer_pause(timer);
-#endif
     }
     else {
         disp_refr = lv_display_get_default();
@@ -393,6 +387,15 @@ void lv_display_refr_timer(lv_timer_t * timer)
         LV_PROFILER_REFR_END;
         return;
     }
+
+    /* Ensure the timer does not run again automatically.
+     * This is done before refreshing in case refreshing invalidates something else.
+     * However if the performance monitor is enabled keep the timer running to count the FPS.
+     * Pause here where the draw buffer exists otherwise lv_display_refr_timer() may not be
+     * called again which would yield a blank screen */
+#if !LV_USE_PERF_MONITOR
+    if(timer) lv_timer_pause(timer);
+#endif
 
     lv_result_t res = lv_display_send_event(disp_refr, LV_EVENT_REFR_START, NULL);
     if(res == LV_RESULT_INVALID) {

--- a/src/drivers/windows/lv_windows_context.c
+++ b/src/drivers/windows/lv_windows_context.c
@@ -98,7 +98,9 @@ void lv_windows_platform_init(void)
     window_class.lpszMenuName = NULL;
     window_class.lpszClassName = L"LVGL.Window";
     window_class.hIconSm = NULL;
-    LV_ASSERT(RegisterClassExW(&window_class));
+    ATOM window_class_atom = RegisterClassExW(&window_class);
+    LV_ASSERT(window_class_atom != 0);
+    LV_UNUSED(window_class_atom);
 }
 
 lv_windows_window_context_t * lv_windows_get_window_context(
@@ -270,6 +272,13 @@ static void lv_windows_display_timer_callback(lv_timer_t * timer)
                 NULL,
                 (uint32_t)context->display_framebuffer_size,
                 LV_DISPLAY_RENDER_MODE_DIRECT);
+
+            /* The new FB is blank. lv_display_set_resolution()
+             * above only invalidates when the resolution changes,
+             * minimize/restore window keeps the same size, so we need an
+             * explicit invalidation */
+            lv_obj_invalidate(lv_display_get_screen_active(
+                                  context->display_device_object));
         }
     }
 
@@ -502,21 +511,27 @@ static bool lv_windows_window_message_callback_nolock(
                                                     lv_windows_display_timer_callback,
                                                     LV_DEF_REFR_PERIOD,
                                                     context);
+                if(!context->display_timer_object) {
+                    return -1;
+                }
 
                 context->display_resolution_changed = false;
                 context->requested_display_resolution.x = 0;
                 context->requested_display_resolution.y = 0;
 
-                context->display_device_object = lv_display_create(0, 0);
+                RECT request_content_size;
+                if(context->simulator_mode) {
+                    GetWindowRect(hWnd, &request_content_size);
+                }
+                else {
+                    GetClientRect(hWnd, &request_content_size);
+                }
+                context->display_device_object = lv_display_create(
+                                                     request_content_size.right - request_content_size.left,
+                                                     request_content_size.bottom - request_content_size.top);
                 if(!context->display_device_object) {
                     return -1;
                 }
-                RECT request_content_size;
-                GetWindowRect(hWnd, &request_content_size);
-                lv_display_set_resolution(
-                    context->display_device_object,
-                    request_content_size.right - request_content_size.left,
-                    request_content_size.bottom - request_content_size.top);
                 lv_display_set_flush_cb(
                     context->display_device_object,
                     lv_windows_display_driver_flush_callback);
@@ -542,6 +557,20 @@ static bool lv_windows_window_message_callback_nolock(
                 lv_windows_register_touch_window(hWnd, 0);
 
                 lv_windows_enable_child_window_dpi_message(hWnd);
+
+                /* Build the frame buffer now so the display is usable when
+                 * lv_windows_create_display() returns. Simulator mode has
+                 * already armed the fields below, hence the guard. */
+                if(!context->display_resolution_changed) {
+                    context->display_resolution_changed = true;
+                    context->requested_display_resolution.x =
+                        lv_display_get_horizontal_resolution(
+                            context->display_device_object);
+                    context->requested_display_resolution.y =
+                        lv_display_get_vertical_resolution(
+                            context->display_device_object);
+                }
+                lv_windows_display_timer_callback(context->display_timer_object);
 
                 break;
             }

--- a/src/drivers/windows/lv_windows_display.c
+++ b/src/drivers/windows/lv_windows_display.c
@@ -166,7 +166,9 @@ static unsigned int __stdcall lv_windows_display_thread_entrypoint(
     ShowWindow(window_handle, SW_SHOW);
     UpdateWindow(window_handle);
 
-    LV_ASSERT(SetEvent(data->mutex));
+    BOOL event_set = SetEvent(data->mutex);
+    LV_ASSERT(event_set);
+    LV_UNUSED(event_set);
 
     data = NULL;
 


### PR DESCRIPTION
Supersedes #9924. Thanks @DhxZzy for finding and reporting both symptoms.

The Windows driver does not start at all on current master. Four separate problems:

RegisterClassExW() and SetEvent() were inside LV_ASSERT(), which discards its argument now that LV_USE_ASSERT defaults to 0, so the class was never registered and the create event never signalled. lv_windows_create_display() hung.
lv_display_create(0, 0) returns NULL since it rejects non-positive sizes.
WM_CREATE sized the display from GetWindowRect(), the whole window including borders, so a requested 800x480 client area produced an 820x523 display and lv_pct() widgets were laid out wrong on the first frame.
The frame buffer was only created by the refresh timer, so the display came back with no draw buffer, and recreating it at an unchanged size never invalidated, leaving a blank window after restoring from minimize.
The lv_refr.c change is needed for 4: lv_display_refr_timer() paused itself before the no-draw-buffer check, and lv_inv_area() skips the refresh request when the area is already pending, so nothing could resume it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

