### PR TITLE
fix(wayland): route input events to the focused window

### DIFF
--- a/src/drivers/wayland/lv_wayland_keyboard.c
+++ b/src/drivers/wayland/lv_wayland_keyboard.c
@@ -48,6 +48,7 @@ static void keyboard_handle_key(void * data, struct wl_keyboard * keyboard, uint
 #endif
 
 static lv_key_t keycode_xkb_to_lv(xkb_keysym_t xkb_key);
+static void push_event(lv_wl_seat_keyboard_t * kbdata, lv_key_t key, lv_indev_state_t state);
 
 /**********************
  *  STATIC VARIABLES
@@ -156,6 +157,16 @@ static void keyboard_read(lv_indev_t * indev, lv_indev_data_t * data)
         return;
     }
 
+    lv_display_t * display = lv_indev_get_display(indev);
+    if(!display) {
+        return;
+    }
+    lv_wl_window_t * window = lv_display_get_driver_data(display);
+    LV_ASSERT(window != NULL);
+    if(window->body != kbdata->focused_surface) {
+        return;
+    }
+
     uint8_t index = kbdata->event_read_index;
     data->key = kbdata->events[index].key;
     data->state = kbdata->events[index].state;
@@ -212,19 +223,34 @@ static void keyboard_handle_enter(void * data, struct wl_keyboard * keyboard, ui
 {
 
     LV_UNUSED(data);
-    LV_UNUSED(keyboard);
     LV_UNUSED(serial);
     LV_UNUSED(keys);
-    LV_UNUSED(surface);
+
+    lv_wl_seat_keyboard_t * kbdata = wl_keyboard_get_user_data(keyboard);
+    LV_ASSERT(kbdata != NULL);
+    kbdata->focused_surface = surface;
 }
 
 static void keyboard_handle_leave(void * data, struct wl_keyboard * keyboard, uint32_t serial,
                                   struct wl_surface * surface)
 {
     LV_UNUSED(serial);
-    LV_UNUSED(keyboard);
     LV_UNUSED(data);
-    LV_UNUSED(surface);
+
+    lv_wl_seat_keyboard_t * kbdata = wl_keyboard_get_user_data(keyboard);
+    LV_ASSERT(kbdata != NULL);
+    if(kbdata->focused_surface != surface) {
+        return;
+    }
+
+    const uint8_t last_event_index = kbdata->event_write_index == 0 ?
+                                     LV_WAYLAND_KEY_EVENT_MAX_COUNT - 1 :
+                                     kbdata->event_write_index - 1;
+
+    /* release last pushed event in case it wasn't a release event*/
+    if(kbdata->events[last_event_index].state != LV_INDEV_STATE_RELEASED) {
+        push_event(kbdata, kbdata->events[last_event_index].key, LV_INDEV_STATE_RELEASED);
+    }
 }
 
 static void keyboard_handle_key(void * data, struct wl_keyboard * keyboard, uint32_t serial, uint32_t time,
@@ -241,11 +267,6 @@ static void keyboard_handle_key(void * data, struct wl_keyboard * keyboard, uint
         return;
     }
 
-    if(kbdata->event_count == LV_WAYLAND_KEY_EVENT_MAX_COUNT) {
-        LV_LOG_WARN("Dropping event as LV_WAYLAND_KEY_EVENT_MAX_COUNT was reached.");
-        return;
-    }
-
     const xkb_keysym_t * syms = XKB_KEY_NoSymbol;
     if(xkb_state_key_get_syms(kbdata->xkb_state, code, &syms) != 1) {
         return;
@@ -256,10 +277,7 @@ static void keyboard_handle_key(void * data, struct wl_keyboard * keyboard, uint
         (state == WL_KEYBOARD_KEY_STATE_PRESSED) ? LV_INDEV_STATE_PRESSED : LV_INDEV_STATE_RELEASED;
 
     if(lv_key != 0) {
-        kbdata->events[kbdata->event_write_index].key = lv_key;
-        kbdata->events[kbdata->event_write_index].state = lv_state;
-        kbdata->event_write_index = (kbdata->event_write_index + 1) % LV_WAYLAND_KEY_EVENT_MAX_COUNT;
-        kbdata->event_count++;
+        push_event(kbdata, lv_key, lv_state);
     }
 }
 
@@ -350,6 +368,19 @@ static lv_key_t keycode_xkb_to_lv(xkb_keysym_t xkb_key)
         default:
             return 0;
     }
+}
+static void push_event(lv_wl_seat_keyboard_t * kbdata, lv_key_t key, lv_indev_state_t state)
+{
+    LV_ASSERT(kbdata != NULL);
+
+    if(kbdata->event_count == LV_WAYLAND_KEY_EVENT_MAX_COUNT) {
+        LV_LOG_WARN("Dropping event as LV_WAYLAND_KEY_EVENT_MAX_COUNT was reached.");
+        return;
+    }
+    kbdata->events[kbdata->event_write_index].key = key;
+    kbdata->events[kbdata->event_write_index].state = state;
+    kbdata->event_write_index = (kbdata->event_write_index + 1) % LV_WAYLAND_KEY_EVENT_MAX_COUNT;
+    kbdata->event_count++;
 }
 
 #endif /* LV_WAYLAND */

