### PR TITLE
refactor(barcode): report render success instead of failure

### DIFF
--- a/docs/src/libs/barcode.mdx
+++ b/docs/src/libs/barcode.mdx
@@ -64,17 +64,19 @@ that setter returns `void`, so a failure is only logged. Render first to get the
 <ApiLink name="lv_barcode_render" /> returns its result, and so does
 <ApiLink name="lv_barcode_update" /> in immediate mode. The rest cannot: the property
 setters return `void`, resizes happen in an event handler, and a deferred fill happens in
-the draw pass. <ApiLink name="lv_barcode_get_render_failed" /> covers those:
+the draw pass. <ApiLink name="lv_barcode_is_render_valid" /> covers those:
 
 ```c
 lv_obj_set_height(barcode, 0);   /* leaves no room for a horizontal barcode */
-if(lv_barcode_get_render_failed(barcode)) {
+if(!lv_barcode_is_render_valid(barcode)) {
     /* the bitmap is blank; give the object a height */
 }
 ```
 
-It is also `true` before any data is set, and `false` again after a success. A failure is
-not retried every redraw - only a change makes the Widget try again.
+It is also `false` before any data is set. A failure is not retried every redraw - only a
+change makes the Widget try again, and that change sets the flag back to `true` before the
+new attempt runs. So `true` means "no known failure", not "the bitmap is up to date"; in
+deferred mode a pending regeneration is also `true`.
 
 ## Notes
 

--- a/include/lvgl/widgets/lv_barcode.h
+++ b/include/lvgl/widgets/lv_barcode.h
@@ -156,16 +156,17 @@ void lv_barcode_set_update_mode(lv_obj_t * obj, lv_barcode_update_mode_t mode);
 lv_barcode_update_mode_t lv_barcode_get_update_mode(lv_obj_t * obj);
 
 /**
- * Get whether the last attempt to generate the bitmap failed. `lv_barcode_render()`, and
+ * Check whether the bitmap is free of a known generation failure. `lv_barcode_render()`, and
  * `lv_barcode_update()` in IMMEDIATE mode, return their result directly; the rest cannot -
  * they run in a void setter, the resize handler, or a deferred fill in the draw pass. Use
  * this for those, e.g. after shrinking the object below the size its data needs.
  * @note A failure is not retried every redraw; only a change makes the Widget try again.
  * @param obj pointer to barcode object
- * @return true: the last generation attempt failed, or no data has been set yet;
- *         false: no generation attempt has failed; deferred changes may still be pending
+ * @return true: no generation attempt is known to have failed. A change re-arms the Widget,
+ *               so this is also true while a deferred regeneration is still pending;
+ *         false: the last generation attempt failed, or no data has been set yet
  */
-bool lv_barcode_get_render_failed(lv_obj_t * obj);
+bool lv_barcode_is_render_valid(lv_obj_t * obj);
 
 /**
  * Get the dark color of a barcode object

--- a/scripts/gdb/lvglgdb/lvgl/widgets/lv_barcode.py
+++ b/scripts/gdb/lvglgdb/lvgl/widgets/lv_barcode.py
@@ -68,9 +68,9 @@ class LVBarcode(LVCanvas):
         return int(self._wv_lv_barcode_t.safe_field("needs_update", 0))
 
     @property
-    def render_failed(self):
-        """The last generation attempt failed (or none has run yet)"""
-        return int(self._wv_lv_barcode_t.safe_field("render_failed", 0))
+    def render_valid(self):
+        """No generation attempt is known to have failed; a change re-arms it"""
+        return int(self._wv_lv_barcode_t.safe_field("render_valid", 0))
 
     @property
     def fitting(self):
@@ -92,7 +92,7 @@ class LVBarcode(LVCanvas):
         d["tiled"] = self.tiled
         d["update_mode"] = self.update_mode
         d["needs_update"] = self.needs_update
-        d["render_failed"] = self.render_failed
+        d["render_valid"] = self.render_valid
         d["fitting"] = self.fitting
         s['widget_data'] = d
         return s

--- a/scripts/gdb/scripts/generators/widget_specs.json
+++ b/scripts/gdb/scripts/generators/widget_specs.json
@@ -145,7 +145,7 @@
         "tiled": "bool",
         "update_mode": "bool",
         "needs_update": "bool",
-        "render_failed": "bool",
+        "render_valid": "bool",
         "fitting": "bool"
       }
     }

--- a/src/widgets/barcode/lv_barcode.c
+++ b/src/widgets/barcode/lv_barcode.c
@@ -163,7 +163,7 @@ lv_result_t lv_barcode_update(lv_obj_t * obj, const char * data)
         LV_LOG_WARN("data is empty");
         barcode_forget_data(barcode);
         barcode->needs_update = false;
-        barcode->render_failed = true;
+        barcode->render_valid = false;
         lv_barcode_clear(obj);
         return LV_RESULT_INVALID;
     }
@@ -213,12 +213,12 @@ lv_barcode_update_mode_t lv_barcode_get_update_mode(lv_obj_t * obj)
     return (lv_barcode_update_mode_t)barcode->update_mode;
 }
 
-bool lv_barcode_get_render_failed(lv_obj_t * obj)
+bool lv_barcode_is_render_valid(lv_obj_t * obj)
 {
-    LV_CHECK_OBJ(obj, MY_CLASS, return true);
+    LV_CHECK_OBJ(obj, MY_CLASS, return false);
 
     lv_barcode_t * barcode = (lv_barcode_t *)obj;
-    return barcode->render_failed;
+    return barcode->render_valid;
 }
 
 lv_color_t lv_barcode_get_dark_color(lv_obj_t * obj)
@@ -278,7 +278,7 @@ static void lv_barcode_constructor(const lv_obj_class_t * class_p, lv_obj_t * ob
     barcode->tiled = false;
     barcode->update_mode = LV_BARCODE_UPDATE_MODE_IMMEDIATE;
     barcode->needs_update = false;
-    barcode->render_failed = true;   /*Nothing generated yet*/
+    barcode->render_valid = false;   /*Nothing generated yet*/
     barcode->fitting = false;
     lv_image_set_inner_align(obj, LV_IMAGE_ALIGN_DEFAULT);
 }
