### PR TITLE
fix(draw/neon): unused variable warnings

### DIFF
--- a/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c
+++ b/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c
@@ -1334,7 +1334,7 @@ static inline uint16x8_t lv_color_24_16_mix_8_with_mask(const uint8_t * src, con
         g_pixels               = vmovl_u8(rgba.val[1]);
         r_pixels               = vmovl_u8(rgba.val[2]);
     }
-    else if(src_px_size == 4) {
+    else {
         const uint8x8x4_t rgba = vld4_u8(src);
         b_pixels               = vmovl_u8(rgba.val[0]);
         g_pixels               = vmovl_u8(rgba.val[1]);
@@ -1359,7 +1359,7 @@ static inline uint16x4_t lv_color_24_16_mix_4_with_mask(const uint8_t * src, con
         g_pixels               = vget_low_u16(vmovl_u8(rgba.val[1]));
         r_pixels               = vget_low_u16(vmovl_u8(rgba.val[2]));
     }
-    else if(src_px_size == 4) {
+    else {
         const uint8x8x4_t rgba = vld4_u8(src);
         b_pixels               = vget_low_u16(vmovl_u8(rgba.val[0]));
         g_pixels               = vget_low_u16(vmovl_u8(rgba.val[1]));
@@ -1385,7 +1385,7 @@ static inline uint16x8_t lv_color_24_16_mix_8_with_opa_mask(const uint8_t * src,
         g_pixels               = vmovl_u8(rgba.val[1]);
         r_pixels               = vmovl_u8(rgba.val[2]);
     }
-    else if(src_px_size == 4) {
+    else {
         const uint8x8x4_t rgba = vld4_u8(src);
         b_pixels               = vmovl_u8(rgba.val[0]);
         g_pixels               = vmovl_u8(rgba.val[1]);
@@ -1412,7 +1412,7 @@ static inline uint16x4_t lv_color_24_16_mix_4_with_opa_mask(const uint8_t * src,
         g_pixels               = vget_low_u16(vmovl_u8(rgba.val[1]));
         r_pixels               = vget_low_u16(vmovl_u8(rgba.val[2]));
     }
-    else if(src_px_size == 4) {
+    else {
         const uint8x8x4_t rgba = vld4_u8(src);
         b_pixels               = vget_low_u16(vmovl_u8(rgba.val[0]));
         g_pixels               = vget_low_u16(vmovl_u8(rgba.val[1]));
@@ -1446,7 +1446,7 @@ static inline uint16x8_t lv_color_24_16_mix_8_with_opa(const uint8_t * src, cons
         g_pixels               = vmovl_u8(rgba.val[1]);
         r_pixels               = vmovl_u8(rgba.val[2]);
     }
-    else if(src_px_size == 4) {
+    else {
         const uint8x8x4_t rgba = vld4_u8(src);
         b_pixels               = vmovl_u8(rgba.val[0]);
         g_pixels               = vmovl_u8(rgba.val[1]);
@@ -1487,7 +1487,7 @@ static inline uint16x4_t lv_color_24_16_mix_4_with_opa(const uint8_t * src, cons
         g_pixels               = vget_low_u16(vmovl_u8(rgba.val[1]));
         r_pixels               = vget_low_u16(vmovl_u8(rgba.val[2]));
     }
-    else if(src_px_size == 4) {
+    else {
         const uint8x8x4_t rgba = vld4_u8(src);
         b_pixels               = vget_low_u16(vmovl_u8(rgba.val[0]));
         g_pixels               = vget_low_u16(vmovl_u8(rgba.val[1]));
@@ -1873,7 +1873,7 @@ static inline uint16x8_t rgb888_to_rgb565_8(const uint8_t * src, uint8_t src_px_
         g_pixels               = vmovl_u8(rgba.val[1]);
         r_pixels               = vmovl_u8(rgba.val[2]);
     }
-    else if(src_px_size == 4) {
+    else {
         const uint8x8x4_t rgba = vld4_u8(src);
         b_pixels               = vmovl_u8(rgba.val[0]);
         g_pixels               = vmovl_u8(rgba.val[1]);
@@ -1899,7 +1899,7 @@ static inline uint16x4_t rgb888_to_rgb565_4(const uint8_t * src, uint8_t src_px_
         g_pixels               = vget_low_u16(vmovl_u8(rgba.val[1]));
         r_pixels               = vget_low_u16(vmovl_u8(rgba.val[2]));
     }
-    else if(src_px_size == 4) {
+    else {
         const uint8x8x4_t rgba = vld4_u8(src);
         b_pixels               = vget_low_u16(vmovl_u8(rgba.val[0]));
         g_pixels               = vget_low_u16(vmovl_u8(rgba.val[1]));


### PR DESCRIPTION
Fixes:

```bash
[358/594] Building C object lvgl/CMakeFiles/lvgl.di...w/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c.o
In file included from /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:13:
In function ‘vandq_u16’,
    inlined from ‘rgb888_to_rgb565_8’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1883:26,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:712:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:1129:14: warning: ‘r_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
 1129 |   return __a & __b;
      |          ~~~~^~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1867:16: note: ‘r_pixels’ was declared here
 1867 |     uint16x8_t r_pixels;
      |                ^~~~~~~~
In function ‘vandq_u16’,
    inlined from ‘rgb888_to_rgb565_8’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1884:26,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:712:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:1129:14: warning: ‘g_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
 1129 |   return __a & __b;
      |          ~~~~^~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1866:16: note: ‘g_pixels’ was declared here
 1866 |     uint16x8_t g_pixels;
      |                ^~~~~~~~
In function ‘vandq_u16’,
    inlined from ‘rgb888_to_rgb565_8’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1885:26,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:712:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:1129:14: warning: ‘b_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
 1129 |   return __a & __b;
      |          ~~~~^~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1865:16: note: ‘b_pixels’ was declared here
 1865 |     uint16x8_t b_pixels;
      |                ^~~~~~~~
In function ‘vand_u16’,
    inlined from ‘rgb888_to_rgb565_4’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1909:26,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:715:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:1066:14: warning: ‘r_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
 1066 |   return __a & __b;
      |          ~~~~^~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1893:16: note: ‘r_pixels’ was declared here
 1893 |     uint16x4_t r_pixels;
      |                ^~~~~~~~
In function ‘vand_u16’,
    inlined from ‘rgb888_to_rgb565_4’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1910:26,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:715:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:1066:14: warning: ‘g_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
 1066 |   return __a & __b;
      |          ~~~~^~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1892:16: note: ‘g_pixels’ was declared here
 1892 |     uint16x4_t g_pixels;
      |                ^~~~~~~~
In function ‘vand_u16’,
    inlined from ‘rgb888_to_rgb565_4’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1911:26,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:715:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:1066:14: warning: ‘b_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
 1066 |   return __a & __b;
      |          ~~~~^~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1891:16: note: ‘b_pixels’ was declared here
 1891 |     uint16x4_t b_pixels;
      |                ^~~~~~~~
In function ‘vshlq_n_u16’,
    inlined from ‘lv_color_32_16_mix_8_internal’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1610:35,
    inlined from ‘lv_color_24_16_mix_8_with_opa’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1458:12,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:749:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:20967:23: warning: ‘r_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
20967 |   return (uint16x8_t) __builtin_aarch64_ashlv8hi ((int16x8_t) __a, __b);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1440:16: note: ‘r_pixels’ was declared here
 1440 |     uint16x8_t r_pixels;
      |                ^~~~~~~~
In function ‘vshlq_n_u16’,
    inlined from ‘lv_color_32_16_mix_8_internal’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1611:35,
    inlined from ‘lv_color_24_16_mix_8_with_opa’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1458:12,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:749:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:20967:23: warning: ‘g_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
20967 |   return (uint16x8_t) __builtin_aarch64_ashlv8hi ((int16x8_t) __a, __b);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1439:16: note: ‘g_pixels’ was declared here
 1439 |     uint16x8_t g_pixels;
      |                ^~~~~~~~
In function ‘vshrq_n_u16’,
    inlined from ‘lv_color_32_16_mix_8_internal’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1612:35,
    inlined from ‘lv_color_24_16_mix_8_with_opa’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1458:12,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:749:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:21305:10: warning: ‘b_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
21305 |   return __builtin_aarch64_lshrv8hi_uus (__a, __b);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1438:16: note: ‘b_pixels’ was declared here
 1438 |     uint16x8_t b_pixels;
      |                ^~~~~~~~
In function ‘vshl_n_u16’,
    inlined from ‘lv_color_32_16_mix_4_internal’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1647:35,
    inlined from ‘lv_color_24_16_mix_4_with_opa’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1499:12,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:752:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:20911:23: warning: ‘r_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
20911 |   return (uint16x4_t) __builtin_aarch64_ashlv4hi ((int16x4_t) __a, __b);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1481:16: note: ‘r_pixels’ was declared here
 1481 |     uint16x4_t r_pixels;
      |                ^~~~~~~~
In function ‘vshl_n_u16’,
    inlined from ‘lv_color_32_16_mix_4_internal’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1648:35,
    inlined from ‘lv_color_24_16_mix_4_with_opa’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1499:12,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:752:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:20911:23: warning: ‘g_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
20911 |   return (uint16x4_t) __builtin_aarch64_ashlv4hi ((int16x4_t) __a, __b);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1480:16: note: ‘g_pixels’ was declared here
 1480 |     uint16x4_t g_pixels;
      |                ^~~~~~~~
In function ‘vshr_n_u16’,
    inlined from ‘lv_color_32_16_mix_4_internal’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1649:35,
    inlined from ‘lv_color_24_16_mix_4_with_opa’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1499:12,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:752:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:21249:10: warning: ‘b_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
21249 |   return __builtin_aarch64_lshrv4hi_uus (__a, __b);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1479:16: note: ‘b_pixels’ was declared here
 1479 |     uint16x4_t b_pixels;
      |                ^~~~~~~~
In function ‘vshlq_n_u16’,
    inlined from ‘lv_color_32_16_mix_8_internal’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1610:35,
    inlined from ‘lv_color_24_16_mix_8_with_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1346:12,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:787:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:20967:23: warning: ‘r_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
20967 |   return (uint16x8_t) __builtin_aarch64_ashlv8hi ((int16x8_t) __a, __b);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_mask’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1328:16: note: ‘r_pixels’ was declared here
 1328 |     uint16x8_t r_pixels;
      |                ^~~~~~~~
In function ‘vshlq_n_u16’,
    inlined from ‘lv_color_32_16_mix_8_internal’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1611:35,
    inlined from ‘lv_color_24_16_mix_8_with_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1346:12,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:787:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:20967:23: warning: ‘g_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
20967 |   return (uint16x8_t) __builtin_aarch64_ashlv8hi ((int16x8_t) __a, __b);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_mask’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1327:16: note: ‘g_pixels’ was declared here
 1327 |     uint16x8_t g_pixels;
      |                ^~~~~~~~
In function ‘vshrq_n_u16’,
    inlined from ‘lv_color_32_16_mix_8_internal’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1612:35,
    inlined from ‘lv_color_24_16_mix_8_with_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1346:12,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:787:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:21305:10: warning: ‘b_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
21305 |   return __builtin_aarch64_lshrv8hi_uus (__a, __b);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_mask’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1326:16: note: ‘b_pixels’ was declared here
 1326 |     uint16x8_t b_pixels;
      |                ^~~~~~~~
In function ‘vshl_n_u16’,
    inlined from ‘lv_color_32_16_mix_4_internal’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1647:35,
    inlined from ‘lv_color_24_16_mix_4_with_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1371:12,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:791:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:20911:23: warning: ‘r_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
20911 |   return (uint16x4_t) __builtin_aarch64_ashlv4hi ((int16x4_t) __a, __b);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_mask’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1353:16: note: ‘r_pixels’ was declared here
 1353 |     uint16x4_t r_pixels;
      |                ^~~~~~~~
In function ‘vshl_n_u16’,
    inlined from ‘lv_color_32_16_mix_4_internal’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1648:35,
    inlined from ‘lv_color_24_16_mix_4_with_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1371:12,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:791:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:20911:23: warning: ‘g_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
20911 |   return (uint16x4_t) __builtin_aarch64_ashlv4hi ((int16x4_t) __a, __b);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_mask’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1352:16: note: ‘g_pixels’ was declared here
 1352 |     uint16x4_t g_pixels;
      |                ^~~~~~~~
In function ‘vshr_n_u16’,
    inlined from ‘lv_color_32_16_mix_4_internal’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1649:35,
    inlined from ‘lv_color_24_16_mix_4_with_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1371:12,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:791:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:21249:10: warning: ‘b_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
21249 |   return __builtin_aarch64_lshrv4hi_uus (__a, __b);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_mask’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1351:16: note: ‘b_pixels’ was declared here
 1351 |     uint16x4_t b_pixels;
      |                ^~~~~~~~
In function ‘vshlq_n_u16’,
    inlined from ‘lv_color_32_16_mix_8_internal’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1610:35,
    inlined from ‘lv_color_24_16_mix_8_with_opa_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1399:12,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:831:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:20967:23: warning: ‘r_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
20967 |   return (uint16x8_t) __builtin_aarch64_ashlv8hi ((int16x8_t) __a, __b);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa_mask’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1379:16: note: ‘r_pixels’ was declared here
 1379 |     uint16x8_t r_pixels;
      |                ^~~~~~~~
In function ‘vshlq_n_u16’,
    inlined from ‘lv_color_32_16_mix_8_internal’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1611:35,
    inlined from ‘lv_color_24_16_mix_8_with_opa_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1399:12,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:831:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:20967:23: warning: ‘g_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
20967 |   return (uint16x8_t) __builtin_aarch64_ashlv8hi ((int16x8_t) __a, __b);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa_mask’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1378:16: note: ‘g_pixels’ was declared here
 1378 |     uint16x8_t g_pixels;
      |                ^~~~~~~~
In function ‘vshrq_n_u16’,
    inlined from ‘lv_color_32_16_mix_8_internal’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1612:35,
    inlined from ‘lv_color_24_16_mix_8_with_opa_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1399:12,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:831:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:21305:10: warning: ‘b_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
21305 |   return __builtin_aarch64_lshrv8hi_uus (__a, __b);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa_mask’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1377:16: note: ‘b_pixels’ was declared here
 1377 |     uint16x8_t b_pixels;
      |                ^~~~~~~~
In function ‘vshl_n_u16’,
    inlined from ‘lv_color_32_16_mix_4_internal’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1647:35,
    inlined from ‘lv_color_24_16_mix_4_with_opa_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1426:12,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:835:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:20911:23: warning: ‘r_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
20911 |   return (uint16x4_t) __builtin_aarch64_ashlv4hi ((int16x4_t) __a, __b);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa_mask’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1406:16: note: ‘r_pixels’ was declared here
 1406 |     uint16x4_t r_pixels;
      |                ^~~~~~~~
In function ‘vshl_n_u16’,
    inlined from ‘lv_color_32_16_mix_4_internal’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1648:35,
    inlined from ‘lv_color_24_16_mix_4_with_opa_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1426:12,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:835:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:20911:23: warning: ‘g_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
20911 |   return (uint16x4_t) __builtin_aarch64_ashlv4hi ((int16x4_t) __a, __b);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa_mask’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1405:16: note: ‘g_pixels’ was declared here
 1405 |     uint16x4_t g_pixels;
      |                ^~~~~~~~
In function ‘vshr_n_u16’,
    inlined from ‘lv_color_32_16_mix_4_internal’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1649:35,
    inlined from ‘lv_color_24_16_mix_4_with_opa_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1426:12,
    inlined from ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa_mask’ at /home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:835:13:
/mnt/ssd/opt/rz-vlp/5.0.14/sysroots/x86_64-pokysdk-linux/usr/lib/aarch64-poky-linux/gcc/aarch64-poky-linux/13.4.0/include/arm_neon.h:21249:10: warning: ‘b_pixels’ may be used uninitialized [-Wmaybe-uninitialized]
21249 |   return __builtin_aarch64_lshrv4hi_uus (__a, __b);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c: In function ‘lv_draw_sw_blend_neon_rgb888_to_rgb565_with_opa_mask’:
/home/andre/dev/lvgl/lv_port_linux/lvgl/src/draw/sw/blend/neon/lv_draw_sw_blend_neon_to_rgb565.c:1404:16: note: ‘b_pixels’ was declared here
 1404 |     uint16x4_t b_pixels;
      |                ^~~~~~~~
```