--- a/src/drivers/wayland/lv_wayland_pointer.c
+++ b/src/drivers/wayland/lv_wayland_pointer.c
@@ -167,12 +167,33 @@ void lv_wayland_seat_pointer_delete(lv_wl_seat_pointer_t * seat_pointer)
  *   STATIC FUNCTIONS
  **********************/
 
+/* The seat has a single pointer shared by every window, only the window the
+ * pointer currently hovers over may report its position and buttons */
+static bool is_indev_focused(lv_indev_t * indev, const lv_wl_seat_pointer_t * seat_pointer)
+{
+    LV_ASSERT(indev != NULL);
+    lv_display_t * disp = lv_indev_get_display(indev);
+    if(!disp) {
+        return false;
+    }
+    lv_wl_window_t * window = lv_display_get_driver_data(disp);
+    LV_ASSERT(window != NULL);
+    return window->body == seat_pointer->focused_surface;
+}
+
 static void pointeraxis_read(lv_indev_t * indev, lv_indev_data_t * data)
 {
     LV_ASSERT(indev != NULL);
     LV_ASSERT(data != NULL);
+
+    data->state = LV_INDEV_STATE_RELEASED;
+    data->enc_diff = 0;
     lv_wl_seat_pointer_t * seat_pointer = lv_indev_get_driver_data(indev);
     if(!seat_pointer) {
+        return;
+    }
+
+    if(!is_indev_focused(indev, seat_pointer)) {
         return;
     }
 
@@ -189,6 +210,12 @@ static void pointer_read(lv_indev_t * indev, lv_indev_data_t * data)
     if(!seat_pointer) {
         return;
     }
+
+    data->state = LV_INDEV_STATE_RELEASED;
+    if(!is_indev_focused(indev, seat_pointer)) {
+        return;
+    }
+
     data->point = seat_pointer->point;
     data->state = seat_pointer->left_btn_state;
 }
