### PR TITLE
fix(nema_gfx): set the fill rule before drawing a gradient background

### DIFF
--- a/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c
+++ b/src/draw/nema_gfx/lv_draw_nema_gfx_fill.c
@@ -99,6 +99,14 @@ void lv_draw_nema_gfx_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc, c
 
         nema_vg_paint_clear(draw_nema_gfx_unit->paint);
 
+        /*The fill rule is global NemaVG state and is not set anywhere in this
+         *file. lv_draw_nema_gfx_vector.c sets it to NEMA_VG_STROKE for every
+         *path that has a stroke and never restores it, so a stroke-only vector
+         *icon leaves the GPU in stroke mode and the next gradient background is
+         *outlined instead of filled. Set it here, as the triangle and label
+         *draw paths already do.*/
+        nema_vg_set_fill_rule(NEMA_VG_FILL_EVEN_ODD);
+
         nema_vg_set_blend(NEMA_BL_SRC_OVER | NEMA_BLOP_SRC_PREMULT);
 
         float stops[LV_GRADIENT_MAX_STOPS];


### PR DESCRIPTION
`lv_draw_nema_gfx_fill.c` never sets the NemaVG fill rule, so it just inherits
whatever the last vector draw left behind. `lv_draw_nema_gfx_vector.c` sets it
to `NEMA_VG_STROKE` for any path that has a stroke and never puts it back.

So after a stroke-only SVG icon, the next object with a gradient background
gets outlined instead of filled. On a full-screen rect the outline lands on the
screen edges and the background just disappears.

`lv_draw_nema_gfx_triangle.c` and `lv_draw_nema_gfx_label.c` both set the rule
before drawing a gradient already. This does the same thing in the fill path,
with the same value they use.

Repro, on hardware with `LV_USE_NEMA_VG`: draw any stroke-only vector path,
then an object with `bg_grad_dir` set. The second one comes out as an outline.

Found it on an STM32U5G9J-DK2 with NeoChrom, where a splash screen lost its
gradient background the moment SVG icons appeared in the same frame. Took me a
while because it only shows up on hardware — the SW renderer has no shared
state, so the same screen was fine in the simulator.

I assumed the RGB565 destination was the problem at first, since SVG icons
rasterise into ARGB8888 buffers and those render fine. Drew two identical
gradient bands and forced one through a layer with
`lv_obj_set_style_opa(obj, 254)`. Both came out as outlines, so it wasn't that.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lvgl/lvgl/pull/10688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

