### PR TITLE
fix(style): fix invalidation and caching mostly related to transition styles

### DIFF
--- a/include/lvgl/core/lv_style.h
+++ b/include/lvgl/core/lv_style.h
@@ -619,8 +619,8 @@ void lv_style_set_transform_scale(lv_style_t * style, int32_t value);
  * Do not pass multiple flags to this function as backwards-compatibility is not guaranteed
  * for that.
  *
- * @param prop Property ID
- * @param flag Flag
+ * @param prop 		a style property like `LV_STYLE_BG_COOR`
+ * @param flag 		a flag like `LV_STYLE_PROP_FLAG_EXT_DRAW_UPDATE`
  * @return true if the flag is set for this property
  */
 static inline bool lv_style_prop_has_flag(lv_style_prop_t prop, uint8_t flag)

--- a/include/lvgl/core/lv_style.h
+++ b/include/lvgl/core/lv_style.h
@@ -616,12 +616,10 @@ void lv_style_set_transform_scale(lv_style_t * style, int32_t value);
 /**
  * @brief Check if the style property has a specified behavioral flag.
  *
- * Do not pass multiple flags to this function as backwards-compatibility is not guaranteed
- * for that.
- *
- * @param prop 		a style property like `LV_STYLE_BG_COOR`
- * @param flag 		a flag like `LV_STYLE_PROP_FLAG_EXT_DRAW_UPDATE`
- * @return true if the flag is set for this property
+ * @param prop      a style property like `LV_STYLE_BG_COLOR`
+ * @param flag      a flag like `LV_STYLE_PROP_FLAG_EXT_DRAW_UPDATE`, or several
+ *                  flags OR-ed together
+ * @return true if at least one of the given flags is set for this property
  */
 static inline bool lv_style_prop_has_flag(lv_style_prop_t prop, uint8_t flag)
 {

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -63,7 +63,7 @@ static lv_style_res_t get_prop_core(const lv_obj_t * obj, lv_style_selector_t se
                                     lv_style_value_t * v);
 static void report_style_change_core(void * style, lv_obj_t * obj);
 static void refresh_children_style(lv_obj_t * obj);
-static bool trans_delete(lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop, trans_t * tr_limit);
+static bool remove_trans_styles(lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop, trans_t * tr_limit);
 static void trans_anim_cb(void * _tr, int32_t v);
 static void trans_anim_start_cb(lv_anim_t * a);
 static void trans_anim_completed_cb(lv_anim_t * a);
@@ -115,11 +115,13 @@ void lv_obj_add_style(lv_obj_t * obj, const lv_style_t * style, lv_style_selecto
     LV_CHECK_ARG_MSG(obj->style_cnt < 63, return,
                      "obj->style_cnt is restricted to 6 bits, so we can't store more than 63 styles");
 
-    trans_delete(obj, selector, LV_STYLE_PROP_ANY, NULL);
+    bool trans_removed = remove_trans_styles(obj, selector, LV_STYLE_PROP_ANY, NULL);
 
     lv_part_t part = lv_obj_style_get_selector_part(selector);
 
-    if(style && part == LV_PART_MAIN && style_has_flag(style, LV_STYLE_PROP_FLAG_TRANSFORM)) {
+    /*If the draw size changes invalidate the old area first*/
+    if(style && part == LV_PART_MAIN &&
+       style_has_flag(style, LV_STYLE_PROP_FLAG_TRANSFORM | LV_STYLE_PROP_FLAG_EXT_DRAW_UPDATE)) {
         lv_obj_invalidate(obj);
     }
 
@@ -152,17 +154,22 @@ void lv_obj_add_style(lv_obj_t * obj, const lv_style_t * style, lv_style_selecto
     obj->styles[i].selector = selector;
 
 #if LV_OBJ_STYLE_CACHE
-    uint32_t * prop_is_set = part == LV_PART_MAIN ? &obj->style_main_prop_is_set : &obj->style_other_prop_is_set;
-    if(lv_style_is_const_internal(style)) {
-        lv_style_const_prop_t * props = style->values_and_props;
-        for(i = 0; props[i].prop != LV_STYLE_PROP_INV; i++) {
-            (*prop_is_set) |= STYLE_PROP_SHIFTED(props[i].prop);
-        }
+    if(trans_removed) {
+        full_cache_refresh(obj, LV_PART_ANY);
     }
     else {
-        lv_style_prop_t * props = (lv_style_prop_t *)style->values_and_props + style->prop_cnt * sizeof(lv_style_value_t);
-        for(i = 0; i < style->prop_cnt; i++) {
-            (*prop_is_set) |= STYLE_PROP_SHIFTED(props[i]);
+        uint32_t * prop_is_set = part == LV_PART_MAIN ? &obj->style_main_prop_is_set : &obj->style_other_prop_is_set;
+        if(lv_style_is_const_internal(style)) {
+            lv_style_const_prop_t * props = style->values_and_props;
+            for(i = 0; props[i].prop != LV_STYLE_PROP_INV; i++) {
+                (*prop_is_set) |= STYLE_PROP_SHIFTED(props[i].prop);
+            }
+        }
+        else {
+            lv_style_prop_t * props = (lv_style_prop_t *)style->values_and_props + style->prop_cnt * sizeof(lv_style_value_t);
+            for(i = 0; i < style->prop_cnt; i++) {
+                (*prop_is_set) |= STYLE_PROP_SHIFTED(props[i]);
+            }
         }
     }
 #endif
@@ -182,7 +189,8 @@ bool lv_obj_replace_style(lv_obj_t * obj, const lv_style_t * old_style, const lv
     lv_part_t part = lv_obj_style_get_selector_part(selector);
 
     /*Similar to lv_obj_add_style, delete transition*/
-    trans_delete(obj, selector, LV_STYLE_PROP_ANY, NULL);
+    bool trans_removed;
+    trans_removed = remove_trans_styles(obj, selector, LV_STYLE_PROP_ANY, NULL);
 
     bool replaced = false;
     uint32_t i;
@@ -209,7 +217,7 @@ bool lv_obj_replace_style(lv_obj_t * obj, const lv_style_t * old_style, const lv
         replaced = true;
         /*Don't break and continue replacing other occurrences*/
     }
-    if(replaced) {
+    if(replaced || trans_removed) {
         full_cache_refresh(obj, part);
         lv_obj_refresh_style(obj, part, LV_STYLE_PROP_ANY);
     }
@@ -414,22 +422,29 @@ void lv_obj_set_local_style_prop(lv_obj_t * obj, lv_style_prop_t prop, lv_style_
     LV_PROFILER_STYLE_BEGIN;
 
     /*Stop running transitions with this property */
-    trans_delete(obj, lv_obj_style_get_selector_part(selector), prop, NULL);
+    bool trans_removed = remove_trans_styles(obj, lv_obj_style_get_selector_part(selector), prop, NULL);
 
     lv_style_t * style = get_local_style(obj, selector);
-    if(selector == LV_PART_MAIN && lv_style_prop_has_flag(prop, LV_STYLE_PROP_FLAG_TRANSFORM)) {
+    /*If the draw size changes invalidate the old area first*/
+    if(selector == LV_PART_MAIN &&
+       lv_style_prop_has_flag(prop, LV_STYLE_PROP_FLAG_TRANSFORM | LV_STYLE_PROP_FLAG_EXT_DRAW_UPDATE)) {
         lv_obj_invalidate(obj);
     }
 
     lv_style_set_prop(style, prop, value);
 
 #if LV_OBJ_STYLE_CACHE
-    uint32_t prop_shifted = STYLE_PROP_SHIFTED(prop);
-    if(lv_obj_style_get_selector_part(selector) == LV_PART_MAIN) {
-        obj->style_main_prop_is_set |= prop_shifted;
+    if(trans_removed) {
+        full_cache_refresh(obj, LV_PART_ANY);
     }
     else {
-        obj->style_other_prop_is_set |= prop_shifted;
+        uint32_t prop_shifted = STYLE_PROP_SHIFTED(prop);
+        if(lv_obj_style_get_selector_part(selector) == LV_PART_MAIN) {
+            obj->style_main_prop_is_set |= prop_shifted;
+        }
+        else {
+            obj->style_other_prop_is_set |= prop_shifted;
+        }
     }
 #endif
 
@@ -1069,17 +1084,17 @@ static lv_style_res_t get_prop_core(const lv_obj_t * obj, lv_style_selector_t se
 
     const uint32_t group = (uint32_t)1 << lv_style_get_prop_group(prop);
     const lv_part_t part = lv_obj_style_get_selector_part(selector);
-    const lv_state_t state = lv_obj_style_get_selector_state(selector);
-    const lv_state_t state_inv = ~state;
     const bool skip_trans = (const bool) obj->skip_trans;
     int32_t weight = -1;
     lv_style_res_t found;
     uint32_t i;
+    /*Handle the transition styles first. They are at the beginning of the style list
+     *as the have the highest precedence. It's a different for loop as in case of transitions
+     *the state doesn't need to be checked. */
     for(i = 0; i < obj->style_cnt; i++) {
         lv_obj_style_t * obj_style = &obj->styles[i];
         if(obj_style->is_trans == false) break;
         if(skip_trans) continue;
-        if(obj_style->is_disabled) continue;
 
         lv_part_t part_act = lv_obj_style_get_selector_part(obj->styles[i].selector);
 
@@ -1091,6 +1106,9 @@ static lv_style_res_t get_prop_core(const lv_obj_t * obj, lv_style_selector_t se
         }
     }
 
+    /*Check the normal local and global styles that are assigned to given state*/
+    const lv_state_t state = lv_obj_style_get_selector_state(selector);
+    const lv_state_t state_inv = ~state;
     for(; i < obj->style_cnt; i++) {
         if((obj->styles[i].style->has_group & group) == 0) continue;
         if(obj->styles[i].is_disabled) continue;
@@ -1168,8 +1186,11 @@ static void refresh_children_style(lv_obj_t * obj)
  * @param part a part of object or 0xFF to remove from all parts
  * @param prop a property or 0xFF to remove all properties
  * @param tr_limit delete transitions only "older" than this. `NULL` if not used
+ * @return true: at lest 1 transition style saw removed.
+ * @note it doesn't update the cache, `full_cache_refresh` needs to be called manually
+ * @note it doesn't invalidate the widget
  */
-static bool trans_delete(lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop, trans_t * tr_limit)
+static bool remove_trans_styles(lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop, trans_t * tr_limit)
 {
     trans_t * tr;
     trans_t * tr_prev;
@@ -1200,6 +1221,7 @@ static bool trans_delete(lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop, t
         }
         tr = tr_prev;
     }
+
     return removed;
 }
 
@@ -1209,6 +1231,7 @@ static void trans_anim_cb(void * _tr, int32_t v)
     lv_obj_t * obj = tr->obj;
 
     uint32_t i;
+    /*Find the transition style of of the descriptor*/
     for(i = 0; i < obj->style_cnt; i++) {
         if(obj->styles[i].is_trans == 0 || obj->styles[i].selector != tr->selector) continue;
 
@@ -1252,18 +1275,33 @@ static void trans_anim_cb(void * _tr, int32_t v)
                 break;
         }
 
+        /*Don't do anything is the prop didn't changed*/
         lv_style_value_t old_value = {0};
-        bool refr = true;
-        if(lv_style_get_prop_internal(obj->styles[i].style, tr->prop, &old_value)) {
-            if(value_final.ptr == old_value.ptr && lv_color_eq(value_final.color, old_value.color) &&
+        if(lv_style_get_prop_internal(obj->styles[i].style, tr->prop, &old_value) == LV_STYLE_RES_FOUND) {
+            if(value_final.ptr == old_value.ptr &&
+               lv_color_eq(value_final.color, old_value.color) &&
                value_final.num == old_value.num) {
-                refr = false;
+                break;
             }
         }
-        lv_style_set_prop((lv_style_t *)obj->styles[i].style, tr->prop, value_final);
-        if(refr) lv_obj_refresh_style(tr->obj, tr->selector, tr->prop);
-        break;
 
+        /*If the draw size changes invalidate the old area first*/
+        lv_part_t part = lv_obj_style_get_selector_part(tr->selector);
+        if(part == LV_PART_MAIN &&
+           lv_style_prop_has_flag(tr->prop, LV_STYLE_PROP_FLAG_TRANSFORM  | LV_STYLE_PROP_FLAG_EXT_DRAW_UPDATE)) {
+            lv_obj_invalidate(tr->obj);
+        }
+        lv_style_set_prop((lv_style_t *)obj->styles[i].style, tr->prop, value_final);
+        uint32_t prop_shifted = STYLE_PROP_SHIFTED(tr->prop);
+        if(part == LV_PART_MAIN) {
+            obj->style_main_prop_is_set |= prop_shifted;
+        }
+        else {
+            obj->style_other_prop_is_set |= prop_shifted;
+        }
+
+        lv_obj_refresh_style(tr->obj, tr->selector, tr->prop);
+        break;
     }
 
 }
@@ -1280,13 +1318,26 @@ static void trans_anim_start_cb(lv_anim_t * a)
     tr->prop = LV_STYLE_PROP_INV;
 
     /*Delete the related transitions if any*/
-    trans_delete(tr->obj, part, prop_tmp, tr);
+    bool trans_removed = remove_trans_styles(tr->obj, part, prop_tmp, tr);
 
     tr->prop = prop_tmp;
 
     lv_obj_style_t * style_trans = get_trans_style(tr->obj, tr->selector);
     /*Be sure `trans_style` has a valid value*/
     lv_style_set_prop((lv_style_t *)style_trans->style, tr->prop, tr->start_value);
+    if(trans_removed) {
+        full_cache_refresh(tr->obj, part);
+    }
+    else {
+        uint32_t prop_shifted = STYLE_PROP_SHIFTED(tr->prop);
+        if(lv_obj_style_get_selector_part(tr->selector) == LV_PART_MAIN) {
+            tr->obj->style_main_prop_is_set |= prop_shifted;
+        }
+        else {
+            tr->obj->style_other_prop_is_set |= prop_shifted;
+        }
+    }
+
     lv_obj_refresh_style(tr->obj, tr->selector, tr->prop);
 
 }
@@ -1539,10 +1590,10 @@ static void remove_style_core(lv_obj_t * obj, const lv_style_t * style, lv_style
     LV_ASSERT(obj != NULL);
     lv_state_t state = lv_obj_style_get_selector_state(selector);
     lv_part_t part = lv_obj_style_get_selector_part(selector);
-    lv_style_prop_t prop = LV_STYLE_PROP_ANY;
-    if(style && style->prop_cnt == 0) prop = LV_STYLE_PROP_INV;
 
-    if(style && part == LV_PART_MAIN && style_has_flag(style, LV_STYLE_PROP_FLAG_TRANSFORM)) {
+    /*If the draw size changes invalidate the old area first*/
+    if(style && part == LV_PART_MAIN &&
+       style_has_flag(style, LV_STYLE_PROP_FLAG_TRANSFORM | LV_STYLE_PROP_FLAG_EXT_DRAW_UPDATE)) {
         lv_obj_invalidate(obj);
     }
 
@@ -1574,7 +1625,7 @@ static void remove_style_core(lv_obj_t * obj, const lv_style_t * style, lv_style
 
         /*This entry is being removed*/
         if(obj->styles[i].is_trans) {
-            trans_delete(obj, part, LV_STYLE_PROP_ANY, NULL);
+            remove_trans_styles(obj, part, LV_STYLE_PROP_ANY, NULL);
         }
         if(obj->styles[i].is_local || obj->styles[i].is_trans) {
             if(obj->styles[i].style) lv_style_reset((lv_style_t *)obj->styles[i].style);
@@ -1597,9 +1648,9 @@ static void remove_style_core(lv_obj_t * obj, const lv_style_t * style, lv_style
         obj->styles = NULL;
     }
 
-    if(prop != LV_STYLE_PROP_INV) {
+    if(deleted) {
         full_cache_refresh(obj, part);
-        lv_obj_refresh_style(obj, part, prop);
+        lv_obj_refresh_style(obj, part, LV_STYLE_PROP_ANY);
     }
 }
 

--- a/src/core/lv_obj_style.c
+++ b/src/core/lv_obj_style.c
@@ -27,6 +27,11 @@
 #define _style_custom_prop_flag_lookup_table LV_GLOBAL_DEFAULT()->style_custom_prop_flag_lookup_table
 #define STYLE_PROP_SHIFTED(prop) ((uint32_t)1 << ((prop) >> 3))
 
+/*Property flags that can change the area where the widget is drawn.
+ *Before changing such a property the old area needs to be invalidated,
+ *else the already drawn pixels are left on the screen.*/
+#define DRAW_AREA_FLAGS (LV_STYLE_PROP_FLAG_TRANSFORM | LV_STYLE_PROP_FLAG_EXT_DRAW_UPDATE)
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -115,15 +120,14 @@ void lv_obj_add_style(lv_obj_t * obj, const lv_style_t * style, lv_style_selecto
     LV_CHECK_ARG_MSG(obj->style_cnt < 63, return,
                      "obj->style_cnt is restricted to 6 bits, so we can't store more than 63 styles");
 
-    bool trans_removed = remove_trans_styles(obj, selector, LV_STYLE_PROP_ANY, NULL);
-
     lv_part_t part = lv_obj_style_get_selector_part(selector);
 
     /*If the draw size changes invalidate the old area first*/
-    if(style && part == LV_PART_MAIN &&
-       style_has_flag(style, LV_STYLE_PROP_FLAG_TRANSFORM | LV_STYLE_PROP_FLAG_EXT_DRAW_UPDATE)) {
+    if(part == LV_PART_MAIN && style_has_flag(style, DRAW_AREA_FLAGS)) {
         lv_obj_invalidate(obj);
     }
+
+    bool trans_removed = remove_trans_styles(obj, selector, LV_STYLE_PROP_ANY, NULL);
 
     /*Try removing the style first to be sure it won't be added twice*/
     lv_obj_remove_style(obj, style, selector);
@@ -153,10 +157,10 @@ void lv_obj_add_style(lv_obj_t * obj, const lv_style_t * style, lv_style_selecto
     obj->styles[i].style = style;
     obj->styles[i].selector = selector;
 
-#if LV_OBJ_STYLE_CACHE
     if(trans_removed) {
         full_cache_refresh(obj, LV_PART_ANY);
     }
+#if LV_OBJ_STYLE_CACHE
     else {
         uint32_t * prop_is_set = part == LV_PART_MAIN ? &obj->style_main_prop_is_set : &obj->style_other_prop_is_set;
         if(lv_style_is_const_internal(style)) {
@@ -188,9 +192,14 @@ bool lv_obj_replace_style(lv_obj_t * obj, const lv_style_t * old_style, const lv
     lv_state_t state = lv_obj_style_get_selector_state(selector);
     lv_part_t part = lv_obj_style_get_selector_part(selector);
 
+    /*If the draw size changes invalidate the old area first*/
+    if((part == LV_PART_MAIN || part == LV_PART_ANY) &&
+       (style_has_flag(old_style, DRAW_AREA_FLAGS) || style_has_flag(new_style, DRAW_AREA_FLAGS))) {
+        lv_obj_invalidate(obj);
+    }
+
     /*Similar to lv_obj_add_style, delete transition*/
-    bool trans_removed;
-    trans_removed = remove_trans_styles(obj, selector, LV_STYLE_PROP_ANY, NULL);
+    bool trans_removed = remove_trans_styles(obj, selector, LV_STYLE_PROP_ANY, NULL);
 
     bool replaced = false;
     uint32_t i;
@@ -322,9 +331,16 @@ void lv_obj_set_style_enabled(lv_obj_t * obj, const lv_style_t * style, lv_style
 
     if(en != obj_style->is_disabled) return; /*Already in the right state*/
 
+    lv_part_t part = lv_obj_style_get_selector_part(selector);
+
+    /*If the draw size changes invalidate the old area first*/
+    if((part == LV_PART_MAIN || part == LV_PART_ANY) && style_has_flag(style, DRAW_AREA_FLAGS)) {
+        lv_obj_invalidate(obj);
+    }
+
     obj_style->is_disabled = !en;
-    full_cache_refresh(obj, lv_obj_style_get_selector_part(selector));
-    lv_obj_refresh_style(obj, lv_obj_style_get_selector_part(selector), LV_STYLE_PROP_ANY);
+    full_cache_refresh(obj, part);
+    lv_obj_refresh_style(obj, part, LV_STYLE_PROP_ANY);
 }
 
 bool lv_obj_get_style_enabled(lv_obj_t * obj, const lv_style_t * style, lv_style_selector_t selector)
@@ -421,22 +437,22 @@ void lv_obj_set_local_style_prop(lv_obj_t * obj, lv_style_prop_t prop, lv_style_
 
     LV_PROFILER_STYLE_BEGIN;
 
+    /*If the draw size changes invalidate the old area first*/
+    if(lv_obj_style_get_selector_part(selector) == LV_PART_MAIN && lv_style_prop_has_flag(prop, DRAW_AREA_FLAGS)) {
+        lv_obj_invalidate(obj);
+    }
+
     /*Stop running transitions with this property */
     bool trans_removed = remove_trans_styles(obj, lv_obj_style_get_selector_part(selector), prop, NULL);
 
     lv_style_t * style = get_local_style(obj, selector);
-    /*If the draw size changes invalidate the old area first*/
-    if(selector == LV_PART_MAIN &&
-       lv_style_prop_has_flag(prop, LV_STYLE_PROP_FLAG_TRANSFORM | LV_STYLE_PROP_FLAG_EXT_DRAW_UPDATE)) {
-        lv_obj_invalidate(obj);
-    }
 
     lv_style_set_prop(style, prop, value);
 
-#if LV_OBJ_STYLE_CACHE
     if(trans_removed) {
         full_cache_refresh(obj, LV_PART_ANY);
     }
+#if LV_OBJ_STYLE_CACHE
     else {
         uint32_t prop_shifted = STYLE_PROP_SHIFTED(prop);
         if(lv_obj_style_get_selector_part(selector) == LV_PART_MAIN) {
@@ -1186,9 +1202,8 @@ static void refresh_children_style(lv_obj_t * obj)
  * @param part a part of object or 0xFF to remove from all parts
  * @param prop a property or 0xFF to remove all properties
  * @param tr_limit delete transitions only "older" than this. `NULL` if not used
- * @return true: at lest 1 transition style saw removed.
+ * @return true: at least 1 transition style was removed.
  * @note it doesn't update the cache, `full_cache_refresh` needs to be called manually
- * @note it doesn't invalidate the widget
  */
 static bool remove_trans_styles(lv_obj_t * obj, lv_part_t part, lv_style_prop_t prop, trans_t * tr_limit)
 {
@@ -1203,6 +1218,13 @@ static bool remove_trans_styles(lv_obj_t * obj, lv_part_t part, lv_style_prop_t 
         tr_prev = lv_ll_get_prev(style_trans_ll_p, tr);
 
         if(tr->obj == obj && (part == tr->selector || part == LV_PART_ANY) && (prop == tr->prop || prop == LV_STYLE_PROP_ANY)) {
+            /*Dropping the transitioned value changes the drawn area right away,
+             *so invalidate the old area first*/
+            if(lv_obj_style_get_selector_part(tr->selector) == LV_PART_MAIN &&
+               lv_style_prop_has_flag(tr->prop, DRAW_AREA_FLAGS)) {
+                lv_obj_invalidate(obj);
+            }
+
             /*Remove any transitioned properties from the trans. style
              *to allow changing it by normal styles*/
             uint32_t i;
@@ -1287,11 +1309,12 @@ static void trans_anim_cb(void * _tr, int32_t v)
 
         /*If the draw size changes invalidate the old area first*/
         lv_part_t part = lv_obj_style_get_selector_part(tr->selector);
-        if(part == LV_PART_MAIN &&
-           lv_style_prop_has_flag(tr->prop, LV_STYLE_PROP_FLAG_TRANSFORM  | LV_STYLE_PROP_FLAG_EXT_DRAW_UPDATE)) {
+        if(part == LV_PART_MAIN && lv_style_prop_has_flag(tr->prop, DRAW_AREA_FLAGS)) {
             lv_obj_invalidate(tr->obj);
         }
         lv_style_set_prop((lv_style_t *)obj->styles[i].style, tr->prop, value_final);
+
+#if LV_OBJ_STYLE_CACHE
         uint32_t prop_shifted = STYLE_PROP_SHIFTED(tr->prop);
         if(part == LV_PART_MAIN) {
             obj->style_main_prop_is_set |= prop_shifted;
@@ -1299,6 +1322,7 @@ static void trans_anim_cb(void * _tr, int32_t v)
         else {
             obj->style_other_prop_is_set |= prop_shifted;
         }
+#endif
 
         lv_obj_refresh_style(tr->obj, tr->selector, tr->prop);
         break;
@@ -1325,18 +1349,22 @@ static void trans_anim_start_cb(lv_anim_t * a)
     lv_obj_style_t * style_trans = get_trans_style(tr->obj, tr->selector);
     /*Be sure `trans_style` has a valid value*/
     lv_style_set_prop((lv_style_t *)style_trans->style, tr->prop, tr->start_value);
+#if LV_OBJ_STYLE_CACHE
     if(trans_removed) {
         full_cache_refresh(tr->obj, part);
     }
     else {
         uint32_t prop_shifted = STYLE_PROP_SHIFTED(tr->prop);
-        if(lv_obj_style_get_selector_part(tr->selector) == LV_PART_MAIN) {
+        if(part == LV_PART_MAIN) {
             tr->obj->style_main_prop_is_set |= prop_shifted;
         }
         else {
             tr->obj->style_other_prop_is_set |= prop_shifted;
         }
     }
+#else
+    LV_UNUSED(trans_removed);
+#endif
 
     lv_obj_refresh_style(tr->obj, tr->selector, tr->prop);
 
@@ -1591,9 +1619,10 @@ static void remove_style_core(lv_obj_t * obj, const lv_style_t * style, lv_style
     lv_state_t state = lv_obj_style_get_selector_state(selector);
     lv_part_t part = lv_obj_style_get_selector_part(selector);
 
-    /*If the draw size changes invalidate the old area first*/
-    if(style && part == LV_PART_MAIN &&
-       style_has_flag(style, LV_STYLE_PROP_FLAG_TRANSFORM | LV_STYLE_PROP_FLAG_EXT_DRAW_UPDATE)) {
+    /*If the draw size changes invalidate the old area first.
+     *`style == NULL` means "any style" (e.g. `lv_obj_remove_style_all()`) so it can't be checked for flags.*/
+    if((part == LV_PART_MAIN || part == LV_PART_ANY) &&
+       (style == NULL || style_has_flag(style, DRAW_AREA_FLAGS))) {
         lv_obj_invalidate(obj);
     }
 

--- a/tests/src/test_cases/test_obj_style_transform_invalidation.c
+++ b/tests/src/test_cases/test_obj_style_transform_invalidation.c
@@ -1,0 +1,284 @@
+#if LV_BUILD_TEST
+#include "../lvgl.h"
+#include "../../lvgl_private.h"
+
+#include "unity/unity.h"
+
+/* Tests that changing a style property which affects the drawn area invalidates
+ * the *old* area too.
+ *
+ * A transformed widget is drawn outside its coordinates, and the area to
+ * invalidate is computed from the current style values. So if the new value is
+ * written first and the widget is invalidated only afterwards, the area the
+ * widget used to occupy is never redrawn and the old pixels stay on the screen.
+ * Every path that can change such a property therefore has to invalidate before
+ * the change.
+ *
+ * The tests shrink the drawn area (so the new area can't cover the old one) and
+ * check through LV_EVENT_INVALIDATE_AREA that the part of the old area which
+ * the widget no longer covers was invalidated. */
+
+static lv_display_t * disp;
+
+#define MAX_CAPTURED 64
+static lv_area_t captured[MAX_CAPTURED];
+static uint32_t captured_cnt;
+
+/* Styles used by the tests. They outlive the widget in every case. */
+static lv_style_t style_big;
+static lv_style_t style_small;
+static lv_style_t style_plain;
+static lv_style_transition_dsc_t trans_dsc;
+
+void setUp(void)
+{
+    disp = lv_display_get_default();
+
+    lv_style_init(&style_big);
+    lv_style_set_transform_scale_y(&style_big, 4 * 256);
+
+    lv_style_init(&style_small);
+    lv_style_set_transform_scale_y(&style_small, 256);
+
+    /*No property that affects the drawn area*/
+    lv_style_init(&style_plain);
+    lv_style_set_bg_color(&style_plain, lv_color_hex(0x00ff00));
+}
+
+void tearDown(void)
+{
+    lv_obj_clean(lv_screen_active());
+    lv_style_reset(&style_big);
+    lv_style_reset(&style_small);
+    lv_style_reset(&style_plain);
+}
+
+/* Record every area the display is asked to invalidate while capturing. */
+static void invalidate_area_cb(lv_event_t * e)
+{
+    TEST_ASSERT_LESS_THAN_UINT32(MAX_CAPTURED, captured_cnt);
+    lv_area_t * area = lv_event_get_param(e);
+    captured[captured_cnt++] = *area;
+}
+
+static void start_capture(void)
+{
+    captured_cnt = 0;
+    lv_display_add_event_cb(disp, invalidate_area_cb, LV_EVENT_INVALIDATE_AREA, NULL);
+}
+
+static void stop_capture(void)
+{
+    lv_display_remove_event_cb_with_user_data(disp, invalidate_area_cb, NULL);
+}
+
+/* True if any captured invalidated area covers the whole given area. */
+static bool area_was_invalidated(const lv_area_t * area)
+{
+    for(uint32_t i = 0; i < captured_cnt; i++) {
+        if(lv_area_is_in(area, &captured[i], 0)) return true;
+    }
+    return false;
+}
+
+/* In LV_DISPLAY_RENDER_MODE_FULL any change redraws the whole screen and
+ * lv_inv_area() sends no LV_EVENT_INVALIDATE_AREA, so there is nothing to
+ * observe. */
+static void skip_in_full_render_mode(void)
+{
+    if(lv_display_get_render_mode(disp) == LV_DISPLAY_RENDER_MODE_FULL) {
+        TEST_IGNORE_MESSAGE("No per-area invalidation in LV_DISPLAY_RENDER_MODE_FULL");
+    }
+}
+
+/* Where the widget is really drawn right now. */
+static lv_area_t drawn_area(lv_obj_t * obj)
+{
+    lv_area_t a = obj->coords;
+    lv_obj_get_transformed_area(obj, &a, LV_OBJ_POINT_TRANSFORM_FLAG_RECURSIVE);
+    return a;
+}
+
+/* A styleless widget in the middle of the screen, scaled up 4x vertically so
+ * there is a large area above and below it that a later shrink has to give
+ * back. */
+static lv_obj_t * create_scaled_obj(void)
+{
+    lv_obj_t * obj = lv_obj_create(lv_screen_active());
+    lv_obj_remove_style_all(obj);
+    lv_obj_set_pos(obj, 100, 100);
+    lv_obj_set_size(obj, 60, 40);
+    lv_obj_set_style_bg_opa(obj, LV_OPA_COVER, 0);
+    lv_obj_add_style(obj, &style_big, 0);
+    lv_refr_now(NULL);
+    return obj;
+}
+
+/* Assert that the strip the widget dropped when it shrank from `before` to its
+ * current area was invalidated. The default pivot is the top left corner, so a
+ * smaller scale_y releases a strip below the new area. Only an invalidation done
+ * before the change can cover it. */
+static void assert_released_strip_was_invalidated(lv_obj_t * obj, const lv_area_t * before)
+{
+    lv_area_t after = drawn_area(obj);
+
+    /*The widget really shrank, otherwise the new area alone could cover the old*/
+    TEST_ASSERT_LESS_THAN_INT32(before->y2 - 4, after.y2);
+
+    lv_area_t strip = {before->x1, after.y2 + 2, before->x2, before->y2};
+    TEST_ASSERT_TRUE(area_was_invalidated(&strip));
+}
+
+/* Baseline: a local style property. */
+void test_local_style_prop_invalidates_the_old_area(void)
+{
+    skip_in_full_render_mode();
+    lv_obj_t * obj = create_scaled_obj();
+    lv_area_t before = drawn_area(obj);
+
+    start_capture();
+    lv_obj_set_style_transform_scale_y(obj, 256, 0);
+    stop_capture();
+
+    assert_released_strip_was_invalidated(obj, &before);
+}
+
+/* Adding a style that overrides the transform. */
+void test_add_style_invalidates_the_old_area(void)
+{
+    skip_in_full_render_mode();
+    lv_obj_t * obj = create_scaled_obj();
+    lv_area_t before = drawn_area(obj);
+
+    start_capture();
+    lv_obj_add_style(obj, &style_small, 0);
+    stop_capture();
+
+    assert_released_strip_was_invalidated(obj, &before);
+}
+
+/* Removing the style that provides the transform. */
+void test_remove_style_invalidates_the_old_area(void)
+{
+    skip_in_full_render_mode();
+    lv_obj_t * obj = create_scaled_obj();
+    lv_area_t before = drawn_area(obj);
+
+    start_capture();
+    lv_obj_remove_style(obj, &style_big, 0);
+    stop_capture();
+
+    assert_released_strip_was_invalidated(obj, &before);
+}
+
+/* lv_obj_remove_style_all() passes no style, so the properties it drops can't be
+ * checked for flags and it has to invalidate unconditionally. */
+void test_remove_style_all_invalidates_the_old_area(void)
+{
+    skip_in_full_render_mode();
+    lv_obj_t * obj = create_scaled_obj();
+    lv_area_t before = drawn_area(obj);
+
+    start_capture();
+    lv_obj_remove_style_all(obj);
+    stop_capture();
+
+    assert_released_strip_was_invalidated(obj, &before);
+}
+
+/* Replacing the style that provides the transform with a smaller one. */
+void test_replace_style_invalidates_the_old_area(void)
+{
+    skip_in_full_render_mode();
+    lv_obj_t * obj = create_scaled_obj();
+    lv_area_t before = drawn_area(obj);
+
+    start_capture();
+    TEST_ASSERT_TRUE(lv_obj_replace_style(obj, &style_big, &style_small, 0));
+    stop_capture();
+
+    assert_released_strip_was_invalidated(obj, &before);
+}
+
+/* Disabling the style that provides the transform. */
+void test_disable_style_invalidates_the_old_area(void)
+{
+    skip_in_full_render_mode();
+    lv_obj_t * obj = create_scaled_obj();
+    lv_area_t before = drawn_area(obj);
+
+    start_capture();
+    lv_obj_set_style_enabled(obj, &style_big, 0, false);
+    stop_capture();
+
+    assert_released_strip_was_invalidated(obj, &before);
+}
+
+/* Start a scale_y transition from 4x down to 1x and stop half way, so a
+ * transition is running and the widget is drawn larger than its coordinates. */
+static lv_obj_t * create_obj_with_running_transition(void)
+{
+    static const lv_style_prop_t props[] = {LV_STYLE_TRANSFORM_SCALE_Y, LV_STYLE_PROP_INV};
+
+    lv_obj_t * obj = lv_obj_create(lv_screen_active());
+    lv_obj_remove_style_all(obj);
+    lv_obj_set_pos(obj, 100, 100);
+    lv_obj_set_size(obj, 60, 40);
+    lv_obj_set_style_bg_opa(obj, LV_OPA_COVER, 0);
+
+    /*4x while pressed, 1x otherwise*/
+    lv_obj_add_style(obj, &style_big, LV_STATE_PRESSED);
+
+    lv_style_transition_dsc_init(&trans_dsc, props, lv_anim_path_linear, 400, 0, NULL);
+    lv_obj_set_style_transition(obj, &trans_dsc, 0);
+
+    /*A transition is only started for a widget that was already rendered*/
+    lv_refr_now(NULL);
+
+    lv_obj_add_state(obj, LV_STATE_PRESSED);
+    lv_test_wait(400);
+    TEST_ASSERT_EQUAL_INT32(4 * 256, lv_obj_get_style_transform_scale_y(obj, LV_PART_MAIN));
+
+    /*Transition back to 1x, stopped half way*/
+    lv_obj_remove_state(obj, LV_STATE_PRESSED);
+    lv_test_wait(200);
+    int32_t scale = lv_obj_get_style_transform_scale_y(obj, LV_PART_MAIN);
+    TEST_ASSERT_GREATER_THAN_INT32(256 + 32, scale);
+    TEST_ASSERT_LESS_THAN_INT32(4 * 256, scale);
+
+    return obj;
+}
+
+/* Every step of a transform transition shrinks the drawn area, so each step has
+ * to invalidate the area the widget had before the step. */
+void test_transition_step_invalidates_the_old_area(void)
+{
+    skip_in_full_render_mode();
+    lv_obj_t * obj = create_obj_with_running_transition();
+    lv_area_t before = drawn_area(obj);
+
+    start_capture();
+    lv_tick_inc(100);
+    lv_timer_handler();
+    stop_capture();
+
+    assert_released_strip_was_invalidated(obj, &before);
+}
+
+/* Killing a running transform transition changes the drawn area right away.
+ * The style being added carries no property that affects the drawn area, so
+ * only the transition removal itself can invalidate the old area. */
+void test_killing_a_transform_transition_invalidates_the_old_area(void)
+{
+    skip_in_full_render_mode();
+    lv_obj_t * obj = create_obj_with_running_transition();
+    lv_area_t before = drawn_area(obj);
+
+    start_capture();
+    lv_obj_add_style(obj, &style_plain, 0);
+    stop_capture();
+
+    assert_released_strip_was_invalidated(obj, &before);
+}
+
+#endif


### PR DESCRIPTION
With out the fix there was residual drawing when `scale_y` was in a transition. 
 
### Notes
- Update the [Documentation](https://github.com/lvgl/lvgl/tree/master/docs) if needed.
- Add [Examples](https://github.com/lvgl/lvgl/tree/master/examples) if relevant.
- Add [Tests](https://github.com/lvgl/lvgl/blob/master/tests/README.md) if applicable.
- If you added new options to `lv_conf_template.h` run [lv_conf_internal_gen.py](https://github.com/lvgl/lvgl/blob/master/scripts/lv_conf_internal_gen.py) and update [Kconfig](https://github.com/lvgl/lvgl/blob/master/Kconfig).
- Run `scripts/code-format.py` (`astyle v3.4.12` needs to installed by running `cd scripts; ./install_astyle.sh`) and follow the [Code Conventions](https://docs.lvgl.io/master/CODING_STYLE.html).
- Mark the Pull request as [Draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) while you are working on the first version, and mark is as _Ready_ when it's ready for review.
- When changes were requested, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify the maintainers.
- Help us to review this Pull Request! Anyone can [approve or request changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews).
