### PR TITLE
fix(opengl): swap red-and-blue channel when rendering a texture

### DIFF
--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -247,7 +247,21 @@ void lv_opengles_render_texture(unsigned int texture, const lv_area_t * texture_
 {
     LV_CHECK_ARG(texture_area != NULL, return);
     LV_CHECK_ARG(texture_clip_area != NULL, return);
-    lv_opengles_render_texture_internal(texture, texture_area, opa, disp_w, disp_h, texture_clip_area, h_flip, v_flip);
+
+    LV_PROFILER_DRAW_BEGIN;
+    lv_opengles_render_params_t params;
+    lv_opengles_render_params_init(&params);
+    params.texture = texture;
+    params.texture_area = texture_area;
+    params.opa = opa;
+    params.disp_w = disp_w;
+    params.disp_h = disp_h;
+    params.texture_clip_area = texture_clip_area;
+    params.h_flip = h_flip;
+    params.v_flip = v_flip;
+    params.rb_swap = true;
+    lv_opengles_render(&params);
+    LV_PROFILER_DRAW_END;
 }
 
 void lv_opengles_render_texture_internal(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
@@ -268,28 +282,6 @@ void lv_opengles_render_texture_internal(unsigned int texture, const lv_area_t *
     params.texture_clip_area = texture_clip_area;
     params.h_flip = h_flip;
     params.v_flip = v_flip;
-    lv_opengles_render(&params);
-    LV_PROFILER_DRAW_END;
-}
-
-void lv_opengles_render_texture_rbswap(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
-                                       int32_t disp_w,
-                                       int32_t disp_h, const lv_area_t * texture_clip_area, bool h_flip, bool v_flip)
-{
-    LV_ASSERT(texture_area != NULL);
-    LV_ASSERT(texture_clip_area != NULL);
-    LV_PROFILER_DRAW_BEGIN;
-    lv_opengles_render_params_t params;
-    lv_opengles_render_params_init(&params);
-    params.texture = texture;
-    params.texture_area = texture_area;
-    params.opa = opa;
-    params.disp_w = disp_w;
-    params.disp_h = disp_h;
-    params.texture_clip_area = texture_clip_area;
-    params.h_flip = h_flip;
-    params.v_flip = v_flip;
-    params.rb_swap = true;
     lv_opengles_render(&params);
     LV_PROFILER_DRAW_END;
 }

--- a/src/drivers/opengles/lv_opengles_glfw.c
+++ b/src/drivers/opengles/lv_opengles_glfw.c
@@ -567,8 +567,8 @@ static void window_update_handler(lv_timer_t * t)
 
 #if LV_USE_DRAW_OPENGLES
                 /*The draw unit rendered into the texture, in the OpenGL channel order*/
-                lv_opengles_render_texture_rbswap(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
-                                                  &texture->area, window->h_flip, texture->disp == NULL ? window->v_flip : !window->v_flip);
+                lv_opengles_render_texture(texture->texture_id, &texture->area, texture->opa, window->hor_res, window->ver_res,
+                                           &texture->area, window->h_flip, texture->disp == NULL ? window->v_flip : !window->v_flip);
 #else
                 if(texture->disp != NULL) {
                     /*The texture display uploaded its buffer, so its color format tells the channel order*/
@@ -578,8 +578,8 @@ static void window_update_handler(lv_timer_t * t)
                 }
                 else {
                     /*A texture of the application, assume the OpenGL channel order*/
-                    lv_opengles_render_texture_rbswap(texture->texture_id, &texture->area, texture->opa, window->hor_res,
-                                                      window->ver_res, &texture->area, window->h_flip, window->v_flip);
+                    lv_opengles_render_texture(texture->texture_id, &texture->area, texture->opa, window->hor_res,
+                                               window->ver_res, &texture->area, window->h_flip, window->v_flip);
                 }
 #endif
             }

--- a/src/drivers/opengles/lv_opengles_private.h
+++ b/src/drivers/opengles/lv_opengles_private.h
@@ -164,21 +164,6 @@ void lv_opengles_render_params_init(lv_opengles_render_params_t * params);
 void lv_opengles_render(const lv_opengles_render_params_t * params);
 
 /**
- * Render a texture using alternate blending mode, with red and blue channels flipped in the shader.
- * @param texture               OpenGL texture ID
- * @param texture_area          the area in the window to render the texture in
- * @param opa                   opacity to blend the texture with existing contents
- * @param disp_w                width of the window/framebuffer being rendered to
- * @param disp_h                height of the window/framebuffer being rendered to
- * @param texture_clip_area     the area of the texture to draw
- * @param h_flip                horizontal flip
- * @param v_flip                vertical flip
- */
-void lv_opengles_render_texture_rbswap(unsigned int texture, const lv_area_t * texture_area, lv_opa_t opa,
-                                       int32_t disp_w, int32_t disp_h, const lv_area_t * texture_clip_area,
-                                       bool h_flip, bool v_flip);
-
-/**
  * Render a texture holding pixels of an LVGL color format, using alternate blending mode.
  * The channel order and the grayscale handling are derived from `cf`.
  * @param texture               OpenGL texture ID


### PR DESCRIPTION
LVGL renders OpenGL textures with red and blue channels swapped to avoid BGRA which is not part of GLES2

When using LVGL to render to an external structure the user is expected to call `lv_opengles_render_texture` which needs to swap red and blue channels by default

There's actually no use-case to not swap these so the `rb_swap` version can collapse in to the normal `lv_opengles_render_texture`

Closes #9976
Fixes #9965
