### PR TITLE
fix(fs/posix): protect POSIX API usage on Win32 build 

### DIFF
--- a/src/fs/lv_fs_posix.c
+++ b/src/fs/lv_fs_posix.c
@@ -11,6 +11,10 @@
 
 #if LV_USE_FS_POSIX
 
+#ifdef _WIN32
+    #error "Win32 does not support the full POSIX API"
+#endif
+
 #include <fcntl.h>
 #include <stdio.h>
 #include <sys/types.h>


### PR DESCRIPTION
## Summary

The PR aims is add a guard POSIX-only calls in lv_fs_posix.c so the file compiles cleanly under MinGW when the POSIX filesystem driver is enabled.

Issue  : 
- https://forum.lvgl.io/t/cant-load-images-from-pendrive/24345/9
