### PR TITLE
fix(demo/widgets): explicitly pass display to theme init funcion

### DIFF
--- a/demos/widgets/lv_demo_widgets.c
+++ b/demos/widgets/lv_demo_widgets.c
@@ -264,7 +264,7 @@ static void color_event_cb(lv_event_t * e)
         lv_palette_t palette_secondary = (*palette_primary) + 3; /*Use another palette as secondary*/
         if(palette_secondary >= LV_PALETTE_LAST) palette_secondary = 0;
 #if LV_USE_THEME_DEFAULT
-        lv_theme_default_init(NULL, lv_palette_main(*palette_primary), lv_palette_main(palette_secondary),
+        lv_theme_default_init(lv_obj_get_display(obj), lv_palette_main(*palette_primary), lv_palette_main(palette_secondary),
                               LV_THEME_DEFAULT_DARK, font_normal);
 #endif
         lv_color_t color = lv_palette_main(*palette_primary);

--- a/demos/widgets/lv_demo_widgets_components.c
+++ b/demos/widgets/lv_demo_widgets_components.c
@@ -113,7 +113,8 @@ void lv_demo_widgets_components_init(void)
 #endif
     }
 #if LV_USE_THEME_DEFAULT
-    lv_theme_default_init(NULL, lv_palette_main(LV_PALETTE_BLUE), lv_palette_main(LV_PALETTE_RED), LV_THEME_DEFAULT_DARK,
+    lv_theme_default_init(lv_display_get_default(), lv_palette_main(LV_PALETTE_BLUE), lv_palette_main(LV_PALETTE_RED),
+                          LV_THEME_DEFAULT_DARK,
                           font_normal);
 #endif
 


### PR DESCRIPTION
Fixes:

```bash
[Warn]	(0.442, +0)	lv_theme_default_init: Deprecated: Calling this function with a NULL display is deprecated. You can retrieve the default display with `lv_display_get_default()` lv_theme_default.c:632
```
