### PR TITLE
fix(opengles): ensure variable is initialized

### DIFF
--- a/src/drivers/opengles/lv_opengles_driver.c
+++ b/src/drivers/opengles/lv_opengles_driver.c
@@ -184,6 +184,7 @@ lv_result_t lv_opengles_gl_format_from_color_format(lv_color_format_t cf, lv_ope
             gl_format->format = GL_RGB;
             gl_format->type = GL_UNSIGNED_SHORT_5_6_5;
             gl_format->rb_swap = true;
+            gl_format->premultiplied = false;
             return LV_RESULT_OK;
         case LV_COLOR_FORMAT_RGB888:
             gl_format->internal_format = GL_RGB;
@@ -211,7 +212,7 @@ lv_result_t lv_opengles_gl_format_from_color_format(lv_color_format_t cf, lv_ope
 
 bool lv_opengles_color_format_is_rb_swap(lv_color_format_t cf)
 {
-    lv_opengles_gl_format_t gl_format;
+    lv_opengles_gl_format_t gl_format = {0};
     if(lv_opengles_gl_format_from_color_format(cf, &gl_format) != LV_RESULT_OK) {
         return false;
     }
@@ -220,7 +221,7 @@ bool lv_opengles_color_format_is_rb_swap(lv_color_format_t cf)
 
 bool lv_opengles_color_format_is_premultiplied(lv_color_format_t cf)
 {
-    lv_opengles_gl_format_t gl_format;
+    lv_opengles_gl_format_t gl_format = {0};
     if(lv_opengles_gl_format_from_color_format(cf, &gl_format) != LV_RESULT_OK) {
         return false;
     }


### PR DESCRIPTION
Fixes:

```bash
[265/644] Building C object lvgl/CMakeFiles/lvgl.dir/src/drivers/opengles/lv_opengles_driver.c.o
In function ‘lv_opengles_color_format_is_premultiplied’,
    inlined from ‘lv_opengles_render_display.part.0’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/drivers/opengles/lv_opengles_driver.c:381:60:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/drivers/opengles/lv_opengles_driver.c:227:21: warning: ‘*(unsigned char *)((char *)&gl_format + offsetof(lv_opengles_gl_format_t, premultiplied))’ may be used uninitialized [-Wmaybe-uninitialized]
  227 |     return gl_format.premultiplied;
      |            ~~~~~~~~~^~~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/drivers/opengles/lv_opengles_driver.c: In function ‘lv_opengles_render_display.part.0’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/drivers/opengles/lv_opengles_driver.c:223:29: note: ‘*(unsigned char *)((char *)&gl_format + offsetof(lv_opengles_gl_format_t, premultiplied))’ was declared here
  223 |     lv_opengles_gl_format_t gl_format;
      |                             ^~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/drivers/opengles/lv_opengles_driver.c: In function ‘lv_opengles_color_format_is_premultiplied’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/drivers/opengles/lv_opengles_driver.c:227:21: warning: ‘*(unsigned char *)((char *)&gl_format + offsetof(lv_opengles_gl_format_t, premultiplied))’ may be used uninitialized [-Wmaybe-uninitialized]
  227 |     return gl_format.premultiplied;
      |            ~~~~~~~~~^~~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/drivers/opengles/lv_opengles_driver.c:223:29: note: ‘*(unsigned char *)((char *)&gl_format + offsetof(lv_opengles_gl_format_t, premultiplied))’ was declared here
  223 |     lv_opengles_gl_format_t gl_format;
      |                             ^~~~~~~~~
In function ‘lv_opengles_color_format_is_premultiplied’,
    inlined from ‘lv_opengles_render’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/drivers/opengles/lv_opengles_driver.c:561:60:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/drivers/opengles/lv_opengles_driver.c:227:21: warning: ‘*(unsigned char *)((char *)&gl_format + offsetof(lv_opengles_gl_format_t, premultiplied))’ may be used uninitialized [-Wmaybe-uninitialized]
  227 |     return gl_format.premultiplied;
      |            ~~~~~~~~~^~~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/drivers/opengles/lv_opengles_driver.c: In function ‘lv_opengles_render’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/drivers/opengles/lv_opengles_driver.c:223:29: note: ‘*(unsigned char *)((char *)&gl_format + offsetof(lv_opengles_gl_format_t, premultiplied))’ was declared here
  223 |     lv_opengles_gl_format_t gl_format;
      |                             ^~~~~~~~~
```
