### PR TITLE
feat(wayland): identify physical outputs by their connector name

### DIFF
--- a/docs/src/integration/embedded_linux/drivers/wayland.mdx
+++ b/docs/src/integration/embedded_linux/drivers/wayland.mdx
@@ -163,13 +163,45 @@ want it:
 
 ```c
 /* Assign to physical display 0 and go fullscreen there */
-lv_wayland_assign_physical_display(disp, 0);
+lv_wayland_set_physical_display(disp, 0);
 lv_wayland_window_set_fullscreen(disp, true);
 ```
 
-<ApiLink name="lv_wayland_unassign_physical_display" /> restores the default behaviour.
+<ApiLink name="LV_WAYLAND_PHYSICAL_DISPLAY_ANY" /> can be used to restore the default behaviour.
 
-If you integrate LVGL into your own event loop, <ApiLink name="lv_wayland_get_fd" /> gives you the
+```c
+lv_wayland_set_physical_display(disp, LV_WAYLAND_PHYSICAL_DISPLAY_ANY);
+```
+
+### Physical outputs
+
+To target a specific physical output, look it up by its connector name:
+
+| Function | Purpose |
+|---|---|
+| <ApiLink name="lv_wayland_get_output_count" /> | Number of outputs the compositor advertises |
+| <ApiLink name="lv_wayland_get_output_name" /> | Connector name of an output, e.g. `"HDMI-A-1"` |
+| <ApiLink name="lv_wayland_get_output_size" /> | Size of an output in pixels |
+| <ApiLink name="lv_wayland_get_display_size" /> | Look up an output by name and get its size |
+
+```c
+/* Open a fullscreen window on the HDMI connector */
+int32_t width, height;
+int32_t output = lv_wayland_get_display_size("HDMI-A-1", &width, &height);
+
+if(output >= 0) {
+    lv_display_t * disp = lv_wayland_window_create(width, height, "My window", NULL);
+    lv_wayland_set_physical_display(disp, output);
+    lv_wayland_window_set_fullscreen(disp, true);
+}
+```
+
+The names come from the `xdg-output` protocol, or from the `wl_output` v4 `name` event when the compositor doesn't support xdg-output.
+If neither is available the name is empty and the lookup returns -1; the size falls back to the output's current mode.
+
+### Event loop
+
+You can integrate LVGL into your own event loop, <ApiLink name="lv_wayland_get_fd" /> gives you the
 compositor's file descriptor to poll.
 
 ## Rendering Backends

--- a/env_support/cmake/dependencies/wayland.cmake
+++ b/env_support/cmake/dependencies/wayland.cmake
@@ -148,7 +148,38 @@ if(NOT EXISTS ${XDG_SHELL_HEADER} OR NOT EXISTS ${XDG_SHELL_SOURCE})
   endif()
 endif()
 
-set(WAYLAND_PROTOCOL_SOURCES ${XDG_SHELL_SOURCE})
+# xdg-output (always) - used to identify physical outputs by connector name
+set(XDG_OUTPUT_XML
+    "${PROTOCOL_ROOT}/unstable/xdg-output/xdg-output-unstable-v1.xml")
+set(XDG_OUTPUT_HEADER "${PROTOCOLS_DIR}/wayland_xdg_output.h")
+set(XDG_OUTPUT_SOURCE "${PROTOCOLS_DIR}/wayland_xdg_output.c")
+
+if(NOT EXISTS ${XDG_OUTPUT_HEADER} OR NOT EXISTS ${XDG_OUTPUT_SOURCE})
+  execute_process(
+    COMMAND wayland-scanner client-header ${XDG_OUTPUT_XML} ${XDG_OUTPUT_HEADER}
+    RESULT_VARIABLE XDG_OUTPUT_HEADER_RESULT
+    ERROR_VARIABLE XDG_OUTPUT_HEADER_ERROR)
+  if(NOT XDG_OUTPUT_HEADER_RESULT EQUAL 0)
+    message(
+      FATAL_ERROR
+        "lvgl: wayland-scanner failed to generate xdg-output header: ${XDG_OUTPUT_HEADER_ERROR}"
+    )
+  endif()
+
+  execute_process(
+    COMMAND wayland-scanner ${WAYLAND_SCANNER_CODE_MODE} ${XDG_OUTPUT_XML}
+            ${XDG_OUTPUT_SOURCE}
+    RESULT_VARIABLE XDG_OUTPUT_SOURCE_RESULT
+    ERROR_VARIABLE XDG_OUTPUT_SOURCE_ERROR)
+  if(NOT XDG_OUTPUT_SOURCE_RESULT EQUAL 0)
+    message(
+      FATAL_ERROR
+        "lvgl: wayland-scanner failed to generate xdg-output source: ${XDG_OUTPUT_SOURCE_ERROR}"
+    )
+  endif()
+endif()
+
+set(WAYLAND_PROTOCOL_SOURCES ${XDG_SHELL_SOURCE} ${XDG_OUTPUT_SOURCE})
 
 # dmabuf (optional) - used by the DMA-BUF and G2D backends
 if(CONFIG_LV_WAYLAND_USE_DMABUF_PROTOCOL)

