### PR TITLE
refactor(qrcode): report render success instead of failure

### DIFF
--- a/docs/src/changelog/migration-v10.mdx
+++ b/docs/src/changelog/migration-v10.mdx
@@ -703,7 +703,7 @@ used afterwards.
 - New: `lv_qrcode_render()` re-encodes the stored payload without taking it as an
   argument, which is how property changes made in the deferred update mode are applied.
 
-- New: `lv_qrcode_get_render_failed()` reports whether the last encode failed, for the
+- New: `lv_qrcode_is_render_valid()` reports whether the last encode succeeded, for the
   re-encodes whose result cannot be returned (the void property setters, and the
   deferred re-encode done by the draw pass).
 

--- a/docs/src/libs/qrcode.mdx
+++ b/docs/src/libs/qrcode.mdx
@@ -75,17 +75,19 @@ either - they are a palette write in both modes.
 re-encodes triggered by a property change cannot: `lv_qrcode_set_size()` and `lv_qrcode_set_quiet_zone()` return
 `void`, and in deferred mode the work happens in the draw pass. A payload that no longer
 fits - typically after shrinking the object - therefore fails without anything returning
-an error. <ApiLink name="lv_qrcode_get_render_failed" /> reports that state:
+an error. <ApiLink name="lv_qrcode_is_render_valid" /> reports that state:
 
 ```c
 lv_qrcode_set_size(qr, 10);   /* too small for this payload */
-if(lv_qrcode_get_render_failed(qr)) {
+if(!lv_qrcode_is_render_valid(qr)) {
     /* the bitmap is blank; pick a larger size */
 }
 ```
 
-It is also `true` on a fresh QR code that has no data yet, and becomes `false` again as
-soon as an encode succeeds.
+It is also `false` on a fresh QR code that has no data yet. A property change re-arms the
+Widget and sets the flag back to `true` before the new encode runs, so `true` means "no
+known failure", not "the bitmap is up to date" - in deferred mode a pending re-encode is
+also `true`.
 
 A failed encode leaves the bitmap marked as out of date, so it is never mistaken for a
 current one, and it is not retried on every redraw - only a property change makes the
@@ -93,7 +95,7 @@ Widget try again.
 
 Encode failures are not logged when the caller can see the result: `lv_qrcode_update()`
 and `lv_qrcode_render()` return it, and the property setters are silent because the state
-is available from `lv_qrcode_get_render_failed()`. Animating a size through values that
+is available from `lv_qrcode_is_render_valid()`. Animating a size through values that
 are all too small therefore produces no log output at all. The one exception is the
 re-encode done by the redraw - there is no caller to return anything to, so that failure
 is logged, along with the warning that the explicit render call was missed.

--- a/include/lvgl/widgets/lv_qrcode.h
+++ b/include/lvgl/widgets/lv_qrcode.h
@@ -146,8 +146,8 @@ void lv_qrcode_set_update_mode(lv_obj_t * obj, lv_qrcode_update_mode_t mode);
 lv_qrcode_update_mode_t lv_qrcode_get_update_mode(lv_obj_t * obj);
 
 /**
- * Get whether the QR code bitmap is missing because the last attempt to generate it
- * failed. Most encodes report their result directly: `lv_qrcode_update()` returns it.
+ * Check whether the QR code bitmap is free of a known encode failure. Most encodes report
+ * their result directly: `lv_qrcode_update()` returns it.
  * The ones that cannot are the re-encodes triggered by a property change - they happen
  * in a void setter or, in LV_QRCODE_UPDATE_MODE_DEFERRED, in the draw pass. Use this to
  * detect those, e.g. after shrinking the object below the size its payload needs.
@@ -157,10 +157,11 @@ lv_qrcode_update_mode_t lv_qrcode_get_update_mode(lv_obj_t * obj);
  *       result; the one exception is the re-encode done by the redraw, which has no
  *       caller, so that one is logged.
  * @param obj pointer to a QR code object
- * @return true: the last generation attempt failed, or no data has been set yet;
- *         false: the bitmap holds a valid QR code
+ * @return true: no encode attempt is known to have failed. A property change re-arms the
+ *               Widget, so this is also true while a deferred re-encode is still pending;
+ *         false: the last encode attempt failed, or no data has been set yet
  */
