### PR TITLE
fix(freetype): unused variable warning

### DIFF
--- a/src/font/freetype/lv_freetype.c
+++ b/src/font/freetype/lv_freetype.c
@@ -372,7 +372,7 @@ static void lv_freetype_cleanup(lv_freetype_context_t * ctx)
 
 static FTC_FaceID lv_freetype_req_face_id(lv_freetype_context_t * ctx, const char * pathname)
 {
-    LV_ASSERT(lv_strlen(pathname) > 0);
+    LV_ASSERT(pathname && pathname[0] != '\0');
 
     lv_ll_t * ll_p = &ctx->face_id_ll;
     face_id_node_t * node;

--- a/src/font/freetype/lv_freetype.c
+++ b/src/font/freetype/lv_freetype.c
@@ -372,8 +372,7 @@ static void lv_freetype_cleanup(lv_freetype_context_t * ctx)
 
 static FTC_FaceID lv_freetype_req_face_id(lv_freetype_context_t * ctx, const char * pathname)
 {
-    size_t len = lv_strlen(pathname);
-    LV_ASSERT(len > 0);
+    LV_ASSERT(lv_strlen(pathname) > 0);
 
     lv_ll_t * ll_p = &ctx->face_id_ll;
     face_id_node_t * node;


### PR DESCRIPTION
Fixes:

```bash
[276/594] Building C object lvgl/CMakeFiles/lvgl.dir/src/font/freetype/lv_freetype.c.o
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/font/freetype/lv_freetype.c: In function ‘lv_freetype_req_face_id’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/font/freetype/lv_freetype.c:375:12: warning: unused variable ‘len’ [-Wunused-variable]
  375 |     size_t len = lv_strlen(pathname);
      |            ^~~
```