### PR TITLE
fix(clib): cast away const in strchr

### DIFF
--- a/src/stdlib/clib/lv_string_clib.c
+++ b/src/stdlib/clib/lv_string_clib.c
@@ -173,7 +173,7 @@ char * lv_strchr(const char * str, int c)
 {
     LV_ASSERT(str != NULL);
 
-    return strchr(str, c);
+    return (char *)strchr(str, c);
 }
 
 /**********************


### PR DESCRIPTION
Fixes:
```bash
/home/andre/dev/lvgl/lvgl/src/stdlib/clib/lv_string_clib.c: In function ‘lv_strchr’:
/home/andre/dev/lvgl/lvgl/src/stdlib/clib/lv_string_clib.c:176:12: warning: return discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  176 |     return strchr(str, c);
      |            ^~~~~~
[507/507] Linking CXX static library liblvgl.a
```