-bool lv_qrcode_get_render_failed(lv_obj_t * obj);
+bool lv_qrcode_is_render_valid(lv_obj_t * obj);
 
 /**********************
  *      MACROS

--- a/scripts/gdb/lvglgdb/lvgl/widgets/lv_qrcode.py
+++ b/scripts/gdb/lvglgdb/lvgl/widgets/lv_qrcode.py
@@ -51,9 +51,9 @@ class LVQrcode(LVCanvas):
         return int(self._wv_lv_qrcode_t.safe_field("needs_update", 0))
 
     @property
-    def render_failed(self):
-        """The last encode attempt failed (or none has run yet)"""
-        return int(self._wv_lv_qrcode_t.safe_field("render_failed", 0))
+    def render_valid(self):
+        """No encode attempt is known to have failed; a change re-arms it"""
+        return int(self._wv_lv_qrcode_t.safe_field("render_valid", 0))
 
     def snapshot(self, include_children=False, include_styles=False):
         """Snapshot with widget-specific fields in widget_data."""
@@ -66,6 +66,6 @@ class LVQrcode(LVCanvas):
         d["quiet_zone"] = self.quiet_zone
         d["update_mode"] = self.update_mode
         d["needs_update"] = self.needs_update
-        d["render_failed"] = self.render_failed
+        d["render_valid"] = self.render_valid
         s['widget_data'] = d
         return s

--- a/scripts/gdb/scripts/generators/widget_specs.json
+++ b/scripts/gdb/scripts/generators/widget_specs.json
@@ -545,7 +545,7 @@
         "quiet_zone": "bool",
         "update_mode": "bool",
         "needs_update": "bool",
-        "render_failed": "bool"
+        "render_valid": "bool"
       }
     }
   },

--- a/src/widgets/qrcode/lv_qrcode.c
+++ b/src/widgets/qrcode/lv_qrcode.c
@@ -136,7 +136,7 @@ lv_result_t lv_qrcode_update(lv_obj_t * obj, const void * data, uint32_t data_le
 
     /*A new payload leaves the bitmap out of date, and makes any earlier failure moot*/
     qrcode->needs_update = true;
-    qrcode->render_failed = false;
+    qrcode->render_valid = true;
 
     /*Setting the data always encodes right away, in either update mode*/
     return lv_qrcode_render(obj);
