### PR TITLE
chore(gen_json): preserve C integer suffixes in enum values

### DIFF
--- a/scripts/gen_json/pycparser_monkeypatch.py
+++ b/scripts/gen_json/pycparser_monkeypatch.py
@@ -2,6 +2,7 @@
 
 import sys
 import os
+import re
 
 try:
     from pycparser import c_ast  # NOQA
@@ -385,16 +386,10 @@ class Enum(c_ast.Enum):
                 try:
                     value = eval("bytearray([b'" + code + "'])[0]")
                 except:  # NOQA
-                    index = code.find('L')
-
-                    while index >= 1:
-                        if code[index - 1].isdigit():
-                            code = list(code)
-                            code.pop(index)
-                            code = ''.join(code)
-
-                        index = code.find('L', index + 1)
-
+                    code = re.sub(
+                        r'(?<!\w)(0[xX][0-9a-fA-F]+|0[bB][01]+|[0-9]+)[uUlL]+',
+                        r'\1', code
+                    )
                     value = eval(code, member_namespace)
 
                 member_namespace[item_dict['name']] = value

--- a/tests/gen_json/test_gen_json.py
+++ b/tests/gen_json/test_gen_json.py
@@ -34,5 +34,28 @@ try:
 except:  # NOQA
     pass
 
+# Check C bitmask enum expressions independently of LVGL's current values.
+sys.path.insert(0, os.path.dirname(SCRIPT_PATH))
+from pycparser import c_parser  # NOQA
+import pycparser_monkeypatch  # NOQA
+
+ast = c_parser.CParser().parse('''
+typedef enum {
+    TEST_FLAG_1 = (1u << 4),
+    TEST_FLAG_2 = (1u << 8),
+    TEST_FLAG_COMBINED = (TEST_FLAG_1 | TEST_FLAG_2)
+} test_flag_t;
+''')
+ast.setup_docs(True, '', '', '')
+values = {
+    item['name']: int(item['value'], 16)
+    for item in ast.to_dict()['enums'][0]['members']
+}
+assert values == {
+    'TEST_FLAG_1': 0x10,
+    'TEST_FLAG_2': 0x100,
+    'TEST_FLAG_COMBINED': 0x110,
+}
+
 print()
 print("TEST PASSED!")


### PR DESCRIPTION
## Description

The JSON generator does not correctly evaluate C integer literal suffixes in enum expressions, such as the `u` suffix in `1u << 3`. When evaluation fails, enum values are replaced by sequential fallback values. This produces incorrect values for LVGL bitmask enums.

This change removes C integer literal suffixes before evaluating the expression while preserving the existing enum parsing flow. A regression test was added for shifted and combined enum values.

### Generated output

Before:

```json
{
    "name": "LV_OBJ_FLAG_CHECKABLE",
    "type": {
        "name": "lv_obj_flag_t",
        "json_type": "lvgl_type"
    },
    "json_type": "enum_member",
    "docstring": "Toggle checked state when the object is clicked ",
    "value": "0x03"
}
```

After:

```json
{
    "name": "LV_OBJ_FLAG_CHECKABLE",
    "type": {
        "name": "lv_obj_flag_t",
        "json_type": "lvgl_type"
    },
    "json_type": "enum_member",
    "docstring": "Toggle checked state when the object is clicked ",
    "value": "0x00000008"
}
```

### Testing

- `python3 tests/gen_json/test_gen_json.py`
- `python3 -m py_compile scripts/gen_json/pycparser_monkeypatch.py tests/gen_json/test_gen_json.py`
- `git diff --check`

### Documentation

Not needed. This is an internal JSON generator fix.

### Examples

Not applicable.

### Configuration

No configuration options were added or changed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

