### PR TITLE
fix(draw/ppa): describe images by their stride, not by their width

### DIFF
--- a/src/draw/espressif/ppa/lv_draw_ppa.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa.c
@@ -158,6 +158,7 @@ static int32_t ppa_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
     t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
     u->task_act = t;
     u->task_act->draw_unit = draw_unit;
+    u->img_sw_fallback = false;
 
     ppa_execute_drawing(u);
 

--- a/src/draw/espressif/ppa/lv_draw_ppa.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa.c
@@ -194,7 +194,12 @@ static void ppa_execute_drawing(lv_draw_ppa_unit_t * u)
             lv_draw_buf_invalidate_cache(buf, &area);
             break;
         case LV_DRAW_TASK_TYPE_IMAGE:
-            lv_draw_ppa_img(t, (lv_draw_image_dsc_t *)t->draw_dsc, &area);
+            /* The image rectangle, not the clipped region:
+             * lv_draw_image_normal_helper() treats this as the image's own area
+             * and measures the clip against it, so handing it a pre-clipped rect
+             * makes the source offsets be taken from the wrong origin and the
+             * wrong part of the image is drawn. */
+            lv_draw_ppa_img(t, (lv_draw_image_dsc_t *)t->draw_dsc, &t->area);
             lv_draw_buf_invalidate_cache(buf, &area);
             break;
         default:

--- a/src/draw/espressif/ppa/lv_draw_ppa_img.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa_img.c
@@ -65,6 +65,13 @@ static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t *
     const int32_t src_pic_w  = lv_ppa_pic_w(decoded->header.stride, draw_dsc->header.w, src_cf);
     const int32_t dest_pic_w = lv_ppa_pic_w(draw_buf->header.stride, draw_buf->header.w, dest_cf);
     if(src_pic_w == 0 || dest_pic_w == 0) {
+        /* lv_draw_sw_image() redraws the whole task, and it runs its own decode
+         * loop, so it must fire exactly once. A partial decoder calls this core
+         * back per decoded chunk (see img_decode_and_draw()), which would
+         * otherwise repeat the full software draw for every chunk. */
+        if(u->img_sw_fallback) return;
+        u->img_sw_fallback = true;
+
         LV_LOG_INFO("PPA draw_img: stride is not a whole number of pixels, drawing in software");
 #if LV_USE_DRAW_SW
         lv_draw_sw_image(t, draw_dsc, &t->area);

--- a/src/draw/espressif/ppa/lv_draw_ppa_img.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa_img.c
@@ -10,6 +10,9 @@
 
 #include "../../lv_draw_image_private.h"
 #include "../../../image/lv_image_decoder_private.h"
+#if LV_USE_DRAW_SW
+    #include "../../sw/lv_draw_sw.h"
+#endif
 
 static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                                  const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
@@ -54,12 +57,27 @@ static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t *
     lv_color_format_t dest_cf = draw_buf->header.cf;
     uint8_t * dest_buf = draw_buf->data;
 
-    extern const lv_image_dsc_t img_benchmark_lvgl_logo_rgb;
+    /* Row pitch, not visible width: see lv_ppa_pic_w(). The task is already
+     * assigned to this unit here, so a picture the PPA cannot describe goes to
+     * the software unit rather than being dropped, which would finish the task
+     * having drawn nothing and leave a hole on the screen. lv_draw_pxp.c falls
+     * back the same way for fills. */
+    const int32_t src_pic_w  = lv_ppa_pic_w(decoded->header.stride, draw_dsc->header.w, src_cf);
+    const int32_t dest_pic_w = lv_ppa_pic_w(draw_buf->header.stride, draw_buf->header.w, dest_cf);
+    if(src_pic_w == 0 || dest_pic_w == 0) {
+        LV_LOG_INFO("PPA draw_img: stride is not a whole number of pixels, drawing in software");
+#if LV_USE_DRAW_SW
+        lv_draw_sw_image(t, draw_dsc, &t->area);
+#else
+        LV_LOG_WARN("PPA draw_img: no software draw unit to fall back on, image skipped");
+#endif
+        return;
+    }
 
     ppa_blend_oper_config_t cfg = {
         .in_bg = {
             .buffer          = (void *)src_buf,
-            .pic_w           = draw_dsc->header.w,
+            .pic_w           = src_pic_w,
             .pic_h           = draw_dsc->header.h,
             .block_w         = lv_area_get_width(clipped_img_area),
             .block_h         = lv_area_get_height(clipped_img_area),
@@ -72,14 +90,18 @@ static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t *
         .bg_alpha_update_mode  = PPA_ALPHA_FIX_VALUE,
         .bg_alpha_fix_val      = 0xFF,
         .bg_ck_en              = false,
+        /* The transparent dummy foreground. Its buffer is the destination, so it
+         * has to be described by the destination's geometry - it was carrying the
+         * source's, which makes the PPA fetch a region that need not exist in
+         * that buffer. It contributes no colour either way. */
         .in_fg = {
             .buffer          = (void *)dest_buf,
-            .pic_w           = draw_dsc->header.w,
-            .pic_h           = draw_dsc->header.h,
+            .pic_w           = dest_pic_w,
+            .pic_h           = draw_buf->header.h,
             .block_w         = lv_area_get_width(clipped_img_area),
             .block_h         = lv_area_get_height(clipped_img_area),
-            .block_offset_x  = src_area.x1,
-            .block_offset_y  = src_area.y1,
+            .block_offset_x  = dest_area.x1,
+            .block_offset_y  = dest_area.y1,
             .blend_cm        = PPA_BLEND_COLOR_MODE_A8,
         },
         .fg_fix_rgb_val = {
@@ -95,7 +117,7 @@ static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t *
         .out = {
             .buffer          = dest_buf,
             .buffer_size     = draw_buf->data_size,
-            .pic_w           = draw_buf->header.w,
+            .pic_w           = dest_pic_w,
             .pic_h           = draw_buf->header.h,
             .block_offset_x  = dest_area.x1,
             .block_offset_y  = dest_area.y1,

--- a/src/draw/espressif/ppa/lv_draw_ppa_private.h
+++ b/src/draw/espressif/ppa/lv_draw_ppa_private.h
@@ -68,6 +68,12 @@ typedef struct lv_draw_ppa_unit {
     ppa_client_handle_t fill_client;
     ppa_client_handle_t blend_client;
     uint8_t * buf;
+    /* Set once the image path has handed the current task to the software unit.
+     * A partial decoder makes lv_draw_image_normal_helper() call the draw core
+     * back once per decoded chunk, and the fallback draws the whole image, so
+     * without this it would redraw it for every chunk. Cleared per task in
+     * ppa_dispatch(). */
+    bool img_sw_fallback;
 } lv_draw_ppa_unit_t;
 
 /**********************

--- a/src/draw/espressif/ppa/lv_draw_ppa_private.h
+++ b/src/draw/espressif/ppa/lv_draw_ppa_private.h
@@ -148,6 +148,31 @@ static inline ppa_blend_color_mode_t lv_color_format_to_ppa_blend(lv_color_forma
     }
 }
 
+/**
+ * Row pitch of a picture, in pixels - what the PPA calls pic_w.
+ *
+ * The PPA has no stride field: it derives the pitch from pic_w times the pixel
+ * size, so a buffer whose stride is padded beyond its width must be described by
+ * that stride and not by its width. LVGL's image converter does pad it - the
+ * 100 px wide benchmark logo is stored with a 448 byte stride, 112 px - and
+ * describing it as 100 px makes every row start 12 px early.
+ *
+ * Returns 0 when the stride is not a whole number of pixels - RGB888 padded to
+ * 320 bytes is 106.67 px - which the PPA cannot describe at all. Callers must
+ * treat that as "not for this draw unit".
+ */
+static inline int32_t lv_ppa_pic_w(uint32_t stride, int32_t w, lv_color_format_t cf)
+{
+    /* LV_STRIDE_AUTO. lv_image_decoder_open() resolves it to width * pixel size
+     * (img_width_to_stride(), no alignment applied), so the pitch is the width. */
+    if(stride == LV_STRIDE_AUTO) return w;
+
+    uint8_t px_size = lv_color_format_get_size(cf);
+    if(px_size == 0 || (stride % px_size) != 0) return 0;
+
+    return (int32_t)(stride / px_size);
+}
+
 static inline ppa_srm_color_mode_t lv_color_format_to_ppa_srm(lv_color_format_t lv_fmt)
 {
     switch(lv_fmt) {


### PR DESCRIPTION
Reported by @halyssonJr: with LV_USE_PPA_IMG enabled, the "Multiple RGB images" benchmark scene renders sheared.

The PPA has no stride field. It derives the row pitch of a picture from pic_w times the pixel size, so pic_w is the pitch, not the visible width. The image path passed header.w, which is only the same thing when the buffer has no padding.

LVGL's image converter does pad. img_benchmark_lvgl_logo_rgb is 100 px wide and stored with a 256, 320 or 448 byte stride depending on LV_COLOR_DEPTH -- 128, 106.67 or 112 px. Describing it as 100 px makes the PPA start every row inside the previous one, which shears the image progressively down the block.

Derive the pitch from the stride instead, for the source and the destination alike, as lv_draw_dave2d_utils.c already does for that peripheral. A stride that is not a whole number of pixels, such as RGB888 padded to 320 bytes, cannot be expressed at all; those draws go to the software unit rather than being dropped, since the task has been assigned to this unit by then and returning would leave a hole on the screen. lv_draw_pxp.c falls back the same way for fills.

The check reads the real strides at draw time rather than predicting them in ppa_evaluate(), which runs before the image is decoded. Mispredicting there would cost either a missing image or an unnecessary software draw; not predicting at all costs neither.

The transparent dummy foreground is corrected while here: its buffer is the destination, but it was described with the source's width, height and block offsets, which makes the PPA fetch a region that need not exist in that buffer. It contributes no colour, so nothing was visible, but the two halves of the description have to agree for the stride change to mean anything.

Destination layers are unaffected in a default build: LV_DRAW_BUF_STRIDE_ALIGN is 1, so their stride already equals the width. Only sources carry padding, which is why images generated at their exact width render correctly while the benchmark asset does not.

Fixes #xxxx <!-- E.g. Fixes #1234 to reference the fixed issue. Can be removed if there is no related issue -->

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

