### PR TITLE
fix(draw/ppa): invalidate the draw buffer after the PPA writes it

### DIFF
--- a/src/draw/espressif/ppa/lv_draw_ppa.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa.c
@@ -25,6 +25,7 @@
 
 static int32_t ppa_evaluate(lv_draw_unit_t * draw_unit, lv_draw_task_t * task);
 static int32_t ppa_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer);
+static bool other_unit_busy(const lv_layer_t * layer, const lv_draw_unit_t * self);
 static int32_t ppa_delete(lv_draw_unit_t * draw_unit);
 static void  ppa_execute_drawing(lv_draw_ppa_unit_t * u);
 
@@ -141,10 +142,25 @@ static int32_t ppa_evaluate(lv_draw_unit_t * u, lv_draw_task_t * t)
     }
 }
 
+static bool other_unit_busy(const lv_layer_t * layer, const lv_draw_unit_t * self)
+{
+    lv_draw_task_t * t = layer->draw_task_head;
+    while(t) {
+        if(t->state == LV_DRAW_TASK_STATE_IN_PROGRESS && t->draw_unit != self) return true;
+        t = t->next;
+    }
+    return false;
+}
+
 static int32_t ppa_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
 {
     lv_draw_ppa_unit_t * u = (lv_draw_ppa_unit_t *)draw_unit;
     if(u->task_act) {
+        return LV_DRAW_UNIT_IDLE;
+    }
+
+    /* Row maintenance would discard another unit's pixels in the same rows */
+    if(other_unit_busy(layer, draw_unit)) {
         return LV_DRAW_UNIT_IDLE;
     }
 
@@ -186,20 +202,27 @@ static void ppa_execute_drawing(lv_draw_ppa_unit_t * u)
     lv_area_t area;
 
     if(!lv_area_intersect(&area, &t->area, &t->clip_area)) return;
-    lv_draw_buf_invalidate_cache(buf, &area);
+
+    /* The handlers take an area relative to the buffer */
+    lv_area_t buf_area = area;
+    lv_area_move(&buf_area, -layer->buf_area.x1, -layer->buf_area.y1);
+
+    lv_draw_buf_flush_cache(buf, &buf_area);
 
     switch(t->type) {
         case LV_DRAW_TASK_TYPE_FILL:
             lv_draw_ppa_fill(t, (lv_draw_fill_dsc_t *)t->draw_dsc, &area);
-            lv_draw_buf_invalidate_cache(buf, &area);
             break;
         case LV_DRAW_TASK_TYPE_IMAGE:
             lv_draw_ppa_img(t, (lv_draw_image_dsc_t *)t->draw_dsc, &t->area);
-            lv_draw_buf_invalidate_cache(buf, &area);
             break;
         default:
-            break;
+            LV_ASSERT_FORMAT_MSG(false, "Invalid draw task type: %d", t->type);
+            return;
     }
+
+    /* The software fallback wrote through the cache, so its lines must survive */
+    if(!u->img_sw_fallback) lv_draw_buf_invalidate_cache(buf, &buf_area);
 }
 
 #endif /*LV_USE_PPA*/

--- a/src/draw/espressif/ppa/lv_draw_ppa_buf.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa_buf.c
@@ -25,6 +25,8 @@
  *  STATIC PROTOTYPES
  *********************/
 static void invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
+static void flush_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
+static void cache_msync_rows(const lv_draw_buf_t * draw_buf, const lv_area_t * area, uint32_t dir);
 
 /**********************
  *   GLOBAL FUNCTIONS
@@ -33,14 +35,48 @@ void lv_draw_buf_ppa_init_handlers(void)
 {
     lv_draw_buf_handlers_t * handlers = lv_draw_buf_get_handlers();
     handlers->invalidate_cache_cb = invalidate_cache;
+    handlers->flush_cache_cb = flush_cache;
 }
 
 /**********************
  *   STATIC FUNCTIONS
  *********************/
 