@@ -180,7 +180,7 @@ void lv_qrcode_set_update_mode(lv_obj_t * obj, lv_qrcode_update_mode_t mode)
      *order that can report the failure is lv_qrcode_update() first, then switch mode.*/
     if(mode == LV_QRCODE_UPDATE_MODE_IMMEDIATE && qrcode->needs_update) {
         qrcode_encode(obj);
-        if(qrcode->render_failed) {
+        if(!qrcode->render_valid) {
             LV_LOG_ERROR("re-encoding on the switch to immediate update mode failed; "
                          "call lv_qrcode_render() before switching the mode to get the result");
         }
@@ -201,11 +201,11 @@ lv_qrcode_update_mode_t lv_qrcode_get_update_mode(lv_obj_t * obj)
     return (lv_qrcode_update_mode_t)qrcode->update_mode;
 }
 
-bool lv_qrcode_get_render_failed(lv_obj_t * obj)
+bool lv_qrcode_is_render_valid(lv_obj_t * obj)
 {
-    LV_CHECK_OBJ(obj, MY_CLASS, return true);
+    LV_CHECK_OBJ(obj, MY_CLASS, return false);
     lv_qrcode_t * qrcode = (lv_qrcode_t *)obj;
-    return qrcode->render_failed;
+    return qrcode->render_valid;
 }
 
 /**********************
@@ -223,7 +223,7 @@ static void lv_qrcode_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj
     qrcode->update_mode = LV_QRCODE_UPDATE_MODE_IMMEDIATE;
     qrcode->needs_update = false;
     /*No bitmap has been generated yet, so there is nothing valid to report*/
-    qrcode->render_failed = true;
+    qrcode->render_valid = false;
 
     /*Set default size*/
     lv_qrcode_set_size(obj, LV_DPI_DEF);
@@ -267,8 +267,8 @@ static void lv_qrcode_event(const lv_obj_class_t * class_p, lv_event_t * e)
         lv_obj_t * obj = lv_event_get_current_target(e);
         lv_qrcode_t * qrcode = (lv_qrcode_t *)obj;
         /*A state that already failed to encode is not retried here: it can only start
-         *working again when a property changes, and that clears `render_failed`.*/
-        if(qrcode->needs_update && !qrcode->render_failed) {
+         *working again when a property changes, and that sets `render_valid` again.*/
+        if(qrcode->needs_update && qrcode->render_valid) {
             /*Only deferred mode leaves the bitmap out of date; immediate mode re-encodes in the setter*/
             LV_ASSERT(qrcode->update_mode == LV_QRCODE_UPDATE_MODE_DEFERRED);
 
@@ -340,7 +340,7 @@ static void qrcode_mark_dirty(lv_obj_t * obj)
     qrcode->needs_update = true;
 
     /*The property change may well make the payload encodable again, so allow a new attempt*/
-    qrcode->render_failed = false;
+    qrcode->render_valid = true;
 
     /*Deferred mode collapses several changes into one re-encode on the next redraw*/
     if(qrcode->update_mode == LV_QRCODE_UPDATE_MODE_IMMEDIATE) qrcode_encode(obj);
@@ -353,14 +353,14 @@ static lv_result_t qrcode_encode(lv_obj_t * obj)
     LV_ASSERT(obj != NULL);
     lv_qrcode_t * qrcode = (lv_qrcode_t *)obj;
 
-    /*Assume failure and clear both flags only on the single success path, so no early
+    /*Start invalid and settle both flags only on the single success path, so no early
      *return can forget to record the outcome. `needs_update` deliberately survives a
      *failure: the bitmap still does not match the properties, and reporting it as up to
-     *date would be a lie. `render_failed` is what keeps the draw hook from retrying a
-     *known-bad state on every frame; a property change clears it to allow a new attempt.
-     *Failures are never logged here - the result is returned, and it is up to the caller
-     *to report it if nothing else will.*/
-    qrcode->render_failed = true;
+     *date would be a lie. A cleared `render_valid` is what keeps the draw hook from
+     *retrying a known-bad state on every frame; a property change sets it again to allow a
+     *new attempt. Failures are never logged here - the result is returned, and it is up to
+     *the caller to report it if nothing else will.*/
+    qrcode->render_valid = false;
 
     if(qrcode->data == NULL) return LV_RESULT_INVALID;
 
@@ -484,7 +484,7 @@ static lv_result_t qrcode_encode(lv_obj_t * obj)
 
     /*Only now does the bitmap match the properties*/
     qrcode->needs_update = false;
-    qrcode->render_failed = false;
+    qrcode->render_valid = true;
     return LV_RESULT_OK;
 }
 

--- a/src/widgets/qrcode/lv_qrcode_private.h
+++ b/src/widgets/qrcode/lv_qrcode_private.h
@@ -40,7 +40,7 @@ struct _lv_qrcode_t {
     uint16_t quiet_zone : 1;        /*Add the QR spec's blank margin around the code (boolean toggle)*/
     uint16_t update_mode : 1;       /*lv_qrcode_update_mode_t: when a property change is re-encoded*/
     uint16_t needs_update : 1;      /*The bitmap is out of date; re-encoded on the next redraw (deferred mode)*/
-    uint16_t render_failed : 1;     /*The last encode attempt failed (or none has run yet)*/
+    uint16_t render_valid : 1;      /*No encode attempt is known to have failed; a change re-arms it*/
 };
 
 

--- a/tests/src/test_cases/libs/test_qrcode.c
+++ b/tests/src/test_cases/libs/test_qrcode.c
@@ -274,11 +274,11 @@ void test_qrcode_deferred_render_failure_is_detectable(void)
     TEST_ASSERT_NOT_NULL(qr);
 
     /*Nothing encoded yet*/
-    TEST_ASSERT_TRUE(lv_qrcode_get_render_failed(qr));
+    TEST_ASSERT_FALSE(lv_qrcode_is_render_valid(qr));
 
     lv_qrcode_set_size(qr, 150);
     TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_update(qr, "https://lvgl.io", 15));
-    TEST_ASSERT_FALSE(lv_qrcode_get_render_failed(qr));
+    TEST_ASSERT_TRUE(lv_qrcode_is_render_valid(qr));
 
     /*In deferred mode the re-encode happens in the draw pass, so nothing returns its
      *result to the caller. Shrinking the canvas below one pixel per QR module makes it
@@ -287,12 +287,12 @@ void test_qrcode_deferred_render_failure_is_detectable(void)
     lv_qrcode_set_size(qr, 10);
     lv_obj_center(qr);
     lv_refr_now(NULL);
-    TEST_ASSERT_TRUE(lv_qrcode_get_render_failed(qr));
+    TEST_ASSERT_FALSE(lv_qrcode_is_render_valid(qr));
 
     /*Growing it back re-encodes successfully*/
     lv_qrcode_set_size(qr, 150);
     lv_refr_now(NULL);
-    TEST_ASSERT_FALSE(lv_qrcode_get_render_failed(qr));
+    TEST_ASSERT_TRUE(lv_qrcode_is_render_valid(qr));
 }
 
 void test_qrcode_failed_render_is_not_retried_every_frame(void)
@@ -321,7 +321,7 @@ void test_qrcode_failed_render_is_not_retried_every_frame(void)
 
     lv_log_register_print_cb(NULL);
 
-    TEST_ASSERT_TRUE(lv_qrcode_get_render_failed(qr));
+    TEST_ASSERT_FALSE(lv_qrcode_is_render_valid(qr));
     TEST_ASSERT_TRUE(((lv_qrcode_t *)qr)->needs_update);
 #if LV_USE_LOG
     TEST_ASSERT_EQUAL(1, encode_error_cnt);
