### PR TITLE
fix(draw/g2d): fix build and draw thread synchronization

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1062,6 +1062,7 @@ config LV_USE_G2D
 
 config LV_USE_DRAW_G2D
 	bool "G2D renderer"
+	select LV_USE_DRAW_SW
 	default n
 	help
 		Accelerate blends, fills and image blits with the NXP G2D API (i.MX 2D GPU).

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -581,6 +581,8 @@
 
 /** Accelerate blends, fills and image blits with the NXP G2D API (i.MX 2D GPU).
  *  Requires the g2d library and its headers.
+ *
+ *  Enable: LV_USE_DRAW_SW
  */
 #define LV_USE_DRAW_G2D 0
 

--- a/src/draw/nxp/g2d/Kconfig
+++ b/src/draw/nxp/g2d/Kconfig
@@ -6,6 +6,7 @@ config LV_USE_G2D
 
 config LV_USE_DRAW_G2D
 	bool "G2D renderer"
+	select LV_USE_DRAW_SW
 	default n
 	help
 		Accelerate blends, fills and image blits with the NXP G2D API (i.MX 2D GPU).

--- a/src/draw/nxp/g2d/lv_draw_g2d.c
+++ b/src/draw/nxp/g2d/lv_draw_g2d.c
@@ -63,6 +63,8 @@ static int32_t _g2d_delete(lv_draw_unit_t * draw_unit);
 
 #if LV_USE_G2D_DRAW_THREAD
     static void _g2d_render_thread_cb(void * ptr);
+
+    static int32_t _g2d_wait_for_finish(lv_draw_unit_t * draw_unit);
 #endif
 
 static void _g2d_execute_drawing(lv_draw_task_t * t);
@@ -92,9 +94,13 @@ void lv_draw_g2d_init(void)
     draw_g2d_unit->base_unit.name = "G2D";
 
 #if LV_USE_G2D_DRAW_THREAD
+    draw_g2d_unit->base_unit.wait_for_finish_cb = _g2d_wait_for_finish;
+
     lv_draw_sw_thread_dsc_t * thread_dsc = &draw_g2d_unit->thread_dsc;
     thread_dsc->idx = 0;
     thread_dsc->draw_unit = (void *) draw_g2d_unit;
+    lv_thread_sync_init(&thread_dsc->new_task_sync);
+    lv_thread_sync_init(&thread_dsc->task_done_sync);
     lv_thread_init(&thread_dsc->thread, "g2ddraw", LV_DRAW_THREAD_PRIO, _g2d_render_thread_cb, LV_DRAW_THREAD_STACK_SIZE,
                    thread_dsc);
 #endif