@@ -322,8 +322,8 @@ static void lv_barcode_event(const lv_obj_class_t * class_p, lv_event_t * e)
         }
     }
     else if(code == LV_EVENT_DRAW_MAIN_BEGIN) {
-        /*A failed state is not retried here; only a change clears `render_failed`*/
-        if(barcode->needs_update && !barcode->render_failed) {
+        /*A failed state is not retried here; only a change makes the Widget try again*/
+        if(barcode->needs_update && barcode->render_valid) {
             LV_ASSERT(barcode->update_mode == LV_BARCODE_UPDATE_MODE_DEFERRED);
 
             /*Safe: the setter already resized the canvas, so nothing is reallocated here*/
@@ -332,7 +332,7 @@ static void lv_barcode_event(const lv_obj_class_t * class_p, lv_event_t * e)
                         "refresh and its result cannot be reported");
 
             if(barcode_fill(obj) != LV_RESULT_OK) {
-                barcode->render_failed = true;
+                barcode->render_valid = false;
                 LV_LOG_ERROR("the barcode could not be filled in during the redraw "
                              "(scale %d, %s); the bitmap is left blank",
                              (int)barcode->scale, barcode->direction == LV_DIR_VER ? "vertical" : "horizontal");
@@ -519,13 +519,13 @@ static bool barcode_fit_only(lv_obj_t * obj)
 {
     lv_barcode_t * barcode = (lv_barcode_t *)obj;
 
-    barcode->render_failed = true;
+    barcode->render_valid = false;
     barcode->needs_update = true;
 
     if(barcode->data == NULL) return false;
     if(!barcode_fit(obj)) return false;
 
-    barcode->render_failed = false;
+    barcode->render_valid = true;
     return true;
 }
 
@@ -610,7 +610,7 @@ static lv_result_t barcode_fill(lv_obj_t * obj)
     lv_free(pattern);
 
     barcode->needs_update = false;
-    barcode->render_failed = false;
+    barcode->render_valid = true;
     return LV_RESULT_OK;
 }
 
@@ -618,12 +618,12 @@ static lv_result_t barcode_render(lv_obj_t * obj)
 {
     lv_barcode_t * barcode = (lv_barcode_t *)obj;
 
-    /*Assume failure so no early return can forget to record it; only barcode_fill()'s
-     *success path clears these. `needs_update` survives a failure on purpose - the bitmap
-     *still does not match the properties - and `render_failed` keeps the draw hook from
-     *retrying a known-bad state every frame. Nothing is logged here: the result is
-     *returned, and the caller reports it if nothing else will.*/
-    barcode->render_failed = true;
+    /*Start invalid so no early return can forget to record a failure; only barcode_fill()'s
+     *success path sets `render_valid`. `needs_update` survives a failure on purpose - the
+     *bitmap still does not match the properties - and a cleared `render_valid` keeps the
+     *draw hook from retrying a known-bad state every frame. Nothing is logged here: the
+     *result is returned, and the caller reports it if nothing else will.*/
+    barcode->render_valid = false;
     barcode->needs_update = true;
 
     if(barcode->data == NULL) return LV_RESULT_INVALID;
@@ -638,7 +638,8 @@ static lv_result_t barcode_mark_dirty(lv_obj_t * obj)
 
     if(barcode->data == NULL) return LV_RESULT_INVALID;
 
-    barcode->render_failed = false;
+    /*The change may well make the data encodable again, so allow a new attempt*/
+    barcode->render_valid = true;
 
     /*The canvas is resized in both modes, because the draw pass cannot do it*/
     const bool ok = (barcode->update_mode == LV_BARCODE_UPDATE_MODE_IMMEDIATE)

--- a/src/widgets/barcode/lv_barcode_private.h
+++ b/src/widgets/barcode/lv_barcode_private.h
@@ -45,7 +45,7 @@ struct _lv_barcode_t {
     uint8_t tiled : 1;              /*Draw a one bar wide bitmap and let the image tiling repeat it*/
     uint8_t update_mode : 1;        /*lv_barcode_update_mode_t: when a property change is regenerated*/
     uint8_t needs_update : 1;       /*The bitmap is out of date; filled in on the next redraw (deferred mode)*/
-    uint8_t render_failed : 1;      /*The last generation attempt failed (or none has run yet)*/
+    uint8_t render_valid : 1;       /*No generation attempt is known to have failed; a change re-arms it*/
     uint8_t fitting : 1;            /*Guard against the re-entrant resize our own reallocation triggers*/
 };
 

--- a/tests/src/test_cases/libs/test_barcode.c
+++ b/tests/src/test_cases/libs/test_barcode.c
@@ -130,14 +130,14 @@ void test_barcode_data_before_size_recovers(void)
     /*A barcode sizes itself to its content, so with no height there is no canvas to
      *allocate. This could not succeed before the change either.*/
     TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_barcode_update(barcode, "https://lvgl.io"));
-    TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_FALSE(lv_barcode_is_render_valid(barcode));
 
     /*New: the data is remembered, so it appears once there is a height to fit it to*/
     lv_barcode_set_dark_color(barcode, lv_color_black());
     lv_barcode_set_light_color(barcode, lv_color_white());
     lv_obj_set_height(barcode, 50);
     lv_obj_update_layout(barcode);
-    TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_TRUE(lv_barcode_is_render_valid(barcode));
     TEST_ASSERT_EQUAL_SCREENSHOT("libs/barcode_1.png");
 }
 
@@ -159,7 +159,7 @@ void test_barcode_encoding_after_data(void)
     TEST_ASSERT_EQUAL(LV_BARCODE_ENCODING_CODE128_RAW, lv_barcode_get_encoding(barcode));
     lv_obj_update_layout(barcode);
     TEST_ASSERT_NOT_EQUAL(gs1_w, lv_obj_get_width(barcode));
-    TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_TRUE(lv_barcode_is_render_valid(barcode));
 
     /*Switching back returns to the original geometry*/
     lv_barcode_set_encoding(barcode, LV_BARCODE_ENCODING_CODE128_GS1);
@@ -186,7 +186,7 @@ void test_barcode_resize_regenerates(void)
     draw_buf = lv_canvas_get_draw_buf(barcode);
     TEST_ASSERT_NOT_NULL(draw_buf);
     TEST_ASSERT_EQUAL(80, draw_buf->header.h);
-    TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_TRUE(lv_barcode_is_render_valid(barcode));
 }
 
 void test_barcode_scale_resizes_the_canvas(void)