--- a/include/lvgl/api_map/lv_api_map_v9_5.h
+++ b/include/lvgl/api_map/lv_api_map_v9_5.h
@@ -35,6 +35,9 @@ typedef lv_display_rotation_t lv_disp_rotation_t;
  *      MACROS
  **********************/
 
+#define lv_wayland_assign_physical_display lv_wayland_window_set_physical_display
+#define lv_wayland_unassign_physical_display(display) lv_wayland_window_set_physical_display(display, LV_WAYLAND_PHYSICAL_DISPLAY_ANY)
+
 #define lv_display_delete_event lv_display_remove_event
 #define lv_observer_remove lv_observer_delete
 #define lv_style_get_prop_inlined lv_style_get_prop

--- a/include/lvgl/drivers/wayland/lv_wayland.h
+++ b/include/lvgl/drivers/wayland/lv_wayland.h
@@ -40,6 +40,40 @@ extern "C" {
  */
 int lv_wayland_get_fd(void);
 
+/**
+ * Get the number of physical outputs (screens) advertised by the compositor
+ * @return the number of outputs, 0 if the driver isn't initialized yet
+ */
+uint8_t lv_wayland_get_output_count(void);
+
+/**
+ * Get the name of a physical output
+ * @param output   index of the output, `0`..`lv_wayland_get_output_count() - 1`
+ * @return the connector name, e.g. "HDMI-A-1", or NULL if `output` is out of range.
+ *         The string is owned by the driver and stays valid until `lv_wayland_deinit`
+ */
+const char * lv_wayland_get_output_name(uint8_t output);
+
+/**
+ * Get the size of a physical output
+ * @param output   index of the output, `0`..`lv_wayland_get_output_count() - 1`
+ * @param width    pointer to store the width in pixels @nullable
+ * @param height   pointer to store the height in pixels @nullable
+ * @return true if the size is known, false if `output` is out of range or the
+ *         compositor hasn't reported a size yet
+ */
+bool lv_wayland_get_output_size(uint8_t output, int32_t * width, int32_t * height);
+
+/**
+ * Look up a physical output by name and get its size
+ * @param name     connector name of the output, e.g. "DSI-1" or "HDMI-A-1"
+ * @param width    pointer to store the width in pixels @nullable
+ * @param height   pointer to store the height in pixels @nullable
+ * @return the index of the output, to be passed to `lv_wayland_window_set_physical_display`,
+ *         or -1 if no output goes by that name
+ */
+int32_t lv_wayland_get_display_size(const char * name, int32_t * width, int32_t * height);
+
 /**********************
  *      MACROS
  **********************/

--- a/include/lvgl/drivers/wayland/lv_wayland_window.h
+++ b/include/lvgl/drivers/wayland/lv_wayland_window.h
@@ -28,6 +28,7 @@ extern "C" {
  **********************/
 
 typedef bool (*lv_wayland_display_close_cb_t)(lv_display_t * display);
+#define LV_WAYLAND_PHYSICAL_DISPLAY_ANY 0xFF
 
 /**********************
  * GLOBAL PROTOTYPES
@@ -60,15 +61,16 @@ bool lv_wayland_window_is_open(lv_display_t * display);
 /**
  * Assigns the window to a specific physical display
  * @param display Reference to the LVGL display associated to the window
- * @param phys_display Physical display number
+ * @param phys_display Physical display number or LV_WAYLAND_PHYSICAL_DISPLAY_ANY
+ *                     to unassign a previously set physical display
  */
-void lv_wayland_assign_physical_display(lv_display_t * display, uint8_t phys_display);
+void lv_wayland_window_set_physical_display(lv_display_t * display, uint8_t phys_display);
 
 /**
  * Unassigns the current physical display attached to the window
  * @param display Reference to the LVGL display associated to the window
  */
-void lv_wayland_unassign_physical_display(lv_display_t * display);
+void lv_wayland_window_remove_physical_display(lv_display_t * display);
 
 /**
  * Sets the fullscreen state of the window

--- a/scripts/static_checks/check_headers.py
+++ b/scripts/static_checks/check_headers.py
@@ -258,6 +258,7 @@ ALLOWED_EXTERNAL_HEADERS: set[str] = {
     "wayland-cursor.h",
     "wayland-egl.h",
     "wayland_linux_dmabuf.h",
+    "wayland_xdg_output.h",
     "wayland_xdg_shell.h",
     "webp/decode.h",
     "windows.h",

--- a/src/drivers/wayland/lv_wayland.c
+++ b/src/drivers/wayland/lv_wayland.c
@@ -42,6 +42,12 @@
  *      DEFINES
  *********************/
 
+#ifdef WL_OUTPUT_NAME_SINCE_VERSION
+    #define LV_WAYLAND_WL_OUTPUT_VERSION 4
+#else
+    #define LV_WAYLAND_WL_OUTPUT_VERSION 2
+#endif
+
 
 /**********************
  *      TYPEDEFS
@@ -71,6 +77,43 @@ static void output_done(void * data, struct wl_output * output);
 static void output_geometry(void * data, struct wl_output * output, int32_t x, int32_t y, int32_t physical_width,
                             int32_t physical_height, int32_t subpixel, const char * make, const char * model, int32_t transform);
 
+#ifdef WL_OUTPUT_NAME_SINCE_VERSION
+    static void output_name(void * data, struct wl_output * output, const char * name);
+    static void output_description(void * data, struct wl_output * output, const char * description);
+#endif
+
+static void xdg_output_logical_position(void * data, struct zxdg_output_v1 * xdg_output, int32_t x, int32_t y);
+static void xdg_output_logical_size(void * data, struct zxdg_output_v1 * xdg_output, int32_t width, int32_t height);
+static void xdg_output_done(void * data, struct zxdg_output_v1 * xdg_output);
+static void xdg_output_name(void * data, struct zxdg_output_v1 * xdg_output, const char * name);
+static void xdg_output_description(void * data, struct zxdg_output_v1 * xdg_output, const char * description);
+
+/* Attaches an zxdg_output_v1 to 'info' so that the compositor reports its
+ * connector name and logical size. No-op if the compositor doesn't support it. */
+#ifdef WL_OUTPUT_NAME_SINCE_VERSION
+
+static void output_name(void * data, struct wl_output * output, const char * name)
+{
+    LV_UNUSED(output);
+    lv_wl_output_info_t * info = data;
+
+    /* The core protocol is authoritative, xdg-output reports the same name */
+    snprintf(info->name, sizeof(info->name), "%s", name);
+}
+
+static void output_description(void * data, struct wl_output * output, const char * description)
+{
+    /* A human readable description of the output,
+     * Skipped since we identify outputs by their connector name */
+    LV_UNUSED(data);
+    LV_UNUSED(output);
+    LV_UNUSED(description);
+}
+
+#endif /*WL_OUTPUT_NAME_SINCE_VERSION*/
+
+static void output_bind_xdg_output(lv_wl_output_info_t * info);
+
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -87,7 +130,19 @@ static const struct wl_output_listener output_listener = {
     .geometry = output_geometry,
     .mode = output_mode,
     .done = output_done,
-    .scale = output_scale
+    .scale = output_scale,
+#ifdef WL_OUTPUT_NAME_SINCE_VERSION
+    .name = output_name,
+    .description = output_description,
+#endif
+};
+
+static const struct zxdg_output_v1_listener xdg_output_listener = {
+    .logical_position = xdg_output_logical_position,
+    .logical_size = xdg_output_logical_size,
+    .done = xdg_output_done,
+    .name = xdg_output_name,
+    .description = xdg_output_description
 };
 
 /**********************
@@ -105,6 +160,67 @@ int lv_wayland_get_fd(void)
         return -1;
     }
     return wl_display_get_fd(lv_wl_ctx.wl_display);
+}
+
+uint8_t lv_wayland_get_output_count(void)
+{
+    return lv_wl_ctx.wl_output_count;
+}
+
+const char * lv_wayland_get_output_name(uint8_t output)
+{
+    LV_CHECK_ARG_FORMAT_MSG(output < lv_wl_ctx.wl_output_count, return NULL,
+                            "Invalid output '%d'. Expected '0'..'%d'",
+                            output, lv_wl_ctx.wl_output_count - 1);
+
+    const lv_wl_output_info_t * info = lv_wl_ctx.physical_outputs[output];
+
+    return info->name;
+}
+
+bool lv_wayland_get_output_size(uint8_t output, int32_t * width, int32_t * height)
+{
+    LV_CHECK_ARG_FORMAT_MSG(output < lv_wl_ctx.wl_output_count, return false,
+                            "Invalid output '%d'. Expected '0'..'%d'",
+                            output, lv_wl_ctx.wl_output_count - 1);
+
+    const lv_wl_output_info_t * info = lv_wl_ctx.physical_outputs[output];
+
+    int32_t w, h;
+    /* Prefer the logical size over the screen resolution */
+    if(info->logical_width > 0 && info->logical_height > 0) {
+        w = info->logical_width;
+        h = info->logical_height;
+    }
+    else {
+        w = info->width;
+        h = info->height;
+    }
+
+    if(width) {
+        *width = w;
+    }
+    if(height) {
+        *height = h;
+    }
+    return w > 0 && h > 0;
+}
+
+int32_t lv_wayland_get_display_size(const char * name, int32_t * width, int32_t * height)
+{
+    LV_CHECK_ARG(name != NULL, return -1);
+
+    for(uint8_t i = 0; i < lv_wl_ctx.wl_output_count; i++) {
+        const char * output_name = lv_wayland_get_output_name(i);
+        if(output_name == NULL || strcmp(name, output_name) != 0) {
+            continue;
+        }
+        lv_wayland_get_output_size(i, width, height);
+        return i;
+    }
+
+    LV_LOG_WARN("No output named '%s'", name);
+    return -1;
 }
 
 /**********************
@@ -147,6 +263,19 @@ lv_result_t lv_wayland_init(void)
     lv_tick_set_cb(tick_get_cb);
     lv_wl_ctx.read_compositor_events_timer = lv_timer_create(read_compositor_events_timer_cb, LV_DEF_REFR_PERIOD, NULL);
 
+    if(lv_wl_ctx.xdg_output_mgr) {
+        for(uint8_t i = 0; i < lv_wl_ctx.wl_output_count; i++) {
+            output_bind_xdg_output(lv_wl_ctx.physical_outputs[i]);
+        }
+        /* Wait for the name and logical size of every output to arrive, so that
+         * `lv_wayland_get_display_size` can be used right after initialization */
+        wl_display_roundtrip(lv_wl_ctx.wl_display);
+    }
+    else {
+        LV_LOG_WARN("zxdg_output_manager_v1 is not available, "
+                    "outputs can't be identified by their connector name");
+    }
+
     is_wayland_initialized = true;
     return LV_RESULT_OK;
 }