@@ -230,7 +236,7 @@ static int32_t _g2d_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 {
     lv_draw_g2d_unit_t * draw_g2d_unit = (lv_draw_g2d_unit_t *) draw_unit;
 
-#if LV_USE_OS
+#if LV_USE_G2D_DRAW_THREAD
     lv_draw_sw_thread_dsc_t * thread_dsc = &draw_g2d_unit->thread_dsc;
 
     /* Return immediately if it's busy with draw task. */
@@ -260,8 +266,7 @@ static int32_t _g2d_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
     thread_dsc->task_act = t;
 
     /* Let the render thread work. */
-    if(thread_dsc->inited)
-        lv_thread_sync_signal(&thread_dsc->sync);
+    lv_thread_sync_signal(&thread_dsc->new_task_sync);
 #else
     draw_g2d_unit->task_act = t;
 
@@ -289,10 +294,10 @@ static int32_t _g2d_delete(lv_draw_unit_t * draw_unit)
     LV_LOG_INFO("Cancel G2D draw thread.");
     thread_dsc->exit_status = true;
 
-    if(thread_dsc->inited)
-        lv_thread_sync_signal(&thread_dsc->sync);
-
+    lv_thread_sync_signal(&thread_dsc->new_task_sync);
     res = lv_thread_delete(&thread_dsc->thread);
+    lv_thread_sync_delete(&thread_dsc->new_task_sync);
+    lv_thread_sync_delete(&thread_dsc->task_done_sync);
 #endif
     g2d_close(g2d_get_handle());
 
@@ -324,16 +329,13 @@ static void _g2d_render_thread_cb(void * ptr)
 {
     lv_draw_sw_thread_dsc_t * thread_dsc = ptr;
 
-    lv_thread_sync_init(&thread_dsc->sync);
-    thread_dsc->inited = true;
-
     while(1) {
         /* Wait for sync if there is no task set. */
         while(thread_dsc->task_act == NULL) {
             if(thread_dsc->exit_status)
                 break;
 
-            lv_thread_sync_wait(&thread_dsc->sync);
+            lv_thread_sync_wait(&thread_dsc->new_task_sync);
         }
 
         if(thread_dsc->exit_status) {
@@ -349,13 +351,25 @@ static void _g2d_render_thread_cb(void * ptr)
         /* Cleanup. */
         thread_dsc->task_act = NULL;
 
+        lv_thread_sync_signal(&thread_dsc->task_done_sync);
+
         /* The draw unit is free now. Request a new dispatching as it can get a new task. */
         lv_draw_dispatch_request();
     }
 
-    thread_dsc->inited = false;
-    lv_thread_sync_delete(&thread_dsc->sync);
     LV_LOG_INFO("Exit G2D draw thread.");
+}
+
+static int32_t _g2d_wait_for_finish(lv_draw_unit_t * draw_unit)
+{
+    lv_draw_g2d_unit_t * draw_g2d_unit = (lv_draw_g2d_unit_t *) draw_unit;
+    lv_draw_sw_thread_dsc_t * thread_dsc = &draw_g2d_unit->thread_dsc;
+
+    while(thread_dsc->task_act) {
+        lv_thread_sync_wait(&thread_dsc->task_done_sync);
+    }
+
+    return 0;
 }
 #endif /*LV_USE_G2D_DRAW_THREAD*/
 

--- a/src/draw/nxp/g2d/lv_draw_g2d.h
+++ b/src/draw/nxp/g2d/lv_draw_g2d.h
@@ -35,7 +35,7 @@ extern "C" {
 
 typedef struct lv_draw_g2d_unit {
     lv_draw_unit_t base_unit;
-#if LV_USE_OS
+#if LV_USE_G2D_DRAW_THREAD
     lv_draw_sw_thread_dsc_t thread_dsc;
 #else
     lv_draw_task_t * task_act;

--- a/src/draw/nxp/g2d/lv_g2d_buf_map.h
+++ b/src/draw/nxp/g2d/lv_g2d_buf_map.h
@@ -25,6 +25,8 @@ extern "C" {
 
 #if LV_USE_DRAW_G2D
 
+#include "../../../misc/lv_array.h"
+
 #include <string.h>
 
 /*********************

--- a/src/lv_conf_check.c
+++ b/src/lv_conf_check.c
@@ -46,8 +46,8 @@
     #error "LV_USE_THORVG must be enabled: Kconfig selects it from LV_USE_VG_LITE_THORVG && LV_USE_DRAW_VG_LITE"
 #endif
 
-#if (LV_USE_SIFLI_EPIC || LV_USE_DRAW_SDL) && !LV_USE_DRAW_SW
-    #error "LV_USE_DRAW_SW must be enabled: Kconfig selects it from LV_USE_SIFLI_EPIC || LV_USE_DRAW_SDL"
+#if (LV_USE_SIFLI_EPIC || LV_USE_DRAW_G2D || LV_USE_DRAW_SDL) && !LV_USE_DRAW_SW
+    #error "LV_USE_DRAW_SW must be enabled: Kconfig selects it from LV_USE_SIFLI_EPIC || LV_USE_DRAW_G2D || LV_USE_DRAW_SDL"
 #endif
 
 #if LV_USE_DRAW_ARM2D_SYNC && !(LV_USE_DRAW_SW)


### PR DESCRIPTION
Enabling `LV_USE_DRAW_G2D` does not build. There are two independent problems: one that breaks every G2D build, and one that breaks the G2D draw thread whenever an OS is configured.

### 1. `lv_array_t` is not visible to the G2D buffer map

`lv_buf_map_t` in `lv_g2d_buf_map.h` holds an array of `lv_array_t` pointers, but the header only includes `lvgl_public.h`. `lv_array_t` is internal and lives in `src/misc/lv_array.h`, which the public headers do not expose, so every translation unit that pulls in `lv_g2d_buf_map.h` fails:

```
src/draw/nxp/g2d/lv_g2d_buf_map.h:48:5: error: unknown type name 'lv_array_t'
   48 |     lv_array_t ** overflow_list;
```

Fixed by including the header directly, the same way the `vg_lite` draw unit and `lv_draw_vector` already do.

### 2. The G2D draw thread no longer matches `lv_draw_sw_thread_dsc_t`

The G2D unit reuses `lv_draw_sw_thread_dsc_t`. That struct no longer has the `sync` and `inited` members; they were replaced by `new_task_sync` and `task_done_sync`. Any `LV_USE_OS` build of `lv_draw_g2d.c` fails:

```
src/draw/nxp/g2d/lv_draw_g2d.c:263:18: error: 'lv_draw_sw_thread_dsc_t' has no member named 'inited'
src/draw/nxp/g2d/lv_draw_g2d.c:264:42: error: 'lv_draw_sw_thread_dsc_t' has no member named 'sync'
```