@@ -331,7 +331,7 @@ void test_qrcode_failed_render_is_not_retried_every_frame(void)
     /*A property change is what allows another attempt - proven by one that can succeed*/
     lv_qrcode_set_size(qr, 150);
     lv_refr_now(NULL);
-    TEST_ASSERT_FALSE(lv_qrcode_get_render_failed(qr));
+    TEST_ASSERT_TRUE(lv_qrcode_is_render_valid(qr));
     TEST_ASSERT_FALSE(((lv_qrcode_t *)qr)->needs_update);
 }
 
@@ -358,14 +358,14 @@ void test_qrcode_failures_are_silent_when_the_caller_sees_the_result(void)
 #if LV_USE_LOG
     TEST_ASSERT_EQUAL(0, encode_error_cnt);
 #endif
-    TEST_ASSERT_TRUE(lv_qrcode_get_render_failed(qr));
+    TEST_ASSERT_FALSE(lv_qrcode_is_render_valid(qr));
 
     /*A failed encode must not claim the bitmap is up to date*/
     TEST_ASSERT_TRUE(((lv_qrcode_t *)qr)->needs_update);
 
     /*A size that fits clears both*/
     lv_qrcode_set_size(qr, 150);
-    TEST_ASSERT_FALSE(lv_qrcode_get_render_failed(qr));
+    TEST_ASSERT_TRUE(lv_qrcode_is_render_valid(qr));
     TEST_ASSERT_FALSE(((lv_qrcode_t *)qr)->needs_update);
 }
 
@@ -383,11 +383,11 @@ void test_qrcode_update_reports_unencodable_payload(void)
     too_long[sizeof(too_long) - 1] = '\0';
     TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_qrcode_update(qr, too_long, sizeof(too_long) - 1));
 
-    TEST_ASSERT_TRUE(lv_qrcode_get_render_failed(qr));
+    TEST_ASSERT_FALSE(lv_qrcode_is_render_valid(qr));
 
     /*A payload that does fit is reported as success*/
     TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_qrcode_update(qr, "https://lvgl.io", 15));
-    TEST_ASSERT_FALSE(lv_qrcode_get_render_failed(qr));
+    TEST_ASSERT_TRUE(lv_qrcode_is_render_valid(qr));
 }
 
 void test_qrcode_canvas_too_small_is_reported(void)
@@ -418,13 +418,13 @@ void test_qrcode_set_data_ignores_null(void)
     TEST_ASSERT_NOT_NULL(qr);
     lv_qrcode_set_size(qr, 150);
     lv_qrcode_set_data(qr, "https://lvgl.io");
-    TEST_ASSERT_FALSE(lv_qrcode_get_render_failed(qr));
+    TEST_ASSERT_TRUE(lv_qrcode_is_render_valid(qr));
 
     /*A NULL string is a no-op, not a crash, and leaves the stored payload alone.
      *The guard is unconditional because lv_strlen() would dereference it even when
      *argument checks are compiled out.*/
     lv_qrcode_set_data(qr, NULL);
-    TEST_ASSERT_FALSE(lv_qrcode_get_render_failed(qr));
+    TEST_ASSERT_TRUE(lv_qrcode_is_render_valid(qr));
     TEST_ASSERT_EQUAL(15, ((lv_qrcode_t *)qr)->data_len);
 }
 


### PR DESCRIPTION
`lv_qrcode_get_render_failed()` and the `render_failed` flag behind it stated the negative:
the field had to be set to `true` in the constructor to mean "nothing generated yet", and
every early return had to remember to record a failure.

Storing the positive fact instead removes that. `render_valid` starts `false` — which is
what a zero-initialised field already is — and only the single success path sets it.

### Changes

- `lv_qrcode_get_render_failed()` -> `lv_qrcode_is_render_valid()`, with the return value
  inverted. Its `LV_CHECK_OBJ` fallback returns `false`, so an invalid object still gets the
  pessimistic answer.
- `render_failed` -> `render_valid` in `lv_qrcode_t`.
- Docs, the migration note, the GDB widget wrapper and its spec follow the rename.

No behaviour change: every site is a faithful inversion. The draw hook still refuses to
retry a known-bad state every frame, and a property change still re-arms it so the deferred
re-encode gets another go.

### Tests

`test_qrcode.c`'s 12 assertions on the flag are inverted with it. 182/182 on
`OPTIONS_TEST_DEFHEAP`, `test_qrcode` included; format clean; GDB wrapper regenerated.

#10615 does the same for `lv_barcode`, so the two widgets keep the
matching API they were given in #10361.