+static void cache_msync_rows(const lv_draw_buf_t * draw_buf, const lv_area_t * area, uint32_t dir)
+{
+    size_t line = esp_cache_get_line_size_by_addr(draw_buf->data);
+    if(line == 0) return; /* Not cached */
+
+    size_t start = 0;
+    size_t end = draw_buf->data_size;
+
+    /* Whole rows, and the area is relative to the buffer */
+    if(area) {
+        uint32_t stride = draw_buf->header.stride;
+        int32_t y1 = area->y1 < 0 ? 0 : area->y1;
+        int32_t y2 = LV_MIN(area->y2, (int32_t)draw_buf->header.h - 1);
+        if(stride == 0 || y2 < y1) return;
+
+        start = (size_t)y1 * stride;
+        end = (size_t)(y2 + 1) * stride;
+    }
+
+    /* M2C is refused unless the range is whole cache lines */
+    start &= ~(line - 1);
+    end = (end + line - 1) & ~(line - 1);
+    if(end > draw_buf->data_size) end = draw_buf->data_size & ~(line - 1);
+    if(start >= end) return;
+
+    esp_cache_msync(draw_buf->data + start, end - start, dir | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
+}
+
 static void invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area)
 {
-    esp_cache_msync(draw_buf->data, draw_buf->data_size, ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
+    cache_msync_rows(draw_buf, area, ESP_CACHE_MSYNC_FLAG_DIR_M2C);
+}
+
+static void flush_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area)
+{
+    cache_msync_rows(draw_buf, area, ESP_CACHE_MSYNC_FLAG_DIR_C2M);
 }
 #endif /* LV_USE_PPA */


### PR DESCRIPTION
The Espressif PPA draw unit never invalidates the draw buffer after the accelerator writes it, so the CPU blends new pixels against stale ones. Anti-aliased text and ARGB images corrupt on every frame; opaque fills and RGB images never do.

## What's wrong

`invalidate_cache()` in `lv_draw_ppa_buf.c` ignores its `area` argument and syncs the whole draw buffer with `ESP_CACHE_MSYNC_FLAG_DIR_C2M`. `ppa_execute_drawing()` calls it both before **and after** each PPA operation, so despite the name nothing is ever invalidated. Once the PPA has written pixels by DMA, the CPU keeps reading its stale cached copy.

Only operations that *read* the destination are affected:

| | reads destination | result |
|---|---|---|
| Anti-aliased text, ARGB blending | yes | corrupt on every frame |
| Opaque fills, RGB images | no | always correct |

That asymmetry is what identified it: RGB images animating correctly while ARGB images in the same scene flickered.

[ESP-IDF's cache synchronisation docs](https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/api-reference/system/mm_sync.html) assign each direction to a slot: `C2M` after the CPU updates an address and before a DMA operation on it, `M2C` after the DMA updates it and before a CPU read. The port issues `C2M` in the slot the docs give to `M2C`.

## The fix

Writeback before the operation, invalidate after it. Two supporting details:

- **`lv_draw_wait_for_finish()` before the operation.** Cache maintenance covers the whole buffer, so no other unit may hold dirty lines while the DMA runs. `is_independent()` only keeps task *rectangles* apart, and a 64-byte cache line spans pixels of more than one task, so a whole-buffer invalidate could otherwise discard a software unit's work.

## Not a regression

`ESP_CACHE_MSYNC_FLAG_DIR_M2C` has never appeared anywhere in this port, in any commit. Present since the port's first commit (#8270), so every release that ships PPA has it, which is likely why it was never reported against a particular version.

## Verification

ESP32-S31-Korvo-1, 320×240 RGB565, partial rendering, two cores with FreeRTOS, draw buffers in PSRAM.
Partial vs full rendering makes no difference.

## Scope

Three files in `src/draw/espressif/ppa/`, 
Verified on ESP32-S31 only.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