@@ -197,11 +224,11 @@ static void pointer_handle_enter(void * data, struct wl_pointer * pointer, uint3
                                  wl_fixed_t sx, wl_fixed_t sy)
 {
     LV_UNUSED(data);
-    LV_UNUSED(surface);
     lv_wl_seat_pointer_t * seat_pointer = wl_pointer_get_user_data(pointer);
     int pos_x = wl_fixed_to_int(sx);
     int pos_y = wl_fixed_to_int(sy);
 
+    seat_pointer->focused_surface = surface;
     seat_pointer->point.x = pos_x;
     seat_pointer->point.y = pos_y;
 
@@ -220,8 +247,17 @@ static void pointer_handle_leave(void * data, struct wl_pointer * pointer, uint3
 {
     LV_UNUSED(data);
     LV_UNUSED(serial);
-    LV_UNUSED(surface);
-    LV_UNUSED(pointer);
+
+    lv_wl_seat_pointer_t * seat_pointer = wl_pointer_get_user_data(pointer);
+    if(seat_pointer->focused_surface != surface) {
+        return;
+    }
+
+    seat_pointer->left_btn_state = LV_INDEV_STATE_RELEASED;
+    seat_pointer->right_btn_state = LV_INDEV_STATE_RELEASED;
+    seat_pointer->wheel_btn_state = LV_INDEV_STATE_RELEASED;
+    seat_pointer->wheel_diff = 0;
+    seat_pointer->focused_surface = NULL;
 }
 
 static void pointer_handle_motion(void * data, struct wl_pointer * pointer, uint32_t time, wl_fixed_t sx, wl_fixed_t sy)

--- a/src/drivers/wayland/lv_wayland_private.h
+++ b/src/drivers/wayland/lv_wayland_private.h
@@ -46,12 +46,23 @@ typedef struct {
     struct wl_pointer * wl_pointer;
     struct wl_surface * cursor_surface;
     struct wl_cursor_theme * cursor_theme;
+
+    /* The surface the pointer currently hovers over, NULL if none */
+    struct wl_surface * focused_surface;
+
     lv_point_t point;
     lv_indev_state_t left_btn_state;
     lv_indev_state_t right_btn_state;
     lv_indev_state_t wheel_btn_state;
     int16_t wheel_diff;
 } lv_wl_seat_pointer_t;
+
+typedef struct {
+    int32_t id;                  /* Wayland touch point ID */
+    struct wl_surface * surface; /* The surface this touch point belongs to */
+    lv_point_t point;            /* Last known coordinates */
+    lv_indev_state_t state;      /* PRESSED or RELEASED */
+} lv_wl_touch_point_t;
 
 typedef struct {
     struct wl_touch * wl_touch;
@@ -61,8 +72,8 @@ typedef struct {
     uint8_t event_cnt;
     uint8_t primary_id;
 #else
-    lv_point_t point;
-    lv_indev_state_t state;
+    /* Active touch points (lv_wl_touch_point_t), one per finger on screen */
+    lv_ll_t touch_point_ll;
 #endif /*LV_USE_GESTURE_RECOGNITION*/
 } lv_wl_seat_touch_t;
 
@@ -71,6 +82,8 @@ typedef struct {
     struct xkb_context * xkb_context;
     struct xkb_keymap * xkb_keymap;
     struct xkb_state * xkb_state;
+    /* The surface that currently has keyboard focus, NULL if none */
+    struct wl_surface * focused_surface;
 
     struct {
         lv_key_t key;

--- a/src/drivers/wayland/lv_wayland_touch.c
+++ b/src/drivers/wayland/lv_wayland_touch.c
@@ -40,6 +40,11 @@ static void touch_handle_frame(void * data, struct wl_touch * wl_touch);
 
 static void touch_handle_cancel(void * data, struct wl_touch * wl_touch);
 
+#if !LV_USE_GESTURE_RECOGNITION
+    static lv_wl_touch_point_t * get_pressed_touch_point(lv_wl_seat_touch_t * tdata, int32_t id);
+    static void touch_point_delete(lv_wl_seat_touch_t * tdata, lv_wl_touch_point_t * touch_point);
+#endif
+
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -100,6 +105,10 @@ lv_wl_seat_touch_t * lv_wayland_seat_touch_create(struct wl_seat * seat)
     wl_touch_add_listener(touch, &touch_listener, NULL);
     wl_touch_set_user_data(touch, wl_seat_touch);
 
+#if !LV_USE_GESTURE_RECOGNITION
+    lv_ll_init(&wl_seat_touch->touch_point_ll, sizeof(lv_wl_touch_point_t));
+#endif
+
     wl_seat_touch->wl_touch = touch;
     lv_wayland_update_indevs(touch_read, wl_seat_touch);
 
@@ -110,6 +119,9 @@ void lv_wayland_seat_touch_delete(lv_wl_seat_touch_t * seat_touch)
 {
     lv_wayland_update_indevs(touch_read, NULL);
     wl_touch_destroy(seat_touch->wl_touch);
+#if !LV_USE_GESTURE_RECOGNITION
+    lv_ll_clear(&seat_touch->touch_point_ll);
+#endif
     lv_free(seat_touch);
 }
 
@@ -146,8 +158,29 @@ static void touch_read(lv_indev_t * indev, lv_indev_data_t * data)
     lv_indev_gesture_recognizers_set_data(indev, data);
 
 #else
-    data->point = tdata->point;
-    data->state = tdata->state;
+    data->state = LV_INDEV_STATE_RELEASED;
+    lv_display_t * disp = lv_indev_get_display(indev);
+    if(!disp) {
+        return;
+    }
+    lv_wl_window_t * window = lv_display_get_driver_data(disp);
+    LV_ASSERT(window != NULL);
+
+    lv_wl_touch_point_t * touch_point;
+    LV_LL_READ(&tdata->touch_point_ll, touch_point) {
+        /* does this touch belong to the this indev's display */
+        if(touch_point->surface != window->body) {
+            continue;
+        }
+
+        data->point = touch_point->point;
+        data->state = touch_point->state;
+
+        if(touch_point->state == LV_INDEV_STATE_RELEASED) {
+            touch_point_delete(tdata, touch_point);
+        }
+        return;
+    }
 #endif
 }
 
@@ -175,9 +208,18 @@ static void touch_handle_down(void * data, struct wl_touch * wl_touch, uint32_t 
     tdata->touches[i].state     = LV_INDEV_STATE_PRESSED;
     tdata->event_cnt++;
 #else
-    tdata->point.x = wl_fixed_to_int(x_w);
-    tdata->point.y = wl_fixed_to_int(y_w);
-    tdata->state = LV_INDEV_STATE_PRESSED;
+    lv_wl_touch_point_t * touch_point = lv_ll_ins_tail(&tdata->touch_point_ll);
+    LV_ASSERT_MALLOC(touch_point);
+    if(!touch_point) {
+        LV_LOG_ERROR("Failed to allocate memory for a touch point");
+        return;
+    }
+
+    touch_point->id = id;
+    touch_point->surface = surface;
+    touch_point->point.x = wl_fixed_to_int(x_w);
+    touch_point->point.y = wl_fixed_to_int(y_w);
+    touch_point->state = LV_INDEV_STATE_PRESSED;
 #endif
 }
 
@@ -201,7 +243,11 @@ static void touch_handle_up(void * data, struct wl_touch * wl_touch, uint32_t se
 
     tdata->event_cnt++;
 #else
-    tdata->state = LV_INDEV_STATE_RELEASED;
+    lv_wl_touch_point_t * touch_point = get_pressed_touch_point(tdata, id);
+    if(touch_point) {
+        /* deleted after LVGL reads it in touch_read */
+        touch_point->state = LV_INDEV_STATE_RELEASED;
+    }
 #endif
 }
 
@@ -242,8 +288,11 @@ static void touch_handle_motion(void * data, struct wl_touch * wl_touch, uint32_
         cur->timestamp = time;
     }
 #else
-    tdata->point.x = wl_fixed_to_int(x_w);
-    tdata->point.y = wl_fixed_to_int(y_w);
+    lv_wl_touch_point_t * touch_point = get_pressed_touch_point(tdata, id);
+    if(touch_point) {
+        touch_point->point.x = wl_fixed_to_int(x_w);
+        touch_point->point.y = wl_fixed_to_int(y_w);
+    }
 #endif
 }
 
@@ -256,8 +305,41 @@ static void touch_handle_frame(void * data, struct wl_touch * wl_touch)
 
 static void touch_handle_cancel(void * data, struct wl_touch * wl_touch)
 {
-    LV_UNUSED(wl_touch);
     LV_UNUSED(data);
+
+#if !LV_USE_GESTURE_RECOGNITION
+    lv_wl_seat_touch_t * tdata = wl_touch_get_user_data(wl_touch);
+    lv_wl_touch_point_t * touch_point;
+    LV_LL_READ(&tdata->touch_point_ll, touch_point) {
+        touch_point->state = LV_INDEV_STATE_RELEASED;
+    }
+    lv_wayland_indevs_ready(touch_read);
+#else
+    LV_UNUSED(wl_touch);
+#endif
 }
+
+#if !LV_USE_GESTURE_RECOGNITION
+
+static lv_wl_touch_point_t * get_pressed_touch_point(lv_wl_seat_touch_t * tdata, int32_t id)
+{
+    LV_ASSERT(tdata != NULL);
+    lv_wl_touch_point_t * touch_point;
+    LV_LL_READ(&tdata->touch_point_ll, touch_point) {
+        if(touch_point->id == id && touch_point->state == LV_INDEV_STATE_PRESSED) {
+            return touch_point;
+        }
+    }
+    return NULL;
+}
+
+static void touch_point_delete(lv_wl_seat_touch_t * tdata, lv_wl_touch_point_t * touch_point)
+{
+    LV_ASSERT(tdata != NULL);
+    lv_ll_remove(&tdata->touch_point_ll, touch_point);
+    lv_free(touch_point);
+}
+
+#endif /*!LV_USE_GESTURE_RECOGNITION*/
 
 #endif /* LV_USE_WAYLAND */


### PR DESCRIPTION
Part 2 of #9884

Co-Authored-by: paulh002 <paul.hollander001@gmail.com>
