### PR TITLE
fix(drm/egl): use native_window to avoid unused var warning

### DIFF
--- a/src/drivers/display/drm/lv_linux_drm_egl.c
+++ b/src/drivers/display/drm/lv_linux_drm_egl.c
@@ -647,7 +647,7 @@ static void drm_destroy_window(void * driver_data, void * native_window)
     lv_drm_ctx_t * ctx = (lv_drm_ctx_t *)driver_data;
     LV_ASSERT(native_window == ctx->gbm_surface);
 
-    if(!ctx->gbm_surface) {
+    if(!native_window) {
         return;
     }
 


### PR DESCRIPTION
Fixes:

```bash
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/drivers/display/drm/lv_linux_drm_egl.c:645:59: warning: unused parameter ‘native_window’ [-Wunused-parameter]
  645 | static void drm_destroy_window(void * driver_data, void * native_window)
      |                                                    ~~~~~~~^~~~~~~~~~~~~
```