@@ -203,7 +203,7 @@ void test_barcode_scale_resizes_the_canvas(void)
     lv_barcode_set_scale(barcode, 2);
     TEST_ASSERT_EQUAL(2, lv_barcode_get_scale(barcode));
     TEST_ASSERT_EQUAL(w1 * 2, (int32_t)lv_canvas_get_draw_buf(barcode)->header.w);
-    TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_TRUE(lv_barcode_is_render_valid(barcode));
 }
 
 void test_barcode_update_mode_default_is_immediate(void)
@@ -261,7 +261,7 @@ void test_barcode_deferred_data_is_not_filled_until_render(void)
      *bars are still pending*/
     TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
     TEST_ASSERT_TRUE(((lv_barcode_t *)barcode)->needs_update);
-    TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_TRUE(lv_barcode_is_render_valid(barcode));
 
     TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_render(barcode));
     TEST_ASSERT_FALSE(((lv_barcode_t *)barcode)->needs_update);
@@ -341,22 +341,22 @@ void test_barcode_failed_render_is_detectable(void)
     lv_obj_center(barcode);
 
     /*Nothing generated yet*/
-    TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_FALSE(lv_barcode_is_render_valid(barcode));
 
     lv_obj_set_height(barcode, 50);
     TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
-    TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_TRUE(lv_barcode_is_render_valid(barcode));
 
     /*Zero height leaves no canvas to allocate, and the resize handler returns void, so
      *this flag is the only way to notice*/
     lv_obj_set_height(barcode, 0);
     lv_obj_update_layout(barcode);
