### PR TITLE
fix(draw/ppa): describe images by their stride, not by their width

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -930,6 +930,7 @@ endmenu
 menu "PPA"
 config LV_USE_PPA
 	bool "PPA renderer"
+	select LV_USE_DRAW_SW
 	default n
 	help
 		Accelerate blends, fills and transforms with the PPA (Pixel Processing

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -513,6 +513,8 @@
 
 /** Accelerate blends, fills and transforms with the PPA (Pixel Processing
  *  Accelerator) peripheral of Espressif SoCs.
+ *
+ *  Enable: LV_USE_DRAW_SW
  */
 #define LV_USE_PPA 0
 

--- a/src/draw/espressif/ppa/Kconfig
+++ b/src/draw/espressif/ppa/Kconfig
@@ -1,5 +1,6 @@
 config LV_USE_PPA
 	bool "PPA renderer"
+	select LV_USE_DRAW_SW
 	default n
 	help
 		Accelerate blends, fills and transforms with the PPA (Pixel Processing

--- a/src/draw/espressif/ppa/lv_draw_ppa.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa.c
@@ -158,6 +158,7 @@ static int32_t ppa_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
     t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
     u->task_act = t;
     u->task_act->draw_unit = draw_unit;
+    u->img_sw_fallback = false;
 
     ppa_execute_drawing(u);
 
@@ -193,7 +194,7 @@ static void ppa_execute_drawing(lv_draw_ppa_unit_t * u)
             lv_draw_buf_invalidate_cache(buf, &area);
             break;
         case LV_DRAW_TASK_TYPE_IMAGE:
-            lv_draw_ppa_img(t, (lv_draw_image_dsc_t *)t->draw_dsc, &area);
+            lv_draw_ppa_img(t, (lv_draw_image_dsc_t *)t->draw_dsc, &t->area);
             lv_draw_buf_invalidate_cache(buf, &area);
             break;
         default:

--- a/src/draw/espressif/ppa/lv_draw_ppa_img.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa_img.c
@@ -10,6 +10,7 @@
 
 #include "../../lv_draw_image_private.h"
 #include "../../../image/lv_image_decoder_private.h"
+#include "../../sw/lv_draw_sw.h"
 
 static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
                                  const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
@@ -54,12 +55,21 @@ static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t *
     lv_color_format_t dest_cf = draw_buf->header.cf;
     uint8_t * dest_buf = draw_buf->data;
 
-    extern const lv_image_dsc_t img_benchmark_lvgl_logo_rgb;
+    const int32_t src_pic_w  = lv_ppa_pic_w(decoded->header.stride, draw_dsc->header.w, src_cf);
+    const int32_t dest_pic_w = lv_ppa_pic_w(draw_buf->header.stride, draw_buf->header.w, dest_cf);
+    if(src_pic_w == 0 || dest_pic_w == 0) {
+        if(u->img_sw_fallback) return;
+        u->img_sw_fallback = true;
+
+        LV_LOG_INFO("PPA draw_img: stride is not a whole number of pixels, using software");
+        lv_draw_sw_image(t, draw_dsc, &t->area);
+        return;
+    }
 
     ppa_blend_oper_config_t cfg = {
         .in_bg = {
             .buffer          = (void *)src_buf,
-            .pic_w           = draw_dsc->header.w,
+            .pic_w           = src_pic_w,
             .pic_h           = draw_dsc->header.h,
             .block_w         = lv_area_get_width(clipped_img_area),
             .block_h         = lv_area_get_height(clipped_img_area),
@@ -74,12 +84,12 @@ static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t *
         .bg_ck_en              = false,
         .in_fg = {
             .buffer          = (void *)dest_buf,
-            .pic_w           = draw_dsc->header.w,
-            .pic_h           = draw_dsc->header.h,
+            .pic_w           = dest_pic_w,
+            .pic_h           = draw_buf->header.h,
             .block_w         = lv_area_get_width(clipped_img_area),
             .block_h         = lv_area_get_height(clipped_img_area),
-            .block_offset_x  = src_area.x1,
-            .block_offset_y  = src_area.y1,
+            .block_offset_x  = dest_area.x1,
+            .block_offset_y  = dest_area.y1,
             .blend_cm        = PPA_BLEND_COLOR_MODE_A8,
         },
         .fg_fix_rgb_val = {
@@ -95,7 +105,7 @@ static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t *
         .out = {
             .buffer          = dest_buf,
             .buffer_size     = draw_buf->data_size,
-            .pic_w           = draw_buf->header.w,
+            .pic_w           = dest_pic_w,
             .pic_h           = draw_buf->header.h,
             .block_offset_x  = dest_area.x1,
             .block_offset_y  = dest_area.y1,

--- a/src/draw/espressif/ppa/lv_draw_ppa_private.h
+++ b/src/draw/espressif/ppa/lv_draw_ppa_private.h
@@ -68,6 +68,7 @@ typedef struct lv_draw_ppa_unit {
     ppa_client_handle_t fill_client;
     ppa_client_handle_t blend_client;
     uint8_t * buf;
+    bool img_sw_fallback;
 } lv_draw_ppa_unit_t;
 
 /**********************
@@ -146,6 +147,16 @@ static inline ppa_blend_color_mode_t lv_color_format_to_ppa_blend(lv_color_forma
         default:
             return PPA_BLEND_COLOR_MODE_RGB565;
     }
+}
+
+static inline int32_t lv_ppa_pic_w(uint32_t stride, int32_t w, lv_color_format_t cf)
+{
+    if(stride == LV_STRIDE_AUTO) return w;
+
+    uint8_t px_size = lv_color_format_get_size(cf);
+    if(px_size == 0 || (stride % px_size) != 0) return 0;
+
+    return (int32_t)(stride / px_size);
 }
 
 static inline ppa_srm_color_mode_t lv_color_format_to_ppa_srm(lv_color_format_t lv_fmt)

--- a/src/lv_conf_check.c
+++ b/src/lv_conf_check.c
@@ -46,8 +46,8 @@
     #error "LV_USE_THORVG must be enabled: Kconfig selects it from LV_USE_VG_LITE_THORVG && LV_USE_DRAW_VG_LITE"
 #endif
 
-#if (LV_USE_SIFLI_EPIC || LV_USE_DRAW_G2D || LV_USE_DRAW_SDL) && !LV_USE_DRAW_SW
-    #error "LV_USE_DRAW_SW must be enabled: Kconfig selects it from LV_USE_SIFLI_EPIC || LV_USE_DRAW_G2D || LV_USE_DRAW_SDL"
+#if (LV_USE_PPA || LV_USE_SIFLI_EPIC || LV_USE_DRAW_G2D || LV_USE_DRAW_SDL) && !LV_USE_DRAW_SW
+    #error "LV_USE_DRAW_SW must be enabled: Kconfig selects it from LV_USE_PPA || LV_USE_SIFLI_EPIC || LV_USE_DRAW_G2D || LV_USE_DRAW_SDL"
 #endif
 
 #if LV_USE_DRAW_ARM2D_SYNC && !(LV_USE_DRAW_SW)


### PR DESCRIPTION
Supersedes #10625 by @youkorr, co-authored on the commit.

Reported by @halyssonJr: with LV_USE_PPA_IMG enabled, the "Multiple RGB images" benchmark scene renders sheared.

The PPA has no stride field. It derives the row pitch of a picture from pic_w times the pixel size, so pic_w is the pitch, not the visible width. The image path passed header.w, which is only the same thing when the buffer has no padding.

LVGL's image converter does pad. img_benchmark_lvgl_logo_rgb is 100 px wide and stored with a 256, 320 or 448 byte stride depending on LV_COLOR_DEPTH -- 128, 106.67 or 112 px. Describing it as 100 px makes the PPA start every row inside the previous one, which shears the image progressively down the block.

Derive the pitch from the stride instead, for the source and the destination alike, as lv_draw_dave2d_utils.c already does for that peripheral. A stride that is not a whole number of pixels, such as RGB888 padded to 320 bytes, cannot be expressed at all; those draws go to the software unit rather than being dropped, since the task has been assigned to this unit by then and returning would leave a hole on the screen. lv_draw_pxp.c falls back the same way for fills.

The check reads the real strides at draw time rather than predicting them in ppa_evaluate(), which runs before the image is decoded. Mispredicting there would cost either a missing image or an unnecessary software draw; not predicting at all costs neither.

The transparent dummy foreground is corrected while here: its buffer is the destination, but it was described with the source's width, height and block offsets, which makes the PPA fetch a region that need not exist in that buffer. It contributes no colour, so nothing was visible, but the two halves of the description have to agree for the stride change to mean anything.

Destination layers are unaffected in a default build: LV_DRAW_BUF_STRIDE_ALIGN is 1, so their stride already equals the width. Only sources carry padding, which is why images generated at their exact width render correctly while the benchmark asset does not.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

