### PR TITLE
refactor(obj_style): rename lv_obj_style_set_enabled to lv_obj_set_style_enabled

### DIFF
--- a/docs/src/changelog/migration-v10.mdx
+++ b/docs/src/changelog/migration-v10.mdx
@@ -482,8 +482,8 @@ Note that these assertions are not required and should be disabled to improve pe
   _Note: Only raw flag constants can be converted automatically. Expressions using variables will be skipped for safety._
 
 - `lv_obj_style_set_disabled()` and `lv_obj_style_get_disabled()` are deprecated
-  in favor of the positive-logic <ApiLink name="lv_obj_style_set_enabled"/> and
-  <ApiLink name="lv_obj_style_get_enabled"/>. Note that the meaning of the
+  in favor of the positive-logic <ApiLink name="lv_obj_set_style_enabled"/> and
+  <ApiLink name="lv_obj_get_style_enabled"/>. Note that the meaning of the
   `bool` is inverted:
   ```c
   /* Before */
@@ -491,8 +491,8 @@ Note that these assertions are not required and should be disabled to improve pe
   bool dis = lv_obj_style_get_disabled(obj, &style, LV_PART_MAIN);
 
   /* After */
-  lv_obj_style_set_enabled(obj, &style, LV_PART_MAIN, false);   /*Disable the style*/
-  bool en = lv_obj_style_get_enabled(obj, &style, LV_PART_MAIN);
+  lv_obj_set_style_enabled(obj, &style, LV_PART_MAIN, false);   /*Disable the style*/
+  bool en = lv_obj_get_style_enabled(obj, &style, LV_PART_MAIN);
   ```
 
 ---

--- a/include/lvgl/core/lv_obj_style.h
+++ b/include/lvgl/core/lv_obj_style.h
@@ -182,7 +182,7 @@ void lv_obj_refresh_style(lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop);
  * @param selector  the selector of a style (e.g. LV_STATE_PRESSED | LV_PART_KNOB)
  * @param en        true: enable the style, false: disable the style
  */
-void lv_obj_style_set_enabled(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector, bool en);
+void lv_obj_set_style_enabled(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector, bool en);
 
 /**
  * Get if a given style is enabled on an object.
@@ -191,7 +191,7 @@ void lv_obj_style_set_enabled(lv_obj_t * obj, const lv_style_t * style, lv_style
  * @param selector  the selector of a style (e.g. LV_STATE_PRESSED | LV_PART_KNOB)
  * @return          true: the style is enabled, false: the style is disabled
  */
-bool lv_obj_style_get_enabled(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector);
+bool lv_obj_get_style_enabled(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector);
 
 /**
  * Temporary disable a style for a selector. It will look like is the style wasn't added
@@ -199,9 +199,9 @@ bool lv_obj_style_get_enabled(lv_obj_t * obj, const lv_style_t * style, lv_style
  * @param style     pointer to a style
  * @param selector  the selector of a style (e.g. LV_STATE_PRESSED | LV_PART_KNOB)
  * @param dis       true: disable the style, false: enable the style
- * @deprecated      Use `lv_obj_style_set_enabled()` instead (with inverted logic).
+ * @deprecated      Use `lv_obj_set_style_enabled()` instead (with inverted logic).
  */
-LV_DEPRECATED("Use lv_obj_style_set_enabled() instead (with inverted logic).")
+LV_DEPRECATED("Use lv_obj_set_style_enabled() instead (with inverted logic).")
 void lv_obj_style_set_disabled(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector, bool dis);
 
 /**
@@ -210,9 +210,9 @@ void lv_obj_style_set_disabled(lv_obj_t * obj, const lv_style_t * style, lv_styl
  * @param style     pointer to a style
  * @param selector  the selector of a style (e.g. LV_STATE_PRESSED | LV_PART_KNOB)
  * @return          true: disable the style, false: enable the style
- * @deprecated      Use `lv_obj_style_get_enabled()` instead (with inverted logic).
+ * @deprecated      Use `lv_obj_get_style_enabled()` instead (with inverted logic).
  */
-LV_DEPRECATED("Use lv_obj_style_get_enabled() instead (with inverted logic).")
+LV_DEPRECATED("Use lv_obj_get_style_enabled() instead (with inverted logic).")
 bool lv_obj_style_get_disabled(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector);
 
 /**

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -298,7 +298,7 @@ void lv_obj_refresh_style(lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop)
     LV_PROFILER_STYLE_END;
 }
 
-void lv_obj_style_set_enabled(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector, bool en)
+void lv_obj_set_style_enabled(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector, bool en)
 {
     LV_CHECK_ARG(obj != NULL, return);
     LV_CHECK_ARG(style != NULL, return);
@@ -313,7 +313,7 @@ void lv_obj_style_set_enabled(lv_obj_t * obj, const lv_style_t * style, lv_style
     lv_obj_refresh_style(obj, lv_obj_style_get_selector_part(selector), LV_STYLE_PROP_ANY);
 }
 
-bool lv_obj_style_get_enabled(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector)
+bool lv_obj_get_style_enabled(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector)
 {
     LV_CHECK_ARG(obj != NULL, return false);
     LV_CHECK_ARG(style != NULL, return false);
@@ -326,16 +326,16 @@ bool lv_obj_style_get_enabled(lv_obj_t * obj, const lv_style_t * style, lv_style
 
 void lv_obj_style_set_disabled(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector, bool dis)
 {
-    LV_LOG_DEPRECATED("use lv_obj_style_set_enabled instead (with inverted logic).");
+    LV_LOG_DEPRECATED("use lv_obj_set_style_enabled instead (with inverted logic).");
     LV_CHECK_ARG(obj != NULL, return);
     LV_CHECK_ARG(style != NULL, return);
 
-    lv_obj_style_set_enabled(obj, style, selector, !dis);
+    lv_obj_set_style_enabled(obj, style, selector, !dis);
 }
 
 bool lv_obj_style_get_disabled(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector)
 {
-    LV_LOG_DEPRECATED("use lv_obj_style_get_enabled instead (with inverted logic).");
+    LV_LOG_DEPRECATED("use lv_obj_get_style_enabled instead (with inverted logic).");
     LV_CHECK_ARG(obj != NULL, return false);
     LV_CHECK_ARG(style != NULL, return false);
 
@@ -1569,7 +1569,7 @@ static void bind_style_observer_cb(lv_observer_t * observer, lv_subject_t * subj
 
     int32_t v = lv_subject_get_int(subject);
     bool en = (v == p->value);
-    lv_obj_style_set_enabled(observer->target, p->style, p->selector, en);
+    lv_obj_set_style_enabled(observer->target, p->style, p->selector, en);
 }
 
 static void bind_style_prop_observer_cb(lv_observer_t * observer, lv_subject_t * subject)


### PR DESCRIPTION
It makes the API consistent: `lv_ +  <widget_type> + _set_ + <what>`

<!-- A clear and concise description of what the bug or new feature is.-->

### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