-    TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_FALSE(lv_barcode_is_render_valid(barcode));
 
     /*Growing it back succeeds*/
     lv_obj_set_height(barcode, 50);
     lv_obj_update_layout(barcode);
-    TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_TRUE(lv_barcode_is_render_valid(barcode));
 }
 
 void test_barcode_failed_render_is_not_retried_every_frame(void)
@@ -373,7 +373,7 @@ void test_barcode_failed_render_is_not_retried_every_frame(void)
     /*A known-bad state must not be retried on every redraw, so the draw hook stays quiet*/
     lv_obj_set_height(barcode, 0);
     lv_obj_update_layout(barcode);
-    TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_FALSE(lv_barcode_is_render_valid(barcode));
     TEST_ASSERT_TRUE(((lv_barcode_t *)barcode)->needs_update);
 
     lv_log_register_print_cb(count_barcode_logs_cb);
@@ -383,7 +383,7 @@ void test_barcode_failed_render_is_not_retried_every_frame(void)
     }
     lv_log_register_print_cb(NULL);
 
-    TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_FALSE(lv_barcode_is_render_valid(barcode));
 #if LV_USE_LOG
     TEST_ASSERT_EQUAL(0, redraw_warning_cnt);
 #endif
@@ -392,7 +392,7 @@ void test_barcode_failed_render_is_not_retried_every_frame(void)
     lv_obj_set_height(barcode, 50);
     lv_obj_update_layout(barcode);
     lv_refr_now(NULL);
-    TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_TRUE(lv_barcode_is_render_valid(barcode));
     TEST_ASSERT_FALSE(((lv_barcode_t *)barcode)->needs_update);
 }
 
@@ -444,21 +444,21 @@ void test_barcode_update_rejects_invalid_data(void)
 #if LV_USE_CHECK_ARG
     /*Without the argument check the data is dereferenced, so only assert this when it is on*/
     TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_barcode_update(barcode, NULL));
-    TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_FALSE(lv_barcode_is_render_valid(barcode));
 #endif
 
     /*Nothing to encode*/
     TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_barcode_update(barcode, ""));
-    TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_FALSE(lv_barcode_is_render_valid(barcode));
 
     TEST_ASSERT_EQUAL(LV_RESULT_OK, lv_barcode_update(barcode, "https://lvgl.io"));
-    TEST_ASSERT_FALSE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_TRUE(lv_barcode_is_render_valid(barcode));
 
     /*Emptying forgets the data, so a property change cannot bring the old barcode back*/
     TEST_ASSERT_EQUAL(LV_RESULT_INVALID, lv_barcode_update(barcode, ""));
-    TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_FALSE(lv_barcode_is_render_valid(barcode));
     lv_barcode_set_scale(barcode, 2);
-    TEST_ASSERT_TRUE(lv_barcode_get_render_failed(barcode));
+    TEST_ASSERT_FALSE(lv_barcode_is_render_valid(barcode));
 }
 
 #else


### PR DESCRIPTION
Follow-up to #10360, which is now merged.

`lv_barcode_get_render_failed()` and the `render_failed` flag behind it stated the
negative: the field had to be set to `true` in the constructor to mean "nothing generated
yet", and every early return had to remember to record a failure.

Storing the positive fact instead removes that. `render_valid` starts `false` — which is
what a zero-initialised field already is — and only the single success path sets it.

### Changes

- `lv_barcode_get_render_failed()` -> `lv_barcode_is_render_valid()`, with the return
  value inverted. Its `LV_CHECK_OBJ` fallback returns `false`, so an invalid object still
  gets the pessimistic answer.
- `render_failed` -> `render_valid` in `lv_barcode_t`.
- Docs, the GDB widget wrapper and its spec follow the rename.

No behaviour change: every site is a faithful inversion. The draw hook still refuses to
retry a known-bad state every frame, and a change still re-arms it so the deferred fill
gets another go.

### Tests

`test_barcode.c`'s 18 assertions on the flag are inverted with it. 182/182 on
`OPTIONS_TEST_DEFHEAP`, `test_barcode` included; format clean; GDB wrapper regenerated.

#10613 does the same for `lv_qrcode`, so the two widgets keep the matching API they were
given in #10361.
