### PR TITLE
fix(draw): remove five unused struct fields

### DIFF
--- a/src/draw/lv_draw_private.h
+++ b/src/draw/lv_draw_private.h
@@ -42,9 +42,6 @@ struct _lv_draw_task_t {
      */
     lv_area_t _real_area;
 
-    /** The original area which is updated*/
-    lv_area_t clip_area_original;
-
     /**
      * The clip area of the layer is saved here when the draw task is created.
      * As the clip area of the layer can be changed as new draw tasks are added its current value needs to be saved.

--- a/src/draw/sw/lv_draw_sw_transform.c
+++ b/src/draw/sw/lv_draw_sw_transform.c
@@ -18,10 +18,6 @@
  *      TYPEDEFS
  **********************/
 typedef struct {
-    int32_t x_in;
-    int32_t y_in;
-    int32_t x_out;
-    int32_t y_out;
     int32_t sinma;
     int32_t cosma;
     int32_t scale_x;


### PR DESCRIPTION
`lv_draw_task_t::clip_area_original` in src/draw/lv_draw_private.h. Left over from the pre-9.x refresh path (added in 6a47c6f33, orphaned by f753265a7). sizeof(lv_draw_task_t) is 92 bytes, so this is 16 of the 92 allocated and zeroed for every draw task on every frame.

`point_transform_dsc_t::x_in`, `y_in`, `x_out`, `y_out` in src/draw/sw/lv_draw_sw_transform.c. Added by 318146a2c, never used. The struct is a local whose address is never taken, so the compiler already drops them anyways. Removing them is readability only: the names suggest the struct carries coordinates, which it doesn't.

Neither struct is public, so this is not an API change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