@@ -179,10 +308,22 @@ void lv_wayland_deinit(void)
     }
 
     for(uint8_t i = 0; i < lv_wl_ctx.wl_output_count; ++i) {
-        if(lv_wl_ctx.physical_outputs[i].wl_output) {
-            wl_output_destroy(lv_wl_ctx.physical_outputs[i].wl_output);
-            lv_wl_ctx.physical_outputs[i].wl_output = NULL;
+        lv_wl_output_info_t * info = lv_wl_ctx.physical_outputs[i];
+        if(info->xdg_output) {
+            zxdg_output_v1_destroy(info->xdg_output);
         }
+        if(info->wl_output) {
+            wl_output_destroy(info->wl_output);
+        }
+        lv_free(info);
+    }
+    lv_free(lv_wl_ctx.physical_outputs);
+    lv_wl_ctx.physical_outputs = NULL;
+    lv_wl_ctx.wl_output_count = 0;
+
+    if(lv_wl_ctx.xdg_output_mgr) {
+        zxdg_output_manager_v1_destroy(lv_wl_ctx.xdg_output_mgr);
+        lv_wl_ctx.xdg_output_mgr = NULL;
     }
 
     if(lv_wl_ctx.wl_compositor) {
@@ -259,8 +400,8 @@ static void output_geometry(void * data, struct wl_output * output, int32_t x, i
     LV_UNUSED(make);
     LV_UNUSED(transform);
 
-    lv_wl_output_info_t * info = data;
-    snprintf(info->name, sizeof(info->name), "%s", model);
+    LV_UNUSED(data);
+    LV_UNUSED(model);
 }
 
 static void output_mode(void * data, struct wl_output * wl_output, uint32_t flags, int32_t width, int32_t height,
@@ -292,6 +433,64 @@ static void output_scale(void * data, struct wl_output * output, int32_t factor)
     info->scale = factor;
 }
 
+static void output_bind_xdg_output(lv_wl_output_info_t * info)
+{
+    if(!lv_wl_ctx.xdg_output_mgr || info->xdg_output || !info->wl_output) {
+        return;
+    }
+
+    info->xdg_output = zxdg_output_manager_v1_get_xdg_output(lv_wl_ctx.xdg_output_mgr, info->wl_output);
+    if(!info->xdg_output) {
+        LV_LOG_WARN("Failed to get the xdg_output of an output");
+        return;
+    }
+
+    zxdg_output_v1_add_listener(info->xdg_output, &xdg_output_listener, info);
+}
+
+static void xdg_output_logical_position(void * data, struct zxdg_output_v1 * xdg_output, int32_t x, int32_t y)
+{
+    LV_UNUSED(data);
+    LV_UNUSED(xdg_output);
+    LV_UNUSED(x);
+    LV_UNUSED(y);
+}
+
+static void xdg_output_logical_size(void * data, struct zxdg_output_v1 * xdg_output, int32_t width, int32_t height)
+{
+    LV_UNUSED(xdg_output);
+    lv_wl_output_info_t * info = data;
+    info->logical_width = width;
+    info->logical_height = height;
+}
+
+static void xdg_output_done(void * data, struct zxdg_output_v1 * xdg_output)
+{
+    /* Deprecated since version 3, the events above are applied immediately */
+    LV_UNUSED(data);
+    LV_UNUSED(xdg_output);
+}
+
+static void xdg_output_name(void * data, struct zxdg_output_v1 * xdg_output, const char * name)
+{
+    LV_UNUSED(xdg_output);
+    lv_wl_output_info_t * info = data;
+
+    /* Only useful below wl_output version 4, which reports the same name */
+    if(info->name[0] == '\0') {
+        snprintf(info->name, sizeof(info->name), "%s", name);
+    }
+}
+
+static void xdg_output_description(void * data, struct zxdg_output_v1 * xdg_output, const char * description)
+{
+    /* A human readable description of the output, not stored since the driver
+     * identifies outputs by their connector name */
+    LV_UNUSED(data);
+    LV_UNUSED(xdg_output);
+    LV_UNUSED(description);
+}
+
 static uint32_t tick_get_cb(void)
 {
     struct timespec t;
@@ -321,13 +520,30 @@ static void handle_global(void * data, struct wl_registry * registry, uint32_t n
         xdg_wm_base_add_listener(ctx->xdg_wm, lv_wayland_xdg_get_wm_base_listener(), ctx);
     }
     else if(strcmp(interface, wl_output_interface.name) == 0) {
-        if(ctx->wl_output_count < LV_WAYLAND_MAX_OUTPUTS) {
-            memset(&ctx->physical_outputs[ctx->wl_output_count], 0, sizeof(lv_wl_output_info_t));
-            struct wl_output * out = wl_registry_bind(registry, name, &wl_output_interface, 1);
-            ctx->physical_outputs[ctx->wl_output_count].wl_output = out;
-            wl_output_add_listener(out, &output_listener, &ctx->physical_outputs[ctx->wl_output_count].wl_output);
-            ctx->wl_output_count++;
+        lv_wl_output_info_t ** outputs = lv_realloc(ctx->physical_outputs,
+                                                    (ctx->wl_output_count + 1) * sizeof(lv_wl_output_info_t *));
+        if(!outputs) {
+            LV_LOG_WARN("Failed to allocate memory for output");
+            return;
         }
+        ctx->physical_outputs = outputs;
+
+        lv_wl_output_info_t * info = lv_zalloc(sizeof(lv_wl_output_info_t));
+        if(!info) {
+            LV_LOG_WARN("Failed to allocate memory for output");
+            return;
+        }
+
+        info->wl_output = wl_registry_bind(registry, name, &wl_output_interface,
+                                           LV_MIN(version, LV_WAYLAND_WL_OUTPUT_VERSION));
+        ctx->physical_outputs[ctx->wl_output_count] = info;
+        ctx->wl_output_count++;
+        wl_output_add_listener(info->wl_output, &output_listener, info);
+
+        output_bind_xdg_output(info);
+    }
+    else if(strcmp(interface, zxdg_output_manager_v1_interface.name) == 0) {
+        ctx->xdg_output_mgr = wl_registry_bind(registry, name, &zxdg_output_manager_v1_interface, LV_MIN(version, 3));
     }
 
     lv_wayland_backend_global_handler(registry, name, interface, version);

--- a/src/drivers/wayland/lv_wayland_private.h
+++ b/src/drivers/wayland/lv_wayland_private.h
@@ -23,6 +23,7 @@ extern "C" {
 #include <sys/poll.h>
 #include <wayland-client-protocol.h>
 #include <wayland_xdg_shell.h>
+#include <wayland_xdg_output.h>
 #include "lv_wayland_backend_private.h"
 
 /*********************
@@ -30,7 +31,6 @@ extern "C" {
  *********************/
 
 #define LV_WAYLAND_DEFAULT_CURSOR_NAME "left_ptr"
-#define LV_WAYLAND_MAX_OUTPUTS 8
 
 /**********************
  *      TYPEDEFS
@@ -86,9 +86,20 @@ typedef struct {
 
 typedef struct {
     struct wl_output * wl_output;
+    struct zxdg_output_v1 * xdg_output;
+
+    /* Connector name, e.g. "HDMI-A-1". Reported by wl_output since version 4,
+     * or by xdg-output on older compositors. Empty if neither is available */
     char name[64];
+
+    /* Resolution of the current mode, in physical pixels */
     int width;
     int height;
+
+    /* Size in the compositor's global space, 0 if xdg-output is unavailable */
+    int logical_width;
+    int logical_height;
+
     int refresh;
     int scale;
     int flags;
@@ -102,10 +113,11 @@ typedef struct {
     lv_wl_seat_t seat;
 
     void * backend_data;
-    lv_wl_output_info_t physical_outputs[LV_WAYLAND_MAX_OUTPUTS];
+    lv_wl_output_info_t ** physical_outputs;
     uint8_t wl_output_count;
 
     struct xdg_wm_base * xdg_wm;
+    struct zxdg_output_manager_v1 * xdg_output_mgr;
 
     lv_ll_t window_ll;
     lv_timer_t * read_compositor_events_timer;

--- a/src/drivers/wayland/lv_wayland_window.c
+++ b/src/drivers/wayland/lv_wayland_window.c
@@ -210,19 +210,25 @@ void lv_wayland_window_set_minimized(lv_display_t * display)
     lv_wayland_xdg_set_minimized(&window->xdg);
 }
 
-void lv_wayland_assign_physical_display(lv_display_t * display, uint8_t phys_display)
+void lv_wayland_window_set_physical_display(lv_display_t * display, uint8_t phys_display)
 {
     LV_CHECK_ARG(display != NULL, return);
     lv_wl_window_t * window = lv_display_get_driver_data(display);
     LV_CHECK_ARG_MSG(window != NULL, return, "Invalid display");
-    LV_CHECK_ARG_FORMAT_MSG(phys_display < lv_wl_ctx.wl_output_count, return,
-                            "Invalid display number '%d'. Expected '0'..'%d'",
+    LV_CHECK_ARG_FORMAT_MSG(phys_display == LV_WAYLAND_PHYSICAL_DISPLAY_ANY ||
+                            phys_display < lv_wl_ctx.wl_output_count, return,
+                            "Invalid display number '%d'. Expected '0'..'%d' or LV_WAYLAND_PHYSICAL_DISPLAY_ANY",
                             phys_display, lv_wl_ctx.wl_output_count - 1);
 
-    window->physical_output = lv_wl_ctx.physical_outputs[phys_display].wl_output;
+    if(phys_display == LV_WAYLAND_PHYSICAL_DISPLAY_ANY) {
+        window->physical_output = NULL;
+    }
+    else {
+        window->physical_output = lv_wl_ctx.physical_outputs[phys_display]->wl_output;
+    }
 }
 
-void lv_wayland_unassign_physical_display(lv_display_t * display)
+void lv_wayland_window_remove_physical_display(lv_display_t * display)
 {
     LV_CHECK_ARG(display != NULL, return);
     lv_wl_window_t * window = lv_display_get_driver_data(display);


### PR DESCRIPTION
Part 1 of #9884
